### PR TITLE
fix(tmux): use short metadata-backed session names

### DIFF
--- a/apps/emdash-desktop/src/main/core/conversations/deleteConversation.test.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/deleteConversation.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { deleteConversation } from './deleteConversation';
+
+const mocks = vi.hoisted(() => ({
+  capture: vi.fn(),
+  deleteRows: vi.fn(),
+  deleteWhere: vi.fn(),
+  emit: vi.fn(),
+  getProject: vi.fn(),
+  killTmuxSessionsByPtyIds: vi.fn(),
+  resolveTask: vi.fn(),
+  selectLimit: vi.fn(),
+}));
+
+vi.mock('@main/db/client', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: mocks.selectLimit }),
+      }),
+    }),
+    delete: mocks.deleteRows,
+  },
+}));
+
+vi.mock('@main/core/projects/project-manager', () => ({
+  projectManager: { getProject: mocks.getProject },
+}));
+
+vi.mock('@main/core/pty/tmux-reaper', () => ({
+  killTmuxSessionsByPtyIds: mocks.killTmuxSessionsByPtyIds,
+}));
+
+vi.mock('@main/lib/telemetry', () => ({
+  telemetryService: { capture: mocks.capture },
+}));
+
+vi.mock('../projects/utils', () => ({
+  resolveTask: mocks.resolveTask,
+}));
+
+vi.mock('./conversation-events', () => ({
+  conversationEvents: { _emit: mocks.emit },
+}));
+
+describe('deleteConversation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.selectLimit.mockResolvedValue([{ type: 'codex' }]);
+    mocks.resolveTask.mockReturnValue(undefined);
+    mocks.getProject.mockReturnValue({ ctx: {} });
+    mocks.killTmuxSessionsByPtyIds.mockResolvedValue(undefined);
+    mocks.deleteWhere.mockResolvedValue(undefined);
+    mocks.deleteRows.mockReturnValue({ where: mocks.deleteWhere });
+  });
+
+  it('preserves the DB record when detached tmux cleanup cannot discover sessions', async () => {
+    mocks.killTmuxSessionsByPtyIds.mockRejectedValue(new Error('Failed to discover tmux sessions'));
+
+    await expect(deleteConversation('project-1', 'task-1', 'conversation-1')).rejects.toThrow(
+      'Failed to discover tmux sessions'
+    );
+
+    expect(mocks.deleteRows).not.toHaveBeenCalled();
+    expect(mocks.emit).not.toHaveBeenCalled();
+    expect(mocks.capture).not.toHaveBeenCalled();
+  });
+
+  it('deletes the DB record only after detached tmux cleanup succeeds', async () => {
+    await deleteConversation('project-1', 'task-1', 'conversation-1');
+
+    expect(mocks.killTmuxSessionsByPtyIds).toHaveBeenCalledTimes(1);
+    expect(mocks.deleteRows).toHaveBeenCalledTimes(1);
+    expect(mocks.killTmuxSessionsByPtyIds.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.deleteRows.mock.invocationCallOrder[0]!
+    );
+  });
+});

--- a/apps/emdash-desktop/src/main/core/conversations/deleteConversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/deleteConversation.ts
@@ -1,6 +1,6 @@
 import { and, eq } from 'drizzle-orm';
 import { projectManager } from '@main/core/projects/project-manager';
