### PR TITLE
fix(ssh): extend BaseAgent instead of implementing for instanceof compatibility

### DIFF
--- a/apps/emdash-desktop/src/main/core/ssh/connect/ssh-connect-auth.ts
+++ b/apps/emdash-desktop/src/main/core/ssh/connect/ssh-connect-auth.ts
@@ -1,6 +1,6 @@
 // Auth assembly: password, key, and agent selection with IdentitiesOnly filtering.
 import ssh2, {
-  type BaseAgent,
+  BaseAgent,
   type ConnectConfig,
   type IdentityCallback,
   type ParsedKey,
@@ -41,7 +41,7 @@ function comparablePublicKey(key: AgentPublicKey): ParsedKey | Buffer | string {
   return key;
 }
 
-class IdentityFilteredAgent implements BaseAgent {
+class IdentityFilteredAgent extends BaseAgent {
   readonly kind = 'identity-filtered-agent';
   declare getStream?: BaseAgent['getStream'];
 
@@ -50,6 +50,7 @@ class IdentityFilteredAgent implements BaseAgent {
     private readonly agent: BaseAgent,
     private readonly allowedKeys: ParsedKey[]
   ) {
+    super();
     if (agent.getStream) {
       this.getStream = agent.getStream.bind(agent);
     }


### PR DESCRIPTION
## Summary

`IdentityFilteredAgent` used `implements BaseAgent` (TypeScript type-level only), but ssh2's `isAgent()` check uses `val instanceof BaseAgent`. Since there's no prototype chain with `implements`, the agent wrapper is silently discarded during `Client.connect` config normalization — causing authentication to fail with no key offered when `IdentitiesOnly yes` is set in ssh config.

## Changes

- Import `BaseAgent` as a value (not `type BaseAgent`)
- Change `class IdentityFilteredAgent implements BaseAgent` → `extends BaseAgent`
- Add `super()` call in constructor

The identity-filtering logic itself is correct and unchanged. This only adds the runtime inheritance that `instanceof` requires.

## Testing

Verified the fix matches the approach described and tested by the issue reporter. The class already correctly implements all `BaseAgent` methods — the only missing piece was the prototype chain.

Closes #2901

---

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.