### PR TITLE
fix(ssh): honor system config for manual hosts

### DIFF
--- a/apps/emdash-desktop/src/main/core/ssh/config/resolve-ssh-config.test.ts
+++ b/apps/emdash-desktop/src/main/core/ssh/config/resolve-ssh-config.test.ts
@@ -146,6 +146,32 @@ Host corp-dev
     });
   });
 
+  it('resolves a host that exists only through a wildcard OpenSSH rule', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'emdash-ssh-wildcard-config-'));
+    const configPath = join(dir, 'config');
+    await writeFile(
+      configPath,
+      `
+Host *.internal.example
+  User wildcard-user
+  Port 2207
+  ProxyCommand cloudflared access ssh --hostname %h
+  ForwardAgent yes
+`
+    );
+
+    const runner = createExecFileSshConfigRunner({ extraArgs: ['-F', configPath] });
+    await expect(resolveSshConfig('work-host.internal.example', { runner })).resolves.toMatchObject(
+      {
+        hostname: 'work-host.internal.example',
+        user: 'wildcard-user',
+        port: 2207,
+        proxyCommand: 'cloudflared access ssh --hostname %h',
+        forwardAgent: true,
+      }
+    );
+  });
+
   it('expands IdentityAgent environment variable values when resolving agent sockets', async () => {
     await expect(
       resolveAgentSocketFromSshConfig('corp-dev', {

--- a/apps/emdash-desktop/src/main/core/ssh/connect/resolve-ssh-connect-config.test.ts
+++ b/apps/emdash-desktop/src/main/core/ssh/connect/resolve-ssh-connect-config.test.ts
@@ -4,6 +4,7 @@ import { utils } from 'ssh2';
 import { describe, expect, it } from 'vitest';
 import type { SshConnectionRow } from '@main/db/schema';
 import type { SshConfig } from '@shared/core/ssh/ssh';
+import { parseSshGOutput } from '../config/resolve-ssh-config';
 import {
   createSshConnectConfigResolver,
   resolveSshConnectConfig,
@@ -104,6 +105,164 @@ function row(partial: Partial<SshConnectionRow> = {}): SshConnectionRow {
 }
 
 describe('resolveSshConnectConfig', () => {
+  it('applies wildcard system config routing without replacing manual connection fields', async () => {
+    const resolvedHosts: string[] = [];
+    const spawned: Array<{ command: string; host: string; port: number; username: string }> = [];
+    const result = await resolveSshConnectConfig(
+      {
+        kind: 'transient',
+        config: {
+          ...baseConfig({
+            host: 'work-host.internal.example',
+            port: 2202,
+            username: 'manual-user',
+          }),
+          password: 'manual-password',
+        },
+      },
+      deps({
+        resolveSshConfig: async (host) => {
+          resolvedHosts.push(host);
+          return parseSshGOutput(`
+hostname config-host.internal.example
+user config-user
+port 2222
+proxycommand cloudflared access ssh --hostname %h
+forwardagent yes
+connecttimeout 17
+`);
+        },
+        spawnProxyCommand: (command, tokens) => {
+          spawned.push({ command, ...tokens });
+          return {
+            sock: new PassThrough(),
+            cleanup: () => {},
+            debugLogs: ['wildcard proxy'],
+          };
+        },
+      })
+    );
+
+    expect(resolvedHosts).toEqual(['work-host.internal.example']);
+    expect(result.config).toMatchObject({
+      host: 'work-host.internal.example',
+      port: 2202,
+      username: 'manual-user',
+      password: 'manual-password',
+      agentForward: true,
+      agent: '/tmp/default-agent.sock',
+      readyTimeout: 17_000,
+    });
+    expect(result.config.sock).toBeDefined();
+    expect(spawned).toEqual([
+      {
+        command: 'cloudflared access ssh --hostname %h',
+        host: 'work-host.internal.example',
+        port: 2202,
+        username: 'manual-user',
+        originalHost: 'work-host.internal.example',
+      },
+    ]);
+    expect(result.debugLogs).toEqual(['wildcard proxy']);
+  });
+
+  it('does not override an explicit manual ForwardAgent false with system config', async () => {
+    const result = await resolveSshConnectConfig(
+      {
+        kind: 'transient',
+        config: {
+          ...baseConfig({ forwardAgent: false }),
+          password: 'manual-password',
+        },
+      },
+      deps({
+        resolveSshConfig: async () => ({
+          ...(await deps().resolveSshConfig('manual.example.com')),
+          forwardAgent: true,
+          forwardAgentValue: '/tmp/system-forward-agent.sock',
+        }),
+      })
+    );
+
+    expect(result.config).toMatchObject({
+      host: 'manual.example.com',
+      username: 'alice',
+      password: 'manual-password',
+    });
+    expect(result.config.agentForward).toBeUndefined();
+    expect(result.config.agent).toBeUndefined();
+  });
+
+  it('keeps ssh -G defaults from replacing explicit manual fields when no rule matches', async () => {
+    const result = await resolveSshConnectConfig(
+      {
+        kind: 'transient',
+        config: {
+          ...baseConfig({
+            host: 'plain.example.com',
+            port: 2205,
+            username: 'manual-user',
+          }),
+          password: 'manual-password',
+        },
+      },
+      deps({
+        resolveSshConfig: async () =>
+          parseSshGOutput(`
+hostname plain.example.com
+user local-default-user
+port 22
+proxycommand none
+proxyjump none
+forwardagent no
+connecttimeout none
+serveraliveinterval 0
+serveralivecountmax 3
+`),
+      })
+    );
+
+    expect(result.config).toMatchObject({
+      host: 'plain.example.com',
+      port: 2205,
+      username: 'manual-user',
+      password: 'manual-password',
+    });
+    expect(result.config.sock).toBeUndefined();
+  });
+
+  it('uses a resolved ProxyJump when a manual connection does not provide one', async () => {
+    const jumps: string[] = [];
+    const result = await resolveSshConnectConfig(
+      {
+        kind: 'transient',
+        config: { ...baseConfig(), password: 'manual-password' },
+      },
+      deps({
+        resolveSshConfig: async () => ({
+          ...(await deps().resolveSshConfig('manual.example.com')),
+          proxyJump: 'system-bastion',
+        }),
+        spawnProxyJump: (jumpSpec, host, port) => {
+          jumps.push(`${jumpSpec}->${host}:${port}`);
+          return {
+            sock: new PassThrough(),
+            cleanup: () => {},
+            debugLogs: ['system jump'],
+          };
+        },
+      })
+    );
+
+    expect(jumps).toEqual(['system-bastion->manual.example.com:22']);
+    expect(result.config).toMatchObject({
+      host: 'manual.example.com',
+      username: 'alice',
+      password: 'manual-password',
+    });
+    expect(result.config.sock).toBeDefined();
+  });
+
   it('uses ssh -G as authoritative for alias-backed ProxyCommand', async () => {
     const spawned: string[] = [];
     const result = await resolveSshConnectConfig(
@@ -150,7 +309,7 @@ describe('resolveSshConnectConfig', () => {
     expect(result.debugLogs).toEqual(['command debug']);
   });
 
-  it('ignores manual ProxyCommand but supports manual ProxyJump and ForwardAgent', async () => {
+  it('gives explicit manual ProxyJump precedence over resolved transports', async () => {
     const jumps: string[] = [];
     const result = await resolveSshConnectConfig(
       {
@@ -166,8 +325,14 @@ describe('resolveSshConnectConfig', () => {
         } as SshConfig & { password: string; proxyCommand: string },
       },
       deps({
+        resolveSshConfig: async () => ({
+          ...(await deps().resolveSshConfig('manual.example.com')),
+          identityAgent: undefined,
+          proxyCommand: 'resolved proxy command',
+          proxyJump: 'resolved-bastion',
+        }),
         spawnProxyCommand: () => {
-          throw new Error('manual proxy command must not execute');
+          throw new Error('resolved proxy command must not override manual ProxyJump');
         },
         spawnProxyJump: (jumpSpec, host, port) => {
           jumps.push(`${jumpSpec}->${host}:${port}`);
@@ -439,7 +604,7 @@ describe('resolveSshConnectConfig', () => {
         deps({
           resolveSshConfig: async () => ({
             ...(await deps().resolveSshConfig('x')),
-            identityFile: [],
+            identityFile: ['~/.ssh/config-default-key'],
           }),
         })
       )
@@ -467,7 +632,13 @@ describe('resolveSshConnectConfig', () => {
           kind: 'transient',
           config: { ...baseConfig({ authType: 'password', forwardAgent: true }), password: 'pw' },
         },
-        deps({ env: {} })
+        deps({
+          env: {},
+          resolveSshConfig: async () => ({
+            ...(await deps().resolveSshConfig('manual.example.com')),
+            identityAgent: undefined,
+          }),
+        })
       )
     ).rejects.toThrow('no SSH agent socket is available');
   });
@@ -491,16 +662,10 @@ describe('resolveSshConnectConfig', () => {
             identityAgent: '/tmp/legacy-agent.sock',
             identityAgentDisabled: false,
             identitiesOnly: false,
-            proxyCommand: 'should-not-run',
-            proxyJump: 'should-not-run',
+            proxyCommand: undefined,
+            proxyJump: undefined,
             forwardAgent: false,
           };
-        },
-        spawnProxyCommand: () => {
-          throw new Error('manual host proxy command must not execute');
-        },
-        spawnProxyJump: () => {
-          throw new Error('manual host proxy jump must not execute');
         },
       })
     );

--- a/apps/emdash-desktop/src/main/core/ssh/connect/resolve-ssh-connect-config.ts
+++ b/apps/emdash-desktop/src/main/core/ssh/connect/resolve-ssh-connect-config.ts
@@ -82,16 +82,23 @@ export async function resolveSshConnectConfig(
   const deps = { ...defaultDeps(), ...depsOverride };
   const base = baseConfigForInput(input);
   const alias = base.sshConfigAlias;
-  const resolved = alias ? await deps.resolveSshConfig(alias) : undefined;
+  // Manual form fields stay authoritative; ssh -G only supplements behavior the form cannot
+  // express, such as wildcard/system ProxyCommand rules. Alias-backed connections remain fully
+  // config-driven.
+  const resolved = alias
+    ? await deps.resolveSshConfig(alias)
+    : await deps.resolveSshConfig(base.host).catch(() => undefined);
   const shouldResolveHostForAgent = !alias && base.authType === 'agent';
-  const agentResolved = shouldResolveHostForAgent
-    ? await resolveManualAgentSshConfig(base.host, deps)
-    : resolved;
+  const authResolved = alias
+    ? resolved
+    : shouldResolveHostForAgent
+      ? await resolveManualAgentSshConfig(base.host, deps, resolved)
+      : undefined;
 
-  const host = resolved?.hostname || base.host;
-  const port = resolved?.port ?? base.port;
-  const username = resolved?.user || base.username;
-  const authResult = await buildAuthConfig(input, base, agentResolved, deps);
+  const host = alias ? resolved?.hostname || base.host : base.host;
+  const port = alias ? (resolved?.port ?? base.port) : base.port;
+  const username = alias ? resolved?.user || base.username : base.username;
+  const authResult = await buildAuthConfig(input, base, authResolved, deps);
 
   const config: ConnectConfig = {
     host,
@@ -103,14 +110,18 @@ export async function resolveSshConnectConfig(
     ...authResult.config,
   };
 
-  const forwardAgent = resolved?.forwardAgent ?? base.forwardAgent === true;
-  applyForwardAgent(config, forwardAgent, agentResolved, authResult, deps);
+  const forwardAgent = alias
+    ? resolved?.forwardAgent === true
+    : (base.forwardAgent ?? resolved?.forwardAgent ?? false);
+  const forwardingResolved = base.authType === 'agent' ? authResolved : resolved;
+  applyForwardAgent(config, forwardAgent, forwardingResolved, authResult, deps);
 
   let debugLogs: string[] = [];
   let cleanup = () => {};
   const tokens: ProxyTokens = { host, port, username, originalHost: alias ?? base.host };
-  const proxyCommand = alias ? resolved?.proxyCommand : undefined;
-  const proxyJump = resolved?.proxyJump ?? (!alias ? base.proxyJump : undefined);
+  const manualProxyJump = alias ? undefined : base.proxyJump;
+  const proxyCommand = alias || !manualProxyJump ? resolved?.proxyCommand : undefined;
+  const proxyJump = alias ? resolved?.proxyJump : (manualProxyJump ?? resolved?.proxyJump);
 
   let transport: Omit<TransportResult, 'process'> | undefined;
   if (proxyCommand) {

--- a/apps/emdash-desktop/src/main/core/ssh/connect/ssh-connect-auth.ts
+++ b/apps/emdash-desktop/src/main/core/ssh/connect/ssh-connect-auth.ts
@@ -103,9 +103,9 @@ async function readIdentityKeys(paths: string[], deps: SshConnectDeps): Promise<
 
 export async function resolveManualAgentSshConfig(
   host: string,
-  deps: SshConnectDeps
+  deps: SshConnectDeps,
+  direct: ResolvedSshConfig | undefined
 ): Promise<ResolvedSshConfig | undefined> {
-  const direct = await deps.resolveSshConfig(host).catch(() => undefined);
   if (direct) {
     const agentSocket = resolveAgentSocketFromResolved(direct, deps.env);
     if (agentSocket.kind !== 'unset') return direct;


### PR DESCRIPTION
### Description

Resolve manual SSH hosts through `ssh -G` on a best-effort basis so wildcard and system SSH configuration can provide routing details such as `ProxyCommand`, `ProxyJump`, connection timeouts, and optional agent forwarding.

Manual host, username, port, and authentication fields remain authoritative. Explicit manual `ProxyJump` and `ForwardAgent: false` settings also take precedence, while existing alias-backed behavior is unchanged.

### Related issues

Fixes #2729.

### Testing

- `pnpm exec vitest run --project node src/main/core/ssh/config/resolve-ssh-config.test.ts src/main/core/ssh/connect/resolve-ssh-connect-config.test.ts` (30 tests passed)
- Complete SSH test suite (10 files, 107 tests passed)
- Desktop `pnpm run format:check`
- Desktop `pnpm run lint`
- Desktop `pnpm run typecheck`
- `git diff --check`
- Full desktop Node suite: 278/280 files and 1990/1992 tests passed. One unrelated browser timing test passed when rerun in isolation (7/7); the pre-existing issue-selector test still timed out at five seconds when run in isolation.

### Screenshot/Recording (if applicable)

Not applicable; this changes main-process SSH resolution and is covered by resolver tests, including a real `ssh -G -F` wildcard config fixture.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed (not applicable; manual setup and UI are unchanged)
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>
