### PR TITLE
feat(tasks): clean up tasks after PR merge

### DIFF
--- a/apps/emdash-desktop/src/main/core/pull-requests/controller.test.ts
+++ b/apps/emdash-desktop/src/main/core/pull-requests/controller.test.ts
@@ -11,6 +11,7 @@ import {
 
 const dbMocks = vi.hoisted(() => ({
   select: vi.fn(),
+  processRepository: vi.fn(),
 }));
 
 vi.mock('@main/core/repository/provider-repository-service', () => ({
@@ -59,6 +60,12 @@ vi.mock('./pr-sync-engine', () => ({
     forceFullSync: vi.fn(),
     sync: vi.fn(),
     cancel: vi.fn(),
+  },
+}));
+
+vi.mock('./pr-auto-cleanup-service', () => ({
+  prAutoCleanupService: {
+    processRepository: dbMocks.processRepository,
   },
 }));
 
@@ -131,6 +138,7 @@ describe('pullRequestController', () => {
     dbMocks.select.mockReset();
     mockPrSyncEngine.forceFullSync.mockResolvedValue(ok());
     mockPrSyncEngine.sync.mockResolvedValue(ok());
+    dbMocks.processRepository.mockResolvedValue(undefined);
   });
 
   it('rejects cross-host pull request creation before calling GitHub', async () => {
@@ -412,6 +420,7 @@ describe('pullRequestController', () => {
       12,
       selectedAuthContext
     );
+    expect(dbMocks.processRepository).not.toHaveBeenCalled();
   });
 
   it('does not create pull requests with the default account when project account resolution fails', async () => {
@@ -473,6 +482,9 @@ describe('pullRequestController', () => {
       12,
       selectedAuthContext
     );
+    await vi.waitFor(() => {
+      expect(dbMocks.processRepository).toHaveBeenCalledWith('https://github.com/acme/repo');
+    });
   });
 
   it('passes the project GitHub account context to pull request reads', async () => {

--- a/apps/emdash-desktop/src/main/core/pull-requests/controller.ts
+++ b/apps/emdash-desktop/src/main/core/pull-requests/controller.ts
@@ -12,6 +12,7 @@ import type {
 } from '@shared/core/pull-requests/pull-requests';
 import { createRPCController } from '@shared/lib/ipc/rpc';
 import { isGitHubDotComHost, parseRepositoryRef } from '@shared/repository-ref';
+import { prAutoCleanupService } from './pr-auto-cleanup-service';
 import { prQueryService } from './pr-query-service';
 import { prSyncEngine } from './pr-sync-engine';
 import { type PrSyncEngineError } from './pr-sync-errors';
@@ -345,7 +346,14 @@ export const pullRequestController = createRPCController({
         return err<PullRequestError>(mapPrSyncEngineError(result.error, 'merge_failed'));
       }
       // Refresh the merged PR
-      void prSyncEngine.syncSingle(repositoryUrl, prNumber, authContext.data);
+      void prSyncEngine
+        .syncSingle(repositoryUrl, prNumber, authContext.data)
+        .then((syncResult) => {
+          if (syncResult.success) return prAutoCleanupService.processRepository(repositoryUrl);
+        })
+        .catch((syncError) => {
+          log.warn('Failed to run post-merge task cleanup:', syncError);
+        });
       return ok({ sha: result.data.sha, merged: result.data.merged });
     } catch (error) {
       log.error('Failed to merge pull request:', error);

--- a/apps/emdash-desktop/src/main/core/pull-requests/pr-auto-cleanup-candidates.db.test.ts
+++ b/apps/emdash-desktop/src/main/core/pull-requests/pr-auto-cleanup-candidates.db.test.ts
@@ -1,0 +1,175 @@
+import { openFixture } from '@tooling/utils/db';
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AppDb } from '@main/db/client';
+import { projectRemotes, projects, pullRequests, tasks, workspaces } from '@main/db/schema';
+import { listPrAutoCleanupCandidates } from './pr-auto-cleanup-candidates';
+
+const mocks = vi.hoisted(() => ({
+  db: undefined as AppDb | undefined,
+}));
+
+vi.mock('@main/db/client', () => ({
+  get db() {
+    if (!mocks.db) throw new Error('Test database not initialized');
+    return mocks.db;
+  },
+}));
+
+const PROJECT_ID = 'project-1';
+const REPOSITORY_URL = 'https://github.com/acme/repo';
+const UPSTREAM_REPOSITORY_URL = 'https://github.com/emdash/repo';
+
+function prRow(overrides: Partial<typeof pullRequests.$inferInsert>) {
+  return {
+    url: 'https://github.com/acme/repo/pull/1',
+    repositoryUrl: REPOSITORY_URL,
+    baseRefName: 'main',
+    baseRefOid: 'base-oid',
+    headRepositoryUrl: REPOSITORY_URL,
+    headRefName: 'feature/cleanup',
+    headRefOid: 'head-oid',
+    identifier: '#1',
+    title: 'Cleanup PR',
+    status: 'merged',
+    isDraft: 0,
+    pullRequestCreatedAt: '2026-01-01T00:00:00.000Z',
+    pullRequestUpdatedAt: '2026-01-02T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('listPrAutoCleanupCandidates', () => {
+  let fixture: Awaited<ReturnType<typeof openFixture>>;
+
+  beforeEach(async () => {
+    fixture = await openFixture('empty');
+    mocks.db = fixture.db;
+
+    await fixture.db.insert(projects).values({
+      id: PROJECT_ID,
+      name: 'Project',
+      path: '/repo',
+    });
+    await fixture.db.insert(projectRemotes).values({
+      projectId: PROJECT_ID,
+      remoteName: 'origin',
+      remoteUrl: REPOSITORY_URL,
+    });
+    await fixture.db.insert(workspaces).values({
+      id: 'workspace-1',
+      type: 'local',
+      kind: 'worktree',
+      location: 'local',
+      path: '/repo/.worktrees/cleanup',
+      branchName: 'feature/cleanup',
+    });
+    await fixture.db.insert(tasks).values({
+      id: 'task-1',
+      projectId: PROJECT_ID,
+      name: 'Cleanup task',
+      status: 'review',
+      workspaceId: 'workspace-1',
+    });
+  });
+
+  afterEach(() => {
+    fixture.close();
+    mocks.db = undefined;
+  });
+
+  it('returns an active task whose current PR is merged', async () => {
+    await fixture.db.insert(pullRequests).values(prRow({}));
+
+    await expect(listPrAutoCleanupCandidates(REPOSITORY_URL)).resolves.toEqual([
+      {
+        taskId: 'task-1',
+        projectId: PROJECT_ID,
+        taskName: 'Cleanup task',
+        prUrl: 'https://github.com/acme/repo/pull/1',
+      },
+    ]);
+  });
+
+  it('associates a fork PR with its head project without crossing same-branch projects', async () => {
+    await fixture.db.insert(projectRemotes).values({
+      projectId: PROJECT_ID,
+      remoteName: 'upstream',
+      remoteUrl: UPSTREAM_REPOSITORY_URL,
+    });
+    await fixture.db.insert(projects).values({
+      id: 'project-2',
+      name: 'Upstream project',
+      path: '/upstream-repo',
+    });
+    await fixture.db.insert(projectRemotes).values({
+      projectId: 'project-2',
+      remoteName: 'origin',
+      remoteUrl: UPSTREAM_REPOSITORY_URL,
+    });
+    await fixture.db.insert(workspaces).values({
+      id: 'workspace-2',
+      type: 'local',
+      kind: 'worktree',
+      location: 'local',
+      path: '/upstream-repo/.worktrees/cleanup',
+      branchName: 'feature/cleanup',
+    });
+    await fixture.db.insert(tasks).values({
+      id: 'task-2',
+      projectId: 'project-2',
+      name: 'Unrelated upstream task',
+      status: 'review',
+      workspaceId: 'workspace-2',
+    });
+    await fixture.db.insert(pullRequests).values(
+      prRow({
+        repositoryUrl: UPSTREAM_REPOSITORY_URL,
+        headRepositoryUrl: REPOSITORY_URL,
+      })
+    );
+
+    await expect(listPrAutoCleanupCandidates(REPOSITORY_URL)).resolves.toEqual([
+      {
+        taskId: 'task-1',
+        projectId: PROJECT_ID,
+        taskName: 'Cleanup task',
+        prUrl: 'https://github.com/acme/repo/pull/1',
+      },
+    ]);
+    await expect(listPrAutoCleanupCandidates(UPSTREAM_REPOSITORY_URL)).resolves.toEqual([
+      {
+        taskId: 'task-1',
+        projectId: PROJECT_ID,
+        taskName: 'Cleanup task',
+        prUrl: 'https://github.com/acme/repo/pull/1',
+      },
+    ]);
+  });
+
+  it('does not use an older merged PR while the task has an open PR', async () => {
+    await fixture.db.insert(pullRequests).values([
+      prRow({}),
+      prRow({
+        url: 'https://github.com/acme/repo/pull/2',
+        identifier: '#2',
+        title: 'Follow-up PR',
+        status: 'open',
+        pullRequestCreatedAt: '2026-02-01T00:00:00.000Z',
+        pullRequestUpdatedAt: '2026-02-02T00:00:00.000Z',
+      }),
+    ]);
+
+    await expect(listPrAutoCleanupCandidates(REPOSITORY_URL)).resolves.toEqual([]);
+  });
+
+  it('ignores archived tasks', async () => {
+    await fixture.db.insert(pullRequests).values(prRow({}));
+    await fixture.db
+      .update(tasks)
+      .set({ archivedAt: '2026-03-01T00:00:00.000Z' })
+      .where(eq(tasks.id, 'task-1'));
+
+    await expect(listPrAutoCleanupCandidates(REPOSITORY_URL)).resolves.toEqual([]);
+  });
+});

--- a/apps/emdash-desktop/src/main/core/pull-requests/pr-auto-cleanup-candidates.ts
+++ b/apps/emdash-desktop/src/main/core/pull-requests/pr-auto-cleanup-candidates.ts
@@ -1,0 +1,74 @@
+import { and, desc, eq, isNull } from 'drizzle-orm';
+import { db } from '@main/db/client';
+import { projectRemotes, pullRequests, tasks, workspaces } from '@main/db/schema';
+import { pullRequestRepositoryScope } from './pr-utils';
+
+export type PrAutoCleanupCandidate = {
+  taskId: string;
+  projectId: string;
+  taskName: string;
+  prUrl: string;
+};
+
+type CandidateRow = PrAutoCleanupCandidate & {
+  prStatus: string;
+  prCreatedAt: string;
+};
+
+/**
+ * Returns the current PR for each active task on a repository, using the same rule as
+ * the renderer: prefer an open PR, otherwise use the most recently created PR. Only
+ * tasks whose current PR is merged are eligible for cleanup.
+ */
+export async function listPrAutoCleanupCandidates(
+  repositoryUrl: string
+): Promise<PrAutoCleanupCandidate[]> {
+  const rows: CandidateRow[] = await db
+    .select({
+      taskId: tasks.id,
+      projectId: tasks.projectId,
+      taskName: tasks.name,
+      prUrl: pullRequests.url,
+      prStatus: pullRequests.status,
+      prCreatedAt: pullRequests.pullRequestCreatedAt,
+    })
+    .from(tasks)
+    .innerJoin(workspaces, eq(tasks.workspaceId, workspaces.id))
+    .innerJoin(
+      pullRequests,
+      and(
+        pullRequestRepositoryScope([repositoryUrl]),
+        eq(pullRequests.headRefName, workspaces.branchName)
+      )
+    )
+    .innerJoin(
+      projectRemotes,
+      and(
+        eq(projectRemotes.projectId, tasks.projectId),
+        eq(projectRemotes.remoteUrl, pullRequests.headRepositoryUrl)
+      )
+    )
+    .where(isNull(tasks.archivedAt))
+    .orderBy(desc(pullRequests.pullRequestCreatedAt));
+
+  const currentByTask = new Map<string, CandidateRow>();
+  for (const row of rows) {
+    const current = currentByTask.get(row.taskId);
+    if (!current || (current.prStatus !== 'open' && row.prStatus === 'open')) {
+      currentByTask.set(row.taskId, row);
+    }
+  }
+
+  return Array.from(currentByTask.values()).flatMap((row) =>
+    row.prStatus === 'merged'
+      ? [
+          {
+            taskId: row.taskId,
+            projectId: row.projectId,
+            taskName: row.taskName,
+            prUrl: row.prUrl,
+          },
+        ]
+      : []
+  );
+}

--- a/apps/emdash-desktop/src/main/core/pull-requests/pr-auto-cleanup-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/pull-requests/pr-auto-cleanup-service.test.ts
@@ -1,17 +1,24 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PrAutoCleanupCandidate } from './pr-auto-cleanup-candidates';
 import {
+  cleanupMergedPrTask,
   PrAutoCleanupService,
   type PrAutoCleanupDependencies,
   type PrAutoCleanupMarker,
 } from './pr-auto-cleanup-service';
+
+const taskServiceMocks = vi.hoisted(() => ({
+  teardown: vi.fn(),
+  archiveTask: vi.fn(),
+  deleteTask: vi.fn(),
+}));
 
 vi.mock('@main/core/settings/settings-service', () => ({
   appSettingsService: { get: vi.fn() },
 }));
 
 vi.mock('@main/core/tasks/task-service', () => ({
-  taskService: { archiveTask: vi.fn(), deleteTask: vi.fn() },
+  taskService: taskServiceMocks,
 }));
 
 vi.mock('@main/db/client', () => ({
@@ -35,6 +42,52 @@ const candidate: PrAutoCleanupCandidate = {
   taskName: 'Fix cleanup',
   prUrl: 'https://github.com/acme/repo/pull/42',
 };
+
+describe('production auto-cleanup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ['archive', 'archive'],
+    ['delete', 'terminate'],
+  ] as const)('does not %s when teardown fails', async (action, teardownMode) => {
+    taskServiceMocks.teardown.mockResolvedValue({
+      success: false,
+      error: { type: 'error', message: 'teardown failed' },
+    });
+
+    await expect(cleanupMergedPrTask(candidate, action)).rejects.toThrow('teardown failed');
+
+    expect(taskServiceMocks.teardown).toHaveBeenCalledWith(candidate.taskId, teardownMode);
+    expect(taskServiceMocks.archiveTask).not.toHaveBeenCalled();
+    expect(taskServiceMocks.deleteTask).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['archive', 'archive'],
+    ['delete', 'terminate'],
+  ] as const)('runs %s after teardown succeeds', async (action, teardownMode) => {
+    taskServiceMocks.teardown.mockResolvedValue({ success: true, data: undefined });
+
+    await cleanupMergedPrTask(candidate, action);
+
+    expect(taskServiceMocks.teardown).toHaveBeenCalledWith(candidate.taskId, teardownMode);
+    if (action === 'archive') {
+      expect(taskServiceMocks.archiveTask).toHaveBeenCalledWith(
+        candidate.projectId,
+        candidate.taskId
+      );
+      expect(taskServiceMocks.deleteTask).not.toHaveBeenCalled();
+    } else {
+      expect(taskServiceMocks.deleteTask).toHaveBeenCalledWith(
+        candidate.projectId,
+        candidate.taskId
+      );
+      expect(taskServiceMocks.archiveTask).not.toHaveBeenCalled();
+    }
+  });
+});
 
 describe('PrAutoCleanupService', () => {
   let mode: 'off' | 'archive' | 'delete';

--- a/apps/emdash-desktop/src/main/core/pull-requests/pr-auto-cleanup-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/pull-requests/pr-auto-cleanup-service.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PrAutoCleanupCandidate } from './pr-auto-cleanup-candidates';
+import {
+  PrAutoCleanupService,
+  type PrAutoCleanupDependencies,
+  type PrAutoCleanupMarker,
+} from './pr-auto-cleanup-service';
+
+vi.mock('@main/core/settings/settings-service', () => ({
+  appSettingsService: { get: vi.fn() },
+}));
+
+vi.mock('@main/core/tasks/task-service', () => ({
+  taskService: { archiveTask: vi.fn(), deleteTask: vi.fn() },
+}));
+
+vi.mock('@main/db/client', () => ({
+  db: {},
+}));
+
+vi.mock('@main/db/kv', () => ({
+  KV: class {
+    get = vi.fn();
+    setOrThrow = vi.fn();
+  },
+}));
+
+vi.mock('@main/lib/events', () => ({
+  events: { emit: vi.fn() },
+}));
+
+const candidate: PrAutoCleanupCandidate = {
+  taskId: 'task-1',
+  projectId: 'project-1',
+  taskName: 'Fix cleanup',
+  prUrl: 'https://github.com/acme/repo/pull/42',
+};
+
+describe('PrAutoCleanupService', () => {
+  let mode: 'off' | 'archive' | 'delete';
+  let active: boolean;
+  let candidates: PrAutoCleanupCandidate[];
+  let markers: Map<string, PrAutoCleanupMarker>;
+  let cleanup: ReturnType<typeof vi.fn<PrAutoCleanupDependencies['cleanup']>>;
+  let notify: ReturnType<typeof vi.fn<PrAutoCleanupDependencies['notify']>>;
+  let listCandidates: ReturnType<typeof vi.fn<PrAutoCleanupDependencies['listCandidates']>>;
+  let deps: PrAutoCleanupDependencies;
+
+  beforeEach(() => {
+    mode = 'off';
+    active = true;
+    candidates = [candidate];
+    markers = new Map();
+    cleanup = vi.fn().mockResolvedValue(undefined);
+    notify = vi.fn();
+    listCandidates = vi.fn(async () => candidates);
+    deps = {
+      getMode: async () => mode,
+      listCandidates,
+      isTaskActive: async () => active,
+      getMarker: async (taskId) => markers.get(taskId) ?? null,
+      cleanup,
+      setMarker: async (taskId, marker) => {
+        markers.set(taskId, marker);
+      },
+      notify,
+    };
+  });
+
+  it('does nothing when automatic cleanup is off', async () => {
+    const service = new PrAutoCleanupService(deps);
+
+    await service.processRepository('https://github.com/acme/repo');
+
+    expect(listCandidates).not.toHaveBeenCalled();
+    expect(cleanup).not.toHaveBeenCalled();
+  });
+
+  it.each(['archive', 'delete'] as const)('runs the selected %s action', async (action) => {
+    mode = action;
+    const service = new PrAutoCleanupService(deps);
+
+    await service.processRepository('https://github.com/acme/repo');
+
+    expect(cleanup).toHaveBeenCalledWith(candidate, action);
+    expect(markers.get(candidate.taskId)).toEqual({
+      version: 1,
+      prUrl: candidate.prUrl,
+      action,
+      completedAt: expect.any(String),
+    });
+    expect(notify).toHaveBeenCalledWith(candidate, action);
+  });
+
+  it('leaves the marker absent after failure and retries on a later sync', async () => {
+    mode = 'archive';
+    cleanup.mockRejectedValueOnce(new Error('teardown failed')).mockResolvedValueOnce(undefined);
+    const service = new PrAutoCleanupService(deps);
+
+    await service.processRepository('https://github.com/acme/repo');
+    expect(markers.has(candidate.taskId)).toBe(false);
+    expect(notify).not.toHaveBeenCalled();
+
+    await service.processRepository('https://github.com/acme/repo');
+    expect(cleanup).toHaveBeenCalledTimes(2);
+    expect(markers.get(candidate.taskId)?.prUrl).toBe(candidate.prUrl);
+    expect(notify).toHaveBeenCalledOnce();
+  });
+
+  it('does not clean the same PR again after a task is restored', async () => {
+    mode = 'archive';
+    const service = new PrAutoCleanupService(deps);
+
+    await service.processRepository('https://github.com/acme/repo');
+    expect(cleanup).toHaveBeenCalledTimes(1);
+
+    // Restoration makes the task active again, but intentionally preserves its marker.
+    active = true;
+    await service.processRepository('https://github.com/acme/repo');
+    expect(cleanup).toHaveBeenCalledTimes(1);
+
+    candidates = [{ ...candidate, prUrl: 'https://github.com/acme/repo/pull/84' }];
+    await service.processRepository('https://github.com/acme/repo');
+    expect(cleanup).toHaveBeenCalledTimes(2);
+    expect(markers.get(candidate.taskId)?.prUrl).toBe('https://github.com/acme/repo/pull/84');
+  });
+
+  it('ignores a stale candidate that is no longer active', async () => {
+    mode = 'delete';
+    active = false;
+    const service = new PrAutoCleanupService(deps);
+
+    await service.processRepository('https://github.com/acme/repo');
+
+    expect(cleanup).not.toHaveBeenCalled();
+    expect(markers.size).toBe(0);
+  });
+
+  it('does not repeat successful cleanup in-session when marker persistence fails', async () => {
+    mode = 'archive';
+    deps.setMarker = vi.fn().mockRejectedValue(new Error('database busy'));
+    const service = new PrAutoCleanupService(deps);
+
+    await service.processRepository('https://github.com/acme/repo');
+    await service.processRepository('https://github.com/acme/repo');
+
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(notify).toHaveBeenCalledOnce();
+    expect(markers.size).toBe(0);
+  });
+});

--- a/apps/emdash-desktop/src/main/core/pull-requests/pr-auto-cleanup-service.ts
+++ b/apps/emdash-desktop/src/main/core/pull-requests/pr-auto-cleanup-service.ts
@@ -1,0 +1,132 @@
+import { KeyedMutex } from '@emdash/core/lib';
+import { eq } from 'drizzle-orm';
+import { appSettingsService } from '@main/core/settings/settings-service';
+import { taskService } from '@main/core/tasks/task-service';
+import { db } from '@main/db/client';
+import { KV } from '@main/db/kv';
+import { tasks } from '@main/db/schema';
+import { events } from '@main/lib/events';
+import { log } from '@main/lib/logger';
+import { taskAutoCleanupChannel } from '@shared/core/tasks/taskEvents';
+import {
+  listPrAutoCleanupCandidates,
+  type PrAutoCleanupCandidate,
+} from './pr-auto-cleanup-candidates';
+
+export type PrAutoCleanupAction = 'archive' | 'delete';
+
+export type PrAutoCleanupMarker = {
+  version: 1;
+  prUrl: string;
+  action: PrAutoCleanupAction;
+  completedAt: string;
+};
+
+type PrAutoCleanupKv = Record<string, PrAutoCleanupMarker>;
+
+export type PrAutoCleanupDependencies = {
+  getMode(): Promise<'off' | PrAutoCleanupAction>;
+  listCandidates(repositoryUrl: string): Promise<PrAutoCleanupCandidate[]>;
+  isTaskActive(taskId: string): Promise<boolean>;
+  getMarker(taskId: string): Promise<PrAutoCleanupMarker | null>;
+  cleanup(candidate: PrAutoCleanupCandidate, action: PrAutoCleanupAction): Promise<void>;
+  setMarker(taskId: string, marker: PrAutoCleanupMarker): Promise<void>;
+  notify(candidate: PrAutoCleanupCandidate, action: PrAutoCleanupAction): void;
+};
+
+export class PrAutoCleanupService {
+  private readonly mutex = new KeyedMutex();
+  private readonly completedInMemory = new Map<string, PrAutoCleanupMarker>();
+
+  constructor(private readonly deps: PrAutoCleanupDependencies = productionDependencies) {}
+
+  async processRepository(repositoryUrl: string): Promise<void> {
+    const mode = await this.deps.getMode();
+    if (mode === 'off') return;
+
+    const candidates = await this.deps.listCandidates(repositoryUrl);
+    await Promise.all(candidates.map((candidate) => this.processCandidate(candidate, mode)));
+  }
+
+  private async processCandidate(
+    candidate: PrAutoCleanupCandidate,
+    action: PrAutoCleanupAction
+  ): Promise<void> {
+    await this.mutex.runExclusive(candidate.taskId, async () => {
+      try {
+        const [active, persistedMarker] = await Promise.all([
+          this.deps.isTaskActive(candidate.taskId),
+          this.deps.getMarker(candidate.taskId),
+        ]);
+        const marker = persistedMarker ?? this.completedInMemory.get(candidate.taskId);
+        if (!active || marker?.prUrl === candidate.prUrl) return;
+
+        await this.deps.cleanup(candidate, action);
+        const completedMarker: PrAutoCleanupMarker = {
+          version: 1,
+          prUrl: candidate.prUrl,
+          action,
+          completedAt: new Date().toISOString(),
+        };
+        this.completedInMemory.set(candidate.taskId, completedMarker);
+        try {
+          await this.deps.setMarker(candidate.taskId, completedMarker);
+        } catch (error) {
+          // Cleanup has already succeeded and cannot always be rolled back (delete).
+          // Retain an in-memory marker to prevent duplicate work in this app session.
+          log.warn('PrAutoCleanupService: failed to persist completion marker', {
+            taskId: candidate.taskId,
+            prUrl: candidate.prUrl,
+            action,
+            error: String(error),
+          });
+        }
+        this.deps.notify(candidate, action);
+      } catch (error) {
+        // A failed TaskService cleanup intentionally leaves the marker absent so the
+        // next successful PR sync can retry without losing teardown work.
+        log.warn('PrAutoCleanupService: cleanup failed', {
+          taskId: candidate.taskId,
+          prUrl: candidate.prUrl,
+          action,
+          error: String(error),
+        });
+      }
+    });
+  }
+}
+
+const markerStore = new KV<PrAutoCleanupKv>('pr-auto-cleanup');
+
+const productionDependencies: PrAutoCleanupDependencies = {
+  getMode: async () => (await appSettingsService.get('tasks')).autoCleanupOnPrMerge,
+  listCandidates: listPrAutoCleanupCandidates,
+  isTaskActive: async (taskId) => {
+    const [row] = await db
+      .select({ archivedAt: tasks.archivedAt })
+      .from(tasks)
+      .where(eq(tasks.id, taskId))
+      .limit(1);
+    return row != null && row.archivedAt == null;
+  },
+  getMarker: (taskId) => markerStore.get(taskId),
+  cleanup: async (candidate, action) => {
+    if (action === 'archive') {
+      await taskService.archiveTask(candidate.projectId, candidate.taskId);
+    } else {
+      await taskService.deleteTask(candidate.projectId, candidate.taskId);
+    }
+  },
+  setMarker: (taskId, marker) => markerStore.setOrThrow(taskId, marker),
+  notify: (candidate, action) => {
+    events.emit(taskAutoCleanupChannel, {
+      taskId: candidate.taskId,
+      projectId: candidate.projectId,
+      taskName: candidate.taskName,
+      prUrl: candidate.prUrl,
+      action,
+    });
+  },
+};
+
+export const prAutoCleanupService = new PrAutoCleanupService();

--- a/apps/emdash-desktop/src/main/core/pull-requests/pr-auto-cleanup-service.ts
+++ b/apps/emdash-desktop/src/main/core/pull-requests/pr-auto-cleanup-service.ts
@@ -98,6 +98,26 @@ export class PrAutoCleanupService {
 
 const markerStore = new KV<PrAutoCleanupKv>('pr-auto-cleanup');
 
+export async function cleanupMergedPrTask(
+  candidate: PrAutoCleanupCandidate,
+  action: PrAutoCleanupAction
+): Promise<void> {
+  // TaskService archive/delete preserve their existing best-effort semantics for
+  // manual actions, so require teardown to succeed before an automatic cleanup
+  // can mutate the task and record its completion marker.
+  const teardownMode = action === 'archive' ? 'archive' : 'terminate';
+  const teardownResult = await taskService.teardown(candidate.taskId, teardownMode);
+  if (!teardownResult.success) {
+    throw new Error(teardownResult.error.message);
+  }
+
+  if (action === 'archive') {
+    await taskService.archiveTask(candidate.projectId, candidate.taskId);
+  } else {
+    await taskService.deleteTask(candidate.projectId, candidate.taskId);
+  }
+}
+
 const productionDependencies: PrAutoCleanupDependencies = {
   getMode: async () => (await appSettingsService.get('tasks')).autoCleanupOnPrMerge,
   listCandidates: listPrAutoCleanupCandidates,
@@ -110,13 +130,7 @@ const productionDependencies: PrAutoCleanupDependencies = {
     return row != null && row.archivedAt == null;
   },
   getMarker: (taskId) => markerStore.get(taskId),
-  cleanup: async (candidate, action) => {
-    if (action === 'archive') {
-      await taskService.archiveTask(candidate.projectId, candidate.taskId);
-    } else {
-      await taskService.deleteTask(candidate.projectId, candidate.taskId);
-    }
-  },
+  cleanup: cleanupMergedPrTask,
   setMarker: (taskId, marker) => markerStore.setOrThrow(taskId, marker),
   notify: (candidate, action) => {
     events.emit(taskAutoCleanupChannel, {

--- a/apps/emdash-desktop/src/main/core/pull-requests/pr-sync-scheduler.test.ts
+++ b/apps/emdash-desktop/src/main/core/pull-requests/pr-sync-scheduler.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => {
     resolveRepository: vi.fn(),
     getProject: vi.fn(),
     projectOn: vi.fn(),
+    processRepository: vi.fn(),
     resolveProjectGitHubAuthContext: vi.fn(),
     emit: vi.fn(),
   };
@@ -63,6 +64,12 @@ vi.mock('./pr-sync-engine', () => ({
   },
 }));
 
+vi.mock('./pr-auto-cleanup-service', () => ({
+  prAutoCleanupService: {
+    processRepository: mocks.processRepository,
+  },
+}));
+
 vi.mock('@main/core/github/services/project-github-auth-context', () => ({
   resolveProjectGitHubAuthContext: mocks.resolveProjectGitHubAuthContext,
 }));
@@ -78,7 +85,9 @@ vi.mock('./project-remotes-service', () => ({
 }));
 
 type SchedulerInternals = {
+  _projectRemoteUrls: Map<string, string[]>;
   _getGitHubRemoteUrls(projectId: string): Promise<string[]>;
+  onTaskProvisioned(projectId: string, taskBranch: string | undefined): Promise<void>;
 };
 
 function createProject(
@@ -112,6 +121,76 @@ function createProject(
 describe('PrSyncScheduler', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(prSyncEngine.sync).mockResolvedValue(ok());
+    vi.mocked(prSyncEngine.syncSingle).mockResolvedValue(ok(null));
+    mocks.processRepository.mockResolvedValue(undefined);
+  });
+
+  it('runs auto-cleanup after the existing repository sync succeeds', async () => {
+    const { project } = createProject();
+    mocks.getProject.mockReturnValue(project);
+    mocks.resolveRepository.mockResolvedValue(
+      ok({
+        host: 'github.com',
+        repositoryUrl: 'https://github.com/acme/repo',
+        nameWithOwner: 'acme/repo',
+        owner: 'acme',
+        repo: 'repo',
+      })
+    );
+    mocks.resolveProjectGitHubAuthContext.mockResolvedValue(ok({ accountId: 'github.com:42' }));
+
+    const scheduler = new PrSyncScheduler();
+    await scheduler.onProjectMounted('project-1');
+
+    await vi.waitFor(() => {
+      expect(mocks.processRepository).toHaveBeenCalledWith('https://github.com/acme/repo');
+    });
+    scheduler.onProjectUnmounted('project-1');
+  });
+
+  it('does not run auto-cleanup after a failed repository sync', async () => {
+    const { project } = createProject();
+    mocks.getProject.mockReturnValue(project);
+    mocks.resolveRepository.mockResolvedValue(
+      ok({
+        host: 'github.com',
+        repositoryUrl: 'https://github.com/acme/repo',
+        nameWithOwner: 'acme/repo',
+        owner: 'acme',
+        repo: 'repo',
+      })
+    );
+    mocks.resolveProjectGitHubAuthContext.mockResolvedValue(ok({ accountId: 'github.com:42' }));
+    vi.mocked(prSyncEngine.sync).mockResolvedValue(
+      err({ type: 'api_error', message: 'sync failed' })
+    );
+
+    const scheduler = new PrSyncScheduler();
+    await scheduler.onProjectMounted('project-1');
+    await Promise.resolve();
+
+    expect(mocks.processRepository).not.toHaveBeenCalled();
+    scheduler.onProjectUnmounted('project-1');
+  });
+
+  it('runs auto-cleanup after a task-triggered single PR sync succeeds', async () => {
+    mocks.resolveProjectGitHubAuthContext.mockResolvedValue(ok({ accountId: 'github.com:42' }));
+
+    const scheduler = new PrSyncScheduler() as unknown as SchedulerInternals;
+    scheduler._projectRemoteUrls.set('project-1', ['https://github.com/acme/repo']);
+    mocks.where.mockReturnValueOnce({
+      limit: vi.fn().mockResolvedValue([{ identifier: '#42' }]),
+    });
+
+    await scheduler.onTaskProvisioned('project-1', 'feature/cleanup');
+
+    await vi.waitFor(() => {
+      expect(prSyncEngine.syncSingle).toHaveBeenCalledWith('https://github.com/acme/repo', 42, {
+        accountId: 'github.com:42',
+      });
+      expect(mocks.processRepository).toHaveBeenCalledWith('https://github.com/acme/repo');
+    });
   });
 
   it('passes selected GitHub account context to mounted project syncs', async () => {

--- a/apps/emdash-desktop/src/main/core/pull-requests/pr-sync-scheduler.ts
+++ b/apps/emdash-desktop/src/main/core/pull-requests/pr-sync-scheduler.ts
@@ -14,6 +14,7 @@ import { events } from '@main/lib/events';
 import { log } from '@main/lib/logger';
 import { prSyncProgressChannel } from '@shared/core/pull-requests/prEvents';
 import { parseRepositoryRef } from '@shared/repository-ref';
+import { prAutoCleanupService } from './pr-auto-cleanup-service';
 import { prSyncEngine } from './pr-sync-engine';
 import { syncProjectRemotes } from './project-remotes-service';
 
@@ -206,7 +207,25 @@ export class PrSyncScheduler implements IInitializable, IDisposable {
     const authContext = await this._resolveAuthContext(projectId, remoteUrl);
     if (!authContext) return;
     // sync() routes to full or incremental based on cursor state.
-    void prSyncEngine.sync(remoteUrl, authContext);
+    this._runPostSyncCleanup(projectId, remoteUrl, prSyncEngine.sync(remoteUrl, authContext));
+  }
+
+  private _runPostSyncCleanup(
+    projectId: string,
+    remoteUrl: string,
+    sync: Promise<{ success: boolean }>
+  ): void {
+    void sync
+      .then((result) => {
+        if (result.success) return prAutoCleanupService.processRepository(remoteUrl);
+      })
+      .catch((error) => {
+        log.warn('PrSyncScheduler: post-sync cleanup failed', {
+          projectId,
+          remoteUrl,
+          error: String(error),
+        });
+      });
   }
 
   private async _syncRemotes(projectId: string, remoteUrls: string[]): Promise<void> {
@@ -218,7 +237,11 @@ export class PrSyncScheduler implements IInitializable, IDisposable {
   private async _syncSingle(projectId: string, remoteUrl: string, prNumber: number): Promise<void> {
     const authContext = await this._resolveAuthContext(projectId, remoteUrl, 'single');
     if (!authContext) return;
-    void prSyncEngine.syncSingle(remoteUrl, prNumber, authContext);
+    this._runPostSyncCleanup(
+      projectId,
+      remoteUrl,
+      prSyncEngine.syncSingle(remoteUrl, prNumber, authContext)
+    );
   }
 
   private _emitAuthResolutionError(

--- a/apps/emdash-desktop/src/main/core/settings/schema.ts
+++ b/apps/emdash-desktop/src/main/core/settings/schema.ts
@@ -41,6 +41,7 @@ export const taskSettingsSchema = z.object({
   deleteBranchByDefault: z.boolean(),
   preserveNameCapitalization: z.boolean(),
   includeIssueContextByDefault: z.boolean(),
+  autoCleanupOnPrMerge: z.enum(['off', 'archive', 'delete']),
 });
 
 export const terminalSettingsSchema = z.object({

--- a/apps/emdash-desktop/src/main/core/settings/settings-registry.ts
+++ b/apps/emdash-desktop/src/main/core/settings/settings-registry.ts
@@ -33,6 +33,7 @@ export const SETTINGS_DEFAULTS = {
     deleteBranchByDefault: false,
     preserveNameCapitalization: false,
     includeIssueContextByDefault: true,
+    autoCleanupOnPrMerge: 'off' as const,
   },
   notifications: {
     enabled: true,

--- a/apps/emdash-desktop/src/main/core/settings/task-settings.test.ts
+++ b/apps/emdash-desktop/src/main/core/settings/task-settings.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { taskSettingsSchema } from './schema';
+import { getDefaultForKey } from './settings-registry';
+
+describe('task auto-cleanup settings', () => {
+  it('defaults to off', () => {
+    expect(getDefaultForKey('tasks').autoCleanupOnPrMerge).toBe('off');
+  });
+
+  it.each(['off', 'archive', 'delete'] as const)('accepts %s', (autoCleanupOnPrMerge) => {
+    const parsed = taskSettingsSchema.parse({
+      ...getDefaultForKey('tasks'),
+      autoCleanupOnPrMerge,
+    });
+
+    expect(parsed.autoCleanupOnPrMerge).toBe(autoCleanupOnPrMerge);
+  });
+
+  it('rejects unknown cleanup actions', () => {
+    expect(() =>
+      taskSettingsSchema.parse({
+        ...getDefaultForKey('tasks'),
+        autoCleanupOnPrMerge: 'destroy',
+      })
+    ).toThrow();
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/settings/components/SettingsPage.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/SettingsPage.tsx
@@ -17,6 +17,7 @@ import { SshConnectionsSettingsCard } from './SshConnectionsSettingsCard';
 import { StorageSettingsPage } from './StorageSettingsPage';
 import {
   AutoApproveByDefaultRow,
+  AutoCleanupOnPrMergeRow,
   AutoGenerateTaskNamesRow,
   AutoTrustWorktreesRow,
   CreateBranchAndWorktreeRow,
@@ -63,6 +64,7 @@ function GeneralSettingsPage() {
       <DeleteBranchByDefaultRow />
       <PreserveTaskNameCapitalizationRow />
       <IncludeIssueContextByDefaultRow />
+      <AutoCleanupOnPrMergeRow />
       <EnableTmuxRow />
       <NotificationSettingsCard />
     </div>

--- a/apps/emdash-desktop/src/renderer/features/settings/components/TaskSettingsRows.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/TaskSettingsRows.test.ts
@@ -1,0 +1,63 @@
+import { createElement, type ReactNode } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AutoCleanupOnPrMergeRow } from './TaskSettingsRows';
+
+const mocks = vi.hoisted(() => ({
+  onValueChange: undefined as ((value: 'off' | 'archive' | 'delete') => void) | undefined,
+  updateAutoCleanupOnPrMerge: vi.fn(),
+  useTaskSettings: vi.fn(),
+}));
+
+vi.mock('@renderer/features/tasks/hooks/useTaskSettings', () => ({
+  useTaskSettings: mocks.useTaskSettings,
+}));
+
+vi.mock('@renderer/lib/ui/select', async () => {
+  const { createElement } = await import('react');
+  return {
+    Select: ({
+      children,
+      onValueChange,
+    }: {
+      children: ReactNode;
+      onValueChange: (value: 'off' | 'archive' | 'delete') => void;
+    }) => {
+      mocks.onValueChange = onValueChange;
+      return createElement('div', null, children);
+    },
+    SelectContent: ({ children }: { children: ReactNode }) => createElement('div', null, children),
+    SelectItem: ({ children, value }: { children: ReactNode; value: string }) =>
+      createElement('div', { 'data-value': value }, children),
+    SelectTrigger: ({ children }: { children: ReactNode }) =>
+      createElement('button', null, children),
+    SelectValue: () => createElement('span', null, 'Off'),
+  };
+});
+
+describe('AutoCleanupOnPrMergeRow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.onValueChange = undefined;
+    mocks.useTaskSettings.mockReturnValue({
+      autoCleanupOnPrMerge: 'off',
+      loading: false,
+      saving: false,
+      isFieldOverridden: () => false,
+      resetAutoCleanupOnPrMerge: vi.fn(),
+      updateAutoCleanupOnPrMerge: mocks.updateAutoCleanupOnPrMerge,
+    });
+  });
+
+  it('shows all safe actions and updates the setting', () => {
+    const html = renderToStaticMarkup(createElement(AutoCleanupOnPrMergeRow));
+
+    expect(html).toContain('Auto-cleanup when a PR merges');
+    expect(html).toContain('Off');
+    expect(html).toContain('Archive');
+    expect(html).toContain('Delete');
+
+    mocks.onValueChange?.('delete');
+    expect(mocks.updateAutoCleanupOnPrMerge).toHaveBeenCalledWith('delete');
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/settings/components/TaskSettingsRows.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/TaskSettingsRows.tsx
@@ -2,6 +2,13 @@ import { Info } from 'lucide-react';
 import React from 'react';
 import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
 import { useTaskSettings } from '@renderer/features/tasks/hooks/useTaskSettings';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@renderer/lib/ui/select';
 import { Switch } from '@renderer/lib/ui/switch';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/lib/ui/tooltip';
 import { ResetToDefaultButton } from './ResetToDefaultButton';
@@ -212,6 +219,43 @@ export const IncludeIssueContextByDefaultRow: React.FC = () => {
             disabled={taskSettings.loading || taskSettings.saving}
             onCheckedChange={taskSettings.updateIncludeIssueContextByDefault}
           />
+        </>
+      }
+    />
+  );
+};
+
+export const AutoCleanupOnPrMergeRow: React.FC = () => {
+  const taskSettings = useTaskSettings();
+
+  return (
+    <SettingRow
+      title="Auto-cleanup when a PR merges"
+      description="Choose whether linked tasks stay active, are archived, or are permanently deleted after their pull request merges."
+      control={
+        <>
+          <ResetToDefaultButton
+            visible={taskSettings.isFieldOverridden('autoCleanupOnPrMerge')}
+            defaultLabel="off"
+            onReset={taskSettings.resetAutoCleanupOnPrMerge}
+            disabled={taskSettings.loading || taskSettings.saving}
+          />
+          <Select
+            value={taskSettings.autoCleanupOnPrMerge}
+            onValueChange={(value) => {
+              if (value) taskSettings.updateAutoCleanupOnPrMerge(value);
+            }}
+            disabled={taskSettings.loading || taskSettings.saving}
+          >
+            <SelectTrigger className="w-[110px] shrink-0" aria-label="PR merge cleanup action">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="off">Off</SelectItem>
+              <SelectItem value="archive">Archive</SelectItem>
+              <SelectItem value="delete">Delete</SelectItem>
+            </SelectContent>
+          </Select>
         </>
       }
     />

--- a/apps/emdash-desktop/src/renderer/features/tasks/hooks/useTaskSettings.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/hooks/useTaskSettings.ts
@@ -8,6 +8,7 @@ export interface TaskSettingsModel {
   deleteBranchByDefault: boolean;
   preserveNameCapitalization: boolean;
   includeIssueContextByDefault: boolean;
+  autoCleanupOnPrMerge: 'off' | 'archive' | 'delete';
   loading: boolean;
   saving: boolean;
   isFieldOverridden: (
@@ -19,6 +20,7 @@ export interface TaskSettingsModel {
       | 'deleteBranchByDefault'
       | 'preserveNameCapitalization'
       | 'includeIssueContextByDefault'
+      | 'autoCleanupOnPrMerge'
   ) => boolean;
   updateAutoGenerateName: (next: boolean) => void;
   updateAutoApproveByDefault: (next: boolean) => void;
@@ -27,6 +29,7 @@ export interface TaskSettingsModel {
   updateDeleteBranchByDefault: (next: boolean) => void;
   updatePreserveNameCapitalization: (next: boolean) => void;
   updateIncludeIssueContextByDefault: (next: boolean) => void;
+  updateAutoCleanupOnPrMerge: (next: 'off' | 'archive' | 'delete') => void;
   resetAutoGenerateName: () => void;
   resetAutoApproveByDefault: () => void;
   resetAutoTrustWorktrees: () => void;
@@ -34,6 +37,7 @@ export interface TaskSettingsModel {
   resetDeleteBranchByDefault: () => void;
   resetPreserveNameCapitalization: () => void;
   resetIncludeIssueContextByDefault: () => void;
+  resetAutoCleanupOnPrMerge: () => void;
 }
 
 export function useTaskSettings(): TaskSettingsModel {
@@ -54,6 +58,7 @@ export function useTaskSettings(): TaskSettingsModel {
     deleteBranchByDefault: tasks?.deleteBranchByDefault ?? false,
     preserveNameCapitalization: tasks?.preserveNameCapitalization ?? false,
     includeIssueContextByDefault: tasks?.includeIssueContextByDefault ?? true,
+    autoCleanupOnPrMerge: tasks?.autoCleanupOnPrMerge ?? 'off',
     loading,
     saving,
     isFieldOverridden,
@@ -64,6 +69,7 @@ export function useTaskSettings(): TaskSettingsModel {
     updateDeleteBranchByDefault: (next) => update({ deleteBranchByDefault: next }),
     updatePreserveNameCapitalization: (next) => update({ preserveNameCapitalization: next }),
     updateIncludeIssueContextByDefault: (next) => update({ includeIssueContextByDefault: next }),
+    updateAutoCleanupOnPrMerge: (next) => update({ autoCleanupOnPrMerge: next }),
     resetAutoGenerateName: () => resetField('autoGenerateName'),
     resetAutoApproveByDefault: () => resetField('autoApproveByDefault'),
     resetAutoTrustWorktrees: () => resetField('autoTrustWorktrees'),
@@ -71,5 +77,6 @@ export function useTaskSettings(): TaskSettingsModel {
     resetDeleteBranchByDefault: () => resetField('deleteBranchByDefault'),
     resetPreserveNameCapitalization: () => resetField('preserveNameCapitalization'),
     resetIncludeIssueContextByDefault: () => resetField('includeIssueContextByDefault'),
+    resetAutoCleanupOnPrMerge: () => resetField('autoCleanupOnPrMerge'),
   };
 }

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { taskAutoCleanupChannel } from '@shared/core/tasks/taskEvents';
 import type { Task } from '@shared/core/tasks/tasks';
 import { TaskManagerStore } from './task-manager';
 import { createUnprovisionedTask } from './task-store';
@@ -19,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   conversationAcquire: vi.fn(),
   conversationRelease: vi.fn(),
   draftComments: [] as MockDraftComments[],
+  eventHandlers: new Map<string, (data: unknown) => void>(),
   getConversationsForProject: vi.fn(),
   getProjectManagerStore: vi.fn(),
   getPullRequestsForTask: vi.fn(),
@@ -29,6 +31,7 @@ const mocks = vi.hoisted(() => ({
   teardownTask: vi.fn(),
   terminalAcquire: vi.fn(),
   terminalRelease: vi.fn(),
+  toastSuccess: vi.fn(),
   viewModels: [] as MockViewModel[],
   viewStateGet: vi.fn(),
   workspaceActivate: vi.fn(),
@@ -39,7 +42,10 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@renderer/lib/ipc', () => ({
   events: {
-    on: vi.fn(() => () => {}),
+    on: vi.fn((event: { name: string }, handler: (data: unknown) => void) => {
+      mocks.eventHandlers.set(event.name, handler);
+      return () => mocks.eventHandlers.delete(event.name);
+    }),
   },
   rpc: {
     conversations: {
@@ -75,6 +81,7 @@ vi.mock('@renderer/lib/stores/view-state-cache', () => ({
 vi.mock('sonner', () => ({
   toast: {
     error: vi.fn(),
+    success: mocks.toastSuccess,
   },
 }));
 
@@ -156,6 +163,7 @@ describe('TaskManagerStore archive lifecycle', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.draftComments.length = 0;
+    mocks.eventHandlers.clear();
     mocks.viewModels.length = 0;
     mocks.archiveTask.mockResolvedValue(undefined);
     mocks.getConversationsForProject.mockResolvedValue([]);
@@ -217,6 +225,33 @@ describe('TaskManagerStore archive lifecycle', () => {
     expect(store.viewModel).toBe(mocks.viewModels[1]);
     expect(mocks.viewModels[1].restoreSnapshot).toHaveBeenCalledWith(snapshot);
     expect(mocks.viewModels[1].initialize).toHaveBeenCalledOnce();
+
+    manager.dispose();
+  });
+
+  it('moves an automatically archived task to its dry archived state', () => {
+    const manager = makeTaskManager();
+    const task = makeTask();
+    const store = createUnprovisionedTask(task);
+    store.transitionToProvisioned(task, '/tmp/workspace-1', 'workspace-1', {} as never);
+    manager.tasks.set(task.id, store);
+
+    mocks.eventHandlers.get(taskAutoCleanupChannel.name)?.({
+      taskId: task.id,
+      projectId: task.projectId,
+      taskName: task.name,
+      prUrl: 'https://github.com/acme/repo/pull/42',
+      action: 'archive',
+    });
+
+    expect((store.data as Task).archivedAt).toBeDefined();
+    expect(store.state).toBe('unprovisioned');
+    expect(store.phase).toBe('idle');
+    expect(mocks.conversationRelease).toHaveBeenCalledWith(task.id);
+    expect(mocks.terminalRelease).toHaveBeenCalledWith(task.id);
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('Task automatically archived', {
+      description: "Task 1's pull request was merged.",
+    });
 
     manager.dispose();
   });

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.ts
@@ -17,6 +17,7 @@ import { gitWorktreeUpdateChannel } from '@shared/core/git/events';
 import { prSyncProgressChannel, prUpdatedChannel } from '@shared/core/pull-requests/prEvents';
 import {
   lifecycleScriptStatusChannel,
+  taskAutoCleanupChannel,
   taskCreatedChannel,
   taskDeletedChannel,
   taskProvisionProgressChannel,
@@ -128,6 +129,7 @@ export class TaskManagerStore {
 
   private _unsubTaskCreated: (() => void) | null = null;
   private _unsubTaskDeleted: (() => void) | null = null;
+  private _unsubTaskAutoCleanup: (() => void) | null = null;
   private _unsubPrUpdated: (() => void) | null = null;
   private _unsubPrSyncProgress: (() => void) | null = null;
   private _unsubGitWorktreeUpdate: (() => void) | null = null;
@@ -166,6 +168,33 @@ export class TaskManagerStore {
       ({ taskId, projectId: evtProjectId }) => {
         if (evtProjectId !== this.projectId) return;
         this._removeTaskLocally(taskId);
+      }
+    );
+
+    this._unsubTaskAutoCleanup = events.on(
+      taskAutoCleanupChannel,
+      ({ taskId, projectId: evtProjectId, taskName, action }) => {
+        if (evtProjectId !== this.projectId) return;
+
+        if (action === 'archive') {
+          const task = this.tasks.get(taskId);
+          if (task && isRegistered(task)) {
+            runInAction(() => {
+              task.data.archivedAt = new Date().toISOString();
+            });
+            this._releaseTaskRegistries(taskId);
+            runInAction(() => {
+              const current = this.tasks.get(taskId);
+              if (current && isRegistered(current)) {
+                current.transitionToDryUnprovisioned({ ...current.data }, 'idle');
+              }
+            });
+          }
+        }
+
+        toast.success(`Task automatically ${action === 'archive' ? 'archived' : 'deleted'}`, {
+          description: `${taskName}'s pull request was merged.`,
+        });
       }
     );
 
@@ -686,6 +715,8 @@ export class TaskManagerStore {
     this._unsubTaskCreated = null;
     this._unsubTaskDeleted?.();
     this._unsubTaskDeleted = null;
+    this._unsubTaskAutoCleanup?.();
+    this._unsubTaskAutoCleanup = null;
     this._unsubPrUpdated?.();
     this._unsubPrUpdated = null;
     this._unsubPrSyncProgress?.();

--- a/apps/emdash-desktop/src/shared/core/tasks/taskEvents.ts
+++ b/apps/emdash-desktop/src/shared/core/tasks/taskEvents.ts
@@ -9,6 +9,14 @@ export const taskDeletedChannel = defineEvent<{
   projectId: string;
 }>('task:deleted');
 
+export const taskAutoCleanupChannel = defineEvent<{
+  taskId: string;
+  projectId: string;
+  taskName: string;
+  prUrl: string;
+  action: 'archive' | 'delete';
+}>('task:auto-cleanup');
+
 export const taskStatusUpdatedChannel = defineEvent<{
   taskId: string;
   projectId: string;


### PR DESCRIPTION
### Description

Add an **Off / Archive / Delete** task setting for automatically cleaning up active tasks after their current pull request is observed as merged. The default remains `Off`.

Cleanup runs only after the existing full, incremental, or single-PR sync succeeds, including the follow-up sync after an in-app merge. It does not add another polling loop. Eligible tasks are matched by branch and by ownership of the PR head repository, including fork PRs, then cleaned up through `TaskService`.

Automatic cleanup requires task teardown to succeed before archive/delete mutates the task. A teardown or cleanup failure leaves the completion marker absent and suppresses the success notification so a later sync can retry. A persistent per-task/PR completion marker prevents the same merged PR from re-cleaning a restored task. The renderer receives a typed event to update archived state and show the selected action.

### Related issues

Fixes #766.

### Testing

- Focused PR auto-cleanup tests: 11/11 passed
- Full desktop Node suite: 2244/2244 passed
- Desktop `pnpm run format:check`
- Desktop `pnpm run lint`
- Desktop `pnpm run typecheck`
- `git diff --check`

### Screenshot/Recording (if applicable)

Not attached. The new setting row and its three values are covered by a component test; cleanup behavior, renderer state, fork ownership, teardown failure, and retry/idempotency are covered by focused service, store, scheduler, controller, and SQLite tests.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed (not applicable; the setting is self-describing and no setup changed)
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>
