### PR TITLE
fix(issue-selector): prevent provider icon clipping

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tasks/components/issue-selector/issue-selector.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/components/issue-selector/issue-selector.tsx
@@ -202,7 +202,7 @@ export const IssueSelector = observer(function IssueSelector({
         <SelectContent>
           {issueProviderOrder.map((p) => (
             <SelectItem key={p} value={p} disabled={isProviderDisabled(p)}>
-              <ProviderLogo provider={p} className="h-3.5 w-3.5" />
+              <ProviderLogo provider={p} className="size-4" size={16} />
               <span>{getIntegrationName(integrationById, p)}</span>
             </SelectItem>
           ))}


### PR DESCRIPTION
### Description

Prevents provider icons from being clipped in the issue integration selector. `SelectItem` renders nested SVGs at 16 px, while the provider icon wrapper was 14 px and its parent hides overflow; matching the wrapper and icon size to the 16 px Open With menu pattern keeps the full icon visible.

### Related issues

[ENG-1894](https://linear.app/general-action/issue/ENG-1894/mondaycom-is-cut-off-in-integration-selector)

### Screenshot/Recording (if applicable)
<img width="123" height="328" alt="Screenshot 2026-07-17 at 18 29 41" src="https://github.com/user-attachments/assets/c77b8dbb-47b8-446b-a99d-0e00fa73abe4" />


<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] Docs are not needed for this visual fix
- [x] The existing focused issue-selector test passes; pixel geometry was verified in the live renderer
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>
