### PR TITLE
ENG-1711: Add sort options to project task page

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/projects/components/task-view/task-list.tsx
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/task-view/task-list.tsx
@@ -5,7 +5,10 @@ import { observer } from 'mobx-react-lite';
 import { useRef } from 'react';
 import { asMounted, getProjectStore } from '@renderer/features/projects/stores/project-selectors';
 import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
-import { getTaskManagerStore } from '@renderer/features/tasks/stores/task-selectors';
+import {
+  getTaskManagerStore,
+  taskAgentStatus,
+} from '@renderer/features/tasks/stores/task-selectors';
 import { ListPopoverCard } from '@renderer/lib/components/list-popover-card';
 import {
   getEffectiveHotkey,
@@ -17,11 +20,63 @@ import { modalStore } from '@renderer/lib/modal/modal-store';
 import { Button } from '@renderer/lib/ui/button';
 import { EmptyState } from '@renderer/lib/ui/empty-state';
 import { SearchInput } from '@renderer/lib/ui/search-input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@renderer/lib/ui/select';
 import { BoundShortcut } from '@renderer/lib/ui/shortcut';
 import { ToggleGroup, ToggleGroupItem } from '@renderer/lib/ui/toggle-group';
 import { cn } from '@renderer/utils/utils';
+import { selectCurrentPr } from '@shared/core/pull-requests/pull-requests';
+import type { ProjectTaskSortBy } from '@shared/view-state';
 import { TaskListEmptyState } from './task-list-empty-state';
 import { TaskRow, type ReadyTask } from './task-row';
+
+const SORT_OPTIONS: { value: ProjectTaskSortBy; label: string }[] = [
+  { value: 'updated-at', label: 'Last used' },
+  { value: 'created-at', label: 'Created at' },
+  { value: 'pr-status', label: 'PR status' },
+  { value: 'unread', label: 'Unread first' },
+];
+
+function latestInstant(task: ReadyTask) {
+  return task.data.lastInteractedAt ?? task.data.updatedAt;
+}
+
+function prStatusRank(task: ReadyTask) {
+  const pr = selectCurrentPr(task.data.prs);
+  if (!pr) return 4;
+  if (pr.status === 'merged') return 0;
+  if (pr.status === 'open' && !pr.isDraft) return 1;
+  if (pr.status === 'closed') return 2;
+  return 3;
+}
+
+function isUnread(task: ReadyTask) {
+  const status = taskAgentStatus(task);
+  return status === 'awaiting-input' || status === 'error' || status === 'completed';
+}
+
+function sortTasks(tasks: ReadyTask[], sortBy: ProjectTaskSortBy) {
+  return [...tasks].sort((a, b) => {
+    let comparison = 0;
+    if (sortBy === 'created-at') {
+      comparison = b.data.createdAt.localeCompare(a.data.createdAt);
+    } else if (sortBy === 'pr-status') {
+      comparison = prStatusRank(a) - prStatusRank(b);
+    } else if (sortBy === 'unread') {
+      comparison = Number(isUnread(b)) - Number(isUnread(a));
+    }
+
+    if (comparison !== 0) return comparison;
+
+    const latestComparison = latestInstant(b).localeCompare(latestInstant(a));
+    return latestComparison || a.data.id.localeCompare(b.data.id);
+  });
+}
 
 function TaskVirtualList({
   tasks,
@@ -205,7 +260,10 @@ export const TaskList = observer(function TaskList() {
 
   if (!taskView) return null;
 
-  const displayTasks = taskView.tab === 'active' ? activeTasks : archivedTasks;
+  const displayTasks = sortTasks(
+    taskView.tab === 'active' ? activeTasks : archivedTasks,
+    taskView.sortBy
+  );
   const q = taskView.searchQuery.trim().toLowerCase();
   const filteredTasks = q
     ? displayTasks.filter((t) => t.data.name.toLowerCase().includes(q))
@@ -236,6 +294,29 @@ export const TaskList = observer(function TaskList() {
               Create Task <BoundShortcut settingsKey="newTask" variant="keycaps" />
             </Button>
           </div>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="text-sm text-foreground-passive">Sort</span>
+          <Select
+            value={taskView.sortBy}
+            onValueChange={(value) => taskView.setSortBy(value as ProjectTaskSortBy)}
+          >
+            <SelectTrigger
+              size="sm"
+              className="w-auto gap-1 border-none p-0 text-foreground-muted hover:text-foreground"
+            >
+              <SelectValue>
+                {SORT_OPTIONS.find(({ value }) => value === taskView.sortBy)?.label}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent align="start" alignItemWithTrigger={false}>
+              {SORT_OPTIONS.map(({ value, label }) => (
+                <SelectItem key={value} value={value}>
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
       </div>
 

--- a/apps/emdash-desktop/src/renderer/features/projects/stores/project-view.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/stores/project-view.test.ts
@@ -14,3 +14,17 @@ describe('TaskViewStore range selection', () => {
     expect(store.lastSelectedId).toBe('1');
   });
 });
+
+describe('ProjectViewStore snapshots', () => {
+  it('persists and restores the task sort option', () => {
+    const store = new ProjectViewStore();
+    store.taskView.setSortBy('pr-status');
+
+    expect(store.snapshot.taskSortBy).toBe('pr-status');
+
+    const restored = new ProjectViewStore();
+    restored.restoreSnapshot(store.snapshot);
+
+    expect(restored.taskView.sortBy).toBe('pr-status');
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/projects/stores/project-view.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/stores/project-view.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { ProjectViewSnapshot } from '@shared/view-state';
 import { ProjectViewStore } from './project-view';
 
 describe('TaskViewStore range selection', () => {
@@ -26,5 +27,14 @@ describe('ProjectViewStore snapshots', () => {
     restored.restoreSnapshot(store.snapshot);
 
     expect(restored.taskView.sortBy).toBe('pr-status');
+  });
+
+  it('keeps the default task sort for an unknown persisted value', () => {
+    const store = new ProjectViewStore();
+    const snapshot = JSON.parse('{"taskSortBy":"future-sort"}') as Partial<ProjectViewSnapshot>;
+
+    store.restoreSnapshot(snapshot);
+
+    expect(store.taskView.sortBy).toBe('updated-at');
   });
 });

--- a/apps/emdash-desktop/src/renderer/features/projects/stores/project-view.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/stores/project-view.ts
@@ -1,7 +1,7 @@
 import { makeAutoObservable } from 'mobx';
 import type { Snapshottable } from '@renderer/lib/stores/snapshottable';
 import type { IssueProviderType } from '@shared/issue-providers';
-import type { ProjectViewSnapshot } from '@shared/view-state';
+import type { ProjectTaskSortBy, ProjectViewSnapshot } from '@shared/view-state';
 
 export type ProjectView = 'tasks' | 'pull-request' | 'settings';
 
@@ -26,6 +26,7 @@ export class ProjectViewStore implements Snapshottable<ProjectViewSnapshot> {
     return {
       activeView: this.activeView,
       taskViewTab: this.taskView.tab,
+      taskSortBy: this.taskView.sortBy,
       selectedIssueProvider: this.selectedIssueProvider ?? undefined,
     };
   }
@@ -33,6 +34,7 @@ export class ProjectViewStore implements Snapshottable<ProjectViewSnapshot> {
   restoreSnapshot(snapshot: Partial<ProjectViewSnapshot>): void {
     if (snapshot.activeView) this.activeView = snapshot.activeView as ProjectView;
     if (snapshot.taskViewTab) this.taskView.setTab(snapshot.taskViewTab);
+    if (snapshot.taskSortBy) this.taskView.setSortBy(snapshot.taskSortBy);
     if (snapshot.selectedIssueProvider)
       this.selectedIssueProvider = snapshot.selectedIssueProvider as IssueProviderType;
   }
@@ -40,6 +42,7 @@ export class ProjectViewStore implements Snapshottable<ProjectViewSnapshot> {
 
 class TaskViewStore {
   tab: 'active' | 'archived' = 'active';
+  sortBy: ProjectTaskSortBy = 'updated-at';
   searchQuery: string = '';
   selectedIds: Set<string> = new Set();
   lastSelectedId: string | null = null;
@@ -50,6 +53,10 @@ class TaskViewStore {
 
   setTab(tab: 'active' | 'archived') {
     this.tab = tab;
+  }
+
+  setSortBy(sortBy: ProjectTaskSortBy) {
+    this.sortBy = sortBy;
   }
 
   setSearchQuery(query: string) {

--- a/apps/emdash-desktop/src/renderer/features/projects/stores/project-view.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/stores/project-view.ts
@@ -5,6 +5,12 @@ import type { ProjectTaskSortBy, ProjectViewSnapshot } from '@shared/view-state'
 
 export type ProjectView = 'tasks' | 'pull-request' | 'settings';
 
+function isProjectTaskSortBy(value: unknown): value is ProjectTaskSortBy {
+  return (
+    value === 'created-at' || value === 'updated-at' || value === 'pr-status' || value === 'unread'
+  );
+}
+
 export class ProjectViewStore implements Snapshottable<ProjectViewSnapshot> {
   activeView: ProjectView = 'tasks';
   taskView: TaskViewStore = new TaskViewStore();
@@ -34,7 +40,7 @@ export class ProjectViewStore implements Snapshottable<ProjectViewSnapshot> {
   restoreSnapshot(snapshot: Partial<ProjectViewSnapshot>): void {
     if (snapshot.activeView) this.activeView = snapshot.activeView as ProjectView;
     if (snapshot.taskViewTab) this.taskView.setTab(snapshot.taskViewTab);
-    if (snapshot.taskSortBy) this.taskView.setSortBy(snapshot.taskSortBy);
+    if (isProjectTaskSortBy(snapshot.taskSortBy)) this.taskView.setSortBy(snapshot.taskSortBy);
     if (snapshot.selectedIssueProvider)
       this.selectedIssueProvider = snapshot.selectedIssueProvider as IssueProviderType;
   }

--- a/apps/emdash-desktop/src/renderer/features/projects/stores/project.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/stores/project.ts
@@ -36,6 +36,7 @@ export class MountedProject {
     return {
       activeView: this.view.activeView,
       taskViewTab: this.view.taskView.tab,
+      taskSortBy: this.view.taskView.sortBy,
     };
   }
 

--- a/apps/emdash-desktop/src/shared/view-state.ts
+++ b/apps/emdash-desktop/src/shared/view-state.ts
@@ -113,9 +113,12 @@ export type TaskViewSnapshot = {
   diffView?: DiffViewSnapshot;
 };
 
+export type ProjectTaskSortBy = 'created-at' | 'updated-at' | 'pr-status' | 'unread';
+
 export type ProjectViewSnapshot = {
   activeView: string;
   taskViewTab: 'active' | 'archived';
+  taskSortBy?: ProjectTaskSortBy;
   selectedIssueProvider?: string;
 };
 


### PR DESCRIPTION
## Summary

- add Last used, Created at, PR status, and Unread first sorting to project task pages
- persist the selected sort per project
- reuse existing task activity and pull request state for ordering
- keep the control consistent with the existing project page UI

## Demo

https://cap.link/evstgv5b4epe7x9

Linear: ENG-1711