### PR TITLE
feat(chat): make font size adjustable

### DIFF
--- a/apps/emdash-desktop/src/main/core/settings/schema.test.ts
+++ b/apps/emdash-desktop/src/main/core/settings/schema.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { CHAT_FONT_SIZE_DEFAULT } from '@shared/core/chat-settings';
+import { interfaceSettingsSchema } from './schema';
+
+describe('interfaceSettingsSchema', () => {
+  it('defaults chatFontSize for legacy persisted settings', () => {
+    const legacySettings = {
+      taskHoverAction: 'delete',
+      autoRightSidebarBehavior: false,
+      showLeftSidebarLineChanges: true,
+      showLeftSidebarPrStatus: true,
+      showLeftSidebarTimestamps: true,
+      hideContextBar: false,
+    };
+
+    expect(interfaceSettingsSchema.parse(legacySettings)).toEqual({
+      ...legacySettings,
+      chatFontSize: CHAT_FONT_SIZE_DEFAULT,
+    });
+  });
+});

--- a/apps/emdash-desktop/src/main/core/settings/schema.ts
+++ b/apps/emdash-desktop/src/main/core/settings/schema.ts
@@ -1,7 +1,11 @@
 import type { AgentProviderId } from '@emdash/plugins/agents';
 import z from 'zod';
 import { BROWSER_ISOLATED_PROFILE_ID } from '@shared/browser';
