### PR TITLE
fix(watch): prevent watcher resubscribe crashes

### DIFF
--- a/packages/core/src/files/tree/file-tree.test.ts
+++ b/packages/core/src/files/tree/file-tree.test.ts
@@ -3,13 +3,21 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import type { Result } from '@emdash/shared';
 import { afterEach, describe, expect, it } from 'vitest';
-import type { IWatchService, WatchEvent, WatchHandle } from '../../services/fs-watch/api';
+import type {
+  IWatchService,
+  WatchEvent,
+  WatchHandle,
+  WatchOptions,
+} from '../../services/fs-watch/api';
 import { FilesRuntime } from '../files-runtime';
 import { FileTree } from './file-tree';
 import type { FileNode } from './models/tree';
 
 class ManualWatchService implements IWatchService {
-  private consumers: Array<(events: WatchEvent[]) => void> = [];
+  private consumers: Array<{
+    onEvents: (events: WatchEvent[]) => void;
+    onResync?: () => void;
+  }> = [];
   private readyCalls = 0;
   private releaseCalls = 0;
 
@@ -21,20 +29,29 @@ class ManualWatchService implements IWatchService {
     return this.releaseCalls;
   }
 
-  watch(_root: string, onEvents: (events: WatchEvent[]) => void): WatchHandle {
-    this.consumers.push(onEvents);
+  watch(
+    _root: string,
+    onEvents: (events: WatchEvent[]) => void,
+    options: WatchOptions = {}
+  ): WatchHandle {
+    const consumer = { onEvents, onResync: options.onResync };
+    this.consumers.push(consumer);
     this.readyCalls += 1;
     return {
       ready: async () => {},
       release: async () => {
         this.releaseCalls += 1;
-        this.consumers = this.consumers.filter((consumer) => consumer !== onEvents);
+        this.consumers = this.consumers.filter((candidate) => candidate !== consumer);
       },
     };
   }
 
   emit(events: WatchEvent[]): void {
-    for (const consumer of this.consumers) consumer(events);
+    for (const consumer of this.consumers) consumer.onEvents(events);
+  }
+
+  resync(): void {
+    for (const consumer of this.consumers) consumer.onResync?.();
   }
 
   async dispose(): Promise<void> {}
@@ -549,6 +566,45 @@ describe('FileTree', () => {
     patched.refreshRegisteredScopes = originalRefreshLoadedScopes;
     patched.applyWatchEvents = originalApplyWatchEvents;
     tree.dispose();
+  });
+
+  it('coalesces a resync burst to one active and one trailing refresh', async () => {
+    const root = await makeRoot();
+    await writeFile(path.join(root, 'a.txt'), 'x', 'utf8');
+    const watcher = new ManualWatchService();
+    const tree = new FileTree({ rootPath: root, watcher });
+    unwrap(await tree.ready());
+
+    const patched = tree as unknown as {
+      refreshRegisteredScopes(): Promise<Result<unknown, unknown>>;
+    };
+    const originalRefreshRegisteredScopes = patched.refreshRegisteredScopes;
+    let refreshCount = 0;
+    let releaseFirstRefresh: () => void = () => {};
+    const firstRefreshEntered = new Promise<void>((resolve) => {
+      patched.refreshRegisteredScopes = async () => {
+        refreshCount += 1;
+        if (refreshCount === 1) {
+          resolve();
+          await new Promise<void>((release) => {
+            releaseFirstRefresh = release;
+          });
+        }
+        return originalRefreshRegisteredScopes.call(tree);
+      };
+    });
+
+    watcher.resync();
+    await firstRefreshEntered;
+    for (let index = 0; index < 10; index += 1) watcher.resync();
+
+    expect(refreshCount).toBe(1);
+    releaseFirstRefresh();
+    await tree.refresh();
+
+    expect(refreshCount).toBe(3);
+    patched.refreshRegisteredScopes = originalRefreshRegisteredScopes;
+    await tree.dispose();
   });
 
   it('runtime leases share one tree per resolved root', async () => {

--- a/packages/core/src/files/tree/file-tree.ts
+++ b/packages/core/src/files/tree/file-tree.ts
@@ -47,6 +47,8 @@ export class FileTree implements IFileTree {
     NodeId | null,
     Promise<Result<FileTreeSequences, FileTreeError>>
   >();
+  private resyncRun: Promise<void> | null = null;
+  private trailingResyncRequested = false;
   private disposed = false;
   private readyPromise: Promise<Result<void, FileTreeError>> | null = null;
 
@@ -66,11 +68,7 @@ export class FileTree implements IFileTree {
       },
       {
         debounceMs: WATCH_DEBOUNCE_MS,
-        onResync: () => {
-          void this.runMutation(() => this.resync()).catch((error) =>
-            this.onError(`file-tree resync ${this.rootPath}`, error)
-          );
-        },
+        onResync: () => this.requestResync(),
       }
     );
     const interval = REVALIDATE_INTERVAL_MS;
@@ -149,8 +147,10 @@ export class FileTree implements IFileTree {
   async dispose(): Promise<void> {
     if (this.disposed) return;
     this.disposed = true;
+    this.trailingResyncRequested = false;
     if (this.revalidateTimer) clearInterval(this.revalidateTimer);
     await this.watch.release();
+    await this.resyncRun?.catch(() => {});
     this.collection.dispose();
   }
 
@@ -401,6 +401,39 @@ export class FileTree implements IFileTree {
     this.collection.resetWithNewGeneration(
       this.store.entries().map((node) => [node.id, node] as const)
     );
+  }
+
+  private requestResync(): void {
+    if (this.disposed) return;
+    if (this.resyncRun) {
+      this.trailingResyncRequested = true;
+      return;
+    }
+
+    const run = this.runMutation(() => this.drainResyncs());
+    this.resyncRun = run;
+    void run.then(
+      () => this.finishResyncRun(run),
+      (error) => {
+        this.onError(`file-tree resync ${this.rootPath}`, error);
+        this.finishResyncRun(run);
+      }
+    );
+  }
+
+  private async drainResyncs(): Promise<void> {
+    do {
+      this.trailingResyncRequested = false;
+      await this.resync();
+    } while (this.trailingResyncRequested && !this.disposed);
+  }
+
+  private finishResyncRun(run: Promise<void>): void {
+    if (this.resyncRun !== run) return;
+    this.resyncRun = null;
+    if (!this.trailingResyncRequested || this.disposed) return;
+    this.trailingResyncRequested = false;
+    this.requestResync();
   }
 
   private runMutation<T>(fn: () => Promise<T>): Promise<T> {

--- a/packages/core/src/services/fs-watch/api/models.ts
+++ b/packages/core/src/services/fs-watch/api/models.ts
@@ -14,9 +14,9 @@ export type WatchOptions = {
   ignore?: string[];
   debounceMs?: number;
   /**
-   * Called after the native watcher recovered from an error (resubscribe), or after a
-   * subprocess-backed watcher reconnects. Events may have been lost in the gap; consumers
-   * should treat all derived state as stale and resync.
+   * Called when the native watcher reports an event gap, after a native resubscribe, or after a
+   * subprocess-backed watcher reconnects. Events may have been lost; consumers should treat all
+   * derived state as stale and resync.
    */
   onResync?: () => void;
 };

--- a/packages/core/src/services/fs-watch/impl/native-watch.test.ts
+++ b/packages/core/src/services/fs-watch/impl/native-watch.test.ts
@@ -1,0 +1,211 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import type parcelWatcher from '@parcel/watcher';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NativeWatch, type ParcelSubscribeFn } from './native-watch';
+
+type SubscribeCallback = Parameters<ParcelSubscribeFn>[1];
+
+const subscribe = vi.fn<ParcelSubscribeFn>();
+
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe('NativeWatch', () => {
+  let root: string;
+  let callbacks: SubscribeCallback[];
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    root = await mkdtemp(path.join(tmpdir(), 'emdash-native-watch-'));
+    callbacks = [];
+    subscribe.mockReset();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  function queueSubscription(
+    subscription: parcelWatcher.AsyncSubscription | Promise<parcelWatcher.AsyncSubscription>
+  ): void {
+    subscribe.mockImplementationOnce((_root, callback) => {
+      callbacks.push(callback);
+      return Promise.resolve(subscription);
+    });
+  }
+
+  async function openWatch(resync = vi.fn(), onError = vi.fn()): Promise<NativeWatch> {
+    const watch = new NativeWatch(root, [], vi.fn(), resync, onError, subscribe);
+    await watch.ready();
+    return watch;
+  }
+
+  it('coalesces dropped-event errors into a resync without replacing the subscription', async () => {
+    const unsubscribe = vi.fn(async () => {});
+    queueSubscription({ unsubscribe });
+    const resync = vi.fn();
+    const onError = vi.fn();
+    const watch = await openWatch(resync, onError);
+
+    const dropped = new Error(
+      'Events were dropped by the FSEvents client. File system must be re-scanned.'
+    );
+    callbacks[0](dropped, []);
+    callbacks[0](dropped, []);
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(onError).toHaveBeenCalledTimes(2);
+    expect(resync).toHaveBeenCalledOnce();
+    expect(subscribe).toHaveBeenCalledOnce();
+    expect(unsubscribe).not.toHaveBeenCalled();
+
+    await watch.dispose();
+  });
+
+  it('unsubscribes the previous subscription before starting a replacement', async () => {
+    const stopped = deferred();
+    const firstUnsubscribe = vi.fn(() => stopped.promise);
+    const secondUnsubscribe = vi.fn(async () => {});
+    queueSubscription({ unsubscribe: firstUnsubscribe });
+    queueSubscription({ unsubscribe: secondUnsubscribe });
+    const resync = vi.fn();
+    const watch = await openWatch(resync);
+
+    callbacks[0](new Error('Watcher failed'), []);
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(firstUnsubscribe).toHaveBeenCalledOnce();
+    expect(subscribe).toHaveBeenCalledOnce();
+
+    callbacks[0](new Error('Late failure during unsubscribe'), []);
+    stopped.resolve();
+    await vi.waitFor(() => expect(subscribe).toHaveBeenCalledTimes(2));
+    await vi.advanceTimersByTimeAsync(500);
+    expect(subscribe).toHaveBeenCalledTimes(2);
+    expect(resync).toHaveBeenCalledOnce();
+
+    await watch.dispose();
+    expect(secondUnsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it('ignores errors delivered by a stale subscription callback', async () => {
+    queueSubscription({ unsubscribe: vi.fn(async () => {}) });
+    queueSubscription({ unsubscribe: vi.fn(async () => {}) });
+    const watch = await openWatch();
+
+    callbacks[0](new Error('Watcher failed'), []);
+    await vi.advanceTimersByTimeAsync(250);
+    await vi.waitFor(() => expect(subscribe).toHaveBeenCalledTimes(2));
+
+    callbacks[0](new Error('Late failure from old watcher'), []);
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(subscribe).toHaveBeenCalledTimes(2);
+    await watch.dispose();
+  });
+
+  it('retries an error reported while the replacement subscription is starting', async () => {
+    const replacement = deferred<parcelWatcher.AsyncSubscription>();
+    const unsubscribes = [vi.fn(async () => {}), vi.fn(async () => {}), vi.fn(async () => {})];
+    queueSubscription({ unsubscribe: unsubscribes[0] });
+    queueSubscription(replacement.promise);
+    queueSubscription({ unsubscribe: unsubscribes[2] });
+    const watch = await openWatch();
+
+    callbacks[0](new Error('Watcher failed'), []);
+    await vi.advanceTimersByTimeAsync(250);
+    await vi.waitFor(() => expect(subscribe).toHaveBeenCalledTimes(2));
+
+    callbacks[1](new Error('Replacement failed immediately'), []);
+    replacement.resolve({ unsubscribe: unsubscribes[1] });
+    await vi.advanceTimersByTimeAsync(249);
+    expect(subscribe).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.waitFor(() => expect(subscribe).toHaveBeenCalledTimes(3));
+
+    expect(unsubscribes[1]).toHaveBeenCalledOnce();
+    await watch.dispose();
+  });
+
+  it('retries when creating the replacement subscription fails', async () => {
+    const firstUnsubscribe = vi.fn(async () => {});
+    const finalUnsubscribe = vi.fn(async () => {});
+    queueSubscription({ unsubscribe: firstUnsubscribe });
+    subscribe.mockRejectedValueOnce(new Error('Replacement setup failed'));
+    queueSubscription({ unsubscribe: finalUnsubscribe });
+    const watch = await openWatch();
+
+    callbacks[0](new Error('Watcher failed'), []);
+    await vi.advanceTimersByTimeAsync(250);
+    await vi.waitFor(() => expect(subscribe).toHaveBeenCalledTimes(2));
+    await vi.advanceTimersByTimeAsync(500);
+    await vi.waitFor(() => expect(subscribe).toHaveBeenCalledTimes(3));
+
+    expect(firstUnsubscribe).toHaveBeenCalledOnce();
+    await watch.dispose();
+    expect(finalUnsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it('does not unsubscribe twice when stopping the previous subscription fails', async () => {
+    const unsubscribe = vi.fn().mockRejectedValue(new Error('Failed to stop watcher'));
+    queueSubscription({ unsubscribe });
+    const watch = await openWatch();
+
+    callbacks[0](new Error('Watcher failed'), []);
+    await vi.advanceTimersByTimeAsync(250);
+    await vi.waitFor(() => expect(unsubscribe).toHaveBeenCalledOnce());
+
+    await expect(watch.dispose()).resolves.toBeUndefined();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(subscribe).toHaveBeenCalledOnce();
+  });
+
+  it('does not create a replacement when disposed during unsubscribe', async () => {
+    const stopped = deferred();
+    const unsubscribe = vi.fn(() => stopped.promise);
+    queueSubscription({ unsubscribe });
+    const resync = vi.fn();
+    const watch = await openWatch(resync);
+
+    callbacks[0](new Error('Watcher failed'), []);
+    await vi.advanceTimersByTimeAsync(250);
+    const disposed = watch.dispose();
+    stopped.resolve();
+    await disposed;
+
+    expect(subscribe).toHaveBeenCalledOnce();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(resync).not.toHaveBeenCalled();
+  });
+
+  it('disposes a replacement that finishes subscribing during disposal', async () => {
+    const replacement = deferred<parcelWatcher.AsyncSubscription>();
+    const replacementUnsubscribe = vi.fn(async () => {});
+    queueSubscription({ unsubscribe: vi.fn(async () => {}) });
+    queueSubscription(replacement.promise);
+    const resync = vi.fn();
+    const watch = await openWatch(resync);
+
+    callbacks[0](new Error('Watcher failed'), []);
+    await vi.advanceTimersByTimeAsync(250);
+    await vi.waitFor(() => expect(subscribe).toHaveBeenCalledTimes(2));
+    const disposed = watch.dispose();
+    replacement.resolve({ unsubscribe: replacementUnsubscribe });
+    await disposed;
+
+    expect(replacementUnsubscribe).toHaveBeenCalledOnce();
+    expect(subscribe).toHaveBeenCalledTimes(2);
+    expect(resync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/services/fs-watch/impl/native-watch.test.ts
+++ b/packages/core/src/services/fs-watch/impl/native-watch.test.ts
@@ -157,18 +157,34 @@ describe('NativeWatch', () => {
     expect(finalUnsubscribe).toHaveBeenCalledOnce();
   });
 
-  it('does not unsubscribe twice when stopping the previous subscription fails', async () => {
-    const unsubscribe = vi.fn().mockRejectedValue(new Error('Failed to stop watcher'));
-    queueSubscription({ unsubscribe });
-    const watch = await openWatch();
+  it('keeps the previous subscription active and retries when stopping it fails', async () => {
+    const firstUnsubscribe = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Failed to stop watcher'))
+      .mockResolvedValueOnce(undefined);
+    const finalUnsubscribe = vi.fn(async () => {});
+    queueSubscription({ unsubscribe: firstUnsubscribe });
+    queueSubscription({ unsubscribe: finalUnsubscribe });
+    const deliver = vi.fn();
+    const watch = new NativeWatch(root, [], deliver, vi.fn(), vi.fn(), subscribe);
+    await watch.ready();
 
     callbacks[0](new Error('Watcher failed'), []);
     await vi.advanceTimersByTimeAsync(250);
-    await vi.waitFor(() => expect(unsubscribe).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(firstUnsubscribe).toHaveBeenCalledOnce());
 
-    await expect(watch.dispose()).resolves.toBeUndefined();
-    expect(unsubscribe).toHaveBeenCalledOnce();
     expect(subscribe).toHaveBeenCalledOnce();
+    callbacks[0](null, [{ type: 'update', path: path.join(root, 'changed.txt') }]);
+    expect(deliver).toHaveBeenCalledWith([
+      { kind: 'update', path: path.join(root, 'changed.txt') },
+    ]);
+
+    await vi.advanceTimersByTimeAsync(500);
+    await vi.waitFor(() => expect(subscribe).toHaveBeenCalledTimes(2));
+
+    expect(firstUnsubscribe).toHaveBeenCalledTimes(2);
+    await watch.dispose();
+    expect(finalUnsubscribe).toHaveBeenCalledOnce();
   });
 
   it('does not create a replacement when disposed during unsubscribe', async () => {

--- a/packages/core/src/services/fs-watch/impl/native-watch.ts
+++ b/packages/core/src/services/fs-watch/impl/native-watch.ts
@@ -5,13 +5,14 @@ import type { WatchEvent } from '../api';
 
 const RESUBSCRIBE_DELAY_MS = 250;
 const MAX_RESUBSCRIBE_DELAY_MS = 30_000;
+const RESYNC_DELAY_MS = 250;
 
 export type ParcelSubscribeFn = typeof parcelWatcher.subscribe;
 
 /**
  * One native subscription per (root, ignore set), shared across consumers.
- * Owns the resubscribe-with-retry reliability logic; after a successful resubscribe it
- * signals resync (events may have been lost in the gap).
+ * Owns event-gap recovery and serialized resubscribe-with-retry; signals resync whenever events
+ * may have been lost.
  */
 export class NativeWatch implements IDisposable {
   readonly root: string;
@@ -22,6 +23,11 @@ export class NativeWatch implements IDisposable {
   private readonly subscribeFn: ParcelSubscribeFn;
   private subscription: Promise<parcelWatcher.AsyncSubscription> | null = null;
   private retryTimer: ReturnType<typeof setTimeout> | null = null;
+  private resyncTimer: ReturnType<typeof setTimeout> | null = null;
+  private restartPromise: Promise<void> | null = null;
+  private generation = 0;
+  private activeGeneration = 0;
+  private retryRequested = false;
   private retryAttempts = 0;
   private disposed = false;
 
@@ -51,19 +57,36 @@ export class NativeWatch implements IDisposable {
   async dispose(): Promise<void> {
     if (this.disposed) return;
     this.disposed = true;
+    this.activeGeneration = 0;
+    this.retryRequested = false;
     if (this.retryTimer) clearTimeout(this.retryTimer);
     this.retryTimer = null;
+    if (this.resyncTimer) clearTimeout(this.resyncTimer);
+    this.resyncTimer = null;
+    await this.restartPromise;
     const subscription = await this.subscription?.catch(() => null);
+    this.subscription = null;
     await subscription?.unsubscribe();
   }
 
   private async subscribe(): Promise<parcelWatcher.AsyncSubscription> {
     await fs.stat(this.root);
+    const generation = ++this.generation;
+    this.activeGeneration = generation;
     return this.subscribeFn(
       this.root,
       (err, events) => {
+        if (this.disposed || generation !== this.activeGeneration) return;
         if (err) {
           this.onError(`watch ${this.root}`, err);
+          if (requiresResync(err)) {
+            this.scheduleResync();
+            return;
+          }
+          if (this.restartPromise) {
+            this.retryRequested = true;
+            return;
+          }
           this.scheduleResubscribe();
           return;
         }
@@ -74,8 +97,29 @@ export class NativeWatch implements IDisposable {
     );
   }
 
+  private scheduleResync(): void {
+    if (this.resyncTimer || this.disposed) return;
+    this.resyncTimer = setTimeout(() => {
+      this.resyncTimer = null;
+      this.signalResync();
+    }, RESYNC_DELAY_MS);
+  }
+
+  private signalResync(): void {
+    if (this.disposed) return;
+    try {
+      this.resync();
+    } catch (error) {
+      this.onError(`resync ${this.root}`, error);
+    }
+  }
+
   private scheduleResubscribe(): void {
     if (this.retryTimer || this.disposed) return;
+    if (this.restartPromise) {
+      this.retryRequested = true;
+      return;
+    }
     const delay = Math.min(
       RESUBSCRIBE_DELAY_MS * 2 ** this.retryAttempts,
       MAX_RESUBSCRIBE_DELAY_MS
@@ -84,21 +128,54 @@ export class NativeWatch implements IDisposable {
     this.retryTimer = setTimeout(() => {
       this.retryTimer = null;
       if (this.disposed) return;
-      const previous = this.subscription;
-      this.subscription = this.subscribe();
-      this.subscription.then(
-        () => {
-          this.retryAttempts = 0;
-          this.resync();
-        },
-        (error) => {
-          this.onError(`resubscribe ${this.root}`, error);
-          this.scheduleResubscribe();
-        }
-      );
-      void previous?.then((subscription) => subscription.unsubscribe()).catch(() => {});
+      const restart = this.restart();
+      const tracked = restart.then((shouldRetry) => {
+        const retry = shouldRetry || this.retryRequested;
+        this.retryRequested = false;
+        if (this.restartPromise === tracked) this.restartPromise = null;
+        if (retry) this.scheduleResubscribe();
+      });
+      this.restartPromise = tracked;
+      void tracked;
     }, delay);
   }
+
+  private async restart(): Promise<boolean> {
+    const previousPromise = this.subscription;
+    this.activeGeneration = 0;
+    const previous = await previousPromise?.catch(() => null);
+    if (this.disposed) return false;
+    if (this.subscription === previousPromise) this.subscription = null;
+
+    try {
+      await previous?.unsubscribe();
+    } catch (error) {
+      this.onError(`unsubscribe ${this.root}`, error);
+      return false;
+    }
+    if (this.disposed) return false;
+
+    const next = this.subscribe();
+    this.subscription = next;
+    try {
+      await next;
+    } catch (error) {
+      this.onError(`resubscribe ${this.root}`, error);
+      return true;
+    }
+    this.retryAttempts = 0;
+    if (this.disposed) return false;
+    this.signalResync();
+    return false;
+  }
+}
+
+/**
+ * Matches the FSEvents dropped-events error emitted by @parcel/watcher.
+ * Keep this in sync with the upstream message; Parcel exposes no structured error code.
+ */
+function requiresResync(error: Error): boolean {
+  return error.message.includes('File system must be re-scanned');
 }
 
 function toWatchEvent(event: parcelWatcher.Event): WatchEvent {

--- a/packages/core/src/services/fs-watch/impl/native-watch.ts
+++ b/packages/core/src/services/fs-watch/impl/native-watch.ts
@@ -142,17 +142,22 @@ export class NativeWatch implements IDisposable {
 
   private async restart(): Promise<boolean> {
     const previousPromise = this.subscription;
+    const previousGeneration = this.activeGeneration;
     this.activeGeneration = 0;
     const previous = await previousPromise?.catch(() => null);
     if (this.disposed) return false;
-    if (this.subscription === previousPromise) this.subscription = null;
 
     try {
       await previous?.unsubscribe();
     } catch (error) {
       this.onError(`unsubscribe ${this.root}`, error);
-      return false;
+      if (!this.disposed && this.subscription === previousPromise) {
+        this.activeGeneration = previousGeneration;
+        this.scheduleResync();
+      }
+      return !this.disposed;
     }
+    if (this.subscription === previousPromise) this.subscription = null;
     if (this.disposed) return false;
 
     const next = this.subscribe();


### PR DESCRIPTION
- treats dropped fsevents notifications as a resync request instead of replacing a healthy subscription
- serializes genuine watcher restarts and ignores stale callbacks during recovery
- coalesces repeated TreeResource resync requests into one active refresh and one trailing refresh
- updates the resync contract to cover recoverable event gaps