### PR TITLE
feat(ui): improve PR navigation affordance

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/projects/components/task-view/task-row-interaction-surface.tsx
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/task-view/task-row-interaction-surface.tsx
@@ -1,0 +1,44 @@
+import { type MouseEvent, type ReactNode } from 'react';
+import { cn } from '@renderer/utils/utils';
+
+interface TaskRowInteractionSurfaceProps {
+  taskName: string;
+  disabled?: boolean;
+  onOpen: () => void;
+  children: ReactNode;
+}
+
+export function TaskRowInteractionSurface({
+  taskName,
+  disabled = false,
+  onOpen,
+  children,
+}: TaskRowInteractionSurfaceProps) {
+  const handleOpen = () => {
+    if (!disabled) onOpen();
+  };
+
+  const handleNavigationButtonClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    handleOpen();
+  };
+
+  return (
+    <div
+      className={cn(
+        'group relative w-full rounded-lg transition-colors hover:bg-background-1',
+        disabled ? 'cursor-default' : 'cursor-pointer'
+      )}
+      onClick={handleOpen}
+    >
+      <button
+        type="button"
+        aria-label={`Open task: ${taskName}`}
+        disabled={disabled}
+        className="focus-visible:ring-ring/50 pointer-events-none absolute inset-0 rounded-lg outline-none focus-visible:ring-2"
+        onClick={handleNavigationButtonClick}
+      />
+      <div className="relative flex w-full items-center gap-2 p-3">{children}</div>
+    </div>
+  );
+}

--- a/apps/emdash-desktop/src/renderer/features/projects/components/task-view/task-row.tsx
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/task-view/task-row.tsx
@@ -18,6 +18,7 @@ import { RelativeTime } from '@renderer/lib/ui/relative-time';
 import { cn } from '@renderer/utils/utils';
 import { selectCurrentPr } from '@shared/core/pull-requests/pull-requests';
 import { type Task } from '@shared/core/tasks/tasks';
+import { TaskRowInteractionSurface } from './task-row-interaction-surface';
 
 export type ReadyTask = TaskStore & { data: Task };
 