-import { CHAT_FONT_SIZE_MAX, CHAT_FONT_SIZE_MIN } from '@shared/core/chat-settings';
+import {
+  CHAT_FONT_SIZE_DEFAULT,
+  CHAT_FONT_SIZE_MAX,
+  CHAT_FONT_SIZE_MIN,
+} from '@shared/core/chat-settings';
 import {
   TERMINAL_FONT_SIZE_MAX,
   TERMINAL_FONT_SIZE_MIN,
@@ -93,7 +97,12 @@ export const interfaceSettingsSchema = z.object({
   showLeftSidebarPrStatus: z.boolean(),
   showLeftSidebarTimestamps: z.boolean(),
   hideContextBar: z.boolean(),
-  chatFontSize: z.number().int().min(CHAT_FONT_SIZE_MIN).max(CHAT_FONT_SIZE_MAX),
+  chatFontSize: z
+    .number()
+    .int()
+    .min(CHAT_FONT_SIZE_MIN)
+    .max(CHAT_FONT_SIZE_MAX)
+    .default(CHAT_FONT_SIZE_DEFAULT),
 });
 
 export const changesViewModeSchema = z.object({

--- a/apps/emdash-desktop/src/main/core/settings/schema.ts
+++ b/apps/emdash-desktop/src/main/core/settings/schema.ts
@@ -1,6 +1,7 @@
 import type { AgentProviderId } from '@emdash/plugins/agents';
 import z from 'zod';
 import { BROWSER_ISOLATED_PROFILE_ID } from '@shared/browser';
+import { CHAT_FONT_SIZE_MAX, CHAT_FONT_SIZE_MIN } from '@shared/core/chat-settings';
 import {
   TERMINAL_FONT_SIZE_MAX,
   TERMINAL_FONT_SIZE_MIN,
@@ -92,6 +93,7 @@ export const interfaceSettingsSchema = z.object({
   showLeftSidebarPrStatus: z.boolean(),
   showLeftSidebarTimestamps: z.boolean(),
   hideContextBar: z.boolean(),
+  chatFontSize: z.number().int().min(CHAT_FONT_SIZE_MIN).max(CHAT_FONT_SIZE_MAX),
 });
 
 export const changesViewModeSchema = z.object({

--- a/apps/emdash-desktop/src/main/core/settings/settings-registry.ts
+++ b/apps/emdash-desktop/src/main/core/settings/settings-registry.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { asAgentProviderId } from '@emdash/plugins/agents/types';
 import { DEFAULT_BROWSER_PROFILE_ID, DEFAULT_BROWSER_PROFILES } from '@shared/browser';
 import type { AppSettings, AppSettingsKey } from '@shared/core/app-settings';
+import { CHAT_FONT_SIZE_DEFAULT } from '@shared/core/chat-settings';
 import { TERMINAL_FONT_SIZE_DEFAULT } from '@shared/core/terminals/terminal-settings';
 import type { OpenInAppId } from '@shared/openInApps';
 import { getDefaultLocalWorktreeDirectory } from './worktree-defaults';
@@ -61,6 +62,7 @@ export const SETTINGS_DEFAULTS = {
     showLeftSidebarPrStatus: true,
     showLeftSidebarTimestamps: true,
     hideContextBar: false,
+    chatFontSize: CHAT_FONT_SIZE_DEFAULT,
   },
   browserPreview: {
     enabled: true,

--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-panel.tsx
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-panel.tsx
@@ -22,6 +22,7 @@ import {
   getProjectStore,
   getProjectViewStore,
 } from '@renderer/features/projects/stores/project-selectors';
+import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
 import { usePaneContext } from '@renderer/features/tabs/pane-context';
 // TODO(conversations-extraction): Inject task editor/file-opening behavior into ACP chat.
 import {
@@ -40,6 +41,7 @@ import {
 } from '@renderer/lib/chat/chat-mention-provider';
 import { ChatTranscript } from '@renderer/lib/chat/chat-transcript';
 import type { ChatCommands, ChatView } from '@renderer/lib/chat/chat-transcript';
+import { setSharedChatFontSize } from '@renderer/lib/chat/shared-chat-context';
 import { AgentIcon } from '@renderer/lib/components/agent-icon';
 import { toast } from '@renderer/lib/hooks/use-toast';
 import { rpc } from '@renderer/lib/ipc';
@@ -48,6 +50,7 @@ import { isHeicLikeFile, isUnstableDropPath } from '@renderer/lib/pty/terminal-i
 import { useAgents } from '@renderer/lib/stores/use-agents';
 import { Button } from '@renderer/lib/ui/button';
 import { log } from '@renderer/utils/logger';
+import { CHAT_FONT_SIZE_DEFAULT } from '@shared/core/chat-settings';
 import { linkedIssueMentionName, type LinkedIssue } from '@shared/core/linked-issue';
 import type { AcpChatStore, AcpPromptAttachment } from './acp-chat-store';
 import type { AcpChatTabResource } from './acp-chat-tab-resource';
@@ -225,10 +228,12 @@ const ComposerForStore = observer(function ComposerForStore({
   store,
   composerSlot,
   onViewerOpen,
+  fontSize,
 }: {
   store: AcpChatStore;
   composerSlot: HTMLElement;
   onViewerOpen: (src?: string, alt?: string) => void;
+  fontSize: number;
 }) {
   const editorApiRef = useRef<PromptEditorRef | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -582,6 +587,7 @@ const ComposerForStore = observer(function ComposerForStore({
     <>
       <input ref={fileInputRef} type="file" multiple hidden onChange={handleFileInputChange} />
       <ChatComposer
+        fontSize={fontSize}
         isWorking={a.isWorking}
         canSubmit={a.canSubmit}
         onSubmit={handleSubmit}
@@ -646,6 +652,12 @@ const ComposerForStore = observer(function ComposerForStore({
 
 export const AcpChatPanel = observer(function AcpChatPanel() {
   const { pane } = usePaneContext();
+  const { value: interfaceSettings } = useAppSettingsKey('interface');
+  const chatFontSize = interfaceSettings?.chatFontSize ?? CHAT_FONT_SIZE_DEFAULT;
+
+  useEffect(() => {
+    setSharedChatFontSize(chatFontSize);
+  }, [chatFontSize]);
 
   const activeTab = pane.resolvedTabs.find((t) => t.isActive && t.kind === 'acp-chat');
   const store = activeTab ? (activeTab.resource as AcpChatTabResource).store : null;
@@ -894,6 +906,7 @@ export const AcpChatPanel = observer(function AcpChatPanel() {
           store={store}
           composerSlot={composerSlot}
           onViewerOpen={handleViewerOpen}
+          fontSize={chatFontSize}
         />
       )}
 

--- a/apps/emdash-desktop/src/renderer/features/settings/components/TerminalSettingsCard.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/TerminalSettingsCard.tsx
@@ -327,7 +327,7 @@ const TerminalSettingsCard: React.FC = () => {
         title="Terminal font size"
         description="Adjust the font size used by terminal sessions and CLI agents."
         control={
-          <div className="flex h-9 w-[183px] flex-shrink-0 items-center justify-between rounded-md border border-border bg-background px-1 shadow-xs">
+          <div className="flex h-9 w-[183px] flex-shrink-0 items-center justify-between rounded-md border border-border bg-background px-1 shadow-xs select-none">
             <Button
               type="button"
               variant="ghost"
@@ -359,7 +359,7 @@ const TerminalSettingsCard: React.FC = () => {
         title="Chat font size"
         description="Zoom chat messages and the composer text in or out."
         control={
-          <div className="flex h-9 w-[183px] flex-shrink-0 items-center justify-between rounded-md border border-border bg-background px-1 shadow-xs">
+          <div className="flex h-9 w-[183px] flex-shrink-0 items-center justify-between rounded-md border border-border bg-background px-1 shadow-xs select-none">
             <Button
               type="button"
               variant="ghost"

--- a/apps/emdash-desktop/src/renderer/features/settings/components/TerminalSettingsCard.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/TerminalSettingsCard.tsx
@@ -1,7 +1,10 @@
 import { detectPlatform } from '@tanstack/react-hotkeys';
-import { ChevronsUpDownIcon, LoaderCircle, Minus, Plus } from 'lucide-react';
-import React, { useCallback, useMemo, useState } from 'react';
-import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
+import { ChevronsUpDownIcon, LoaderCircle, Minus, Plus, RotateCcw } from 'lucide-react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import {
+  getAppSettingValueSnapshot,
+  useAppSettingsKey,
+} from '@renderer/features/settings/use-app-settings-key';
 import { useInstalledFonts } from '@renderer/features/settings/use-installed-fonts';
 import { TerminalShellOptionLabel } from '@renderer/lib/components/terminal-shell-option-label';
 import {
@@ -75,6 +78,9 @@ const DEFAULT_OPTION: FontOption = {
 const clampFontSize = (size: number) =>
   Math.min(TERMINAL_FONT_SIZE_MAX, Math.max(TERMINAL_FONT_SIZE_MIN, size));
 
+const clampChatFontSize = (size: number) =>
+  Math.min(CHAT_FONT_SIZE_MAX, Math.max(CHAT_FONT_SIZE_MIN, size));
+
 const isMac = detectPlatform() === 'mac';
 
 const TerminalSettingsCard: React.FC = () => {
@@ -86,7 +92,7 @@ const TerminalSettingsCard: React.FC = () => {
   } = useAppSettingsKey('terminal');
   const {
     value: interfaceSettings,
-    update: updateInterface,
+    updateAsync: updateInterfaceAsync,
     isLoading: interfaceLoading,
     isSaving: interfaceSaving,
   } = useAppSettingsKey('interface');
@@ -99,6 +105,8 @@ const TerminalSettingsCard: React.FC = () => {
   const fontFamily = terminal?.fontFamily ?? '';
   const fontSize = terminal?.fontSize ?? TERMINAL_FONT_SIZE_DEFAULT;
   const chatFontSize = interfaceSettings?.chatFontSize ?? CHAT_FONT_SIZE_DEFAULT;
+  const pendingChatFontSizeRef = useRef<number | null>(null);
+  const chatFontSizeUpdateQueueRef = useRef(Promise.resolve());
   const autoCopyOnSelection = terminal?.autoCopyOnSelection ?? false;
   const macOptionIsMeta = terminal?.macOptionIsMeta ?? false;
   const defaultShell = terminal?.defaultShell ?? 'system';
@@ -177,6 +185,28 @@ const TerminalSettingsCard: React.FC = () => {
       );
     },
     [update]
+  );
+
+  const applyChatFontSize = useCallback(
+    (next: number) => {
+      const normalized = clampChatFontSize(next);
+      pendingChatFontSizeRef.current = normalized;
+      chatFontSizeUpdateQueueRef.current = chatFontSizeUpdateQueueRef.current
+        .then(() => updateInterfaceAsync({ chatFontSize: normalized }))
+        .catch(() => undefined);
+    },
+    [updateInterfaceAsync]
+  );
+
+  const adjustChatFontSize = useCallback(
+    (delta: number) => {
+      const latest =
+        pendingChatFontSizeRef.current ??
+        getAppSettingValueSnapshot('interface')?.chatFontSize ??
+        CHAT_FONT_SIZE_DEFAULT;
+      applyChatFontSize(latest + delta);
+    },
+    [applyChatFontSize]
   );
 
   const toggleAutoCopy = useCallback(
@@ -365,7 +395,7 @@ const TerminalSettingsCard: React.FC = () => {
               variant="ghost"
               size="icon-xs"
               disabled={interfaceLoading || interfaceSaving || chatFontSize <= CHAT_FONT_SIZE_MIN}
-              onClick={() => updateInterface({ chatFontSize: chatFontSize - 1 })}
+              onClick={() => adjustChatFontSize(-1)}
               aria-label="Zoom chat text out"
             >
               <Minus />
@@ -379,10 +409,22 @@ const TerminalSettingsCard: React.FC = () => {
               variant="ghost"
               size="icon-xs"
               disabled={interfaceLoading || interfaceSaving || chatFontSize >= CHAT_FONT_SIZE_MAX}
-              onClick={() => updateInterface({ chatFontSize: chatFontSize + 1 })}
+              onClick={() => adjustChatFontSize(1)}
               aria-label="Zoom chat text in"
             >
               <Plus />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              disabled={
+                interfaceLoading || interfaceSaving || chatFontSize === CHAT_FONT_SIZE_DEFAULT
+              }
+              onClick={() => applyChatFontSize(CHAT_FONT_SIZE_DEFAULT)}
+              aria-label={`Reset chat font size to ${CHAT_FONT_SIZE_DEFAULT} px`}
+            >
+              <RotateCcw />
             </Button>
           </div>
         }

--- a/apps/emdash-desktop/src/renderer/features/settings/components/TerminalSettingsCard.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/TerminalSettingsCard.tsx
@@ -106,6 +106,7 @@ const TerminalSettingsCard: React.FC = () => {
   const fontSize = terminal?.fontSize ?? TERMINAL_FONT_SIZE_DEFAULT;
   const chatFontSize = interfaceSettings?.chatFontSize ?? CHAT_FONT_SIZE_DEFAULT;
   const pendingChatFontSizeRef = useRef<number | null>(null);
+  const chatFontSizeUpdateVersionRef = useRef(0);
   const chatFontSizeUpdateQueueRef = useRef(Promise.resolve());
   const autoCopyOnSelection = terminal?.autoCopyOnSelection ?? false;
   const macOptionIsMeta = terminal?.macOptionIsMeta ?? false;
@@ -190,9 +191,15 @@ const TerminalSettingsCard: React.FC = () => {
   const applyChatFontSize = useCallback(
     (next: number) => {
       const normalized = clampChatFontSize(next);
+      const updateVersion = ++chatFontSizeUpdateVersionRef.current;
       pendingChatFontSizeRef.current = normalized;
       chatFontSizeUpdateQueueRef.current = chatFontSizeUpdateQueueRef.current
         .then(() => updateInterfaceAsync({ chatFontSize: normalized }))
+        .finally(() => {
+          if (updateVersion === chatFontSizeUpdateVersionRef.current) {
+            pendingChatFontSizeRef.current = null;
+          }
+        })
         .catch(() => undefined);
     },
     [updateInterfaceAsync]

--- a/apps/emdash-desktop/src/renderer/features/settings/components/TerminalSettingsCard.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/TerminalSettingsCard.tsx
@@ -31,6 +31,11 @@ import {
 } from '@renderer/lib/ui/select';
 import { Switch } from '@renderer/lib/ui/switch';
 import {
+  CHAT_FONT_SIZE_DEFAULT,
+  CHAT_FONT_SIZE_MAX,
+  CHAT_FONT_SIZE_MIN,
+} from '@shared/core/chat-settings';
+import {
   TERMINAL_FONT_SIZE_DEFAULT,
   TERMINAL_FONT_SIZE_MAX,
   TERMINAL_FONT_SIZE_MIN,
@@ -79,6 +84,12 @@ const TerminalSettingsCard: React.FC = () => {
     isLoading: loading,
     isSaving: saving,
   } = useAppSettingsKey('terminal');
+  const {
+    value: interfaceSettings,
+    update: updateInterface,
+    isLoading: interfaceLoading,
+    isSaving: interfaceSaving,
+  } = useAppSettingsKey('interface');
   const [pickerOpen, setPickerOpen] = useState<boolean>(false);
   const [query, setQuery] = useState<string>('');
   const { fonts: installedFonts, isLoading: loadingFonts } = useInstalledFonts();
@@ -87,6 +98,7 @@ const TerminalSettingsCard: React.FC = () => {
 
   const fontFamily = terminal?.fontFamily ?? '';
   const fontSize = terminal?.fontSize ?? TERMINAL_FONT_SIZE_DEFAULT;
+  const chatFontSize = interfaceSettings?.chatFontSize ?? CHAT_FONT_SIZE_DEFAULT;
   const autoCopyOnSelection = terminal?.autoCopyOnSelection ?? false;
   const macOptionIsMeta = terminal?.macOptionIsMeta ?? false;
   const defaultShell = terminal?.defaultShell ?? 'system';
@@ -337,6 +349,38 @@ const TerminalSettingsCard: React.FC = () => {
               disabled={loading || saving || fontSize >= TERMINAL_FONT_SIZE_MAX}
               onClick={() => applyFontSize(fontSize + 1)}
               aria-label="Increase terminal font size"
+            >
+              <Plus />
+            </Button>
+          </div>
+        }
+      />
+      <SettingRow
+        title="Chat font size"
+        description="Zoom chat messages and the composer text in or out."
+        control={
+          <div className="flex h-9 w-[183px] flex-shrink-0 items-center justify-between rounded-md border border-border bg-background px-1 shadow-xs">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              disabled={interfaceLoading || interfaceSaving || chatFontSize <= CHAT_FONT_SIZE_MIN}
+              onClick={() => updateInterface({ chatFontSize: chatFontSize - 1 })}
+              aria-label="Zoom chat text out"
+            >
+              <Minus />
+            </Button>
+            <div className="flex min-w-14 items-baseline justify-center gap-1 text-sm text-foreground tabular-nums">
+              <span>{chatFontSize}</span>
+              <span className="text-muted-foreground text-xs">px</span>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              disabled={interfaceLoading || interfaceSaving || chatFontSize >= CHAT_FONT_SIZE_MAX}
+              onClick={() => updateInterface({ chatFontSize: chatFontSize + 1 })}
+              aria-label="Zoom chat text in"
             >
               <Plus />
             </Button>

--- a/apps/emdash-desktop/src/renderer/lib/chat/shared-chat-context.ts
+++ b/apps/emdash-desktop/src/renderer/lib/chat/shared-chat-context.ts
@@ -1,10 +1,18 @@
-import { createChatContext, type ChatContext } from '@emdash/chat-ui';
+import {
+  createChatContext,
+  DEFAULT_CONFIG,
+  type ChatConfig,
+  type ChatContext,
+  type RoleName,
+} from '@emdash/chat-ui';
 import { rpc } from '@renderer/lib/ipc';
+import { CHAT_FONT_SIZE_DEFAULT } from '@shared/core/chat-settings';
 import { advertisedCommandProvider } from './advertised-command-provider';
 import { chatMentionProvider, registerIssueMentionIcons } from './chat-mention-provider';
 
 let shared: ChatContext | null = null;
 let didPreloadIssueMentionIcons = false;
+let currentFontSize = CHAT_FONT_SIZE_DEFAULT;
 
 /**
  * Create the process-long ChatContext. Call once from the renderer bootstrap
@@ -31,6 +39,27 @@ export function initSharedChatContext(): ChatContext {
  */
 export function getSharedChatContext(): ChatContext {
   return shared ?? initSharedChatContext();
+}
+
+export function setSharedChatFontSize(fontSize: number): void {
+  if (fontSize === currentFontSize) return;
+  currentFontSize = fontSize;
+
+  const roles: ChatConfig['roles'] = { ...DEFAULT_CONFIG.roles };
+  const sizeDelta = fontSize - CHAT_FONT_SIZE_DEFAULT;
+  for (const name of Object.keys(roles) as RoleName[]) {
+    const role = roles[name];
+    roles[name] = {
+      ...role,
+      size: role.size + sizeDelta,
+      lineHeight: role.lineHeight + sizeDelta,
+    };
+  }
+
+  getSharedChatContext().setConfig({
+    ...DEFAULT_CONFIG,
+    roles,
+  });
 }
 
 function preloadIssueMentionIcons(): void {

--- a/apps/emdash-desktop/src/shared/core/chat-settings.ts
+++ b/apps/emdash-desktop/src/shared/core/chat-settings.ts
@@ -1,0 +1,3 @@
+export const CHAT_FONT_SIZE_DEFAULT = 14;
+export const CHAT_FONT_SIZE_MIN = 10;
+export const CHAT_FONT_SIZE_MAX = 24;

--- a/packages/chat-ui/src/ChatRoot.tsx
+++ b/packages/chat-ui/src/ChatRoot.tsx
@@ -294,19 +294,17 @@ export function ChatRoot(props: ChatRootProps) {
     ...state().parseCaches,
   }));
 
-  // Theme and CSS vars — set once at creation time. Color theme changes are
-  // free (CSS-variable themed). Typography changes require bumping measureEpoch.
-  const resolved = props.context.theme;
-  const scrollElStyle = (() => {
-    const tv = resolved.themeVars;
+  // Theme and CSS vars update reactively when the host changes typography.
+  const theme = () => props.context.theme;
+  const scrollElStyle = createMemo(() => {
+    const tv = theme().themeVars;
     const style: Record<string, string> = {};
     for (const k of Object.keys(tv) as ThemeVarKey[]) {
       const ref = String(vars[k as keyof typeof vars]);
       style[ref.startsWith('var(') ? ref.slice(4, -1) : ref] = tv[k];
     }
     return style;
-  })();
-  const theme = () => resolved;
+  });
   const contentClass = () => props.contentClass ?? DEFAULT_CONTENT_CLASS;
   const commands = () => props.commands?.() ?? {};
   const [composerPlacement, setComposerPlacementSignal] = createSignal<ComposerPlacement>(
@@ -652,9 +650,13 @@ export function ChatRoot(props: ChatRootProps) {
   let lastVisibleEnd = -1;
 
   // ── Count sync effect ─────────────────────────────────────────────────────
+  let previousMeasureEpoch = untrack(measureEpoch);
   createEffect(() => {
     const us = units();
     const t = theme();
+    const currentMeasureEpoch = measureEpoch();
+    const typographyChanged = currentMeasureEpoch !== previousMeasureEpoch;
+    previousMeasureEpoch = currentMeasureEpoch;
     untrack(() => {
       const estimateCtx = {
         theme: t,
@@ -668,8 +670,8 @@ export function ChatRoot(props: ChatRootProps) {
       // lastWidth > 0 iff onCleanup wrote a snapshot on a prior dispose.
       // Skip the Map.get pass entirely on cold mounts (empty heightmap).
       const currentState = state();
-      const hasHeightmapSnapshot = currentState.heightmap.lastWidth > 0;
-      virt.setCount(us.length, (i) => {
+      const hasHeightmapSnapshot = !typographyChanged && currentState.heightmap.lastWidth > 0;
+      const estimateUnit = (i: number) => {
         const u = us.at(i);
         if (!u) return 60;
         // Use the persisted measured height if available (avoids scrollbar drift
@@ -685,7 +687,14 @@ export function ChatRoot(props: ChatRootProps) {
           unitDef?.estimate?.(u.data, estimateCtx, unitDef.vars ?? {}) ??
           genericEstimate(u.data as unknown as ChatItem, estimateCtx);
         return unitReservedHeight(u, contentH);
-      });
+      };
+      virt.setCount(us.length, estimateUnit);
+      if (typographyChanged) {
+        currentState.heightmap.lastWidth = 0;
+        for (let i = 0; i < us.length; i++) {
+          virt.setSize(i, estimateUnit(i));
+        }
+      }
       refreshTotal();
       // Defer projection to the write phase: projectAnchor will fire once per
       // frame (not once per row) preventing layout thrashing on streaming updates.
@@ -1670,7 +1679,7 @@ export function ChatRoot(props: ChatRootProps) {
                   }}
                   data-chat-scroll
                   class={`${scrollContainer}${props.class ? ` ${props.class}` : ''}`}
-                  style={scrollElStyle}
+                  style={scrollElStyle()}
                 >
                   {/* Zero-height probe: same max-width cap as rows; the width
                       ResizeObserver targets this to isolate layout-width changes

--- a/packages/chat-ui/src/chat-context.ts
+++ b/packages/chat-ui/src/chat-context.ts
@@ -16,7 +16,7 @@
  *   const view  = createChatView({ context: ctx, state, parent });
  */
 
-import { createRoot, createSignal } from 'solid-js';
+import { batch, createRoot, createSignal } from 'solid-js';
 import type { SharedCaches } from './core/caches';
 import { createSharedCaches } from './core/caches';
 import type { ChatConfig } from './core/config';
@@ -73,6 +73,8 @@ export type ChatContext = {
    * when fonts load or theme typography changes.
    */
   readonly measureEpoch: () => number;
+  /** Update typography and chip geometry across every mounted chat view. */
+  setConfig(config: ChatConfig): void;
   /**
    * Bump the measurement epoch, invalidating all per-block geometry caches.
    * Call after fonts load (handled automatically) or after a typography change.
@@ -90,16 +92,19 @@ export type ChatContext = {
  * invalidates all block geometry caches.
  */
 export function createChatContext(opts: ChatContextOptions = {}): ChatContext {
-  const config = opts.config ?? DEFAULT_CONFIG;
-  const theme = opts.theme ?? buildChatTheme(config);
+  const initialConfig = opts.config ?? DEFAULT_CONFIG;
+  const initialTheme = opts.theme ?? buildChatTheme(initialConfig);
   const sharedCaches = createSharedCaches(opts.highlighter);
 
+  let theme!: () => ChatTheme;
+  let setTheme!: (theme: ChatTheme) => void;
   let measureEpoch!: () => number;
   let bumpEpoch!: () => void;
   let disposeRoot!: () => void;
 
   createRoot((dispose) => {
     disposeRoot = dispose;
+    [theme, setTheme] = createSignal(initialTheme);
     const [epoch, setEpoch] = createSignal(0);
     measureEpoch = epoch;
     bumpEpoch = () => setEpoch((e) => e + 1);
@@ -114,12 +119,24 @@ export function createChatContext(opts: ChatContextOptions = {}): ChatContext {
   });
 
   return {
-    theme,
-    config,
+    get theme() {
+      return theme();
+    },
+    get config() {
+      return theme().config;
+    },
     mentionProvider: opts.mentionProvider,
     commandProvider: opts.commandProvider,
     sharedCaches,
     measureEpoch,
+    setConfig(config) {
+      const nextTheme = buildChatTheme(config);
+      sharedCaches.clearTextMeasure();
+      batch(() => {
+        setTheme(nextTheme);
+        bumpEpoch();
+      });
+    },
     bumpEpoch,
     dispose() {
       disposed = true;

--- a/packages/chat-ui/src/chat-view.contract.test.tsx
+++ b/packages/chat-ui/src/chat-view.contract.test.tsx
@@ -6,7 +6,7 @@
  * Monaco-style model-swap introduced in the ChatView setModel refactor.
  */
 
-import { DEFAULT_THEME } from '@core/theme';
+import { DEFAULT_CONFIG, DEFAULT_THEME } from '@core/theme';
 import { describe, expect, it } from 'vitest';
 import { createChatContext } from '@/chat-context';
 import { createChatView } from '@/chat-view';
@@ -107,6 +107,38 @@ describe('createChatView', () => {
     const probeRect = probe!.getBoundingClientRect();
     expect(Math.abs(pinRect.left - probeRect.left)).toBeLessThan(1);
     expect(Math.abs(pinRect.width - probeRect.width)).toBeLessThan(1);
+
+    view.dispose();
+    ctx.dispose();
+    state.dispose();
+    document.body.removeChild(host);
+  });
+
+  it('updates rendered typography when the shared config changes', async () => {
+    const ctx = createChatContext();
+    const state = createChatState(ctx);
+    state.transcript.history.seed(generateMockTranscript(10, 12));
+
+    const host = document.createElement('div');
+    host.style.cssText = 'position:fixed;top:0;left:0;width:800px;height:600px;';
+    document.body.appendChild(host);
+
+    const view = createChatView({ context: ctx, state, parent: host });
+    await nextPaint();
+
+    const scrollEl = host.querySelector('[data-chat-scroll]') as HTMLElement;
+    expect(scrollEl.style.getPropertyValue('--chat-type-body-font-size')).toBe('14px');
+
+    ctx.setConfig({
+      ...DEFAULT_CONFIG,
+      roles: {
+        ...DEFAULT_CONFIG.roles,
+        body: { ...DEFAULT_CONFIG.roles.body, size: 18, lineHeight: 24 },
+      },
+    });
+    await nextPaint();
+
+    expect(scrollEl.style.getPropertyValue('--chat-type-body-font-size')).toBe('18px');
 
     view.dispose();
     ctx.dispose();

--- a/packages/ui/src/react/components/chat-composer/index.tsx
+++ b/packages/ui/src/react/components/chat-composer/index.tsx
@@ -177,6 +177,8 @@ export interface ComposerAgentOption {
 export interface ChatComposerProps {
   disabled?: boolean;
   isWorking?: boolean;
+  /** Font size for the editable message text and placeholder. */
+  fontSize?: number;
   /** False while the session is still starting up. Blocks Send/Enter but keeps the editor typeable. */
   canSubmit?: boolean;
   /** Hide the submit/stop control for draft-only composer surfaces. */
@@ -531,6 +533,7 @@ function ComposerAgentSelector({
 export function ChatComposer({
   disabled = false,
   isWorking = false,
+  fontSize,
   canSubmit = true,
   showSubmitButton = true,
   placeholder,
@@ -739,9 +742,11 @@ export function ChatComposer({
     : isWorking
       ? 'Add a follow-up'
       : (placeholder ?? 'Send a message, tag @files or use /commands');
+  const composerStyle: (React.CSSProperties & { '--chat-composer-font-size': string }) | undefined =
+    fontSize === undefined ? undefined : { '--chat-composer-font-size': `${fontSize}px` };
 
   return (
-    <div className={cx(styles.composerRoot, className)}>
+    <div className={cx(styles.composerRoot, className)} style={composerStyle}>
       {canShowQueuedPrompts && (
         <QueuedPromptsBand
           prompts={queuedPrompts}

--- a/packages/ui/src/react/components/prompt-editor/prompt-editor.css.ts
+++ b/packages/ui/src/react/components/prompt-editor/prompt-editor.css.ts
@@ -19,7 +19,7 @@ export const editorPlaceholder = style({
   position: 'absolute',
   top: 0,
   left: 0,
-  fontSize: tokenVars.textSm,
+  fontSize: `var(--chat-composer-font-size, ${tokenVars.textSm})`,
   lineHeight: 1.4,
   userSelect: 'none',
   color: vars.foregroundPassive,
@@ -28,7 +28,7 @@ export const editorPlaceholder = style({
 // These classes are assigned via TipTap editorProps.attributes.class
 export const promptEditorContentClass = style({
   outline: 'none',
-  fontSize: tokenVars.textSm,
+  fontSize: `var(--chat-composer-font-size, ${tokenVars.textSm})`,
   lineHeight: 1.4,
   color: vars.foreground,
   minHeight: '1.25rem',


### PR DESCRIPTION
### Description

Adds a persistent chat font-size setting for the new chat UI. The control lives directly below Terminal font size in Settings and supports decreasing, increasing, and resetting the size between 10 px and 24 px.

Open chat transcripts and the composer update immediately. Transcript measurements and virtualization are refreshed when the font size changes so Markdown, code blocks, and tables continue to lay out correctly.

### Related issues

ENG-1887

### Screenshot/Recording (if applicable)
https://cap.link/7p44td8t675j2jz

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed, or no docs were needed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit message and PR title

</details>