-import { killTmuxSession, makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
+import { killTmuxSessionsByPtyIds } from '@main/core/pty/tmux-reaper';
 import { db } from '@main/db/client';
 import { conversations } from '@main/db/schema';
 import { telemetryService } from '@main/lib/telemetry';
@@ -52,10 +52,9 @@ export async function deleteConversation(
   } else {
     const project = projectManager.getProject(projectId);
     if (project) {
-      await killTmuxSession(
-        project.ctx,
-        makeTmuxSessionName(makePtySessionId(projectId, taskId, conversationId))
-      );
+      await killTmuxSessionsByPtyIds(project.ctx, [
+        makePtySessionId(projectId, taskId, conversationId),
+      ]);
     }
   }
   telemetryService.capture('conversation_deleted', {

--- a/apps/emdash-desktop/src/main/core/conversations/deleteConversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/deleteConversation.ts
@@ -25,6 +25,20 @@ export async function deleteConversation(
     )
     .limit(1);
 
+  if (convRow?.type !== 'acp') {
+    const task = resolveTask(projectId, taskId);
+    if (task) {
+      await task.conversations.stopSession(conversationId);
+    } else {
+      const project = projectManager.getProject(projectId);
+      if (project) {
+        await killTmuxSessionsByPtyIds(project.ctx, [
+          makePtySessionId(projectId, taskId, conversationId),
+        ]);
+      }
+    }
+  }
+
   await db
     .delete(conversations)
     .where(
@@ -36,27 +50,6 @@ export async function deleteConversation(
     );
 
   conversationEvents._emit('conversation:deleted', conversationId);
-
-  if (convRow?.type === 'acp') {
-    telemetryService.capture('conversation_deleted', {
-      project_id: projectId,
-      task_id: taskId,
-      conversation_id: conversationId,
-    });
-    return;
-  }
-
-  const task = resolveTask(projectId, taskId);
-  if (task) {
-    await task.conversations.stopSession(conversationId);
-  } else {
-    const project = projectManager.getProject(projectId);
-    if (project) {
-      await killTmuxSessionsByPtyIds(project.ctx, [
-        makePtySessionId(projectId, taskId, conversationId),
-      ]);
-    }
-  }
   telemetryService.capture('conversation_deleted', {
     project_id: projectId,
     task_id: taskId,

--- a/apps/emdash-desktop/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CONVERSATION_FRESH_RECOVERY_GRACE_MS } from '@main/core/conversations/conversation-session-supervisor';
 import type { Pty, PtyExitInfo } from '@main/core/pty/pty';
 import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
+import { makeTmuxSession } from '@main/core/pty/tmux-session-name';
 import type { IFilesRuntime } from '@main/core/runtime/types';
 import { agentSessionExitedChannel } from '@shared/core/agents/agentEvents';
 import type { Conversation } from '@shared/core/conversations/conversations';
@@ -911,22 +912,25 @@ describe('conversation provider respawn state', () => {
   it('kills tmux when explicitly stopping a detached local conversation', async () => {
     const exitHandlers: Array<(info: PtyExitInfo) => void> = [];
     spawnLocalPty.mockReturnValue(fakePty(exitHandlers));
-    const ctx = {
-      exec: vi.fn(async () => ({ stdout: '', stderr: '' })),
-    };
-    const provider = localProvider({ tmux: true, ctx: ctx as never });
     const item = conversation();
     const sessionId = makePtySessionId(item.projectId, item.taskId, item.id);
+    const tmuxSession = makeTmuxSession(sessionId, '/tmp/task-1');
+    const ctx = {
+      exec: vi.fn(async (_command: string, args: string[]) => ({
+        stdout:
+          args[0] === 'list-sessions'
+            ? `${tmuxSession.name}\t${item.projectId}\t${item.taskId}\t${item.id}\n`
+            : '',
+        stderr: '',
+      })),
+    };
+    const provider = localProvider({ tmux: true, ctx: ctx as never });
 
     await provider.startSession(item);
     await provider.detachSession(item.id);
     await provider.stopSession(item.id);
 
-    expect(ctx.exec).toHaveBeenCalledWith('tmux', [
-      'kill-session',
-      '-t',
-      expect.stringContaining(Buffer.from(sessionId, 'utf8').toString('base64url')),
-    ]);
+    expect(ctx.exec).toHaveBeenCalledWith('tmux', ['kill-session', '-t', tmuxSession.name]);
     expect((provider as unknown as RespawnState).knownSessionIds.has(sessionId)).toBe(false);
   });
 
@@ -936,22 +940,25 @@ describe('conversation provider respawn state', () => {
       success: true,
       data: fakePty(exitHandlers),
     });
-    const ctx = {
-      exec: vi.fn(async () => ({ stdout: '', stderr: '' })),
-    };
-    const provider = sshProvider(undefined, { tmux: true, ctx: ctx as never });
     const item = conversation();
     const sessionId = makePtySessionId(item.projectId, item.taskId, item.id);
+    const tmuxSession = makeTmuxSession(sessionId, '/tmp/task-1');
+    const ctx = {
+      exec: vi.fn(async (_command: string, args: string[]) => ({
+        stdout:
+          args[0] === 'list-sessions'
+            ? `${tmuxSession.name}\t${item.projectId}\t${item.taskId}\t${item.id}\n`
+            : '',
+        stderr: '',
+      })),
+    };
+    const provider = sshProvider(undefined, { tmux: true, ctx: ctx as never });
 
     await provider.startSession(item);
     await provider.detachSession(item.id);
     await provider.stopSession(item.id);
 
-    expect(ctx.exec).toHaveBeenCalledWith('tmux', [
-      'kill-session',
-      '-t',
-      expect.stringContaining(Buffer.from(sessionId, 'utf8').toString('base64url')),
-    ]);
+    expect(ctx.exec).toHaveBeenCalledWith('tmux', ['kill-session', '-t', tmuxSession.name]);
     expect((provider as unknown as RespawnState).knownSessionIds.has(sessionId)).toBe(false);
   });
 

--- a/apps/emdash-desktop/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
@@ -962,6 +962,47 @@ describe('conversation provider respawn state', () => {
     expect((provider as unknown as RespawnState).knownSessionIds.has(sessionId)).toBe(false);
   });
 
+  it('keeps a detached local conversation retryable when tmux discovery fails', async () => {
+    const exitHandlers: Array<(info: PtyExitInfo) => void> = [];
+    spawnLocalPty.mockReturnValue(fakePty(exitHandlers));
+    const item = conversation();
+    const sessionId = makePtySessionId(item.projectId, item.taskId, item.id);
+    const ctx = {
+      exec: vi.fn(async () => {
+        throw new Error('connection timed out');
+      }),
+    };
+    const provider = localProvider({ tmux: true, ctx: ctx as never });
+
+    await provider.startSession(item);
+    await provider.detachSession(item.id);
+
+    await expect(provider.stopSession(item.id)).rejects.toThrow('Failed to discover tmux sessions');
+    expect((provider as unknown as RespawnState).knownSessionIds.has(sessionId)).toBe(true);
+  });
+
+  it('keeps a detached SSH conversation retryable when tmux discovery fails', async () => {
+    const exitHandlers: Array<(info: PtyExitInfo) => void> = [];
+    openSsh2Pty.mockResolvedValue({
+      success: true,
+      data: fakePty(exitHandlers),
+    });
+    const item = conversation();
+    const sessionId = makePtySessionId(item.projectId, item.taskId, item.id);
+    const ctx = {
+      exec: vi.fn(async () => {
+        throw new Error('connection timed out');
+      }),
+    };
+    const provider = sshProvider(undefined, { tmux: true, ctx: ctx as never });
+
+    await provider.startSession(item);
+    await provider.detachSession(item.id);
+
+    await expect(provider.stopSession(item.id)).rejects.toThrow('Failed to discover tmux sessions');
+    expect((provider as unknown as RespawnState).knownSessionIds.has(sessionId)).toBe(true);
+  });
+
   it('ignores stale local attach exits after a tmux conversation is rehydrated', async () => {
     const firstExitHandlers: Array<(info: PtyExitInfo) => void> = [];
     const secondExitHandlers: Array<(info: PtyExitInfo) => void> = [];

--- a/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
@@ -20,7 +20,8 @@ import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
 import { logLocalPtySpawnWarnings, resolveLocalPtySpawn } from '@main/core/pty/pty-spawn-platform';
 import { makePtyId } from '@main/core/pty/ptyId';
 import { getTerminalColorEnv } from '@main/core/pty/terminal-color-scheme';
-import { killTmuxSession, makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
+import { killTmuxSessionsByPtyIds } from '@main/core/pty/tmux-reaper';
+import { makeTmuxSession } from '@main/core/pty/tmux-session-name';
 import { providerOverrideSettings } from '@main/core/settings/provider-settings-service';
 import type { ResolvedShellProfile } from '@main/core/terminal-shell/types';
 import { events } from '@main/lib/events';
@@ -165,7 +166,7 @@ export class LocalConversationProvider implements ConversationProvider {
       const customEnv = providerConfig?.env ?? {};
       const providerVars: Record<string, string> = { ...agentCommand.env, ...customEnv };
 
-      const tmuxSessionName = this.tmux ? makeTmuxSessionName(sessionId) : undefined;
+      const tmuxSession = this.tmux ? makeTmuxSession(sessionId, this.taskPath) : undefined;
 
       const resolved = resolveLocalPtySpawn({
         platform: process.platform,
@@ -176,7 +177,7 @@ export class LocalConversationProvider implements ConversationProvider {
           command: { kind: 'argv', command: agentCommand.command, args: agentCommand.args },
           shellProfile: this.shellProfile,
           shellSetup: this.shellSetup,
-          tmuxSessionName,
+          tmuxSession,
         },
       });
 
@@ -315,7 +316,7 @@ export class LocalConversationProvider implements ConversationProvider {
       }
     }
     if (this.tmux) {
-      await killTmuxSession(this.ctx, makeTmuxSessionName(sessionId));
+      await killTmuxSessionsByPtyIds(this.ctx, [sessionId]);
     }
     this.supervisor.forget(sessionId);
   }
@@ -324,7 +325,7 @@ export class LocalConversationProvider implements ConversationProvider {
     const sessionIds = Array.from(this.knownSessionIds);
     await this.detachAll();
     if (this.tmux) {
-      await Promise.all(sessionIds.map((id) => killTmuxSession(this.ctx, makeTmuxSessionName(id))));
+      await killTmuxSessionsByPtyIds(this.ctx, sessionIds);
     }
     for (const sessionId of sessionIds) {
       this.supervisor.forget(sessionId);

--- a/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
@@ -301,7 +301,6 @@ export class LocalConversationProvider implements ConversationProvider {
 
   async stopSession(conversationId: string): Promise<void> {
     const sessionId = makePtySessionId(this.projectId, this.taskId, conversationId);
-    this.knownSessionIds.delete(sessionId);
     const pty = this.supervisor.stop(sessionId) ?? this.sessions.get(sessionId);
     this.sessions.delete(sessionId);
     ptySessionRegistry.unregister(sessionId);
@@ -318,6 +317,7 @@ export class LocalConversationProvider implements ConversationProvider {
     if (this.tmux) {
       await killTmuxSessionsByPtyIds(this.ctx, [sessionId]);
     }
+    this.knownSessionIds.delete(sessionId);
     this.supervisor.forget(sessionId);
   }
 

--- a/apps/emdash-desktop/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/ssh-conversation.ts
@@ -10,8 +10,8 @@ import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
 import { resolveSshCommand } from '@main/core/pty/spawn-utils';
 import { openSsh2Pty } from '@main/core/pty/ssh2-pty';
 import { getTerminalColorEnv } from '@main/core/pty/terminal-color-scheme';
-import { killTmuxSessionTree } from '@main/core/pty/tmux-reaper';
-import { makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
+import { killTmuxSessionsByPtyIds } from '@main/core/pty/tmux-reaper';
+import { makeTmuxSession } from '@main/core/pty/tmux-session-name';
 import type { IFilesRuntime } from '@main/core/runtime/types';
 import { providerOverrideSettings } from '@main/core/settings/provider-settings-service';
 import type { SshClientProxy } from '@main/core/ssh/lifecycle/ssh-client-proxy';
@@ -156,7 +156,7 @@ export class SshConversationProvider implements ConversationProvider {
       const customEnv = providerConfig?.env ?? {};
       const providerEnv: Record<string, string> = { ...agentCommand.env, ...customEnv };
 
-      const tmuxSessionName = this.tmux ? makeTmuxSessionName(sessionId) : undefined;
+      const tmuxSession = this.tmux ? makeTmuxSession(sessionId, this.taskPath) : undefined;
 
       const cfg: AgentSessionConfig = {
         taskId: this.taskId,
@@ -166,7 +166,7 @@ export class SshConversationProvider implements ConversationProvider {
         args: agentCommand.args,
         cwd: this.taskPath,
         shellSetup: this.shellSetup,
-        tmuxSessionName,
+        tmuxSession,
         autoApprove: conversation.autoApprove ?? false,
         resume: agentSession.isResuming,
       };
@@ -342,7 +342,7 @@ export class SshConversationProvider implements ConversationProvider {
       }
     }
     if (this.tmux) {
-      await killTmuxSessionTree(this.ctx, makeTmuxSessionName(sessionId));
+      await killTmuxSessionsByPtyIds(this.ctx, [sessionId], { reapDescendants: true });
     }
     this.supervisor.forget(sessionId);
   }
@@ -351,9 +351,7 @@ export class SshConversationProvider implements ConversationProvider {
     const sessionIds = Array.from(this.knownSessionIds);
     await this.detachAll();
     if (this.tmux) {
-      await Promise.all(
-        sessionIds.map((id) => killTmuxSessionTree(this.ctx, makeTmuxSessionName(id)))
-      );
+      await killTmuxSessionsByPtyIds(this.ctx, sessionIds, { reapDescendants: true });
     }
     for (const sessionId of sessionIds) {
       this.supervisor.forget(sessionId);

--- a/apps/emdash-desktop/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/ssh-conversation.ts
@@ -327,7 +327,6 @@ export class SshConversationProvider implements ConversationProvider {
 
   async stopSession(conversationId: string): Promise<void> {
     const sessionId = makePtySessionId(this.projectId, this.taskId, conversationId);
-    this.knownSessionIds.delete(sessionId);
     const pty = this.supervisor.stop(sessionId) ?? this.sessions.get(sessionId);
     this.sessions.delete(sessionId);
     ptySessionRegistry.unregister(sessionId);
@@ -344,6 +343,7 @@ export class SshConversationProvider implements ConversationProvider {
     if (this.tmux) {
       await killTmuxSessionsByPtyIds(this.ctx, [sessionId], { reapDescendants: true });
     }
+    this.knownSessionIds.delete(sessionId);
     this.supervisor.forget(sessionId);
   }
 

--- a/apps/emdash-desktop/src/main/core/pty/pty-spawn-platform.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/pty-spawn-platform.test.ts
@@ -1,6 +1,12 @@
+import { execFileSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import type { ResolvedShellProfile } from '@main/core/terminal-shell/types';
+import { makePtySessionId } from '@shared/core/pty/ptySessionId';
 import { resolveLocalPtySpawn } from './pty-spawn-platform';
+import { makeTmuxSession } from './tmux-session-name';
 
 const winEnv = {
   ComSpec: 'C:\\Windows\\System32\\cmd.exe',
@@ -401,7 +407,12 @@ describe('resolveLocalPtySpawn - Windows', () => {
         kind: 'interactive-shell',
         cwd: 'C:\\repo',
         shellSetup: 'source ~/.nvm/nvm.sh',
-        tmuxSessionName: 'session-1',
+        tmuxSession: {
+          name: 'session-1',
+          projectId: 'project-1',
+          taskId: 'task-1',
+          leafId: 'terminal-1',
+        },
       },
     });
 
@@ -458,6 +469,60 @@ describe('resolveLocalPtySpawn - POSIX', () => {
       cwd: '/repo',
       warnings: [],
     });
+  });
+
+  it('executes the local tmux wrapper and resumes an identity under its previous label', () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'emdash-local-tmux-'));
+    const tmuxStub = path.join(tempDir, 'tmux');
+    const callsFile = path.join(tempDir, 'calls.log');
+    try {
+      writeFileSync(
+        tmuxStub,
+        `#!/bin/sh
+printf '%s\\n' "$*" >> "$TMUX_CALLS"
+if [ "$1" = "list-sessions" ]; then
+  printf '%s\\t%s\\t%s\\t%s\\n' "$TMUX_EXISTING_NAME" "$TMUX_PROJECT" "$TMUX_TASK" "$TMUX_LEAF"
+fi
+exit 0
+`
+      );
+      chmodSync(tmuxStub, 0o755);
+      const sessionId = makePtySessionId('local-project', 'local-task', 'local-leaf');
+      const oldSession = makeTmuxSession(sessionId, '/tmp/old-local-label');
+      const currentSession = makeTmuxSession(sessionId, '/tmp/current-local-label');
+      const result = resolveLocalPtySpawn({
+        platform: 'darwin',
+        env: posixEnv,
+        intent: {
+          kind: 'run-command',
+          cwd: tempDir,
+          shellProfile: shProfile,
+          command: { kind: 'shell-line', commandLine: 'echo should-not-start' },
+          tmuxSession: currentSession,
+        },
+      });
+
+      execFileSync(result.command, result.args, {
+        cwd: result.cwd,
+        env: {
+          ...process.env,
+          PATH: `${tempDir}:/usr/bin:/bin`,
+          TMPDIR: tempDir,
+          TMUX_CALLS: callsFile,
+          TMUX_EXISTING_NAME: oldSession.name,
+          TMUX_PROJECT: oldSession.projectId,
+          TMUX_TASK: oldSession.taskId,
+          TMUX_LEAF: oldSession.leafId,
+        },
+      });
+
+      const calls = readFileSync(callsFile, 'utf8');
+      expect(calls).toContain('list-sessions -F');
+      expect(calls).not.toContain('new-session');
+      expect(calls).toContain(`attach-session -t ${oldSession.name}`);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('uses the selected terminal shell profile for interactive shells', () => {

--- a/apps/emdash-desktop/src/main/core/pty/pty-spawn-platform.ts
+++ b/apps/emdash-desktop/src/main/core/pty/pty-spawn-platform.ts
@@ -4,6 +4,7 @@ import type { ResolvedShellProfile } from '@main/core/terminal-shell/types';
 import { log } from '@main/lib/logger';
 import { quoteCshArg } from '@main/utils/shellEscape';
 import { getWindowsEnvValue } from '@main/utils/windows-env';
+import type { TmuxSessionConfig } from '@shared/core/pty/tmux';
 import { buildTmuxShellLine } from './tmux-session-name';
 
 export type PtyCommandSpec =
@@ -16,7 +17,7 @@ export type PtySpawnIntent =
       cwd: string;
       shellProfile?: ResolvedShellProfile;
       shellSetup?: string;
-      tmuxSessionName?: string;
+      tmuxSession?: TmuxSessionConfig;
     }
   | {
       kind: 'run-command';
@@ -24,7 +25,7 @@ export type PtySpawnIntent =
       command: PtyCommandSpec;
       shellProfile?: ResolvedShellProfile;
       shellSetup?: string;
-      tmuxSessionName?: string;
+      tmuxSession?: TmuxSessionConfig;
     };
 
 export type LocalPtySpawnWarning = 'shell_setup_ignored_on_windows' | 'tmux_unsupported_on_windows';
@@ -192,7 +193,7 @@ function resolveWindowsCommandPath({
 function windowsWarnings(intent: PtySpawnIntent): LocalPtySpawnWarning[] {
   const warnings: LocalPtySpawnWarning[] = [];
   if (intent.shellSetup) warnings.push('shell_setup_ignored_on_windows');
-  if (intent.tmuxSessionName) warnings.push('tmux_unsupported_on_windows');
+  if (intent.tmuxSession) warnings.push('tmux_unsupported_on_windows');
   return warnings;
 }
 
@@ -350,7 +351,7 @@ function resolvePosixSpawn(intent: PtySpawnIntent, env: NodeJS.ProcessEnv): Reso
   const setupWrapperArgs = getSetupWrapperArgs(intent);
 
   if (intent.kind === 'interactive-shell') {
-    if (intent.tmuxSessionName) {
+    if (intent.tmuxSession) {
       const commandLine = intent.shellSetup
         ? `${intent.shellSetup} && exec ${quotePosixArg(shell)} ${interactiveArgs.join(' ')}`
         : `exec ${quotePosixArg(shell)} ${interactiveArgs.join(' ')}`;
@@ -358,7 +359,7 @@ function resolvePosixSpawn(intent: PtySpawnIntent, env: NodeJS.ProcessEnv): Reso
         command: shell,
         args: [
           ...(intent.shellSetup ? setupWrapperArgs : commandArgs),
-          buildTmuxShellLine(intent.tmuxSessionName, commandLine),
+          buildTmuxShellLine(intent.tmuxSession, commandLine, shellArgQuoter(intent)),
         ],
         cwd: intent.cwd,
         warnings: [],
@@ -398,10 +399,13 @@ function resolvePosixSpawn(intent: PtySpawnIntent, env: NodeJS.ProcessEnv): Reso
     ? `${intent.shellSetup} && ${commandLine}`
     : commandLine;
 
-  if (intent.tmuxSessionName) {
+  if (intent.tmuxSession) {
     return {
       command: shell,
-      args: [...commandArgs, buildTmuxShellLine(intent.tmuxSessionName, fullCommandLine)],
+      args: [
+        ...commandArgs,
+        buildTmuxShellLine(intent.tmuxSession, fullCommandLine, shellArgQuoter(intent)),
+      ],
       cwd: intent.cwd,
       warnings: [],
     };

--- a/apps/emdash-desktop/src/main/core/pty/spawn-utils.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/spawn-utils.test.ts
@@ -1,9 +1,15 @@
+import { execFileSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import type { RemoteShellProfile } from '@main/core/ssh/lifecycle/remote-shell-profile';
 import type { ResolvedShellProfile } from '@main/core/terminal-shell/types';
 import type { AgentSessionConfig } from '@shared/core/agents/agent-session';
+import { makePtySessionId } from '@shared/core/pty/ptySessionId';
 import type { GeneralSessionConfig } from '@shared/core/terminals/general-session';
 import { resolveSshCommand } from './spawn-utils';
+import { makeTmuxSession } from './tmux-session-name';
 
 function makeAgentConfig(overrides: Partial<AgentSessionConfig> = {}): AgentSessionConfig {
   return {
@@ -157,17 +163,73 @@ describe('resolveSshCommand', () => {
     const result = resolveSshCommand(
       'agent',
       makeAgentConfig({
-        tmuxSessionName: 'agent-session',
+        tmuxSession: {
+          name: 'agent-session',
+          projectId: 'project-1',
+          taskId: 'task-1',
+          leafId: 'conv-1',
+        },
       }),
       undefined,
       zshProfile
     );
 
-    expect(result).toContain('tmux has-session -t \\"agent-session\\"');
-    expect(result).toContain('tmux -u new-session -d -s \\"agent-session\\"');
-    expect(result).toContain('tmux -u attach-session -t \\"agent-session\\"');
-    expect(result).toContain('/bin/sh -c');
-    expect(result).toContain("'\\''claude'\\'' '\\''--resume'\\'' '\\''conv-1'\\''");
+    expect(result).toContain('preferred_name=$1');
+    expect(result).toContain('find_matching_session');
+    expect(result).toContain('list-sessions -F');
+    expect(result).toContain('new-session -d -s "$session_name"');
+    expect(result).toContain('attach-session -t "$session_name"');
+    expect(result).toContain("'agent-session'");
+    expect(result).toContain('/bin/sh');
+    expect(result).toContain('claude');
+    expect(result).toContain('--resume');
+    expect(result).toContain('conv-1');
+  });
+
+  it('executes the generated SSH command and resumes an identity under its previous label', () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'emdash-ssh-tmux-'));
+    const tmuxStub = path.join(tempDir, 'tmux');
+    const callsFile = path.join(tempDir, 'calls.log');
+    try {
+      writeFileSync(
+        tmuxStub,
+        `#!/bin/sh
+printf '%s\\n' "$*" >> "$TMUX_CALLS"
+if [ "$1" = "list-sessions" ]; then
+  printf '%s\\t%s\\t%s\\t%s\\n' "$TMUX_EXISTING_NAME" "$TMUX_PROJECT" "$TMUX_TASK" "$TMUX_LEAF"
+fi
+exit 0
+`
+      );
+      chmodSync(tmuxStub, 0o755);
+      const sessionId = makePtySessionId('ssh-project', 'ssh-task', 'ssh-leaf');
+      const oldSession = makeTmuxSession(sessionId, '/tmp/old-ssh-label');
+      const currentSession = makeTmuxSession(sessionId, '/tmp/current-ssh-label');
+      const remoteEnv = {
+        PATH: `${tempDir}:/usr/bin:/bin`,
+        TMPDIR: tempDir,
+        TMUX_CALLS: callsFile,
+        TMUX_EXISTING_NAME: oldSession.name,
+        TMUX_PROJECT: oldSession.projectId,
+        TMUX_TASK: oldSession.taskId,
+        TMUX_LEAF: oldSession.leafId,
+      };
+      const command = resolveSshCommand(
+        'agent',
+        makeAgentConfig({ cwd: tempDir, tmuxSession: currentSession }),
+        remoteEnv,
+        { shell: '/bin/sh', env: {} }
+      );
+
+      execFileSync('/bin/sh', ['-c', command], { env: process.env });
+
+      const calls = readFileSync(callsFile, 'utf8');
+      expect(calls).toContain('list-sessions -F');
+      expect(calls).not.toContain('new-session');
+      expect(calls).toContain(`attach-session -t ${oldSession.name}`);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('launches remote general terminals with the captured remote shell', () => {

--- a/apps/emdash-desktop/src/main/core/pty/spawn-utils.ts
+++ b/apps/emdash-desktop/src/main/core/pty/spawn-utils.ts
@@ -37,7 +37,7 @@ function posixShellLineForSsh(
       const line = cfg.shellSetup ? `${cfg.shellSetup} && ${baseCmd}` : baseCmd;
       return {
         cwd: cfg.cwd,
-        line: cfg.tmuxSessionName ? buildTmuxShellLine(cfg.tmuxSessionName, line) : line,
+        line: cfg.tmuxSession ? buildTmuxShellLine(cfg.tmuxSession, line, quoteArg) : line,
       };
     }
     case 'general': {
@@ -48,7 +48,7 @@ function posixShellLineForSsh(
       const line = cfg.shellSetup ? `${cfg.shellSetup} && ${baseCmd}` : baseCmd;
       return {
         cwd: cfg.cwd,
-        line: cfg.tmuxSessionName ? buildTmuxShellLine(cfg.tmuxSessionName, line) : line,
+        line: cfg.tmuxSession ? buildTmuxShellLine(cfg.tmuxSession, line, quoteArg) : line,
       };
     }
     default:

--- a/apps/emdash-desktop/src/main/core/pty/tmux-reaper.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/tmux-reaper.test.ts
@@ -5,6 +5,7 @@ import {
   killTmuxSessionsByPtyIds,
   killTmuxSessionTree,
   listEmdashTmuxSessions,
+  TmuxSessionDiscoveryError,
 } from './tmux-reaper';
 import {
   makeLegacyTmuxSessionName,
@@ -163,6 +164,39 @@ describe('listEmdashTmuxSessions', () => {
     ]);
   });
 
+  it('falls back to names and show-options when old tmux returns literal metadata placeholders', async () => {
+    const { ctx, calls } = makeCtx((command, args) => {
+      if (command === 'tmux' && args[0] === 'list-sessions' && args[2] !== '#{session_name}') {
+        return {
+          stdout: `emdash-work-token\t#{${TMUX_PROJECT_ID_OPTION}}\t#{${TMUX_TASK_ID_OPTION}}\t#{${TMUX_LEAF_ID_OPTION}}\n`,
+          stderr: '',
+        };
+      }
+      if (command === 'tmux' && args[0] === 'list-sessions') {
+        return { stdout: 'emdash-work-token\n', stderr: '' };
+      }
+      if (command === 'tmux' && args[0] === 'show-options') {
+        return {
+          stdout: `${TMUX_PROJECT_ID_OPTION} project-1\n${TMUX_TASK_ID_OPTION} task-1\n${TMUX_LEAF_ID_OPTION} leaf-1\n`,
+          stderr: '',
+        };
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    expect(await listEmdashTmuxSessions(ctx)).toEqual([
+      {
+        name: 'emdash-work-token',
+        identity: { projectId: 'project-1', taskId: 'task-1', leafId: 'leaf-1' },
+      },
+    ]);
+    expect(calls.map(({ args }) => args[0])).toEqual([
+      'list-sessions',
+      'list-sessions',
+      'show-options',
+    ]);
+  });
+
   it('keeps partially tagged or unrelated prefixed sessions unowned', async () => {
     const { ctx } = makeCtx((command, args) => {
       if (command === 'tmux' && args[0] === 'list-sessions') {
@@ -184,6 +218,65 @@ describe('listEmdashTmuxSessions', () => {
       }),
     } as unknown as IExecutionContext;
     expect(await listEmdashTmuxSessions(ctx)).toEqual([]);
+  });
+
+  it('rejects when both rich and name-only discovery fail for an unknown reason', async () => {
+    const ctx = {
+      exec: vi.fn(async () => {
+        throw Object.assign(new Error('SSH connection dropped'), {
+          stderr: 'channel closed',
+        });
+      }),
+    } as unknown as IExecutionContext;
+
+    await expect(listEmdashTmuxSessions(ctx)).rejects.toBeInstanceOf(TmuxSessionDiscoveryError);
+    expect(ctx.exec).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not treat an unspecified failed-to-connect error as an absent tmux server', async () => {
+    const ctx = {
+      exec: vi.fn(async () => {
+        throw new Error('failed to connect to server: permission denied');
+      }),
+    } as unknown as IExecutionContext;
+
+    await expect(listEmdashTmuxSessions(ctx)).rejects.toBeInstanceOf(TmuxSessionDiscoveryError);
+  });
+
+  it('propagates transient show-options failures after name-only fallback', async () => {
+    const { ctx } = makeCtx((command, args) => {
+      if (command === 'tmux' && args[0] === 'list-sessions' && args[2] !== '#{session_name}') {
+        throw new Error('unknown format');
+      }
+      if (command === 'tmux' && args[0] === 'list-sessions') {
+        return { stdout: 'emdash-work-token\n', stderr: '' };
+      }
+      if (command === 'tmux' && args[0] === 'show-options') {
+        throw new Error('SSH connection dropped');
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    await expect(listEmdashTmuxSessions(ctx)).rejects.toThrow('SSH connection dropped');
+  });
+
+  it('keeps a session unowned when it disappears before show-options', async () => {
+    const { ctx } = makeCtx((command, args) => {
+      if (command === 'tmux' && args[0] === 'list-sessions' && args[2] !== '#{session_name}') {
+        throw new Error('unknown format');
+      }
+      if (command === 'tmux' && args[0] === 'list-sessions') {
+        return { stdout: 'emdash-work-token\n', stderr: '' };
+      }
+      if (command === 'tmux' && args[0] === 'show-options') {
+        throw new Error("can't find session: emdash-work-token");
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    expect(await listEmdashTmuxSessions(ctx)).toEqual([
+      { name: 'emdash-work-token', identity: null },
+    ]);
   });
 });
 
@@ -270,5 +363,18 @@ describe('killTmuxSessionsByPtyIds', () => {
 
     expect(killSessionTargets(calls)).toEqual(['emdash-work-token', legacyName]);
     expect(calls.filter(({ args }) => args[0] === 'list-sessions')).toHaveLength(1);
+  });
+
+  it('propagates discovery failure instead of reporting cleanup success', async () => {
+    const ctx = {
+      exec: vi.fn(async () => {
+        throw new Error('connection timed out');
+      }),
+    } as unknown as IExecutionContext;
+
+    await expect(
+      killTmuxSessionsByPtyIds(ctx, [makePtySessionId('project-1', 'task-1', 'leaf-1')])
+    ).rejects.toBeInstanceOf(TmuxSessionDiscoveryError);
+    expect(ctx.exec).not.toHaveBeenCalledWith('tmux', expect.arrayContaining(['kill-session']));
   });
 });

--- a/apps/emdash-desktop/src/main/core/pty/tmux-reaper.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/tmux-reaper.test.ts
@@ -1,8 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ExecResult, IExecutionContext } from '@main/core/execution-context/types';
 import { makePtySessionId } from '@shared/core/pty/ptySessionId';
-import { killTmuxSessionTree, listEmdashTmuxSessions } from './tmux-reaper';
-import { makeTmuxSessionName } from './tmux-session-name';
+import {
+  killTmuxSessionsByPtyIds,
+  killTmuxSessionTree,
+  listEmdashTmuxSessions,
+} from './tmux-reaper';
+import {
+  makeLegacyTmuxSessionName,
+  TMUX_LEAF_ID_OPTION,
+  TMUX_PROJECT_ID_OPTION,
+  TMUX_TASK_ID_OPTION,
+} from './tmux-session-name';
 
 type ExecCall = { command: string; args: string[] };
 type ExecHandler = (command: string, args: string[]) => ExecResult;
@@ -42,13 +51,130 @@ beforeEach(() => {
 });
 
 describe('listEmdashTmuxSessions', () => {
-  it('returns only emdash-prefixed session names', async () => {
+  it('returns only emdash-prefixed sessions with metadata from one list call', async () => {
     const { ctx } = makeCtx((command, args) =>
       command === 'tmux' && args[0] === 'list-sessions'
-        ? { stdout: 'emdash-a\nother-session\nemdash-b\n', stderr: '' }
+        ? {
+            stdout:
+              'emdash-work-a\tproject-a\ttask-a\tleaf-a\n' +
+              'other-session\tforeign\ttask\tleaf\n' +
+              'emdash-work-b\tproject-b\ttask-b\tleaf-b\n',
+            stderr: '',
+          }
         : { stdout: '', stderr: '' }
     );
-    expect(await listEmdashTmuxSessions(ctx)).toEqual(['emdash-a', 'emdash-b']);
+    expect(await listEmdashTmuxSessions(ctx)).toEqual([
+      {
+        name: 'emdash-work-a',
+        identity: { projectId: 'project-a', taskId: 'task-a', leafId: 'leaf-a' },
+      },
+      {
+        name: 'emdash-work-b',
+        identity: { projectId: 'project-b', taskId: 'task-b', leafId: 'leaf-b' },
+      },
+    ]);
+    expect(ctx.exec).toHaveBeenCalledTimes(1);
+    expect(ctx.exec).toHaveBeenCalledWith('tmux', [
+      'list-sessions',
+      '-F',
+      `#{session_name}\t#{${TMUX_PROJECT_ID_OPTION}}\t#{${TMUX_TASK_ID_OPTION}}\t#{${TMUX_LEAF_ID_OPTION}}`,
+    ]);
+  });
+
+  it('decodes sessions created by versions that stored identity in the name', async () => {
+    const sessionId = makePtySessionId('legacy-project', 'legacy-task', 'legacy-leaf');
+    const name = makeLegacyTmuxSessionName(sessionId);
+    const { ctx } = makeCtx((command, args) =>
+      command === 'tmux' && args[0] === 'list-sessions'
+        ? { stdout: `${name}\t\t\t\n`, stderr: '' }
+        : { stdout: '', stderr: '' }
+    );
+
+    expect(await listEmdashTmuxSessions(ctx)).toEqual([
+      {
+        name,
+        identity: {
+          projectId: 'legacy-project',
+          taskId: 'legacy-task',
+          leafId: 'legacy-leaf',
+        },
+      },
+    ]);
+    expect(ctx.exec).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to show-options when old tmux cannot expand user options in formats', async () => {
+    const { ctx, calls } = makeCtx((command, args) => {
+      if (command === 'tmux' && args[0] === 'list-sessions' && args[2] !== '#{session_name}') {
+        throw new Error('unknown format');
+      }
+      if (command === 'tmux' && args[0] === 'list-sessions') {
+        return { stdout: 'emdash-work-token\n', stderr: '' };
+      }
+      if (command === 'tmux' && args[0] === 'show-options') {
+        return {
+          stdout: `${TMUX_PROJECT_ID_OPTION} project-1\n${TMUX_TASK_ID_OPTION} task-1\n${TMUX_LEAF_ID_OPTION} leaf-1\n`,
+          stderr: '',
+        };
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    expect(await listEmdashTmuxSessions(ctx)).toEqual([
+      {
+        name: 'emdash-work-token',
+        identity: { projectId: 'project-1', taskId: 'task-1', leafId: 'leaf-1' },
+      },
+    ]);
+    expect(calls.map(({ args }) => args[0])).toEqual([
+      'list-sessions',
+      'list-sessions',
+      'show-options',
+    ]);
+  });
+
+  it('falls back to names when an old tmux returns success with empty rich output', async () => {
+    const { ctx, calls } = makeCtx((command, args) => {
+      if (command === 'tmux' && args[0] === 'list-sessions' && args[2] !== '#{session_name}') {
+        return { stdout: '', stderr: '' };
+      }
+      if (command === 'tmux' && args[0] === 'list-sessions') {
+        return { stdout: 'emdash-work-token\n', stderr: '' };
+      }
+      if (command === 'tmux' && args[0] === 'show-options') {
+        return {
+          stdout: `${TMUX_PROJECT_ID_OPTION} project-1\n${TMUX_TASK_ID_OPTION} task-1\n${TMUX_LEAF_ID_OPTION} leaf-1\n`,
+          stderr: '',
+        };
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    expect(await listEmdashTmuxSessions(ctx)).toEqual([
+      {
+        name: 'emdash-work-token',
+        identity: { projectId: 'project-1', taskId: 'task-1', leafId: 'leaf-1' },
+      },
+    ]);
+    expect(calls.map(({ args }) => args[0])).toEqual([
+      'list-sessions',
+      'list-sessions',
+      'show-options',
+    ]);
+  });
+
+  it('keeps partially tagged or unrelated prefixed sessions unowned', async () => {
+    const { ctx } = makeCtx((command, args) => {
+      if (command === 'tmux' && args[0] === 'list-sessions') {
+        return { stdout: 'emdash-unowned\tproject-1\t\tleaf-1\n', stderr: '' };
+      }
+      if (command === 'tmux' && args[0] === 'show-options') {
+        return { stdout: `${TMUX_PROJECT_ID_OPTION} project-1\n`, stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    expect(await listEmdashTmuxSessions(ctx)).toEqual([{ name: 'emdash-unowned', identity: null }]);
   });
 
   it('returns [] when tmux has no server / errors out', async () => {
@@ -63,7 +189,7 @@ describe('listEmdashTmuxSessions', () => {
 
 describe('killTmuxSessionTree', () => {
   it('snapshots the pane tree before kill-session, then SIGKILLs the escaped descendants', async () => {
-    const name = makeTmuxSessionName(makePtySessionId('p', 't', 'c'));
+    const name = makeLegacyTmuxSessionName(makePtySessionId('p', 't', 'c'));
     const { ctx, calls } = makeCtx(treeHandler());
 
     await killTmuxSessionTree(ctx, name);
@@ -117,5 +243,32 @@ describe('killTmuxSessionTree', () => {
       }),
     } as unknown as IExecutionContext;
     await expect(killTmuxSessionTree(ctx, 'emdash-x')).resolves.toBeUndefined();
+  });
+});
+
+describe('killTmuxSessionsByPtyIds', () => {
+  it('resolves friendly and legacy names by identity with one list call per batch', async () => {
+    const legacyId = makePtySessionId('project-1', 'task-1', 'legacy-leaf');
+    const legacyName = makeLegacyTmuxSessionName(legacyId);
+    const { ctx, calls } = makeCtx((command, args) => {
+      if (command === 'tmux' && args[0] === 'list-sessions') {
+        return {
+          stdout:
+            'emdash-work-token\tproject-1\ttask-1\tfriendly-leaf\n' +
+            `${legacyName}\t\t\t\n` +
+            'emdash-foreign\tproject-2\ttask-2\tleaf-2\n',
+          stderr: '',
+        };
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    await killTmuxSessionsByPtyIds(ctx, [
+      makePtySessionId('project-1', 'task-1', 'friendly-leaf'),
+      legacyId,
+    ]);
+
+    expect(killSessionTargets(calls)).toEqual(['emdash-work-token', legacyName]);
+    expect(calls.filter(({ args }) => args[0] === 'list-sessions')).toHaveLength(1);
   });
 });

--- a/apps/emdash-desktop/src/main/core/pty/tmux-reaper.ts
+++ b/apps/emdash-desktop/src/main/core/pty/tmux-reaper.ts
@@ -39,7 +39,62 @@ function legacyIdentity(sessionName: string): TmuxSessionIdentity | null {
 
 function identityFromFields(fields: string[]): TmuxSessionIdentity | null {
   const [projectId, taskId, leafId] = fields;
-  return projectId && taskId && leafId ? { projectId, taskId, leafId } : null;
+  if (!projectId || !taskId || !leafId) return null;
+  if (
+    projectId === `#{${TMUX_PROJECT_ID_OPTION}}` ||
+    taskId === `#{${TMUX_TASK_ID_OPTION}}` ||
+    leafId === `#{${TMUX_LEAF_ID_OPTION}}`
+  ) {
+    return null;
+  }
+  return { projectId, taskId, leafId };
+}
+
+function hasLiteralIdentityOptions(line: string): boolean {
+  const [, projectId, taskId, leafId] = line.split('\t');
+  return (
+    projectId === `#{${TMUX_PROJECT_ID_OPTION}}` ||
+    taskId === `#{${TMUX_TASK_ID_OPTION}}` ||
+    leafId === `#{${TMUX_LEAF_ID_OPTION}}`
+  );
+}
+
+function tmuxErrorText(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+  const withOutput = error as Error & { stderr?: unknown; stdout?: unknown };
+  return [error.message, withOutput.stderr, withOutput.stdout]
+    .filter((value): value is string => typeof value === 'string')
+    .join('\n');
+}
+
+function isNoTmuxServerError(error: unknown): boolean {
+  const text = tmuxErrorText(error);
+  return (
+    /no server running/i.test(text) ||
+    /failed to connect to server:\s*(?:no such file|connection refused)/i.test(text) ||
+    /error connecting to .*tmux.*(?:no such file|connection refused)/i.test(text) ||
+    /no sessions/i.test(text)
+  );
+}
+
+function isMissingTmuxSessionError(error: unknown): boolean {
+  const text = tmuxErrorText(error);
+  return (
+    isNoTmuxServerError(error) ||
+    /can't find session/i.test(text) ||
+    /no such session/i.test(text) ||
+    /session .* not found/i.test(text)
+  );
+}
+
+export class TmuxSessionDiscoveryError extends Error {
+  constructor(
+    readonly richFormatError: unknown,
+    readonly nameListError: unknown
+  ) {
+    super('Failed to discover tmux sessions');
+    this.name = 'TmuxSessionDiscoveryError';
+  }
 }
 
 function identityFromOptionList(stdout: string): TmuxSessionIdentity | null {
@@ -63,8 +118,9 @@ async function readIdentityFromOptions(
   try {
     const { stdout } = await ctx.exec('tmux', ['show-options', '-t', sessionName]);
     return identityFromOptionList(stdout);
-  } catch {
-    return null;
+  } catch (err) {
+    if (isMissingTmuxSessionError(err)) return null;
+    throw err;
   }
 }
 
@@ -73,8 +129,12 @@ async function listSessionLines(ctx: IExecutionContext): Promise<string[]> {
   try {
     const { stdout } = await ctx.exec('tmux', ['list-sessions', '-F', TMUX_SESSION_LIST_FORMAT]);
     const lines = stdout.split('\n').filter(Boolean);
-    if (lines.length > 0) return lines;
-    formatError = new Error('rich tmux session format returned an empty result');
+    if (lines.length > 0 && !lines.some(hasLiteralIdentityOptions)) return lines;
+    formatError = new Error(
+      lines.length === 0
+        ? 'rich tmux session format returned an empty result'
+        : 'rich tmux session format returned literal user-option placeholders'
+    );
   } catch (err) {
     formatError = err;
   }
@@ -86,11 +146,14 @@ async function listSessionLines(ctx: IExecutionContext): Promise<string[]> {
     const { stdout } = await ctx.exec('tmux', ['list-sessions', '-F', '#{session_name}']);
     return stdout.split('\n').filter(Boolean);
   } catch (err) {
-    log.debug('listEmdashTmuxSessions: no tmux sessions', {
-      error: String(err),
-      formatError: String(formatError),
-    });
-    return [];
+    if (isNoTmuxServerError(err)) {
+      log.debug('listEmdashTmuxSessions: no tmux server', {
+        error: tmuxErrorText(err),
+        formatError: tmuxErrorText(formatError),
+      });
+      return [];
+    }
+    throw new TmuxSessionDiscoveryError(formatError, err);
   }
 }
 
@@ -101,27 +164,22 @@ async function listSessionLines(ctx: IExecutionContext): Promise<string[]> {
  * formats fall back to one show-options call for each friendly-named session.
  */
 export async function listEmdashTmuxSessions(ctx: IExecutionContext): Promise<EmdashTmuxSession[]> {
-  try {
-    const lines = await listSessionLines(ctx);
-    const sessions = lines
-      .map((line): EmdashTmuxSession | null => {
-        const [name, ...metadata] = line.split('\t');
-        if (!name?.startsWith(TMUX_SESSION_PREFIX)) return null;
-        return { name, identity: identityFromFields(metadata) ?? legacyIdentity(name) };
-      })
-      .filter((session): session is EmdashTmuxSession => session !== null);
+  const lines = await listSessionLines(ctx);
+  const sessions = lines
+    .map((line): EmdashTmuxSession | null => {
+      const [name, ...metadata] = line.split('\t');
+      if (!name?.startsWith(TMUX_SESSION_PREFIX)) return null;
+      return { name, identity: identityFromFields(metadata) ?? legacyIdentity(name) };
+    })
+    .filter((session): session is EmdashTmuxSession => session !== null);
 
-    await Promise.all(
-      sessions.map(async (session) => {
-        if (session.identity) return;
-        session.identity = await readIdentityFromOptions(ctx, session.name);
-      })
-    );
-    return sessions;
-  } catch (err) {
-    log.debug('listEmdashTmuxSessions: no tmux sessions', { error: String(err) });
-    return [];
-  }
+  await Promise.all(
+    sessions.map(async (session) => {
+      if (session.identity) return;
+      session.identity = await readIdentityFromOptions(ctx, session.name);
+    })
+  );
+  return sessions;
 }
 
 /**

--- a/apps/emdash-desktop/src/main/core/pty/tmux-reaper.ts
+++ b/apps/emdash-desktop/src/main/core/pty/tmux-reaper.ts
@@ -1,25 +1,123 @@
 import { collectDescendantPids, parsePidPpidPairs } from '@emdash/core/pty';
 import type { IExecutionContext } from '@main/core/execution-context/types';
 import { log } from '@main/lib/logger';
-import { killTmuxSession, TMUX_SESSION_PREFIX } from './tmux-session-name';
+import { makePtySessionId, parsePtySessionId } from '@shared/core/pty/ptySessionId';
+import type { TmuxSessionIdentity } from '@shared/core/pty/tmux';
+import {
+  decodeLegacyTmuxSessionName,
+  killTmuxSession,
+  TMUX_LEAF_ID_OPTION,
+  TMUX_PROJECT_ID_OPTION,
+  TMUX_SESSION_PREFIX,
+  TMUX_TASK_ID_OPTION,
+} from './tmux-session-name';
 
 // NOTE: this module must stay free of DB imports. It is loaded by the SSH
 // conversation/terminal providers (for killTmuxSessionTree); pulling in the DB
 // client here would break their unit tests, which run without Electron's `app`.
 // DB-dependent reconciliation lives in ./tmux-reconcile.
 
-/**
- * List the names of all `emdash-*` tmux sessions on the context's host.
- * Returns `[]` when no tmux server is running (tmux exits non-zero), tmux is
- * absent, or the command otherwise fails — callers treat that as "nothing to do".
- */
-export async function listEmdashTmuxSessions(ctx: IExecutionContext): Promise<string[]> {
+export type EmdashTmuxSession = {
+  name: string;
+  identity: TmuxSessionIdentity | null;
+};
+
+const TMUX_SESSION_LIST_FORMAT = [
+  '#{session_name}',
+  `#{${TMUX_PROJECT_ID_OPTION}}`,
+  `#{${TMUX_TASK_ID_OPTION}}`,
+  `#{${TMUX_LEAF_ID_OPTION}}`,
+].join('\t');
+
+function legacyIdentity(sessionName: string): TmuxSessionIdentity | null {
+  const sessionId = decodeLegacyTmuxSessionName(sessionName);
+  if (!sessionId) return null;
+  const parsed = parsePtySessionId(sessionId);
+  if (!parsed) return null;
+  return { projectId: parsed.projectId, taskId: parsed.scopeId, leafId: parsed.leafId };
+}
+
+function identityFromFields(fields: string[]): TmuxSessionIdentity | null {
+  const [projectId, taskId, leafId] = fields;
+  return projectId && taskId && leafId ? { projectId, taskId, leafId } : null;
+}
+
+function identityFromOptionList(stdout: string): TmuxSessionIdentity | null {
+  const options = new Map<string, string>();
+  for (const line of stdout.split('\n')) {
+    const separator = line.indexOf(' ');
+    if (separator <= 0) continue;
+    options.set(line.slice(0, separator), line.slice(separator + 1).trim());
+  }
+  return identityFromFields([
+    options.get(TMUX_PROJECT_ID_OPTION) ?? '',
+    options.get(TMUX_TASK_ID_OPTION) ?? '',
+    options.get(TMUX_LEAF_ID_OPTION) ?? '',
+  ]);
+}
+
+async function readIdentityFromOptions(
+  ctx: IExecutionContext,
+  sessionName: string
+): Promise<TmuxSessionIdentity | null> {
+  try {
+    const { stdout } = await ctx.exec('tmux', ['show-options', '-t', sessionName]);
+    return identityFromOptionList(stdout);
+  } catch {
+    return null;
+  }
+}
+
+async function listSessionLines(ctx: IExecutionContext): Promise<string[]> {
+  let formatError: unknown;
+  try {
+    const { stdout } = await ctx.exec('tmux', ['list-sessions', '-F', TMUX_SESSION_LIST_FORMAT]);
+    const lines = stdout.split('\n').filter(Boolean);
+    if (lines.length > 0) return lines;
+    formatError = new Error('rich tmux session format returned an empty result');
+  } catch (err) {
+    formatError = err;
+  }
+
+  // Old tmux releases may reject user-option expansion in a format or return a
+  // successful empty result for it. Listing names alone still lets us decode
+  // legacy names and read friendly-session options with show-options below.
   try {
     const { stdout } = await ctx.exec('tmux', ['list-sessions', '-F', '#{session_name}']);
-    return stdout
-      .split('\n')
-      .map((line) => line.trim())
-      .filter((name) => name.startsWith(TMUX_SESSION_PREFIX));
+    return stdout.split('\n').filter(Boolean);
+  } catch (err) {
+    log.debug('listEmdashTmuxSessions: no tmux sessions', {
+      error: String(err),
+      formatError: String(formatError),
+    });
+    return [];
+  }
+}
+
+/**
+ * List all `emdash-*` sessions with their persisted identity. Modern tmux
+ * returns every identity in one list-sessions call. Legacy encoded names are
+ * decoded directly, while old tmux versions that cannot expand user options in
+ * formats fall back to one show-options call for each friendly-named session.
+ */
+export async function listEmdashTmuxSessions(ctx: IExecutionContext): Promise<EmdashTmuxSession[]> {
+  try {
+    const lines = await listSessionLines(ctx);
+    const sessions = lines
+      .map((line): EmdashTmuxSession | null => {
+        const [name, ...metadata] = line.split('\t');
+        if (!name?.startsWith(TMUX_SESSION_PREFIX)) return null;
+        return { name, identity: identityFromFields(metadata) ?? legacyIdentity(name) };
+      })
+      .filter((session): session is EmdashTmuxSession => session !== null);
+
+    await Promise.all(
+      sessions.map(async (session) => {
+        if (session.identity) return;
+        session.identity = await readIdentityFromOptions(ctx, session.name);
+      })
+    );
+    return sessions;
   } catch (err) {
     log.debug('listEmdashTmuxSessions: no tmux sessions', { error: String(err) });
     return [];
@@ -103,4 +201,30 @@ export async function killTmuxSessionTree(
   if (descendants.length > 0) {
     await reapPids(ctx, descendants);
   }
+}
+
+/**
+ * Kill every tmux session matching one of the PTY session ids. Resolving by
+ * persisted identity keeps stop/delete behavior compatible with legacy names,
+ * friendly names, and workspace label changes. A batch performs one session
+ * listing on modern tmux.
+ */
+export async function killTmuxSessionsByPtyIds(
+  ctx: IExecutionContext,
+  sessionIds: Iterable<string>,
+  options: { reapDescendants?: boolean } = {}
+): Promise<void> {
+  const wanted = new Set(sessionIds);
+  if (wanted.size === 0) return;
+
+  const sessions = await listEmdashTmuxSessions(ctx);
+  const matches = sessions.filter(({ identity }) => {
+    if (!identity) return false;
+    return wanted.has(makePtySessionId(identity.projectId, identity.taskId, identity.leafId));
+  });
+  await Promise.all(
+    matches.map(({ name }) =>
+      options.reapDescendants ? killTmuxSessionTree(ctx, name) : killTmuxSession(ctx, name)
+    )
+  );
 }

--- a/apps/emdash-desktop/src/main/core/pty/tmux-reconcile.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/tmux-reconcile.test.ts
@@ -4,7 +4,7 @@ import { getProjectSessionLeafIds } from '@main/core/tasks/session-targets';
 import { makePtySessionId } from '@shared/core/pty/ptySessionId';
 import { createLifecycleScriptTerminalId } from '@shared/core/terminals/terminals';
 import { reconcileProjectTmuxSessions } from './tmux-reconcile';
-import { makeTmuxSessionName } from './tmux-session-name';
+import { makeLegacyTmuxSessionName } from './tmux-session-name';
 
 vi.mock('@main/core/tasks/session-targets', () => ({
   getProjectSessionLeafIds: vi.fn(),
@@ -52,13 +52,17 @@ beforeEach(() => {
 
 describe('reconcileProjectTmuxSessions', () => {
   const projectId = 'projA';
-  const liveConversation = makeTmuxSessionName(makePtySessionId(projectId, 't1', 'conv-live'));
-  const liveTerminal = makeTmuxSessionName(makePtySessionId(projectId, 't1', 'term-live'));
-  const deadConversation = makeTmuxSessionName(makePtySessionId(projectId, 't1', 'conv-dead'));
-  const lifecycleSession = makeTmuxSessionName(
+  const liveConversation = makeLegacyTmuxSessionName(
+    makePtySessionId(projectId, 't1', 'conv-live')
+  );
+  const liveTerminal = makeLegacyTmuxSessionName(makePtySessionId(projectId, 't1', 'term-live'));
+  const deadConversation = makeLegacyTmuxSessionName(
+    makePtySessionId(projectId, 't1', 'conv-dead')
+  );
+  const lifecycleSession = makeLegacyTmuxSessionName(
     makePtySessionId(projectId, 'ws1', createLifecycleScriptTerminalId('run'))
   );
-  const otherProjectSession = makeTmuxSessionName(makePtySessionId('projB', 't1', 'conv-x'));
+  const otherProjectSession = makeLegacyTmuxSessionName(makePtySessionId('projB', 't1', 'conv-x'));
   const unparseableSession = 'emdash-not*base64url';
 
   it('reaps only this project orphans, preserving live, lifecycle and foreign sessions', async () => {

--- a/apps/emdash-desktop/src/main/core/pty/tmux-reconcile.ts
+++ b/apps/emdash-desktop/src/main/core/pty/tmux-reconcile.ts
@@ -1,17 +1,15 @@
 import type { IExecutionContext } from '@main/core/execution-context/types';
 import { getProjectSessionLeafIds } from '@main/core/tasks/session-targets';
 import { log } from '@main/lib/logger';
-import { parsePtySessionId } from '@shared/core/pty/ptySessionId';
 import { LIFECYCLE_SCRIPT_TERMINAL_ID_PREFIX } from '@shared/core/terminals/terminals';
 import { killTmuxSessionTree, listEmdashTmuxSessions } from './tmux-reaper';
-import { decodeTmuxSessionName } from './tmux-session-name';
 
 /**
  * Reap orphaned emdash tmux sessions for `projectId` on the context's host.
  *
  * A session is reaped only when its leaf entity (conversation or terminal) no
  * longer exists in the DB. To stay safe on a tmux server shared by several
- * projects / hosts, only sessions whose encoded `projectId` matches are even
+ * projects / hosts, only sessions whose persisted `projectId` matches are even
  * considered, and workspace lifecycle-script sessions (not DB-tracked) are
  * always preserved. Detached-but-still-tracked sessions are kept, so
  * preserve-on-close resumability (PR #2281) is unaffected.
@@ -23,22 +21,19 @@ export async function reconcileProjectTmuxSessions(
   ctx: IExecutionContext,
   projectId: string
 ): Promise<void> {
-  const sessionNames = await listEmdashTmuxSessions(ctx);
-  if (sessionNames.length === 0) return;
+  const sessions = await listEmdashTmuxSessions(ctx);
+  if (sessions.length === 0) return;
 
   // Resolve this project's reapable sessions BEFORE touching the DB: only
-  // sessions that decode to this projectId, excluding lifecycle-script terminals
+  // sessions that belong to this projectId, excluding lifecycle-script terminals
   // (which create tmux sessions but have no DB row). On a tmux server shared by
   // several projects this avoids a DB round-trip on every project mount when
   // nothing on the host belongs to the project being opened.
   const candidates: Array<{ name: string; leafId: string }> = [];
-  for (const name of sessionNames) {
-    const sessionId = decodeTmuxSessionName(name);
-    if (!sessionId) continue;
-    const parsed = parsePtySessionId(sessionId);
-    if (!parsed || parsed.projectId !== projectId) continue;
-    if (parsed.leafId.startsWith(LIFECYCLE_SCRIPT_TERMINAL_ID_PREFIX)) continue;
-    candidates.push({ name, leafId: parsed.leafId });
+  for (const { name, identity } of sessions) {
+    if (!identity || identity.projectId !== projectId) continue;
+    if (identity.leafId.startsWith(LIFECYCLE_SCRIPT_TERMINAL_ID_PREFIX)) continue;
+    candidates.push({ name, leafId: identity.leafId });
   }
   if (candidates.length === 0) return;
 

--- a/apps/emdash-desktop/src/main/core/pty/tmux-session-name.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/tmux-session-name.test.ts
@@ -1,45 +1,766 @@
+import { execFile, execFileSync, type ChildProcess } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
 import { describe, expect, it } from 'vitest';
 import { makePtySessionId } from '@shared/core/pty/ptySessionId';
 import {
   buildTmuxShellLine,
-  decodeTmuxSessionName,
-  makeTmuxSessionName,
+  decodeLegacyTmuxSessionName,
+  makeLegacyTmuxSessionName,
+  makeTmuxSession,
+  TMUX_LEAF_ID_OPTION,
+  TMUX_PROJECT_ID_OPTION,
+  TMUX_TASK_ID_OPTION,
 } from './tmux-session-name';
 
-describe('buildTmuxShellLine', () => {
-  it('enables tmux mouse scrolling and deep history before attach', () => {
-    const result = buildTmuxShellLine('agent-session', 'exec /bin/zsh -il');
+const execFileAsync = promisify(execFile);
 
-    expect(result).toMatch(/^\/bin\/sh -c /);
-    expect(result).toContain('tmux has-session -t \\"agent-session\\"');
-    expect(result).toContain(
-      'tmux -u new-session -d -s \\"agent-session\\" \\"exec /bin/zsh -il\\"'
+async function waitForPath(candidate: string, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!existsSync(candidate)) {
+    if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${candidate}`);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+function waitForChildExit(
+  child: ChildProcess,
+  timeoutMs = 2_000
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  return new Promise((resolve, reject) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolve({ code: child.exitCode, signal: child.signalCode });
+      return;
+    }
+    const timeout = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`Timed out waiting for child ${child.pid ?? 'unknown'} to exit`));
+    }, timeoutMs);
+    child.once('exit', (code, signal) => {
+      clearTimeout(timeout);
+      resolve({ code, signal });
+    });
+  });
+}
+
+function installBlockingRmdirStub(tempDir: string): void {
+  const rmdirStub = path.join(tempDir, 'rmdir');
+  writeFileSync(
+    rmdirStub,
+    `#!/bin/sh
+if [ "$1" = "$TMUX_RACE_GUARD" ] && [ ! -e "$TMUX_RACE_RELEASE" ]; then
+  : > "$TMUX_RACE_BLOCKED"
+  while [ ! -e "$TMUX_RACE_RELEASE" ]; do
+    sleep 0.01
+  done
+fi
+PATH=/usr/bin:/bin
+exec rmdir "$@"
+`
+  );
+  chmodSync(rmdirStub, 0o755);
+}
+
+function installBlockingClaimLnStub(tempDir: string): void {
+  const lnStub = path.join(tempDir, 'ln');
+  writeFileSync(
+    lnStub,
+    `#!/bin/sh
+original_parent=$PPID
+case "$2" in
+  *.claim.*)
+    if [ ! -e "$TMUX_KILL_CLAIM_ONCE" ]; then
+      : > "$TMUX_KILL_CLAIM_ONCE"
+      : > "$TMUX_KILL_CLAIM_BLOCKED"
+      while [ ! -e "$TMUX_KILL_CLAIM_RELEASE" ]; do
+        sleep 0.01
+      done
+      kill -0 "$original_parent" 2>/dev/null || exit 1
+    fi
+    ;;
+esac
+PATH=/usr/bin:/bin
+exec ln "$@"
+`
+  );
+  chmodSync(lnStub, 0o755);
+}
+
+function installStatefulTmuxStub(tempDir: string): {
+  callsFile: string;
+  stateFile: string;
+} {
+  const tmuxStub = path.join(tempDir, 'tmux');
+  const callsFile = path.join(tempDir, 'calls.log');
+  const stateFile = path.join(tempDir, 'sessions.tsv');
+  writeFileSync(callsFile, '');
+  writeFileSync(stateFile, '');
+  writeFileSync(
+    tmuxStub,
+    `#!/bin/sh
+printf '%s\\n' "$*" >> "$TMUX_CALLS"
+if [ "$1" = "-u" ]; then shift; fi
+
+case "$1" in
+  list-sessions)
+    format=$3
+    if [ -n "\${TMUX_TERM_OWNER_LOCK:-}" ]; then
+      owner=$(sed -n '1p' "$TMUX_TERM_OWNER_LOCK")
+      kill -TERM "$owner"
+      exit 0
+    fi
+    if [ "\${TMUX_OLD_FORMAT:-0}" = 1 ] && [ "$format" != '#{session_name}' ]; then
+      exit 1
+    fi
+    if [ "\${TMUX_RICH_EMPTY:-0}" = 1 ] && [ "$format" != '#{session_name}' ]; then
+      exit 0
+    fi
+    if [ "$format" = '#{session_name}' ]; then
+      cut -f1 "$TMUX_STATE"
+    elif [ "\${TMUX_EMPTY_FORMAT:-0}" = 1 ]; then
+      awk -F '\\t' '{ printf "%s\\t\\t\\t\\n", $1 }' "$TMUX_STATE"
+    else
+      cat "$TMUX_STATE"
+    fi
+    ;;
+  show-options)
+    target=$3
+    awk -F '\\t' -v target="$target" '
+      $1 == target {
+        if ($2 != "") print "${TMUX_PROJECT_ID_OPTION} " $2
+        if ($3 != "") print "${TMUX_TASK_ID_OPTION} " $3
+        if ($4 != "") print "${TMUX_LEAF_ID_OPTION} " $4
+      }
+    ' "$TMUX_STATE"
+    ;;
+  has-session)
+    target=$3
+    awk -F '\\t' -v target="$target" '$1 == target { found = 1 } END { exit !found }' "$TMUX_STATE"
+    ;;
+  new-session)
+    shift
+    name=
+    project=
+    task=
+    leaf=
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -s) shift; name=$1 ;;
+        ${TMUX_PROJECT_ID_OPTION}) shift; project=$1 ;;
+        ${TMUX_TASK_ID_OPTION}) shift; task=$1 ;;
+        ${TMUX_LEAF_ID_OPTION}) shift; leaf=$1 ;;
+      esac
+      shift
+    done
+    if [ -n "\${TMUX_NEW_DELAY:-}" ]; then sleep "$TMUX_NEW_DELAY"; fi
+    if awk -F '\\t' -v target="$name" '$1 == target { found = 1 } END { exit !found }' "$TMUX_STATE"; then
+      exit 1
+    fi
+    printf '%s\\t%s\\t%s\\t%s\\n' "$name" "$project" "$task" "$leaf" >> "$TMUX_STATE"
+    ;;
+esac
+`
+  );
+  chmodSync(tmuxStub, 0o755);
+  return { callsFile, stateFile };
+}
+
+function tmuxStubEnv(
+  tempDir: string,
+  files: { callsFile: string; stateFile: string },
+  extra: NodeJS.ProcessEnv = {}
+): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    PATH: `${tempDir}:/usr/bin:/bin`,
+    TMPDIR: tempDir,
+    TMUX_CALLS: files.callsFile,
+    TMUX_STATE: files.stateFile,
+    ...extra,
+  };
+}
+
+describe('makeTmuxSession', () => {
+  it('uses a short recognizable workspace label and deterministic collision-resistant token', () => {
+    const sessionId = makePtySessionId('project-1', 'task-2', 'conversation-3');
+
+    const session = makeTmuxSession(sessionId, '/tmp/My workspace.with punctuation');
+
+    expect(session).toMatchObject({
+      projectId: 'project-1',
+      taskId: 'task-2',
+      leafId: 'conversation-3',
+    });
+    expect(session.name).toMatch(/^emdash-My-workspace-with-punctu-[A-Za-z0-9_-]{10}$/);
+    expect(session.name.length).toBeLessThanOrEqual(42);
+    expect(makeTmuxSession(sessionId, '/tmp/My workspace.with punctuation')).toEqual(session);
+    expect(makeTmuxSession(`${sessionId}-other`, '/tmp/workspace').name).not.toBe(session.name);
+  });
+
+  it('rejects malformed PTY session ids', () => {
+    expect(() => makeTmuxSession('not-a-pty-id', '/tmp/workspace')).toThrow(
+      'Invalid PTY session id'
     );
-    expect(result).toContain('tmux set-option -t \\"agent-session\\" mouse on');
-    expect(result).toContain('tmux set-option -t \\"agent-session\\" history-limit 100000');
-    expect(result).toContain('tmux -u attach-session -t \\"agent-session\\"');
-    expect(result.indexOf('mouse on')).toBeLessThan(result.indexOf('attach-session'));
-    expect(result.indexOf('history-limit')).toBeLessThan(result.indexOf('attach-session'));
   });
 });
 
-describe('decodeTmuxSessionName', () => {
-  it('round-trips a PTY session id through make/decode', () => {
+describe('buildTmuxShellLine', () => {
+  const session = makeTmuxSession(
+    makePtySessionId('project-1', 'task-2', 'conversation-3'),
+    '/tmp/task-workspace'
+  );
+
+  it('atomically tags a new session before configuring and attaching', () => {
+    const result = buildTmuxShellLine(session, 'exec /bin/zsh -il');
+
+    expect(result).toContain("'/bin/sh' '-c'");
+    expect(result).toContain('preferred_name=$1');
+    expect(result).toContain('legacy_name=$2');
+    expect(result).toContain(
+      `new-session -d -s "$session_name" "$command_line" \\; set-option -t "$session_name" ${TMUX_PROJECT_ID_OPTION}`
+    );
+    expect(result).toContain(`${TMUX_TASK_ID_OPTION} "$task_id"`);
+    expect(result).toContain(`${TMUX_LEAF_ID_OPTION} "$leaf_id"`);
+    expect(result).toContain('tmux set-option -t "$session_name" mouse on');
+    expect(result).toContain('tmux set-option -t "$session_name" history-limit 100000');
+    expect(result).toContain('exec tmux -u attach-session -t "$session_name"');
+    expect(result.indexOf('new-session')).toBeLessThan(result.indexOf('mouse on'));
+    expect(result.indexOf('history-limit')).toBeLessThan(result.indexOf('attach-session'));
+  });
+
+  it('passes identity and command values as safely quoted positional argv', () => {
+    const hostileSession = {
+      name: 'emdash-work-$(touch /tmp/unsafe)',
+      projectId: 'project`whoami`',
+      taskId: 'task $HOME',
+      leafId: 'leaf;echo unsafe',
+    };
+    const result = buildTmuxShellLine(hostileSession, "printf '$HOME' && echo `whoami`");
+
+    expect(result).toContain("'emdash-work-$(touch /tmp/unsafe)'");
+    expect(result).toContain("'project`whoami`'");
+    expect(result).toContain("'task $HOME'");
+    expect(result).toContain("'leaf;echo unsafe'");
+    expect(result).toContain("'printf '\\''$HOME'\\'' && echo `whoami`'");
+  });
+
+  it('does not evaluate shell syntax embedded in tmux values or the wrapped command', () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'emdash-tmux-argv-'));
+    const tmuxStub = path.join(tempDir, 'tmux');
+    const callsFile = path.join(tempDir, 'calls.log');
+    const injectionMarker = path.join(tempDir, 'injected');
+    try {
+      writeFileSync(
+        tmuxStub,
+        `#!/bin/sh
+{
+  printf 'CALL\n'
+  for arg do printf 'ARG=<%s>\n' "$arg"; done
+} >> "$TMUX_CALLS"
+if [ "$1" = "has-session" ]; then exit 1; fi
+exit 0
+`
+      );
+      chmodSync(tmuxStub, 0o755);
+      const hostileCommand = `printf ready; touch ${injectionMarker}`;
+      const line = buildTmuxShellLine(
+        {
+          name: `emdash-work-$(touch ${injectionMarker})`,
+          projectId: `project-$(touch ${injectionMarker})`,
+          taskId: 'task; touch unsafe',
+          leafId: 'leaf `touch unsafe`',
+        },
+        hostileCommand
+      );
+
+      execFileSync('/bin/sh', ['-c', line], {
+        env: {
+          ...process.env,
+          PATH: `${tempDir}:/usr/bin:/bin`,
+          TMUX_CALLS: callsFile,
+        },
+      });
+
+      expect(existsSync(injectionMarker)).toBe(false);
+      const calls = readFileSync(callsFile, 'utf8');
+      expect(calls).toContain(`ARG=<${hostileCommand}>`);
+      expect(calls).toContain(`ARG=<project-$(touch ${injectionMarker})>`);
+      expect(calls).toContain('ARG=<task; touch unsafe>');
+      expect(calls).toContain('ARG=<leaf `touch unsafe`>');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('checks the legacy encoded name before creating a new friendly session', () => {
+    const result = buildTmuxShellLine(session, 'echo ready');
+    const legacyName = makeLegacyTmuxSessionName(
+      makePtySessionId(session.projectId, session.taskId, session.leafId)
+    );
+
+    expect(result).toContain('tmux has-session -t "$legacy_name"');
+    expect(result).toContain(`'${legacyName}'`);
+  });
+
+  it('resumes the session found by persisted identity after the workspace label changes', () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'emdash-tmux-rename-'));
+    try {
+      const files = installStatefulTmuxStub(tempDir);
+      const sessionId = makePtySessionId('project-1', 'task-2', 'conversation-3');
+      const original = makeTmuxSession(sessionId, '/tmp/original-workspace');
+      const renamed = makeTmuxSession(sessionId, '/tmp/renamed-workspace');
+      writeFileSync(
+        files.stateFile,
+        `${original.name}\t${original.projectId}\t${original.taskId}\t${original.leafId}\n`
+      );
+
+      execFileSync('/bin/sh', ['-c', buildTmuxShellLine(renamed, 'echo should-not-start')], {
+        env: tmuxStubEnv(tempDir, files),
+      });
+
+      const calls = readFileSync(files.callsFile, 'utf8');
+      expect(calls).not.toContain('new-session');
+      expect(calls).toContain(`attach-session -t ${original.name}`);
+      expect(calls).not.toContain(`attach-session -t ${renamed.name}`);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('serializes concurrent resumes with different workspace labels into one session', async () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'emdash-tmux-concurrent-'));
+    try {
+      const files = installStatefulTmuxStub(tempDir);
+      const sessionId = makePtySessionId('project-race', 'task-race', 'leaf-race');
+      const first = makeTmuxSession(sessionId, '/tmp/first-label');
+      const second = makeTmuxSession(sessionId, '/tmp/second-label');
+      const env = tmuxStubEnv(tempDir, files, { TMUX_NEW_DELAY: '0.2' });
+
+      await Promise.all([
+        execFileAsync('/bin/sh', ['-c', buildTmuxShellLine(first, 'echo first')], { env }),
+        execFileAsync('/bin/sh', ['-c', buildTmuxShellLine(second, 'echo second')], { env }),
+      ]);
+
+      const state = readFileSync(files.stateFile, 'utf8').trim().split('\n');
+      const calls = readFileSync(files.callsFile, 'utf8');
+      const creationCalls = calls.split('\n').filter((call) => call.includes('new-session'));
+      const attachTargets = calls
+        .split('\n')
+        .filter((call) => call.includes('attach-session'))
+        .map((call) => call.match(/-t ([^ ]+)$/)?.[1]);
+
+      expect(state).toHaveLength(1);
+      expect(creationCalls).toHaveLength(1);
+      expect(attachTargets).toHaveLength(2);
+      expect(new Set(attachTargets)).toEqual(new Set([state[0].split('\t')[0]]));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('resumes an untagged legacy encoded session instead of creating a friendly duplicate', () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'emdash-tmux-legacy-'));
+    try {
+      const files = installStatefulTmuxStub(tempDir);
+      const sessionId = makePtySessionId('legacy-project', 'legacy-task', 'legacy-leaf');
+      const legacyName = makeLegacyTmuxSessionName(sessionId);
+      const session = makeTmuxSession(sessionId, '/tmp/friendly-workspace');
+      writeFileSync(files.stateFile, `${legacyName}\t\t\t\n`);
+
+      execFileSync('/bin/sh', ['-c', buildTmuxShellLine(session, 'echo should-not-start')], {
+        env: tmuxStubEnv(tempDir, files),
+      });
+
+      const calls = readFileSync(files.callsFile, 'utf8');
+      expect(calls).not.toContain('new-session');
+      expect(calls).toContain(`attach-session -t ${legacyName}`);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses show-options identity lookup when old tmux rejects rich list formats', () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'emdash-tmux-old-'));
+    try {
+      const files = installStatefulTmuxStub(tempDir);
+      const sessionId = makePtySessionId('old-project', 'old-task', 'old-leaf');
+      const original = makeTmuxSession(sessionId, '/tmp/old-label');
+      const renamed = makeTmuxSession(sessionId, '/tmp/new-label');
+      writeFileSync(
+        files.stateFile,
+        `${original.name}\t${original.projectId}\t${original.taskId}\t${original.leafId}\n`
+      );
+
+      execFileSync('/bin/sh', ['-c', buildTmuxShellLine(renamed, 'echo should-not-start')], {
+        env: tmuxStubEnv(tempDir, files, { TMUX_OLD_FORMAT: '1' }),
+      });
+
+      const calls = readFileSync(files.callsFile, 'utf8');
+      expect(calls).toContain('list-sessions -F #{session_name}');
+      expect(calls).toContain(`show-options -t ${original.name}`);
+      expect(calls).not.toContain('new-session');
+      expect(calls).toContain(`attach-session -t ${original.name}`);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses show-options when old tmux accepts rich formats but expands user options empty', () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'emdash-tmux-old-empty-'));
+    try {
+      const files = installStatefulTmuxStub(tempDir);
+      const sessionId = makePtySessionId('old-project', 'old-task', 'old-leaf');
+      const original = makeTmuxSession(sessionId, '/tmp/old-empty-label');
+      const renamed = makeTmuxSession(sessionId, '/tmp/new-empty-label');
+      writeFileSync(
+        files.stateFile,
+        `${original.name}\t${original.projectId}\t${original.taskId}\t${original.leafId}\n`
+      );
+
+      execFileSync('/bin/sh', ['-c', buildTmuxShellLine(renamed, 'echo should-not-start')], {
+        env: tmuxStubEnv(tempDir, files, { TMUX_EMPTY_FORMAT: '1' }),
+      });
+
+      const calls = readFileSync(files.callsFile, 'utf8');
+      expect(calls).toContain(`show-options -t ${original.name}`);
+      expect(calls).not.toContain('new-session');
+      expect(calls).toContain(`attach-session -t ${original.name}`);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the names fallback when an old tmux returns success with no rich-format output', () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'emdash-tmux-old-success-empty-'));
+    try {
+      const files = installStatefulTmuxStub(tempDir);
+      const sessionId = makePtySessionId('empty-project', 'empty-task', 'empty-leaf');
+      const original = makeTmuxSession(sessionId, '/tmp/old-success-empty-label');
+      const renamed = makeTmuxSession(sessionId, '/tmp/new-success-empty-label');
+      writeFileSync(
+        files.stateFile,
+        `${original.name}\t${original.projectId}\t${original.taskId}\t${original.leafId}\n`
+      );
+
+      execFileSync('/bin/sh', ['-c', buildTmuxShellLine(renamed, 'echo should-not-start')], {
+        env: tmuxStubEnv(tempDir, files, { TMUX_RICH_EMPTY: '1' }),
+      });
+
+      const calls = readFileSync(files.callsFile, 'utf8');
+      expect(calls).toContain('list-sessions -F #{session_name}');
+      expect(calls).toContain(`show-options -t ${original.name}`);
+      expect(calls).not.toContain('new-session');
+      expect(calls).toContain(`attach-session -t ${original.name}`);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('recovers a lock orphaned by a crashed wrapper before creating the session', () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'emdash-tmux-stale-lock-'));
+    try {
+      const files = installStatefulTmuxStub(tempDir);
+      const sessionId = makePtySessionId('stale-project', 'stale-task', 'stale-leaf');
+      const session = makeTmuxSession(sessionId, '/tmp/stale-lock-label');
+      const identityToken = session.name.slice(-10);
+      const lockFile = path.join(tempDir, `emdash-tmux-${identityToken}.lock`);
+      writeFileSync(lockFile, '99999999\n');
+
+      execFileSync('/bin/sh', ['-c', buildTmuxShellLine(session, 'echo create-once')], {
+        env: tmuxStubEnv(tempDir, files),
+      });
+
+      const calls = readFileSync(files.callsFile, 'utf8');
+      expect(calls.match(/new-session/g)).toHaveLength(1);
+      expect(calls).toContain(`attach-session -t ${session.name}`);
+      expect(existsSync(lockFile)).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reclaims a stable stale lock when its live pid belongs to a different process instance', async () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'emdash-tmux-reused-pid-lock-'));
+    try {
+      const files = installStatefulTmuxStub(tempDir);
+      const sessionId = makePtySessionId('reused-project', 'reused-task', 'reused-leaf');
+      const session = makeTmuxSession(sessionId, '/tmp/reused-pid-label');
+      const identityToken = session.name.slice(-10);
+      const lockFile = path.join(tempDir, `emdash-tmux-${identityToken}.lock`);
+      const staleOwnerCandidate = `${lockFile}.${process.pid}`;
+      writeFileSync(lockFile, `${process.pid}\nMon Jan  1 00:00:00 2001\n`);
+      linkSync(lockFile, staleOwnerCandidate);
+
+      const child = execFile(
+        '/bin/sh',
+        ['-c', `exec ${buildTmuxShellLine(session, 'echo create-once')}`],
+        { env: tmuxStubEnv(tempDir, files) }
+      );
+      expect(await waitForChildExit(child)).toEqual({ code: 0, signal: null });
+
+      const calls = readFileSync(files.callsFile, 'utf8');
+      expect(calls.match(/new-session/g)).toHaveLength(1);
+      expect(calls).toContain(`attach-session -t ${session.name}`);
+      expect(existsSync(lockFile)).toBe(false);
+      expect(existsSync(staleOwnerCandidate)).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('serializes competing stale cleaners and keeps replacement owners behind the cleanup guard', async () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'emdash-tmux-cleaner-race-'));
+    const children: ChildProcess[] = [];
+    try {
+      const files = installStatefulTmuxStub(tempDir);
+      const sessionId = makePtySessionId('race-project', 'race-task', 'race-leaf');
+      const session = makeTmuxSession(sessionId, '/tmp/cleaner-race-label');
+      const identityToken = session.name.slice(-10);
+      const lockFile = path.join(tempDir, `emdash-tmux-${identityToken}.lock`);
+      const cleanupGuard = `${lockFile}.cleanup`;
+      const blocked = path.join(tempDir, 'cleanup-guard-release-blocked');
+      const release = path.join(tempDir, 'release-cleanup-guard');
+      const staleOwnerCandidate = `${lockFile}.${process.pid}`;
+      writeFileSync(lockFile, `${process.pid}\nMon Jan  1 00:00:00 2001\n`);
+      linkSync(lockFile, staleOwnerCandidate);
+      installBlockingRmdirStub(tempDir);
+      const env = tmuxStubEnv(tempDir, files, {
+        TMUX_NEW_DELAY: '0.2',
+        TMUX_RACE_GUARD: cleanupGuard,
+        TMUX_RACE_BLOCKED: blocked,
+        TMUX_RACE_RELEASE: release,
+      });
+      const spawnWrapper = () => {
+        const child = execFile(
+          '/bin/sh',
+          ['-c', `exec ${buildTmuxShellLine(session, 'echo create-once')}`],
+          { env }
+        );
+        children.push(child);
+        return child;
+      };
+
+      // A and B both contend to clean the same stale inode. The sole cleaner
+      // is paused after deleting it but before releasing the guard.
+      spawnWrapper();
+      spawnWrapper();
+      await waitForPath(blocked, 4_000);
+      expect(existsSync(cleanupGuard)).toBe(true);
+      expect(existsSync(lockFile)).toBe(false);
+
+      // C arrives in the exact replacement window. It must remain behind the
+      // guard rather than publishing a lock that a delayed cleaner can unlink.
+      const replacement = spawnWrapper();
+      if (!replacement.pid) throw new Error('Replacement wrapper child has no pid');
+      await waitForPath(`${lockFile}.${replacement.pid}`);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(existsSync(lockFile)).toBe(false);
+
+      writeFileSync(release, 'release\n');
+      expect(await Promise.all(children.map((child) => waitForChildExit(child, 4_000)))).toEqual([
+        { code: 0, signal: null },
+        { code: 0, signal: null },
+        { code: 0, signal: null },
+      ]);
+
+      const state = readFileSync(files.stateFile, 'utf8').trim().split('\n');
+      const calls = readFileSync(files.callsFile, 'utf8');
+      expect(state).toHaveLength(1);
+      expect(calls.match(/new-session/g)).toHaveLength(1);
+      expect(calls.match(/attach-session/g)).toHaveLength(3);
+      expect(existsSync(lockFile)).toBe(false);
+      expect(existsSync(cleanupGuard)).toBe(false);
+      expect(existsSync(staleOwnerCandidate)).toBe(false);
+    } finally {
+      for (const child of children) {
+        if (child.exitCode === null) child.kill('SIGKILL');
+      }
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('recovers a nonempty cleanup guard after its sole cleaner is killed', async () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'emdash-tmux-killed-cleaner-'));
+    let killedCleaner: ChildProcess | undefined;
+    try {
+      const files = installStatefulTmuxStub(tempDir);
+      installBlockingClaimLnStub(tempDir);
+      const sessionId = makePtySessionId('killed-project', 'killed-task', 'killed-leaf');
+      const session = makeTmuxSession(sessionId, '/tmp/killed-cleaner-label');
+      const identityToken = session.name.slice(-10);
+      const lockFile = path.join(tempDir, `emdash-tmux-${identityToken}.lock`);
+      const cleanupGuard = `${lockFile}.cleanup`;
+      const staleOwnerCandidate = `${lockFile}.${process.pid}`;
+      const claimOnce = path.join(tempDir, 'claim-once');
+      const claimBlocked = path.join(tempDir, 'claim-blocked');
+      const claimRelease = path.join(tempDir, 'claim-release');
+      writeFileSync(lockFile, `${process.pid}\nMon Jan  1 00:00:00 2001\n`);
+      linkSync(lockFile, staleOwnerCandidate);
+      const env = tmuxStubEnv(tempDir, files, {
+        TMUX_KILL_CLAIM_ONCE: claimOnce,
+        TMUX_KILL_CLAIM_BLOCKED: claimBlocked,
+        TMUX_KILL_CLAIM_RELEASE: claimRelease,
+      });
+
+      killedCleaner = execFile(
+        '/bin/sh',
+        ['-c', `exec ${buildTmuxShellLine(session, 'echo killed-cleaner')}`],
+        { env }
+      );
+      await waitForPath(claimBlocked, 4_000);
+      expect(existsSync(cleanupGuard)).toBe(true);
+      expect(readdirSync(cleanupGuard).filter((entry) => entry.startsWith('owner.'))).toHaveLength(
+        1
+      );
+
+      killedCleaner.kill('SIGKILL');
+      expect(await waitForChildExit(killedCleaner)).toEqual({ code: null, signal: 'SIGKILL' });
+      writeFileSync(claimRelease, 'release\n');
+
+      const recovery = execFile(
+        '/bin/sh',
+        ['-c', `exec ${buildTmuxShellLine(session, 'echo recovered')}`],
+        { env }
+      );
+      expect(await waitForChildExit(recovery, 4_000)).toEqual({ code: 0, signal: null });
+
+      const calls = readFileSync(files.callsFile, 'utf8');
+      expect(calls.match(/new-session/g)).toHaveLength(1);
+      expect(calls).toContain(`attach-session -t ${session.name}`);
+      expect(existsSync(lockFile)).toBe(false);
+      expect(existsSync(cleanupGuard)).toBe(false);
+      expect(existsSync(staleOwnerCandidate)).toBe(false);
+    } finally {
+      if (killedCleaner?.exitCode === null) killedCleaner.kill('SIGKILL');
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not treat empty process identities as proof that an orphan guard owner is live', async () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'emdash-tmux-empty-guard-identity-'));
+    try {
+      const files = installStatefulTmuxStub(tempDir);
+      const sessionId = makePtySessionId('empty-guard-project', 'empty-guard-task', 'empty-leaf');
+      const session = makeTmuxSession(sessionId, '/tmp/empty-guard-identity-label');
+      const identityToken = session.name.slice(-10);
+      const lockFile = path.join(tempDir, `emdash-tmux-${identityToken}.lock`);
+      const cleanupGuard = `${lockFile}.cleanup`;
+      const falseOwnerCandidate = `${lockFile}.${process.pid}`;
+      writeFileSync(falseOwnerCandidate, `${process.pid}\n\n`);
+      const inode = statSync(falseOwnerCandidate).ino;
+      mkdirSync(cleanupGuard);
+      linkSync(falseOwnerCandidate, path.join(cleanupGuard, `owner.${process.pid}.${inode}`));
+
+      const recovery = execFile(
+        '/bin/sh',
+        ['-c', `exec ${buildTmuxShellLine(session, 'echo recovered-empty-identity')}`],
+        { env: tmuxStubEnv(tempDir, files) }
+      );
+      expect(await waitForChildExit(recovery)).toEqual({ code: 0, signal: null });
+
+      expect(existsSync(cleanupGuard)).toBe(false);
+      expect(existsSync(falseOwnerCandidate)).toBe(false);
+      const calls = readFileSync(files.callsFile, 'utf8');
+      expect(calls.match(/new-session/g)).toHaveLength(1);
+      expect(calls).toContain(`attach-session -t ${session.name}`);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('exits on TERM while waiting without releasing another wrapper lock', async () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'emdash-tmux-term-waiter-'));
+    let child: ChildProcess | undefined;
+    try {
+      const files = installStatefulTmuxStub(tempDir);
+      const sessionId = makePtySessionId('term-project', 'term-task', 'term-waiter');
+      const session = makeTmuxSession(sessionId, '/tmp/term-waiter-label');
+      const identityToken = session.name.slice(-10);
+      const lockFile = path.join(tempDir, `emdash-tmux-${identityToken}.lock`);
+      const ownerCandidate = `${lockFile}.${process.pid}`;
+      const ownerIdentity = execFileSync('ps', ['-o', 'lstart=', '-p', String(process.pid)], {
+        encoding: 'utf8',
+      }).trim();
+      writeFileSync(lockFile, `${process.pid}\n${ownerIdentity}\n`);
+      linkSync(lockFile, ownerCandidate);
+
+      child = execFile(
+        '/bin/sh',
+        ['-c', `exec ${buildTmuxShellLine(session, 'echo should-not-run')}`],
+        { env: tmuxStubEnv(tempDir, files) }
+      );
+      if (!child.pid) throw new Error('Wrapper child has no pid');
+      const waiterCandidate = `${lockFile}.${child.pid}`;
+      await waitForPath(waiterCandidate);
+      child.kill('SIGTERM');
+
+      expect(await waitForChildExit(child)).toEqual({ code: 143, signal: null });
+      expect(existsSync(lockFile)).toBe(true);
+      expect(existsSync(ownerCandidate)).toBe(true);
+      expect(existsSync(waiterCandidate)).toBe(false);
+      expect(readFileSync(files.callsFile, 'utf8')).toBe('');
+    } finally {
+      if (child?.exitCode === null) child.kill('SIGKILL');
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('exits on TERM as the owner and releases its lock before session creation', async () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'emdash-tmux-term-owner-'));
+    try {
+      const files = installStatefulTmuxStub(tempDir);
+      const sessionId = makePtySessionId('term-project', 'term-task', 'term-owner');
+      const session = makeTmuxSession(sessionId, '/tmp/term-owner-label');
+      const identityToken = session.name.slice(-10);
+      const lockFile = path.join(tempDir, `emdash-tmux-${identityToken}.lock`);
+
+      const child = execFile(
+        '/bin/sh',
+        ['-c', `exec ${buildTmuxShellLine(session, 'echo should-not-run')}`],
+        { env: tmuxStubEnv(tempDir, files, { TMUX_TERM_OWNER_LOCK: lockFile }) }
+      );
+
+      expect(await waitForChildExit(child)).toEqual({ code: 143, signal: null });
+      expect(existsSync(lockFile)).toBe(false);
+      const calls = readFileSync(files.callsFile, 'utf8');
+      expect(calls).toContain('list-sessions -F');
+      expect(calls).not.toContain('new-session');
+      expect(calls).not.toContain('attach-session');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('decodeLegacyTmuxSessionName', () => {
+  it('round-trips a PTY session id through the legacy name format', () => {
     const sessionId = makePtySessionId('proj-1', 'task-2', 'conv-3');
-    const name = makeTmuxSessionName(sessionId);
-    expect(decodeTmuxSessionName(name)).toBe(sessionId);
+    const name = makeLegacyTmuxSessionName(sessionId);
+    expect(decodeLegacyTmuxSessionName(name)).toBe(sessionId);
   });
 
   it('returns null for a name without the emdash- prefix', () => {
-    expect(decodeTmuxSessionName('other-abc')).toBeNull();
+    expect(decodeLegacyTmuxSessionName('other-abc')).toBeNull();
   });
 
   it('returns null for the bare prefix', () => {
-    expect(decodeTmuxSessionName('emdash-')).toBeNull();
+    expect(decodeLegacyTmuxSessionName('emdash-')).toBeNull();
   });
 
   it('returns null when the suffix does not re-encode to the same name', () => {
-    // Contains characters that base64url-decode lossily, so the round-trip guard rejects it.
-    expect(decodeTmuxSessionName('emdash-not*base64url')).toBeNull();
+    expect(decodeLegacyTmuxSessionName('emdash-not*base64url')).toBeNull();
   });
 });

--- a/apps/emdash-desktop/src/main/core/pty/tmux-session-name.ts
+++ b/apps/emdash-desktop/src/main/core/pty/tmux-session-name.ts
@@ -1,47 +1,451 @@
+import { createHash } from 'node:crypto';
+import path from 'node:path';
 import type { IExecutionContext } from '@main/core/execution-context/types';
 import { log } from '@main/lib/logger';
+import { quoteShellArg } from '@main/utils/shellEscape';
+import { makePtySessionId, parsePtySessionId } from '@shared/core/pty/ptySessionId';
+import type { TmuxSessionConfig } from '@shared/core/pty/tmux';
 
 export const TMUX_SESSION_PREFIX = 'emdash-';
+export const TMUX_PROJECT_ID_OPTION = '@emdash_project_id';
+export const TMUX_TASK_ID_OPTION = '@emdash_task_id';
+export const TMUX_LEAF_ID_OPTION = '@emdash_leaf_id';
 const TMUX_HISTORY_LIMIT = 100_000;
+const TMUX_WORKSPACE_LABEL_LIMIT = 24;
+const TMUX_ID_TOKEN_LENGTH = 10;
 
-export function buildTmuxShellLine(sessionName: string, commandLine: string): string {
-  const quotedName = JSON.stringify(sessionName);
-  const quotedCmd = JSON.stringify(commandLine);
+const TMUX_WRAPPER_SCRIPT = `preferred_name=$1
+legacy_name=$2
+command_line=$3
+project_id=$4
+task_id=$5
+leaf_id=$6
+identity_token=$7
+lock_file=\${TMPDIR:-/tmp}/emdash-tmux-$identity_token.lock
+lock_candidate=$lock_file.$$
+stale_candidate=$lock_file.stale.$$
+observed_candidate=$lock_file.observed.$$
+cleanup_claim=$lock_file.claim.$$
+cleanup_guard=$lock_file.cleanup
+cleanup_marker=
+guard_snapshot=$lock_file.guard-stale.$$
+lock_held=0
+cleanup_guard_held=0
+stale_observations=0
+
+release_lock() {
+  if [ "$lock_held" = 1 ]; then
+    if [ -e "$lock_file" ] && [ "$lock_file" -ef "$lock_candidate" ]; then
+      rm -f "$lock_file"
+    fi
+    lock_held=0
+  fi
+  rm -f "$lock_candidate" "$stale_candidate" "$observed_candidate" "$cleanup_claim" "$guard_snapshot"
+  if [ "$cleanup_guard_held" = 1 ]; then
+    if [ -n "$cleanup_marker" ]; then
+      rm -f "$cleanup_marker"
+    fi
+    rmdir "$cleanup_guard" 2>/dev/null || true
+    cleanup_guard_held=0
+  fi
+}
+
+find_in_rich_rows() {
+  rows=$1
+  fallback_name=
+  tab=$(printf '\\t')
+  while IFS="$tab" read -r candidate_name candidate_project candidate_task candidate_leaf; do
+    if [ "$candidate_project" = "$project_id" ] && [ "$candidate_task" = "$task_id" ] && [ "$candidate_leaf" = "$leaf_id" ]; then
+      if [ "$candidate_name" = "$preferred_name" ]; then
+        printf '%s\\n' "$candidate_name"
+        return
+      fi
+      if [ -z "$fallback_name" ]; then
+        fallback_name=$candidate_name
+      fi
+    fi
+  done <<EMDASH_TMUX_ROWS
+$rows
+EMDASH_TMUX_ROWS
+  if [ -n "$fallback_name" ]; then
+    printf '%s\\n' "$fallback_name"
+  fi
+}
+
+find_in_option_list() {
+  option_rows=$1
+  candidate_project=
+  candidate_task=
+  candidate_leaf=
+  while IFS= read -r option_row; do
+    option_name=\${option_row%% *}
+    option_value=\${option_row#* }
+    case "$option_name" in
+      ${TMUX_PROJECT_ID_OPTION}) candidate_project=$option_value ;;
+      ${TMUX_TASK_ID_OPTION}) candidate_task=$option_value ;;
+      ${TMUX_LEAF_ID_OPTION}) candidate_leaf=$option_value ;;
+    esac
+  done <<EMDASH_TMUX_OPTIONS
+$option_rows
+EMDASH_TMUX_OPTIONS
+  [ "$candidate_project" = "$project_id" ] && [ "$candidate_task" = "$task_id" ] && [ "$candidate_leaf" = "$leaf_id" ]
+}
+
+find_with_old_tmux() {
+  session_names=$(tmux list-sessions -F '#{session_name}' 2>/dev/null) || return
+  fallback_name=
+  while IFS= read -r candidate_name; do
+    case "$candidate_name" in
+      ${TMUX_SESSION_PREFIX}*) ;;
+      *) continue ;;
+    esac
+    if [ "$candidate_name" = "$legacy_name" ]; then
+      printf '%s\\n' "$candidate_name"
+      return
+    fi
+    option_rows=$(tmux show-options -t "$candidate_name" 2>/dev/null) || continue
+    if find_in_option_list "$option_rows"; then
+      if [ "$candidate_name" = "$preferred_name" ]; then
+        printf '%s\\n' "$candidate_name"
+        return
+      fi
+      if [ -z "$fallback_name" ]; then
+        fallback_name=$candidate_name
+      fi
+    fi
+  done <<EMDASH_TMUX_NAMES
+$session_names
+EMDASH_TMUX_NAMES
+  if [ -n "$fallback_name" ]; then
+    printf '%s\\n' "$fallback_name"
+  fi
+}
+
+find_matching_session() {
+  if rich_rows=$(tmux list-sessions -F '#{session_name}\t#{${TMUX_PROJECT_ID_OPTION}}\t#{${TMUX_TASK_ID_OPTION}}\t#{${TMUX_LEAF_ID_OPTION}}' 2>/dev/null); then
+    case "$rich_rows" in
+      *'#{${TMUX_PROJECT_ID_OPTION}}'*) find_with_old_tmux ;;
+      *)
+        session_match=$(find_in_rich_rows "$rich_rows")
+        if [ -n "$session_match" ]; then
+          printf '%s\\n' "$session_match"
+        else
+          # Some older tmux releases accept the rich format but either expand
+          # user options to empty strings or return a successful empty result.
+          # Listing names separately distinguishes that from no server and
+          # lets us recover identity through show-options.
+          find_with_old_tmux
+        fi
+        ;;
+    esac
+  else
+    find_with_old_tmux
+  fi
+}
+
+recover_stale_cleanup_guard() {
+  rm -f "$guard_snapshot"
+  for guard_marker in "$cleanup_guard"/owner.*; do
+    [ -e "$guard_marker" ] || continue
+    if ! ln "$guard_marker" "$guard_snapshot" 2>/dev/null; then
+      continue
+    fi
+
+    guard_owner=$(sed -n '1p' "$guard_snapshot" 2>/dev/null || true)
+    guard_identity=$(sed -n '2p' "$guard_snapshot" 2>/dev/null || true)
+    guard_owner_matches=0
+    case "$guard_owner" in
+      ''|*[!0-9]*) ;;
+      *)
+        guard_owner_candidate=$lock_file.$guard_owner
+        if kill -0 "$guard_owner" 2>/dev/null && [ -e "$guard_owner_candidate" ] && [ "$guard_owner_candidate" -ef "$guard_snapshot" ]; then
+          guard_current_identity=$(ps -o lstart= -p "$guard_owner" 2>/dev/null || true)
+          if [ -n "$guard_identity" ] && [ "$guard_current_identity" = "$guard_identity" ]; then
+            guard_owner_matches=1
+          fi
+        fi
+        ;;
+    esac
+
+    if [ "$guard_owner_matches" = 1 ]; then
+      rm -f "$guard_snapshot"
+      return 1
+    fi
+
+    # owner.<pid>.<inode> is unique while this snapshot keeps the old inode
+    # alive. A replacement guard therefore has a different marker path; even
+    # PID reuse cannot make a competing waiter unlink the replacement marker.
+    if [ -e "$guard_marker" ] && [ "$guard_marker" -ef "$guard_snapshot" ]; then
+      rm -f "$guard_marker"
+    fi
+    case "$guard_owner" in
+      ''|*[!0-9]*) ;;
+      *)
+        guard_owner_candidate=$lock_file.$guard_owner
+        if [ -e "$guard_owner_candidate" ] && [ "$guard_owner_candidate" -ef "$guard_snapshot" ]; then
+          rm -f "$guard_owner_candidate"
+        fi
+        ;;
+    esac
+    rm -f "$guard_snapshot"
+  done
+  rmdir "$cleanup_guard" 2>/dev/null || true
+  [ ! -d "$cleanup_guard" ]
+}
+
+trap 'release_lock' EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+rm -f "$lock_candidate" "$stale_candidate" "$observed_candidate" "$cleanup_claim" "$guard_snapshot"
+original_umask=$(umask)
+umask 077
+process_identity=$(ps -o lstart= -p "$$" 2>/dev/null || true)
+if ! printf '%s\\n%s\\n' "$$" "$process_identity" > "$lock_candidate"; then
+  umask "$original_umask"
+  exit 1
+fi
+umask "$original_umask"
+candidate_inode=$(ls -di "$lock_candidate" 2>/dev/null | awk '{ print $1 }')
+case "$candidate_inode" in
+  ''|*[!0-9]*) exit 1 ;;
+esac
+cleanup_marker=$cleanup_guard/owner.$$.$candidate_inode
+
+lock_attempt=0
+while [ "$lock_held" = 0 ]; do
+  # A stale cleaner holds this directory across validation and deletion. New
+  # owners wait for it and also re-check after linking, closing the race where
+  # a cleaner could otherwise unlink a replacement between -ef and rm.
+  if [ -d "$cleanup_guard" ]; then
+    # An empty directory can only be an interrupted guard acquisition/release.
+    # rmdir cannot remove a live guard because its owner marker makes it
+    # non-empty; if it catches another acquisition window, that contender's
+    # marker link fails and it safely retries.
+    rmdir "$cleanup_guard" 2>/dev/null || true
+  fi
+  if [ -d "$cleanup_guard" ]; then
+    recover_stale_cleanup_guard || true
+  fi
+  if [ -d "$cleanup_guard" ]; then
+    lock_attempt=$((lock_attempt + 1))
+    if [ "$lock_attempt" -ge 300 ]; then
+      exit 1
+    fi
+    sleep 0.1
+    continue
+  fi
+
+  if ln "$lock_candidate" "$lock_file" 2>/dev/null; then
+    if [ -d "$cleanup_guard" ]; then
+      if [ -e "$lock_file" ] && [ "$lock_file" -ef "$lock_candidate" ]; then
+        rm -f "$lock_file"
+      fi
+      lock_attempt=$((lock_attempt + 1))
+      if [ "$lock_attempt" -ge 300 ]; then
+        exit 1
+      fi
+      sleep 0.1
+      continue
+    fi
+    lock_held=1
+    break
+  fi
+
+  # A hard link snapshots the lock inode. If the owner is dead, remove the
+  # public lock only after atomically becoming the sole stale cleaner.
+  rm -f "$stale_candidate"
+  if ln "$lock_file" "$stale_candidate" 2>/dev/null; then
+    lock_owner=$(sed -n '1p' "$stale_candidate" 2>/dev/null || true)
+    lock_identity=$(sed -n '2p' "$stale_candidate" 2>/dev/null || true)
+    owner_matches=0
+    case "$lock_owner" in
+      ''|*[!0-9]*) ;;
+      *)
+        if kill -0 "$lock_owner" 2>/dev/null; then
+          owner_candidate=$lock_file.$lock_owner
+          current_identity=$(ps -o lstart= -p "$lock_owner" 2>/dev/null || true)
+          if [ -e "$owner_candidate" ] && [ "$owner_candidate" -ef "$stale_candidate" ] && [ -n "$lock_identity" ] && [ "$current_identity" = "$lock_identity" ]; then
+            owner_matches=1
+          fi
+        fi
+        ;;
+    esac
+
+    if [ "$owner_matches" = 1 ]; then
+      stale_observations=0
+      rm -f "$observed_candidate"
+    else
+      # Do not trust kill -0 alone: a crashed wrapper's pid may already have
+      # been reused by an unrelated process. Observe the same lock inode for a
+      # few bounded retries before attempting the guarded cleanup below.
+      if [ -e "$observed_candidate" ] && [ "$observed_candidate" -ef "$stale_candidate" ]; then
+        stale_observations=$((stale_observations + 1))
+      else
+        rm -f "$observed_candidate"
+        if ln "$stale_candidate" "$observed_candidate" 2>/dev/null; then
+          stale_observations=1
+        else
+          stale_observations=0
+        fi
+      fi
+      if [ "$stale_observations" -ge 3 ] && mkdir "$cleanup_guard" 2>/dev/null; then
+        cleanup_guard_held=1
+        if ! ln "$lock_candidate" "$cleanup_marker" 2>/dev/null; then
+          rmdir "$cleanup_guard" 2>/dev/null || true
+          cleanup_guard_held=0
+        fi
+        rm -f "$cleanup_claim"
+        if [ "$cleanup_guard_held" = 1 ] && ln "$lock_file" "$cleanup_claim" 2>/dev/null && [ "$cleanup_claim" -ef "$observed_candidate" ]; then
+          # The guard prevents another cleaner from acting and makes every new
+          # owner back out before it becomes valid. The claimed inode therefore
+          # remains the public lock until this unlink, with no check/rm gap in
+          # which a replacement can appear.
+          rm -f "$lock_file"
+          case "$lock_owner" in
+            ''|*[!0-9]*) ;;
+            *)
+              owner_candidate=$lock_file.$lock_owner
+              if [ -e "$owner_candidate" ] && [ "$owner_candidate" -ef "$cleanup_claim" ]; then
+                rm -f "$owner_candidate"
+              fi
+              ;;
+          esac
+        fi
+        rm -f "$cleanup_claim" "$observed_candidate"
+        stale_observations=0
+        rm -f "$cleanup_marker"
+        if rmdir "$cleanup_guard" 2>/dev/null; then
+          cleanup_guard_held=0
+        fi
+      fi
+    fi
+    rm -f "$stale_candidate"
+  fi
+  lock_attempt=$((lock_attempt + 1))
+  if [ "$lock_attempt" -ge 300 ]; then
+    exit 1
+  fi
+  sleep 0.1
+done
+
+session_name=$(find_matching_session)
+
+if [ -z "$session_name" ] && tmux has-session -t "$legacy_name" 2>/dev/null; then
+  session_name=$legacy_name
+fi
+
+if [ -z "$session_name" ]; then
+  session_name=$preferred_name
+  if ! tmux -u new-session -d -s "$session_name" "$command_line" \\; set-option -t "$session_name" ${TMUX_PROJECT_ID_OPTION} "$project_id" \\; set-option -t "$session_name" ${TMUX_TASK_ID_OPTION} "$task_id" \\; set-option -t "$session_name" ${TMUX_LEAF_ID_OPTION} "$leaf_id"; then
+    session_name=$(find_matching_session)
+    if [ -z "$session_name" ]; then
+      exit 1
+    fi
+  fi
+else
+  tmux set-option -t "$session_name" ${TMUX_PROJECT_ID_OPTION} "$project_id" \\; set-option -t "$session_name" ${TMUX_TASK_ID_OPTION} "$task_id" \\; set-option -t "$session_name" ${TMUX_LEAF_ID_OPTION} "$leaf_id"
+fi
+
+tmux set-option -t "$session_name" mouse on 2>/dev/null || true
+tmux set-option -t "$session_name" history-limit ${TMUX_HISTORY_LIMIT} 2>/dev/null || true
+release_lock
+trap - HUP INT TERM
+trap - EXIT
+exec tmux -u attach-session -t "$session_name"`;
+
+/**
+ * Builds the POSIX wrapper used by both local and SSH-backed PTYs.
+ *
+ * Dynamic values are passed to `/bin/sh -c` as positional arguments instead of
+ * being interpolated into the script. New sessions and their identity options
+ * are created in one tmux command queue, so reconciliation can never observe a
+ * friendly-named session before it has been tagged.
+ */
+export function buildTmuxShellLine(
+  session: TmuxSessionConfig,
+  commandLine: string,
+  quoteArg: (value: string) => string = quoteShellArg
+): string {
+  const sessionId = makePtySessionId(session.projectId, session.taskId, session.leafId);
+  const legacyName = makeLegacyTmuxSessionName(sessionId);
   // `-u` forces tmux into UTF-8 mode regardless of the inherited locale. GUI-launched
   // apps (e.g. Electron on macOS) often have no LANG set, so without this tmux assumes a
   // non-UTF-8 locale and mangles multibyte glyphs like Nerd-font/box-drawing characters.
-  const checkExists = `tmux has-session -t ${quotedName} 2>/dev/null`;
-  const newSession = `tmux -u new-session -d -s ${quotedName} ${quotedCmd}`;
-  const enableMouse = `tmux set-option -t ${quotedName} mouse on 2>/dev/null || true`;
-  const setHistoryLimit = `tmux set-option -t ${quotedName} history-limit ${TMUX_HISTORY_LIMIT} 2>/dev/null || true`;
-  const configure = `(${enableMouse}) && (${setHistoryLimit})`;
-  const attach = `tmux -u attach-session -t ${quotedName}`;
-  const script = `(${checkExists} || ${newSession}) && ${configure} && ${attach}`;
-  return `/bin/sh -c ${JSON.stringify(script)}`;
+  return [
+    '/bin/sh',
+    '-c',
+    TMUX_WRAPPER_SCRIPT,
+    'emdash-tmux',
+    session.name,
+    legacyName,
+    commandLine,
+    session.projectId,
+    session.taskId,
+    session.leafId,
+    tmuxIdentityToken(sessionId),
+  ]
+    .map(quoteArg)
+    .join(' ');
 }
 
-export function makeTmuxSessionName(sessionId: string): string {
+/** The deterministic base64url name used before friendly tmux names. */
+export function makeLegacyTmuxSessionName(sessionId: string): string {
   const encoded = Buffer.from(sessionId, 'utf8').toString('base64url');
   return `${TMUX_SESSION_PREFIX}${encoded}`;
 }
 
 /**
- * Inverse of {@link makeTmuxSessionName}. Returns the encoded PTY session id, or
+ * Inverse of {@link makeLegacyTmuxSessionName}. Returns the encoded PTY session id, or
  * `null` if the name is not a well-formed emdash tmux session name. The
  * round-trip guard rejects anything that does not re-encode to exactly the same
  * name, so unrelated `emdash-*` sessions are never misread as ours.
  */
-export function decodeTmuxSessionName(sessionName: string): string | null {
+export function decodeLegacyTmuxSessionName(sessionName: string): string | null {
   if (!sessionName.startsWith(TMUX_SESSION_PREFIX)) return null;
   const encoded = sessionName.slice(TMUX_SESSION_PREFIX.length);
   if (!encoded) return null;
   try {
     const sessionId = Buffer.from(encoded, 'base64url').toString('utf8');
-    if (makeTmuxSessionName(sessionId) !== sessionName) return null;
+    if (makeLegacyTmuxSessionName(sessionId) !== sessionName) return null;
     return sessionId;
   } catch {
     return null;
   }
+}
+
+function workspaceLabel(workspacePath: string): string {
+  const base = path.basename(workspacePath) || 'workspace';
+  const sanitized = base
+    .normalize('NFKC')
+    .replace(/[^\p{L}\p{N}_-]+/gu, '-')
+    .replace(/^-+|-+$/g, '');
+  return Array.from(sanitized || 'workspace')
+    .slice(0, TMUX_WORKSPACE_LABEL_LIMIT)
+    .join('');
+}
+
+/**
+ * Build a short, recognizable name while keeping collision resistance in a
+ * deterministic token. Identity is persisted separately in tmux user options.
+ */
+export function makeTmuxSession(sessionId: string, workspacePath: string): TmuxSessionConfig {
+  const parsed = parsePtySessionId(sessionId);
+  if (!parsed) throw new Error(`Invalid PTY session id: ${sessionId}`);
+  const token = tmuxIdentityToken(sessionId);
+  return {
+    name: `${TMUX_SESSION_PREFIX}${workspaceLabel(workspacePath)}-${token}`,
+    projectId: parsed.projectId,
+    taskId: parsed.scopeId,
+    leafId: parsed.leafId,
+  };
+}
+
+function tmuxIdentityToken(sessionId: string): string {
+  return createHash('sha256')
+    .update(sessionId, 'utf8')
+    .digest('base64url')
+    .slice(0, TMUX_ID_TOKEN_LENGTH);
 }
 
 export async function killTmuxSession(ctx: IExecutionContext, sessionName: string): Promise<void> {

--- a/apps/emdash-desktop/src/main/core/tasks/operations/archiveTask.test.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/archiveTask.test.ts
@@ -41,6 +41,7 @@ describe('archiveTask', () => {
     vi.clearAllMocks();
     mocks.updateSet.mockReturnValue({ where: mocks.updateWhere });
     mocks.updateWhere.mockResolvedValue(undefined);
+    mocks.teardownTask.mockResolvedValue({ success: true });
   });
 
   it('archives by reaping the runtime without deleting workspace assets', async () => {
@@ -71,5 +72,23 @@ describe('archiveTask', () => {
       task_id: 'task-1',
     });
     expect(mocks.selectLimit).toHaveBeenCalledTimes(1);
+    expect(mocks.teardownTask.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.updateSet.mock.invocationCallOrder[0]!
+    );
+  });
+
+  it('keeps the task unarchived when runtime teardown fails', async () => {
+    mocks.selectLimit.mockResolvedValueOnce([{ id: 'task-1', workspaceId: 'workspace-1' }]);
+    mocks.teardownTask.mockResolvedValue({
+      success: false,
+      error: { type: 'error', message: 'Failed to discover tmux sessions' },
+    });
+
+    await expect(archiveTask('project-1', 'task-1')).rejects.toThrow(
+      'Failed to teardown task before archiving: Failed to discover tmux sessions'
+    );
+
+    expect(mocks.updateSet).not.toHaveBeenCalled();
+    expect(mocks.capture).not.toHaveBeenCalled();
   });
 });

--- a/apps/emdash-desktop/src/main/core/tasks/operations/archiveTask.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/archiveTask.ts
@@ -2,12 +2,18 @@ import { eq, sql } from 'drizzle-orm';
 import { taskSessionManager } from '@main/core/tasks/task-session-manager';
 import { db } from '@main/db/client';
 import { tasks } from '@main/db/schema';
-import { log } from '@main/lib/logger';
 import { telemetryService } from '@main/lib/telemetry';
 
 export async function archiveTask(projectId: string, taskId: string): Promise<void> {
   const [task] = await db.select().from(tasks).where(eq(tasks.id, taskId)).limit(1);
   if (!task) return;
+
+  // Reap the tmux session + agent process before persisting the archive. If cleanup
+  // cannot prove success, keep the task live and unarchived so the operation can retry.
+  const teardownResult = await taskSessionManager.teardownTask(taskId, 'archive');
+  if (!teardownResult.success) {
+    throw new Error(`Failed to teardown task before archiving: ${teardownResult.error.message}`);
+  }
 
   await db
     .update(tasks)
@@ -17,16 +23,4 @@ export async function archiveTask(projectId: string, taskId: string): Promise<vo
     })
     .where(eq(tasks.id, taskId));
   telemetryService.capture('task_archived', { project_id: projectId, task_id: taskId });
-
-  // 'archive' reaps the tmux session + agent process but keeps the worktree and the
-  // persisted session id, so Restore can resume. Plain 'detach' would leak the tmux
-  // session indefinitely (#2689).
-  const teardownResult = await taskSessionManager.teardownTask(taskId, 'archive').catch((e) => {
-    log.warn('archiveTask: teardown failed', { taskId, error: String(e) });
-    return null;
-  });
-
-  if (teardownResult && !teardownResult.success) {
-    log.warn('archiveTask: teardown failed', { taskId, error: teardownResult.error.message });
-  }
 }

--- a/apps/emdash-desktop/src/main/core/tasks/operations/deleteTask.test.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/deleteTask.test.ts
@@ -89,6 +89,24 @@ describe('deleteTask', () => {
     expect(mocks.delViewState).toHaveBeenCalledWith('task:task-1:tabs');
   });
 
+  it('preserves task and workspace records when mounted runtime teardown fails', async () => {
+    mocks.selectLimit.mockResolvedValueOnce([{ id: 'task-1', workspaceId: 'workspace-1' }]);
+    mocks.getProject.mockReturnValue({});
+    mocks.teardownTask.mockResolvedValue({
+      success: false,
+      error: { type: 'error', message: 'Failed to discover tmux sessions' },
+    });
+
+    await expect(deleteTask('project-1', 'task-1')).rejects.toThrow(
+      'Failed to teardown task before deletion: Failed to discover tmux sessions'
+    );
+
+    expect(mocks.deleteWhere).not.toHaveBeenCalled();
+    expect(mocks.delViewState).not.toHaveBeenCalled();
+    expect(mocks.capture).not.toHaveBeenCalled();
+    expect(mocks.selectLimit).toHaveBeenCalledTimes(1);
+  });
+
   it('preserves the workspace file index when an archived sibling still references the workspace', async () => {
     mocks.selectLimit
       .mockResolvedValueOnce([{ id: 'task-1', workspaceId: 'workspace-1' }])

--- a/apps/emdash-desktop/src/main/core/tasks/operations/deleteTask.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/deleteTask.ts
@@ -29,13 +29,9 @@ export async function deleteTask(
   const project = projectManager.getProject(projectId);
 
   if (project) {
-    const teardownResult = await taskSessionManager.teardownTask(taskId, 'terminate').catch((e) => {
-      log.warn('deleteTask: teardown failed', { taskId, error: String(e) });
-      return null;
-    });
-
-    if (teardownResult && !teardownResult.success) {
-      log.warn('deleteTask: teardown failed', { taskId, error: teardownResult.error.message });
+    const teardownResult = await taskSessionManager.teardownTask(taskId, 'terminate');
+    if (!teardownResult.success) {
+      throw new Error(`Failed to teardown task before deletion: ${teardownResult.error.message}`);
     }
   }
 

--- a/apps/emdash-desktop/src/main/core/tasks/task-session-manager.test.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/task-session-manager.test.ts
@@ -1,19 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IExecutionContext } from '@main/core/execution-context/types';
 import type { TaskProvider } from '../projects/project-provider';
-import { executeTeardown } from './task-session-manager';
+import { executeTeardown, taskSessionManager } from './task-session-manager';
 
-const teardown = vi.fn();
+const mocks = vi.hoisted(() => ({
+  getTaskSessionLeafIds: vi.fn(),
+  teardown: vi.fn(),
+}));
 
 vi.mock('@main/core/workspaces/workspace-registry', () => ({
   workspaceRegistry: {
-    teardown: (...args: unknown[]) => teardown(...args),
+    teardown: (...args: unknown[]) => mocks.teardown(...args),
   },
 }));
 
 // session-targets pulls in the real DB client; it is only used by the fallback path,
 // not by executeTeardown, so a stub keeps this unit test free of a SQLite import.
 vi.mock('@main/core/tasks/session-targets', () => ({
-  getTaskSessionLeafIds: vi.fn(),
+  getTaskSessionLeafIds: mocks.getTaskSessionLeafIds,
 }));
 
 function makeTask() {
@@ -26,6 +30,7 @@ function makeTask() {
 describe('executeTeardown', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.getTaskSessionLeafIds.mockResolvedValue({ conversationIds: [], terminalIds: [] });
   });
 
   it('detach keeps tmux + agent running and keeps the workspace', async () => {
@@ -36,7 +41,7 @@ describe('executeTeardown', () => {
     expect(terminals.detachAll).toHaveBeenCalledTimes(1);
     expect(conversations.destroyAll).not.toHaveBeenCalled();
     expect(terminals.destroyAll).not.toHaveBeenCalled();
-    expect(teardown).toHaveBeenCalledWith('workspace-1', 'detach');
+    expect(mocks.teardown).toHaveBeenCalledWith('workspace-1', 'detach');
   });
 
   it('terminate reaps tmux + agent and destroys the workspace', async () => {
@@ -47,7 +52,7 @@ describe('executeTeardown', () => {
     expect(terminals.destroyAll).toHaveBeenCalledTimes(1);
     expect(conversations.detachAll).not.toHaveBeenCalled();
     expect(terminals.detachAll).not.toHaveBeenCalled();
-    expect(teardown).toHaveBeenCalledWith('workspace-1', 'terminate');
+    expect(mocks.teardown).toHaveBeenCalledWith('workspace-1', 'terminate');
   });
 
   // The regression for #2689: archive must reap the tmux session + agent process
@@ -61,6 +66,85 @@ describe('executeTeardown', () => {
     expect(conversations.detachAll).not.toHaveBeenCalled();
     expect(terminals.detachAll).not.toHaveBeenCalled();
     // crucially NOT 'terminate', which would run onDestroy and remove the worktree.
-    expect(teardown).toHaveBeenCalledWith('workspace-1', 'detach');
+    expect(mocks.teardown).toHaveBeenCalledWith('workspace-1', 'detach');
+  });
+
+  it('keeps a failed teardown registered so cleanup can be retried', async () => {
+    const { task, conversations } = makeTask();
+    conversations.destroyAll
+      .mockRejectedValueOnce(new Error('Failed to discover tmux sessions'))
+      .mockResolvedValueOnce(undefined);
+    const ctx = {
+      root: undefined,
+      supportsLocalSpawn: false,
+      exec: vi.fn(),
+      execStreaming: vi.fn(),
+      dispose: vi.fn(),
+    } as unknown as IExecutionContext;
+    const tornDown = vi.fn();
+    const removeHook = taskSessionManager.hooks.on('task:torn-down', tornDown);
+
+    try {
+      await taskSessionManager.registerTask(
+        'retryable-task',
+        {
+          path: '/repo',
+          workspaceId: 'workspace-retry',
+          taskProvider: task,
+        },
+        'project-retry',
+        ctx
+      );
+
+      const failed = await taskSessionManager.teardownTask('retryable-task', 'terminate');
+      expect(failed).toEqual({
+        success: false,
+        error: { type: 'error', message: 'Failed to discover tmux sessions' },
+      });
+      expect(taskSessionManager.getTask('retryable-task')).toBe(task);
+      expect(tornDown).not.toHaveBeenCalled();
+
+      await expect(taskSessionManager.teardownTask('retryable-task', 'terminate')).resolves.toEqual(
+        { success: true, data: undefined }
+      );
+      expect(taskSessionManager.getTask('retryable-task')).toBeUndefined();
+      expect(tornDown).toHaveBeenCalledTimes(1);
+    } finally {
+      removeHook();
+    }
+  });
+
+  it('does not retain failed providers during project shutdown', async () => {
+    const { task, conversations } = makeTask();
+    conversations.destroyAll.mockRejectedValue(new Error('Failed to discover tmux sessions'));
+    const ctx = {
+      root: undefined,
+      supportsLocalSpawn: false,
+      exec: vi.fn(),
+      execStreaming: vi.fn(),
+      dispose: vi.fn(),
+    } as unknown as IExecutionContext;
+    const tornDown = vi.fn();
+    const removeHook = taskSessionManager.hooks.on('task:torn-down', tornDown);
+
+    try {
+      await taskSessionManager.registerTask(
+        'shutdown-task',
+        {
+          path: '/repo',
+          workspaceId: 'workspace-shutdown',
+          taskProvider: task,
+        },
+        'project-shutdown',
+        ctx
+      );
+
+      await taskSessionManager.teardownAllForProject('project-shutdown', 'terminate');
+
+      expect(taskSessionManager.getTask('shutdown-task')).toBeUndefined();
+      expect(tornDown).toHaveBeenCalledTimes(1);
+    } finally {
+      removeHook();
+    }
   });
 });

--- a/apps/emdash-desktop/src/main/core/tasks/task-session-manager.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/task-session-manager.ts
@@ -1,7 +1,7 @@
 import { LifecycleMap } from '@emdash/shared';
 import { ok, type Result } from '@emdash/shared';
 import type { IExecutionContext } from '@main/core/execution-context/types';
-import { killTmuxSession, makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
+import { killTmuxSessionsByPtyIds } from '@main/core/pty/tmux-reaper';
 import { getTaskSessionLeafIds } from '@main/core/tasks/session-targets';
 import type { WorkspaceBootstrapResult } from '@main/core/workspaces/workspace-bootstrap-service';
 import { workspaceRegistry, type TeardownMode } from '@main/core/workspaces/workspace-registry';
@@ -91,9 +91,7 @@ async function cleanupDetachedSessions(
   const sessionIds = [...conversationIds, ...terminalIds].map((leafId) =>
     makePtySessionId(projectId, taskId, leafId)
   );
-  await Promise.all(
-    sessionIds.map((sessionId) => killTmuxSession(ctx, makeTmuxSessionName(sessionId)))
-  );
+  await killTmuxSessionsByPtyIds(ctx, sessionIds);
 }
 
 class TaskSessionManager {

--- a/apps/emdash-desktop/src/main/core/tasks/task-session-manager.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/task-session-manager.ts
@@ -155,7 +155,8 @@ class TaskSessionManager {
 
   async teardownTask(
     taskId: string,
-    mode: TaskTeardownMode = 'terminate'
+    mode: TaskTeardownMode = 'terminate',
+    options: { retainOnFailure?: boolean } = {}
   ): Promise<Result<void, TeardownTaskError>> {
     const result = this._lifecycle.teardown(
       taskId,
@@ -176,10 +177,11 @@ class TaskSessionManager {
           });
           return { success: false as const, error: toTeardownError(e) };
         }
-      }
+      },
+      { retainOnFailure: options.retainOnFailure ?? true }
     );
 
-    return result ?? ok();
+    return (await result) ?? ok();
   }
 
   async teardownAllForProject(projectId: string, mode: TeardownMode): Promise<void> {
@@ -204,7 +206,15 @@ class TaskSessionManager {
       );
     } else {
       // teardownTask handles _tasksByProject cleanup in onFinally.
-      await Promise.all(taskIds.map((id) => this.teardownTask(id, 'terminate')));
+      await Promise.all(
+        taskIds.map((id) =>
+          this.teardownTask(id, 'terminate', {
+            // Project shutdown disposes the execution context immediately after this
+            // call, so retaining providers would leave unusable fast-path entries.
+            retainOnFailure: false,
+          })
+        )
+      );
     }
   }
 

--- a/apps/emdash-desktop/src/main/core/terminals/deleteTerminal.test.ts
+++ b/apps/emdash-desktop/src/main/core/terminals/deleteTerminal.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { deleteTerminal } from './deleteTerminal';
+
+const mocks = vi.hoisted(() => ({
+  capture: vi.fn(),
+  deleteRows: vi.fn(),
+  deleteWhere: vi.fn(),
+  killTerminal: vi.fn(),
+  resolveTask: vi.fn(),
+}));
+
+vi.mock('@main/db/client', () => ({
+  db: {
+    delete: mocks.deleteRows,
+  },
+}));
+
+vi.mock('@main/lib/telemetry', () => ({
+  telemetryService: { capture: mocks.capture },
+}));
+
+vi.mock('../projects/utils', () => ({
+  resolveTask: mocks.resolveTask,
+}));
+
+describe('deleteTerminal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveTask.mockReturnValue({
+      terminals: { killTerminal: mocks.killTerminal },
+    });
+    mocks.killTerminal.mockResolvedValue(undefined);
+    mocks.deleteWhere.mockResolvedValue(undefined);
+    mocks.deleteRows.mockReturnValue({ where: mocks.deleteWhere });
+  });
+
+  it('preserves the DB record when tmux cleanup fails', async () => {
+    mocks.killTerminal.mockRejectedValue(new Error('Failed to discover tmux sessions'));
+
+    await expect(
+      deleteTerminal({
+        projectId: 'project-1',
+        taskId: 'task-1',
+        terminalId: 'terminal-1',
+      })
+    ).rejects.toThrow('Failed to discover tmux sessions');
+
+    expect(mocks.deleteRows).not.toHaveBeenCalled();
+    expect(mocks.capture).not.toHaveBeenCalled();
+  });
+
+  it('deletes the DB record only after terminal cleanup succeeds', async () => {
+    await deleteTerminal({
+      projectId: 'project-1',
+      taskId: 'task-1',
+      terminalId: 'terminal-1',
+    });
+
+    expect(mocks.killTerminal).toHaveBeenCalledTimes(1);
+    expect(mocks.deleteRows).toHaveBeenCalledTimes(1);
+    expect(mocks.killTerminal.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.deleteRows.mock.invocationCallOrder[0]!
+    );
+  });
+});

--- a/apps/emdash-desktop/src/main/core/terminals/deleteTerminal.ts
+++ b/apps/emdash-desktop/src/main/core/terminals/deleteTerminal.ts
@@ -13,6 +13,9 @@ export async function deleteTerminal({
   taskId: string;
   terminalId: string;
 }) {
+  const task = resolveTask(projectId, taskId);
+  await task?.terminals.killTerminal(terminalId);
+
   await db
     .delete(terminals)
     .where(
@@ -23,8 +26,6 @@ export async function deleteTerminal({
       )
     );
 
-  const task = resolveTask(projectId, taskId);
-  await task?.terminals.killTerminal(terminalId);
   telemetryService.capture('terminal_deleted', {
     terminal_id: terminalId,
     project_id: projectId,

--- a/apps/emdash-desktop/src/main/core/terminals/impl/local-terminal-provider.test.ts
+++ b/apps/emdash-desktop/src/main/core/terminals/impl/local-terminal-provider.test.ts
@@ -73,6 +73,8 @@ describe('LocalTerminalProvider', () => {
     previewServerServiceMock.registerDetectedTarget.mockResolvedValue(undefined);
     previewServerServiceMock.handleTerminalSourceClosed.mockClear();
     vi.mocked(ptySessionRegistry.register).mockClear();
+    ctx.exec.mockReset();
+    ctx.exec.mockResolvedValue({ stdout: '', stderr: '' });
   });
 
   it('registers user terminals with their display name for resource monitor labels', async () => {
@@ -149,5 +151,26 @@ describe('LocalTerminalProvider', () => {
       port: 5173,
       urlPath: '/',
     });
+  });
+
+  it('keeps a terminal retryable when tmux discovery fails', async () => {
+    const provider = new LocalTerminalProvider({
+      projectId: terminal.projectId,
+      scopeId: terminal.taskId,
+      taskPath: '/repo',
+      tmux: true,
+      ctx,
+    });
+    await provider.spawnTerminal(terminal);
+    ctx.exec.mockRejectedValue(new Error('connection timed out'));
+
+    await expect(provider.killTerminal(terminal.id)).rejects.toThrow(
+      'Failed to discover tmux sessions'
+    );
+
+    const sessionId = makePtySessionId(terminal.projectId, terminal.taskId, terminal.id);
+    expect(
+      (provider as unknown as { knownSessionIds: Set<string> }).knownSessionIds.has(sessionId)
+    ).toBe(true);
   });
 });

--- a/apps/emdash-desktop/src/main/core/terminals/impl/local-terminal-provider.ts
+++ b/apps/emdash-desktop/src/main/core/terminals/impl/local-terminal-provider.ts
@@ -13,7 +13,8 @@ import {
   type PtySpawnIntent,
 } from '@main/core/pty/pty-spawn-platform';
 import { getTerminalColorEnv } from '@main/core/pty/terminal-color-scheme';
-import { killTmuxSession, makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
+import { killTmuxSessionsByPtyIds } from '@main/core/pty/tmux-reaper';
+import { makeTmuxSession } from '@main/core/pty/tmux-session-name';
 import { resolveTerminalShellWithSystemFallback } from '@main/core/terminal-shell/resolver';
 import type { ResolvedShellProfile } from '@main/core/terminal-shell/types';
 import { log } from '@main/lib/logger';
@@ -154,14 +155,14 @@ export class LocalTerminalProvider implements TerminalProvider {
           command,
           shellProfile,
           shellSetup: shellSetup ?? this.shellSetup,
-          tmuxSessionName: this.tmux ? makeTmuxSessionName(sessionId) : undefined,
+          tmuxSession: this.tmux ? makeTmuxSession(sessionId, this.taskPath) : undefined,
         }
       : {
           kind: 'interactive-shell',
           cwd: this.taskPath,
           shellProfile,
           shellSetup: shellSetup ?? this.shellSetup,
-          tmuxSessionName: this.tmux ? makeTmuxSessionName(sessionId) : undefined,
+          tmuxSession: this.tmux ? makeTmuxSession(sessionId, this.taskPath) : undefined,
         };
     const resolved = resolveLocalPtySpawn({
       platform: process.platform,
@@ -308,7 +309,7 @@ export class LocalTerminalProvider implements TerminalProvider {
     }
     this.shellProfiles.delete(sessionId);
     if (this.tmux) {
-      await killTmuxSession(this.ctx, makeTmuxSessionName(sessionId));
+      await killTmuxSessionsByPtyIds(this.ctx, [sessionId]);
     }
   }
 
@@ -316,7 +317,7 @@ export class LocalTerminalProvider implements TerminalProvider {
     const sessionIds = Array.from(this.knownSessionIds);
     await this.detachAll();
     if (this.tmux) {
-      await Promise.all(sessionIds.map((id) => killTmuxSession(this.ctx, makeTmuxSessionName(id))));
+      await killTmuxSessionsByPtyIds(this.ctx, sessionIds);
     }
     this.knownSessionIds.clear();
     this.shellProfiles.clear();

--- a/apps/emdash-desktop/src/main/core/terminals/impl/local-terminal-provider.ts
+++ b/apps/emdash-desktop/src/main/core/terminals/impl/local-terminal-provider.ts
@@ -298,7 +298,6 @@ export class LocalTerminalProvider implements TerminalProvider {
 
   async killTerminal(terminalId: string): Promise<void> {
     const sessionId = makePtySessionId(this.projectId, this.scopeId, terminalId);
-    this.knownSessionIds.delete(sessionId);
     const pty = this.sessions.get(sessionId);
     if (pty) {
       try {
@@ -311,6 +310,7 @@ export class LocalTerminalProvider implements TerminalProvider {
     if (this.tmux) {
       await killTmuxSessionsByPtyIds(this.ctx, [sessionId]);
     }
+    this.knownSessionIds.delete(sessionId);
   }
 
   async destroyAll(): Promise<void> {

--- a/apps/emdash-desktop/src/main/core/terminals/impl/ssh-terminal-provider.test.ts
+++ b/apps/emdash-desktop/src/main/core/terminals/impl/ssh-terminal-provider.test.ts
@@ -91,6 +91,8 @@ describe('SshTerminalProvider', () => {
     previewServerServiceMock.registerDetectedTarget.mockResolvedValue(undefined);
     previewServerServiceMock.handleTerminalSourceClosed.mockClear();
     vi.mocked(ptySessionRegistry.register).mockClear();
+    ctx.exec.mockReset();
+    ctx.exec.mockResolvedValue({ stdout: '', stderr: '' });
     proxy.getRemoteShellProfile = vi.fn(async () => ({
       shell: '/bin/bash',
       env: { PATH: '/usr/bin', HOME: '/home/me' },
@@ -178,5 +180,28 @@ describe('SshTerminalProvider', () => {
       port: 5173,
       urlPath: '/',
     });
+  });
+
+  it('keeps a terminal retryable when tmux discovery fails', async () => {
+    const provider = new SshTerminalProvider({
+      projectId: terminal.projectId,
+      scopeId: terminal.taskId,
+      taskPath: '/repo',
+      tmux: true,
+      ctx,
+      proxy,
+      connectionId: 'ssh-1',
+    });
+    await provider.spawnTerminal(terminal);
+    ctx.exec.mockRejectedValue(new Error('connection timed out'));
+
+    await expect(provider.killTerminal(terminal.id)).rejects.toThrow(
+      'Failed to discover tmux sessions'
+    );
+
+    const sessionId = makePtySessionId(terminal.projectId, terminal.taskId, terminal.id);
+    expect(
+      (provider as unknown as { knownSessionIds: Set<string> }).knownSessionIds.has(sessionId)
+    ).toBe(true);
   });
 });

--- a/apps/emdash-desktop/src/main/core/terminals/impl/ssh-terminal-provider.ts
+++ b/apps/emdash-desktop/src/main/core/terminals/impl/ssh-terminal-provider.ts
@@ -7,8 +7,8 @@ import { ptySessionRegistry, type PtySessionMetadata } from '@main/core/pty/pty-
 import { resolveSshCommand } from '@main/core/pty/spawn-utils';
 import { openSsh2Pty } from '@main/core/pty/ssh2-pty';
 import { getTerminalColorEnv } from '@main/core/pty/terminal-color-scheme';
-import { killTmuxSessionTree } from '@main/core/pty/tmux-reaper';
-import { makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
+import { killTmuxSessionsByPtyIds } from '@main/core/pty/tmux-reaper';
+import { makeTmuxSession } from '@main/core/pty/tmux-session-name';
 import { sshConnectionManager } from '@main/core/ssh/lifecycle/production-ssh-connection-manager';
 import type { SshClientProxy } from '@main/core/ssh/lifecycle/ssh-client-proxy';
 import type { SshConnectionManagerEvent } from '@main/core/ssh/lifecycle/ssh-connection-manager';
@@ -169,7 +169,7 @@ export class SshTerminalProvider implements TerminalProvider {
       taskId: this.scopeId,
       cwd: this.taskPath,
       shellSetup: shellSetup ?? this.shellSetup,
-      tmuxSessionName: this.tmux ? makeTmuxSessionName(sessionId) : undefined,
+      tmuxSession: this.tmux ? makeTmuxSession(sessionId, this.taskPath) : undefined,
       command: command?.command,
       args: command?.args,
     };
@@ -347,7 +347,7 @@ export class SshTerminalProvider implements TerminalProvider {
     this.terminals.delete(terminalId);
     this.shellProfiles.delete(sessionId);
     if (this.tmux) {
-      await killTmuxSessionTree(this.ctx, makeTmuxSessionName(sessionId));
+      await killTmuxSessionsByPtyIds(this.ctx, [sessionId], { reapDescendants: true });
     }
   }
 
@@ -356,9 +356,7 @@ export class SshTerminalProvider implements TerminalProvider {
     const sessionIds = Array.from(this.knownSessionIds);
     await this.detachAll();
     if (this.tmux) {
-      await Promise.all(
-        sessionIds.map((id) => killTmuxSessionTree(this.ctx, makeTmuxSessionName(id)))
-      );
+      await killTmuxSessionsByPtyIds(this.ctx, sessionIds, { reapDescendants: true });
     }
     this.knownSessionIds.clear();
     this.terminals.clear();

--- a/apps/emdash-desktop/src/main/core/terminals/impl/ssh-terminal-provider.ts
+++ b/apps/emdash-desktop/src/main/core/terminals/impl/ssh-terminal-provider.ts
@@ -335,7 +335,6 @@ export class SshTerminalProvider implements TerminalProvider {
 
   async killTerminal(terminalId: string): Promise<void> {
     const sessionId = makePtySessionId(this.projectId, this.scopeId, terminalId);
-    this.knownSessionIds.delete(sessionId);
     const pty = this.sessions.get(sessionId);
     if (pty) {
       try {
@@ -349,6 +348,7 @@ export class SshTerminalProvider implements TerminalProvider {
     if (this.tmux) {
       await killTmuxSessionsByPtyIds(this.ctx, [sessionId], { reapDescendants: true });
     }
+    this.knownSessionIds.delete(sessionId);
   }
 
   async destroyAll(): Promise<void> {

--- a/apps/emdash-desktop/src/main/db/legacy-port/importers/relational/conversations.ts
+++ b/apps/emdash-desktop/src/main/db/legacy-port/importers/relational/conversations.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { IExecutionContext } from '@main/core/execution-context/types';
-import { makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
+import { makeLegacyTmuxSessionName as makeEncodedTmuxSessionName } from '@main/core/pty/tmux-session-name';
 import { conversations, tasks } from '@main/db/schema';
 import { log } from '@main/lib/logger';
 import { makePtySessionId } from '@shared/core/pty/ptySessionId';
@@ -323,7 +323,7 @@ async function renameLegacyTmuxSession(params: {
   if (!tmuxExec || !legacyPtyId) return;
 
   const oldName = makeLegacyTmuxSessionName(legacyPtyId);
-  const newName = makeTmuxSessionName(
+  const newName = makeEncodedTmuxSessionName(
     makePtySessionId(mappedProjectId, mappedTaskId, conversationId)
   );
   if (oldName === newName) return;

--- a/apps/emdash-desktop/src/main/db/legacy-port/importers/relational/relational.test.ts
+++ b/apps/emdash-desktop/src/main/db/legacy-port/importers/relational/relational.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { afterEach, describe, expect, it } from 'vitest';
-import { makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
+import { makeLegacyTmuxSessionName } from '@main/core/pty/tmux-session-name';
 import { makePtySessionId } from '@shared/core/pty/ptySessionId';
 import { createDrizzleClient } from '../../../drizzleClient';
 import { ensureImportedTaskWorkspaces } from '../../task-workspace-backfill';
@@ -851,7 +851,7 @@ describe('legacy-port table passes', () => {
       tmuxExec,
     });
 
-    const newTmuxName = makeTmuxSessionName(
+    const newTmuxName = makeLegacyTmuxSessionName(
       makePtySessionId('proj-legacy-tmux', 'task-legacy-tmux', mappedChatUuid)
     );
 

--- a/apps/emdash-desktop/src/shared/core/agents/agent-session.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agent-session.ts
@@ -1,4 +1,5 @@
 import type { AgentProviderId } from '@emdash/plugins/agents';
+import type { TmuxSessionConfig } from '@shared/core/pty/tmux';
 
 export interface AgentSessionConfig {
   taskId: string;
@@ -9,7 +10,7 @@ export interface AgentSessionConfig {
   cwd: string;
   sessionId?: string;
   shellSetup?: string;
-  tmuxSessionName?: string;
+  tmuxSession?: TmuxSessionConfig;
   autoApprove: boolean;
   resume: boolean;
 }

--- a/apps/emdash-desktop/src/shared/core/pty/tmux.ts
+++ b/apps/emdash-desktop/src/shared/core/pty/tmux.ts
@@ -1,0 +1,9 @@
+export type TmuxSessionIdentity = {
+  projectId: string;
+  taskId: string;
+  leafId: string;
+};
+
+export type TmuxSessionConfig = TmuxSessionIdentity & {
+  name: string;
+};

--- a/apps/emdash-desktop/src/shared/core/terminals/general-session.ts
+++ b/apps/emdash-desktop/src/shared/core/terminals/general-session.ts
@@ -1,3 +1,5 @@
+import type { TmuxSessionConfig } from '@shared/core/pty/tmux';
+
 export interface GeneralSession {
   type: 'general';
   config: GeneralSessionConfig;
@@ -8,7 +10,7 @@ export interface GeneralSessionConfig {
   cwd: string;
   projectPath?: string;
   shellSetup?: string;
-  tmuxSessionName?: string;
+  tmuxSession?: TmuxSessionConfig;
   command?: string;
   args?: string[];
 }

--- a/packages/shared/src/lifecycle-map.test.ts
+++ b/packages/shared/src/lifecycle-map.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import { LifecycleMap } from './lifecycle-map';
+import { err, ok } from './result';
+
+describe('LifecycleMap teardown retention', () => {
+  it('retains the active value and suppresses postTeardown for a failed result', async () => {
+    const postTeardown = vi.fn();
+    const lifecycle = new LifecycleMap<string, Error, Error>({ postTeardown });
+    await lifecycle.provision('resource-1', async () => ok('value'));
+    const failure = new Error('cleanup failed');
+
+    await expect(
+      lifecycle.teardown('resource-1', async () => err(failure), { retainOnFailure: true })
+    ).resolves.toEqual({ success: false, error: failure });
+
+    expect(lifecycle.get('resource-1')).toBe('value');
+    expect(postTeardown).not.toHaveBeenCalled();
+    expect(lifecycle.teardownStatus('resource-1')).toEqual({ status: 'error', error: failure });
+  });
+
+  it('retains the active value and suppresses postTeardown when teardown throws', async () => {
+    const postTeardown = vi.fn();
+    const lifecycle = new LifecycleMap<string, Error, Error>({ postTeardown });
+    await lifecycle.provision('resource-1', async () => ok('value'));
+
+    await expect(
+      lifecycle.teardown(
+        'resource-1',
+        async () => {
+          throw new Error('cleanup crashed');
+        },
+        { retainOnFailure: true }
+      )
+    ).rejects.toThrow('cleanup crashed');
+
+    expect(lifecycle.get('resource-1')).toBe('value');
+    expect(postTeardown).not.toHaveBeenCalled();
+    expect(lifecycle.teardownStatus('resource-1')).toEqual({ status: 'not-started' });
+  });
+
+  it('allows retained teardown to retry and only publishes the successful teardown', async () => {
+    const postTeardown = vi.fn();
+    const lifecycle = new LifecycleMap<string, Error, Error>({ postTeardown });
+    await lifecycle.provision('resource-1', async () => ok('value'));
+    await lifecycle.teardown('resource-1', async () => err(new Error('cleanup failed')), {
+      retainOnFailure: true,
+    });
+
+    await expect(
+      lifecycle.teardown('resource-1', async () => ok(), { retainOnFailure: true })
+    ).resolves.toEqual({ success: true, data: undefined });
+
+    expect(lifecycle.get('resource-1')).toBeUndefined();
+    expect(postTeardown).toHaveBeenCalledTimes(1);
+    expect(postTeardown).toHaveBeenCalledWith('resource-1', 'value');
+    expect(lifecycle.teardownStatus('resource-1')).toEqual({ status: 'not-started' });
+  });
+
+  it('preserves the existing remove-on-failure default', async () => {
+    const postTeardown = vi.fn();
+    const lifecycle = new LifecycleMap<string, Error, Error>({ postTeardown });
+    await lifecycle.provision('resource-1', async () => ok('value'));
+
+    await lifecycle.teardown('resource-1', async () => err(new Error('cleanup failed')));
+
+    expect(lifecycle.get('resource-1')).toBeUndefined();
+    expect(postTeardown).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/shared/src/lifecycle-map.ts
+++ b/packages/shared/src/lifecycle-map.ts
@@ -11,6 +11,11 @@ export type LifecycleHooks<T> = {
   postTeardown?: (id: string, value: T) => Promise<void> | void;
 };
 
+export type TeardownOptions = {
+  /** Keep the active value and suppress postTeardown when cleanup fails so callers can retry. */
+  retainOnFailure?: boolean;
+};
+
 /**
  * Manages the lifecycle state machine for a collection of async resources.
  *
@@ -99,7 +104,8 @@ export class LifecycleMap<T, PE, TE> {
 
   teardown(
     id: string,
-    run: (value: T) => Promise<Result<void, TE>>
+    run: (value: T) => Promise<Result<void, TE>>,
+    options: TeardownOptions = {}
   ): Promise<Result<void, TE>> | null {
     const inFlight = this._tearingDown.get(id);
     if (inFlight) return inFlight;
@@ -108,17 +114,23 @@ export class LifecycleMap<T, PE, TE> {
     if (value === undefined) return null;
 
     const promise = (async () => {
+      let success = false;
       try {
         await this._hooks.preTeardown?.(id, value);
         const result = await run(value);
-        if (!result.success) {
-          this._teardownErrors.set(id, result.error);
+        if (result.success) {
+          success = true;
+          this._teardownErrors.delete(id);
+          return ok<void>();
         }
-        return result.success ? ok<void>() : err(result.error);
+        this._teardownErrors.set(id, result.error);
+        return err(result.error);
       } finally {
-        this._active.delete(id);
         this._tearingDown.delete(id);
-        await this._hooks.postTeardown?.(id, value);
+        if (success || !options.retainOnFailure) {
+          this._active.delete(id);
+          await this._hooks.postTeardown?.(id, value);
+        }
       }
     })();
 


### PR DESCRIPTION
### Description

Replace the full base64url PTY identifier in tmux session names with a short, recognizable `emdash-<workspace>-<token>` name. The full project/task/leaf identity now lives in tmux user options, so reconciliation and cleanup remain lossless without consuming the status bar.

The reader supports both metadata-backed sessions and legacy encoded names, including old tmux versions that cannot expose user options in `list-sessions` formats. Local and SSH creation, attach, stop, reaping, and restart reconciliation all resolve sessions through the persisted identity.

Concurrent starts serialize per identity. The executable regression coverage includes label changes, legacy attach, old-tmux fallbacks, injection-safe arguments, competing creators, stale locks, PID reuse, signal cleanup, multi-cleaner replacement races, and cleanup-owner crashes.

### Related issues

Fixes #2706.

### Testing

- Complete desktop Node project: 280 files / 2012 tests
- Complete main-db project: 26 files / 161 tests
- Complete migrations project: 7 files / 20 tests
- Complete browser project: 3 files / 37 tests (`CI=1 --maxWorkers=1`)
- Complete scripts project: 1 file / 14 tests
- Focused tmux/local/SSH/reconciliation suites: 6 files / 109 tests
- TERM waiter/owner regressions: 15 repeated runs / 30 assertions passed
- `pnpm --filter @emdash/emdash-desktop format:check`
- `pnpm nx lint emdash-desktop`
- `pnpm nx typecheck emdash-desktop`
- `git diff --check`

### Screenshot/Recording (if applicable)

Not applicable; the shorter name is covered through executable tmux stubs because tmux is not installed in the test environment.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed (not applicable; no setup or user workflow changed)
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