@@ -44,7 +45,10 @@ export const TaskRow = observer(function TaskRow({
       projectId: task.data.projectId,
       tasks: [{ taskId: task.data.id, taskName: task.data.name }],
       onSuccess: ({ deleteWorktree, deleteBranch }) =>
-        void taskManager?.deleteTasks([task.data.id], { deleteWorktree, deleteBranch }),
+        void taskManager?.deleteTasks([task.data.id], {
+          deleteWorktree,
+          deleteBranch,
+        }),
     });
   const handleRename = () =>
     showRename({
@@ -73,13 +77,16 @@ export const TaskRow = observer(function TaskRow({
       onConvertAutomation={undefined}
       onDelete={handleDelete}
     >
-      <button
-        onClick={() => {
-          if (isArchived) return;
+      <TaskRowInteractionSurface
+        taskName={task.data.name}
+        disabled={isArchived}
+        onOpen={() => {
           handleProvision();
-          navigate('task', { projectId: task.data.projectId, taskId: task.data.id });
+          navigate('task', {
+            projectId: task.data.projectId,
+            taskId: task.data.id,
+          });
         }}
-        className="group flex w-full items-center gap-2 rounded-lg p-3 transition-colors hover:bg-background-1"
       >
         <div
           onPointerDownCapture={(e) => {
@@ -128,7 +135,7 @@ export const TaskRow = observer(function TaskRow({
             />
           )}
         </div>
-      </button>
+      </TaskRowInteractionSurface>
     </TaskContextMenu>
   );
 });

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/pr-entry-header.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/pr-entry-header.tsx
@@ -1,0 +1,30 @@
+import { ExternalLink } from 'lucide-react';
+import { PrNavigationButton } from '@renderer/lib/components/pr-navigation-button';
+import { PrNumberBadge } from '@renderer/lib/components/pr-number-badge';
+import { StatusIcon } from '@renderer/lib/components/pr-status-icon';
+import { PrUrlCopyButton } from '@renderer/lib/components/pr-url-copy-button';
+import { getPrNumber, type PullRequest } from '@shared/core/pull-requests/pull-requests';
+
+export function PullRequestEntryHeader({ pr }: { pr: PullRequest }) {
+  return (
+    <div className="group/header flex items-center justify-between gap-2">
+      <PrNavigationButton
+        pr={pr}
+        className="group focus-visible:ring-ring/50 relative flex min-w-0 flex-1 items-center gap-2 rounded-md text-left transition-colors outline-none hover:bg-background-1 focus-visible:ring-2"
+      >
+        <StatusIcon className="size-4" pr={pr} disableTooltip />
+        <span className="min-w-0 flex-1 truncate text-sm font-normal">{pr.title}</span>
+        <div className="transition-opacity duration-200 group-hover:opacity-0 group-focus-visible:opacity-0">
+          <PrNumberBadge number={getPrNumber(pr) ?? 0} />
+        </div>
+        <span className="absolute right-0 flex items-center bg-linear-to-r from-transparent to-background pr-0.5 pl-4 opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-visible:opacity-100">
+          <ExternalLink aria-hidden="true" className="size-3.5 text-foreground-muted" />
+        </span>
+      </PrNavigationButton>
+      <PrUrlCopyButton
+        url={pr.url}
+        className="opacity-0 group-focus-within/header:opacity-100 group-hover/header:opacity-100 focus-visible:opacity-100"
+      />
+    </div>
+  );
+}

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/pr-entry.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/pr-entry.tsx
@@ -1,4 +1,3 @@
-import { ExternalLink } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { useState } from 'react';
 import {
@@ -6,20 +5,17 @@ import {
   useWorkspaceViewModel,
 } from '@renderer/features/tasks/task-view-context';
 import { PrMergeLine } from '@renderer/lib/components/pr-merge-line';
-import { PrNumberBadge } from '@renderer/lib/components/pr-number-badge';
-import { StatusIcon } from '@renderer/lib/components/pr-status-icon';
-import { PrUrlCopyButton } from '@renderer/lib/components/pr-url-copy-button';
 import { toast } from '@renderer/lib/hooks/use-toast';
-import { rpc } from '@renderer/lib/ipc';
 import { type SplitButtonAction } from '@renderer/lib/ui/split-button';
 import { ToggleGroup, ToggleGroupItem } from '@renderer/lib/ui/toggle-group';
 import { cn } from '@renderer/utils/utils';
-import { getPrNumber, type PullRequest } from '@shared/core/pull-requests/pull-requests';
+import { type PullRequest } from '@shared/core/pull-requests/pull-requests';
 import { PrChecksList } from './checks-list';
 import { CommitRangeCommitsList } from './commits-list';
 import { PrFilesList } from './files-list';
 import { MergeFooter } from './merge-footer';
 import { computeMergeUiState } from './merge-ui-state';
+import { PullRequestEntryHeader } from './pr-entry-header';
 import { commitRangeForPullRequest } from './use-commits';
 
 export type MergeMode = 'merge' | 'squash' | 'rebase';
@@ -107,25 +103,7 @@ export const PullRequestEntry = observer(function PullRequestEntry({ pr }: { pr:
   return (
     <div className={cn('flex min-h-0 flex-1 flex-col border-t border-border')}>
       <div className="flex w-full flex-col gap-2 p-2.5">
-        <div className="group/header flex items-center justify-between gap-2">
-          <button
-            className="group relative flex min-w-0 flex-1 items-center gap-2"
-            onClick={() => rpc.app.openExternal(pr.url)}
-          >
-            <StatusIcon className="size-4" pr={pr} />
-            <span className="min-w-0 flex-1 truncate text-sm font-normal">{pr.title}</span>
-            <div className="transition-opacity duration-200 group-hover:opacity-0">
-              <PrNumberBadge number={getPrNumber(pr) ?? 0} />
-            </div>
-            <span className="absolute right-0 flex items-center bg-linear-to-r from-transparent to-background pr-0.5 pl-4 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
-              <ExternalLink className="size-3.5 text-foreground-muted" />
-            </span>
-          </button>
-          <PrUrlCopyButton
-            url={pr.url}
-            className="opacity-0 group-hover/header:opacity-100 focus-visible:opacity-100"
-          />
-        </div>
+        <PullRequestEntryHeader pr={pr} />
         <PrMergeLine pr={pr} />
       </div>
       <div className="flex min-h-0 flex-1 flex-col px-2.5">

--- a/apps/emdash-desktop/src/renderer/lib/components/pr-badge.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/pr-badge.tsx
@@ -63,6 +63,18 @@ export function PrBadge({ variant = 'default', pr, className, hoverDelay }: PrBa
     }, 100);
   };
 
+  const cancelPreview = () => {
+    if (openTimerRef.current !== null) {
+      window.clearTimeout(openTimerRef.current);
+      openTimerRef.current = null;
+    }
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+    setPreviewOpen(false);
+  };
+
   const renderBadge = () => {
     switch (variant) {
       case 'default':
@@ -107,6 +119,7 @@ export function PrBadge({ variant = 'default', pr, className, hoverDelay }: PrBa
       >
         <PrNavigationButton
           pr={pr}
+          onNavigate={cancelPreview}
           className="group flex h-full min-w-0 items-center rounded-l-md outline-none focus-visible:bg-background-1"
         >
           {renderBadge()}

--- a/apps/emdash-desktop/src/renderer/lib/components/pr-badge.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/pr-badge.tsx
@@ -1,13 +1,12 @@
-import { ExternalLink } from 'lucide-react';
+import { ChevronDown, ExternalLink } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
 import { PrMergeLine } from '@renderer/lib/components/pr-merge-line';
+import { PrNavigationButton } from '@renderer/lib/components/pr-navigation-button';
 import { PrUrlCopyButton } from '@renderer/lib/components/pr-url-copy-button';
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/lib/ui/popover';
 import { cn } from '@renderer/utils/utils';
 import { getPrNumber, type PullRequest } from '@shared/core/pull-requests/pull-requests';
-import { rpc } from '../ipc';
-import { Button } from '../ui/button';
 import { RelativeTime } from '../ui/relative-time';
-import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import { PrNumberBadge } from './pr-number-badge';
 import { StatusIcon } from './pr-status-icon';
 
@@ -19,26 +18,75 @@ interface PrBadgeProps {
 }
 
 export function PrBadge({ variant = 'default', pr, className, hoverDelay }: PrBadgeProps) {
+  const prNumber = getPrNumber(pr);
+  const detailsAccessibleLabel = `Show details for pull request${
+    prNumber == null ? `: ${pr.title}` : ` #${prNumber}`
+  }`;
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const badgeRef = useRef<HTMLSpanElement>(null);
+  const openTimerRef = useRef<number | null>(null);
+  const closeTimerRef = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      if (openTimerRef.current !== null) window.clearTimeout(openTimerRef.current);
+      if (closeTimerRef.current !== null) window.clearTimeout(closeTimerRef.current);
+    },
+    []
+  );
+
+  const openPreview = (delay = hoverDelay ?? 0) => {
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+    if (previewOpen || openTimerRef.current !== null) return;
+    if (delay <= 0) {
+      setPreviewOpen(true);
+      return;
+    }
+    openTimerRef.current = window.setTimeout(() => {
+      openTimerRef.current = null;
+      setPreviewOpen(true);
+    }, delay);
+  };
+
+  const closePreview = () => {
+    if (openTimerRef.current !== null) {
+      window.clearTimeout(openTimerRef.current);
+      openTimerRef.current = null;
+    }
+    if (closeTimerRef.current !== null) window.clearTimeout(closeTimerRef.current);
+    closeTimerRef.current = window.setTimeout(() => {
+      closeTimerRef.current = null;
+      setPreviewOpen(false);
+    }, 100);
+  };
+
   const renderBadge = () => {
     switch (variant) {
       case 'default':
         return (
           <div
             className={cn(
-              'flex h-5 max-w-52 items-center gap-1.5 rounded-md bg-background-2 px-1.5 leading-none',
+              'flex h-full max-w-52 items-center gap-1.5 px-1.5 leading-none',
               className
             )}
           >
             <StatusIcon className="size-3" pr={pr} disableTooltip />
-            <span className="shrink-0 font-sans text-xs leading-none text-foreground-muted">
-              #{getPrNumber(pr) ?? 0}
-            </span>
-            <span className="truncate text-xs leading-none text-foreground-muted">{pr.title}</span>
+            <span className="shrink-0 font-sans text-xs leading-none">#{prNumber ?? 0}</span>
+            <span className="truncate text-xs leading-none">{pr.title}</span>
+            <ExternalLink
+              aria-hidden="true"
+              className="size-3 shrink-0 opacity-60 transition-opacity group-focus-within/pr-badge:opacity-100 group-hover/pr-badge:opacity-100"
+            />
           </div>
         );
       case 'compact':
         return (
-          <div className={cn('flex h-5 items-center justify-center px-1 leading-none', className)}>
+          <div
+            className={cn('flex h-full items-center justify-center px-1 leading-none', className)}
+          >
             <StatusIcon className="size-3" pr={pr} disableTooltip />
           </div>
         );
@@ -46,32 +94,55 @@ export function PrBadge({ variant = 'default', pr, className, hoverDelay }: PrBa
   };
 
   return (
-    <Popover>
-      <PopoverTrigger className="flex items-center leading-none" openOnHover delay={hoverDelay}>
-        {renderBadge()}
-      </PopoverTrigger>
-      <PopoverContent className="w-auto max-w-sm min-w-72">
+    <Popover open={previewOpen} onOpenChange={setPreviewOpen}>
+      <span
+        ref={badgeRef}
+        className={cn(
+          'group/pr-badge inline-flex h-5 items-center rounded-md border border-border bg-background-2 leading-none text-foreground-muted transition-colors hover:bg-background-1 hover:text-foreground focus-within:border-ring focus-within:text-foreground focus-within:ring-2 focus-within:ring-ring/50',
+          variant === 'compact' &&
+            'border-transparent bg-transparent hover:border-border hover:bg-background-2'
+        )}
+        onMouseMove={() => openPreview()}
+        onMouseLeave={closePreview}
+      >
+        <PrNavigationButton
+          pr={pr}
+          className="group flex h-full min-w-0 items-center rounded-l-md outline-none focus-visible:bg-background-1"
+        >
+          {renderBadge()}
+        </PrNavigationButton>
+        <span className="flex h-full" onClick={(event) => event.stopPropagation()}>
+          <PopoverTrigger
+            type="button"
+            aria-label={detailsAccessibleLabel}
+            className={cn(
+              'flex cursor-pointer items-center justify-center rounded-r-md border-l border-border outline-none hover:bg-background-2 focus-visible:bg-background-2',
+              variant === 'compact' ? 'h-5 w-3' : 'size-5'
+            )}
+          >
+            <ChevronDown
+              aria-hidden="true"
+              className={variant === 'compact' ? 'size-2' : 'size-3'}
+            />
+          </PopoverTrigger>
+        </span>
+      </span>
+      <PopoverContent
+        anchor={badgeRef}
+        initialFocus={false}
+        finalFocus={false}
+        className="w-auto max-w-sm min-w-72"
+        onMouseEnter={() => openPreview(0)}
+        onMouseLeave={closePreview}
+      >
         <div className="flex flex-col gap-2">
           <div className="no-wrap flex items-center justify-between gap-2">
             <div className="flex min-w-0 items-center gap-2">
-              <StatusIcon pr={pr} className="size-3" />
+              <StatusIcon pr={pr} className="size-3" disableTooltip />
               <span className="min-w-0 truncate text-sm leading-snug text-foreground">
                 {pr.title}
               </span>
               <PrNumberBadge number={getPrNumber(pr) ?? 0} />
-              <Tooltip>
-                <TooltipTrigger>
-                  <Button
-                    variant="ghost"
-                    size="icon-xs"
-                    className="cursor-pointer"
-                    onClick={() => rpc.app.openExternal(pr.url)}
-                  >
-                    <ExternalLink className="size-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Open PR on GitHub</TooltipContent>
-              </Tooltip>
               <PrUrlCopyButton url={pr.url} />
             </div>
             <RelativeTime

--- a/apps/emdash-desktop/src/renderer/lib/components/pr-navigation-button.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/pr-navigation-button.tsx
@@ -5,9 +5,16 @@ import { rpc } from '../ipc';
 
 type PrNavigationButtonProps = Omit<ComponentProps<'button'>, 'aria-label' | 'onClick' | 'type'> & {
   pr: PullRequest;
+  onNavigate?: () => void;
 };
 
-export function PrNavigationButton({ pr, className, children, ...props }: PrNavigationButtonProps) {
+export function PrNavigationButton({
+  pr,
+  className,
+  children,
+  onNavigate,
+  ...props
+}: PrNavigationButtonProps) {
   const prNumber = getPrNumber(pr);
   const accessibleLabel = `Open pull request${
     prNumber == null ? '' : ` #${prNumber}`
@@ -21,6 +28,7 @@ export function PrNavigationButton({ pr, className, children, ...props }: PrNavi
       className={cn('cursor-pointer', className)}
       onClick={(event) => {
         event.stopPropagation();
+        onNavigate?.();
         void rpc.app.openExternal(pr.url);
       }}
     >

--- a/apps/emdash-desktop/src/renderer/lib/components/pr-navigation-button.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/pr-navigation-button.tsx
@@ -1,0 +1,30 @@
+import { type ComponentProps } from 'react';
+import { cn } from '@renderer/utils/utils';
+import { getPrNumber, type PullRequest } from '@shared/core/pull-requests/pull-requests';
+import { rpc } from '../ipc';
+
+type PrNavigationButtonProps = Omit<ComponentProps<'button'>, 'aria-label' | 'onClick' | 'type'> & {
+  pr: PullRequest;
+};
+
+export function PrNavigationButton({ pr, className, children, ...props }: PrNavigationButtonProps) {
+  const prNumber = getPrNumber(pr);
+  const accessibleLabel = `Open pull request${
+    prNumber == null ? '' : ` #${prNumber}`
+  }: ${pr.title}`;
+
+  return (
+    <button
+      {...props}
+      type="button"
+      aria-label={accessibleLabel}
+      className={cn('cursor-pointer', className)}
+      onClick={(event) => {
+        event.stopPropagation();
+        void rpc.app.openExternal(pr.url);
+      }}
+    >
+      {children}
+    </button>
+  );
+}

--- a/apps/emdash-desktop/src/renderer/tests/browser/pr-badge.test.tsx
+++ b/apps/emdash-desktop/src/renderer/tests/browser/pr-badge.test.tsx
@@ -1,0 +1,243 @@
+import { type ReactNode } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import { TaskRowInteractionSurface } from '@renderer/features/projects/components/task-view/task-row-interaction-surface';
+import { PullRequestEntryHeader } from '@renderer/features/tasks/diff-view/changes-panel/components/pr-entry/pr-entry-header';
+import { PrBadge } from '@renderer/lib/components/pr-badge';
+import { type PullRequest } from '@shared/core/pull-requests/pull-requests';
+
+const mocks = vi.hoisted(() => ({
+  openExternal: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@renderer/lib/ipc', () => ({
+  rpc: {
+    app: {
+      openExternal: mocks.openExternal,
+    },
+  },
+}));
+
+const pr: PullRequest = {
+  url: 'https://github.com/generalaction/emdash/pull/2082',
+  provider: 'github',
+  repositoryUrl: 'https://github.com/generalaction/emdash',
+  baseRefName: 'main',
+  baseRefOid: 'base-sha',
+  headRepositoryUrl: 'https://github.com/generalaction/emdash',
+  headRefName: 'improve-pr-badge',
+  headRefOid: 'head-sha',
+  identifier: '#2082',
+  title: 'Improve PR badge navigation',
+  description: null,
+  status: 'open',
+  isDraft: false,
+  additions: 1,
+  deletions: 0,
+  changedFiles: 1,
+  commitCount: 1,
+  mergeableStatus: 'MERGEABLE',
+  mergeStateStatus: 'CLEAN',
+  reviewDecision: null,
+  createdAt: '2026-05-18T01:26:32Z',
+  updatedAt: '2026-05-18T01:26:32Z',
+  author: null,
+  labels: [],
+  assignees: [],
+  checks: [],
+};
+
+const accessibleName = 'Open pull request #2082: Improve PR badge navigation';
+const detailsAccessibleName = 'Show details for pull request #2082';
+
+describe('PrBadge', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    mocks.openExternal.mockClear();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    flushSync(() => root.unmount());
+    container.remove();
+  });
+
+  it.each(['default', 'compact'] as const)(
+    'exposes the %s badge as a labelled PR navigation button',
+    async (variant) => {
+      render(<PrBadge variant={variant} pr={pr} />);
+      const trigger = page.getByRole('button', { name: accessibleName });
+
+      await expect.element(trigger).toBeVisible();
+      await expect.element(trigger).toHaveAttribute('type', 'button');
+      await expect.element(trigger).toHaveClass(/cursor-pointer/);
+      await expect.element(trigger).not.toHaveAttribute('aria-haspopup');
+    }
+  );
+
+  it('keeps compact preview control narrower than the default badge segment', async () => {
+    render(<PrBadge variant="compact" pr={pr} />);
+    const details = page.getByRole('button', { name: detailsAccessibleName });
+
+    await expect.element(details).toHaveClass(/h-5/);
+    await expect.element(details).toHaveClass(/w-3/);
+    await expect.element(details).not.toHaveClass(/size-5/);
+  });
+
+  it('gives each preview control a PR-specific accessible name with a title fallback', async () => {
+    const fallbackPr = {
+      ...pr,
+      url: 'https://github.com/generalaction/emdash/pull/fallback',
+      identifier: null,
+      title: 'Fallback PR title',
+    };
+    render(
+      <>
+        <PrBadge pr={pr} />
+        <PrBadge pr={fallbackPr} />
+      </>
+    );
+
+    const numberedDetails = page.getByRole('button', { name: detailsAccessibleName });
+    const fallbackDetails = page.getByRole('button', {
+      name: 'Show details for pull request: Fallback PR title',
+    });
+    await expect.element(numberedDetails).toBeVisible();
+    await expect.element(fallbackDetails).toBeVisible();
+    expect(
+      new Set(
+        [...container.querySelectorAll('[aria-label^="Show details for pull request"]')].map(
+          (element) => element.getAttribute('aria-label')
+        )
+      ).size
+    ).toBe(2);
+  });
+
+  it('opens the pull request directly without bubbling the row click', async () => {
+    const parentClick = vi.fn();
+    render(
+      <div onClick={parentClick}>
+        <PrBadge pr={pr} />
+      </div>
+    );
+
+    await userEvent.click(page.getByRole('button', { name: accessibleName }));
+
+    expect(mocks.openExternal).toHaveBeenCalledOnce();
+    expect(mocks.openExternal).toHaveBeenCalledWith(pr.url);
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['Enter', '{Enter}'],
+    ['Space', ' '],
+  ])('opens the pull request with the %s key', async (_keyName, key) => {
+    render(<PrBadge variant="compact" pr={pr} />);
+    const trigger = page.getByRole('button', { name: accessibleName });
+
+    await userEvent.tab();
+    await expect.element(trigger).toHaveFocus();
+    await userEvent.keyboard(key);
+
+    expect(mocks.openExternal).toHaveBeenCalledOnce();
+    expect(mocks.openExternal).toHaveBeenCalledWith(pr.url);
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it('keeps the hover preview and copy action available', async () => {
+    render(<PrBadge pr={pr} hoverDelay={0} />);
+
+    await userEvent.hover(page.getByRole('button', { name: accessibleName }));
+
+    await expect.element(page.getByRole('button', { name: 'Copy PR URL' })).toBeVisible();
+  });
+
+  it('exposes preview and copy as a separate keyboard action', async () => {
+    render(<PrBadge pr={pr} />);
+    const navigation = page.getByRole('button', { name: accessibleName });
+    const details = page.getByRole('button', {
+      name: detailsAccessibleName,
+    });
+
+    await userEvent.tab();
+    await expect.element(navigation).toHaveFocus();
+    expect(document.querySelector('[aria-label="Copy PR URL"]')).toBeNull();
+
+    await userEvent.tab();
+    await expect.element(details).toHaveFocus();
+    await userEvent.keyboard('{Enter}');
+
+    const copy = page.getByRole('button', { name: 'Copy PR URL' });
+    await expect.element(copy).toBeVisible();
+    await userEvent.tab();
+    await expect.element(copy).toHaveFocus();
+  });
+
+  it('keeps task navigation, selection, and PR controls as independent siblings', async () => {
+    const openTask = vi.fn();
+    const selectTask = vi.fn();
+    render(
+      <TaskRowInteractionSurface taskName="Investigate badge behavior" onOpen={openTask}>
+        <div onClick={(event) => event.stopPropagation()}>
+          <button
+            type="button"
+            role="checkbox"
+            aria-checked="false"
+            aria-label="Select task"
+            onClick={() => selectTask()}
+          />
+        </div>
+        <span>Investigate badge behavior</span>
+        <PrBadge pr={pr} hoverDelay={0} />
+      </TaskRowInteractionSurface>
+    );
+
+    expect(container.querySelector('button button')).toBeNull();
+
+    const taskNavigation = page.getByRole('button', {
+      name: 'Open task: Investigate badge behavior',
+    });
+    await userEvent.tab();
+    await expect.element(taskNavigation).toHaveFocus();
+    await userEvent.keyboard('{Enter}');
+    expect(openTask).toHaveBeenCalledOnce();
+
+    await userEvent.click(page.getByText('Investigate badge behavior'));
+    expect(openTask).toHaveBeenCalledTimes(2);
+
+    await userEvent.click(page.getByRole('checkbox', { name: 'Select task' }));
+    expect(selectTask).toHaveBeenCalledOnce();
+    expect(openTask).toHaveBeenCalledTimes(2);
+
+    await userEvent.click(page.getByRole('button', { name: accessibleName }));
+    expect(mocks.openExternal).toHaveBeenCalledOnce();
+    expect(openTask).toHaveBeenCalledTimes(2);
+
+    await userEvent.click(page.getByRole('button', { name: detailsAccessibleName }));
+    expect(openTask).toHaveBeenCalledTimes(2);
+  });
+
+  it('improves the changes-panel PR navigation affordance', async () => {
+    render(<PullRequestEntryHeader pr={pr} />);
+    const navigation = page.getByRole('button', { name: accessibleName });
+
+    expect(container.querySelector('button button')).toBeNull();
+    await expect.element(navigation).toHaveClass(/cursor-pointer/);
+    await expect.element(navigation).toHaveClass(/hover:bg-background-1/);
+    await expect.element(navigation).toHaveClass(/focus-visible:ring-2/);
+    await userEvent.click(navigation);
+
+    expect(mocks.openExternal).toHaveBeenCalledOnce();
+    expect(mocks.openExternal).toHaveBeenCalledWith(pr.url);
+  });
+
+  function render(node: ReactNode) {
+    flushSync(() => root.render(node));
+  }
+});

--- a/apps/emdash-desktop/src/renderer/tests/browser/pr-badge.test.tsx
+++ b/apps/emdash-desktop/src/renderer/tests/browser/pr-badge.test.tsx
@@ -134,6 +134,18 @@ describe('PrBadge', () => {
     expect(parentClick).not.toHaveBeenCalled();
   });
 
+  it('cancels a delayed hover preview when direct navigation starts', async () => {
+    render(<PrBadge pr={pr} hoverDelay={100} />);
+    const navigation = page.getByRole('button', { name: accessibleName });
+
+    await userEvent.hover(navigation);
+    await userEvent.click(navigation);
+    await new Promise((resolve) => window.setTimeout(resolve, 150));
+
+    expect(mocks.openExternal).toHaveBeenCalledOnce();
+    expect(document.querySelector('[aria-label="Copy PR URL"]')).toBeNull();
+  });
+
   it.each([
     ['Enter', '{Enter}'],
     ['Space', ' '],


### PR DESCRIPTION
### Description

Make linked pull requests clearly navigable from the project task list, compact sidebar badge, and changes panel. PR navigation is now a labelled native button with pointer, hover, focus, contrast, and external-link affordances.

Badge navigation and the details preview are separate controls: clicking or pressing Enter/Space on the PR action only opens the pull request, while the PR-specific details button opens the existing preview and keeps Copy PR URL keyboard-accessible. The compact details segment remains narrow to preserve sidebar space.

The project task row now uses sibling task, selection, PR navigation, and PR details controls instead of nesting buttons. The changes-panel header uses the same navigation semantics and visible focus treatment.

### Related issues

Fixes #2082.

### Testing

- Focused Chromium component tests: 1 file, 11 tests passed
- Complete desktop browser project: 4 files, 48 tests passed
- Desktop `pnpm run format:check`
- Desktop `pnpm run lint`
- Desktop `pnpm run typecheck`
- `git diff --check`

Browser coverage includes default and compact badge click/Enter/Space behavior, hover preview, details-to-Copy Tab order, unique accessible names, compact footprint, non-nested task-row controls, task/checkbox/PR event isolation, and the changes-panel navigation surface.

### Screenshot/Recording (if applicable)

Not attached because the repository does not provide a deterministic seeded task-with-PR fixture for these contextual surfaces. The browser suite renders and exercises the production presentation components directly.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed (not applicable; no setup or documented workflow changed)
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>
