### PR TITLE
fix(chat-ui): center stop button icon

### DIFF
--- a/packages/ui/src/react/components/chat-composer/chat-composer.css.ts
+++ b/packages/ui/src/react/components/chat-composer/chat-composer.css.ts
@@ -273,6 +273,13 @@ export const barMeter = style({ display: 'flex', alignItems: 'center', gap: '0.1
 /** Send button override — fully rounded pill shape. */
 export const sendButtonRound = style({ borderRadius: '9999px' });
 
+export const stopIcon = style({
+  width: '0.5rem',
+  height: '0.5rem',
+  borderRadius: '0.0625rem',
+  backgroundColor: 'currentColor',
+});
+
 // ── Context usage indicator ────────────────────────────────────────────────────
 
 /** Donut SVG container — sized to match other toolbar icons. */

--- a/packages/ui/src/react/components/chat-composer/index.tsx
+++ b/packages/ui/src/react/components/chat-composer/index.tsx
@@ -1,14 +1,6 @@
 import { Button } from '@react/primitives/button';
 import { cx } from '@styles/utilities/cx';
-import {
-  ArrowUp,
-  ChevronRight,
-  CircleAlert,
-  Paperclip,
-  ShieldCheck,
-  Square,
-  X,
-} from 'lucide-react';
+import { ArrowUp, ChevronRight, CircleAlert, Paperclip, ShieldCheck, X } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 import { Combobox } from '@/react/primitives/combobox/combobox';
 import { DropdownMenu } from '@/react/primitives/dropdown-menu';
@@ -1025,7 +1017,7 @@ export function ChatComposer({
                   onClick={onStop}
                   aria-label="Stop generation"
                 >
-                  <Square style={{ width: '0.625rem', height: '0.625rem', fill: 'currentColor' }} />
+                  <span className={styles.stopIcon} aria-hidden="true" />
                 </Button>
               ) : (
                 <Button


### PR DESCRIPTION
### Description

Centers the stop glyph inside ChatUI's circular destructive button. The Lucide outline icon rasterized off-center at this small size, so the composer now renders a fixed 8 × 8 px rounded square that the button's flex layout centers exactly.

### Related issues

[ENG-1881](https://linear.app/general-action/issue/ENG-1881/stop-button-in-chatui-is-not-centered)


### Screenshot/Recording (if applicable)
<img width="96" height="55" alt="image" src="https://github.com/user-attachments/assets/c90322fc-1598-4112-a687-ebeb3e3d4aa6" />

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks and documented the unrelated failing test
- [x] Docs are unchanged because this is a visual bug fix with no behavior or setup changes
- [x] The visual regression was verified in Storybook with Playwright geometry measurements
- [x] I only added comments where the logic is not obvious
- [x] I used a Conventional Commit and PR title

</details>