### PR TITLE
fix(automations): make sidebar close button clickable

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/automations/components/AutomationsView.tsx
+++ b/apps/emdash-desktop/src/renderer/features/automations/components/AutomationsView.tsx
@@ -111,7 +111,7 @@ export function AutomationsView() {
         onOpenChange={(open) => !open && closeSheet()}
         onOpenChangeComplete={handleSheetOpenChangeComplete}
       >
-        <SheetContent showCloseButton={false}>
+        <SheetContent showCloseButton={false} className="[-webkit-app-region:no-drag]">
           {creating && (
             <CreateAutomationView
               onClose={closeSheet}


### PR DESCRIPTION
### Description

Marks the automations detail sheet as an Electron `no-drag` region so the title-area drag handle no longer intercepts clicks on the sidebar's close button.

### Related issues

[ENG-1889](https://linear.app/general-action/issue/ENG-1889/the-x-for-closing-the-automations-sidebar-doesnt-work)

### Screenshot/Recording (if applicable)

https://cap.link/2rm2zzsnm5xea2s

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] Docs are not affected by this behavior fix
- [x] I explained why an automated regression test is not applicable
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for the commit message and PR title

</details>