### PR TITLE
fix(chat): avoid clipping agent mode label descenders

### DIFF
--- a/packages/ui/src/react/components/chat-composer/index.tsx
+++ b/packages/ui/src/react/components/chat-composer/index.tsx
@@ -958,7 +958,7 @@ export function ChatComposer({
                       gap: '0.25rem',
                       color: selected ? 'var(--em-foreground)' : 'var(--em-foreground-muted)',
                       fontSize: 'var(--em-text-xs)',
-                      lineHeight: 1,
+                      lineHeight: 1.25,
                     }}
                   >
                     <ShieldCheck style={{ width: '0.75rem', height: '0.75rem', flexShrink: 0 }} />


### PR DESCRIPTION
### Description

Increase the permission-mode trigger's line height so labels with descenders, such as `Agent`, are not clipped at the bottom. This mirrors the existing model-label treatment and keeps the change scoped to the affected trigger.

### Screenshot/Recording (if applicable)

![Agent mode label with fully visible descender](https://ampcode.com/attachments/1dc4f1e6935f6caa196b1d8099c800e9a7abe30cd826e6a8437ed8b650087167.png)

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] Docs are not affected
- [x] A focused visual regression was manually verified; no logic behavior changed
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and the PR title

</details>
