### PR TITLE
feat(ui): edit queued prompts in composer

### DIFF
--- a/packages/ui/src/react/components/chat-composer/index.tsx
+++ b/packages/ui/src/react/components/chat-composer/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@react/primitives/button';
 import { cx } from '@styles/utilities/cx';
 import { ArrowUp, Check, ChevronRight, CircleAlert, Paperclip, ShieldCheck, X } from 'lucide-react';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Combobox } from '@/react/primitives/combobox/combobox';
 import { DropdownMenu } from '@/react/primitives/dropdown-menu';
 import { ComboboxPopover } from '../combobox-popover';
@@ -574,12 +574,12 @@ export function ChatComposer({
   const [editingQueuedPromptId, setEditingQueuedPromptId] = useState<string | null>(null);
   const [dragActive, setDragActive] = useState(false);
 
-  const restoreStashedDraft = () => {
+  const restoreStashedDraft = useCallback(() => {
     editingQueuedPromptIdRef.current = null;
     setEditingQueuedPromptId(null);
     editorRef.current?.setText(stashedDraftRef.current);
     editorRef.current?.focus();
-  };
+  }, []);
 
   const beginQueuedPromptEdit = (id: string) => {
     const prompt = queuedPrompts.find((item) => item.id === id);
@@ -603,11 +603,8 @@ export function ChatComposer({
   useEffect(() => {
     if (!editingQueuedPromptId) return;
     if (queuedPrompts.some((prompt) => prompt.id === editingQueuedPromptId)) return;
-    editingQueuedPromptIdRef.current = null;
-    setEditingQueuedPromptId(null);
-    editorRef.current?.setText(stashedDraftRef.current);
-    editorRef.current?.focus();
-  }, [editingQueuedPromptId, queuedPrompts]);
+    restoreStashedDraft();
+  }, [editingQueuedPromptId, queuedPrompts, restoreStashedDraft]);
 
   // Retain the last notice so its content stays rendered while the band
   // collapses out, letting the exit transition play before unmount.
@@ -782,7 +779,7 @@ export function ChatComposer({
         <QueuedPromptsBand
           prompts={queuedPrompts}
           editingPromptId={editingQueuedPromptId}
-          onEdit={beginQueuedPromptEdit}
+          onStartEdit={beginQueuedPromptEdit}
           onDelete={onDeleteQueuedPrompt}
           onReorder={onReorderQueuedPrompts}
           onSendNow={onSendQueuedPromptNow}

--- a/packages/ui/src/react/components/chat-composer/index.tsx
+++ b/packages/ui/src/react/components/chat-composer/index.tsx
@@ -582,11 +582,10 @@ export function ChatComposer({
   }, []);
 
   const beginQueuedPromptEdit = (id: string) => {
+    if (editingQueuedPromptIdRef.current) return;
     const prompt = queuedPrompts.find((item) => item.id === id);
     if (!prompt) return;
-    if (!editingQueuedPromptIdRef.current) {
-      stashedDraftRef.current = editorRef.current?.getText() ?? '';
-    }
+    stashedDraftRef.current = editorRef.current?.getText() ?? '';
     editingQueuedPromptIdRef.current = id;
     setEditingQueuedPromptId(id);
     editorRef.current?.setText(prompt.text);
@@ -595,7 +594,7 @@ export function ChatComposer({
 
   const saveQueuedPromptEdit = (text: string) => {
     const id = editingQueuedPromptIdRef.current;
-    if (!id || !text.trim() || !onEditQueuedPrompt) return;
+    if (!id || !onEditQueuedPrompt) return;
     onEditQueuedPrompt(id, text);
     restoreStashedDraft();
   };
@@ -865,6 +864,7 @@ export function ChatComposer({
               if (!editingQueuedPromptIdRef.current) onInputChange?.(text);
             }}
             onSubmit={shouldHandleSubmitAttempt ? handleSubmit : undefined}
+            onCancel={editingQueuedPromptId ? restoreStashedDraft : undefined}
             onMentionInsert={onMentionInsert}
             mentionProvider={mentionProvider}
             renderMentionIcon={renderMentionIcon}
@@ -1052,18 +1052,31 @@ export function ChatComposer({
 
             {showSubmitButton ? (
               editingQueuedPromptId ? (
-                <Button
-                  variant="primary"
-                  size="sm"
-                  icon
-                  className={styles.sendButtonRound}
-                  onClick={() => saveQueuedPromptEdit(editorRef.current?.getText() ?? '')}
-                  disabled={disabled}
-                  aria-label="Save queued prompt"
-                  title="Save queued prompt"
-                >
-                  <Check />
-                </Button>
+                <>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    icon
+                    onClick={restoreStashedDraft}
+                    disabled={disabled}
+                    aria-label="Cancel queued prompt edit"
+                    title="Cancel queued prompt edit"
+                  >
+                    <X />
+                  </Button>
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    icon
+                    className={styles.sendButtonRound}
+                    onClick={() => saveQueuedPromptEdit(editorRef.current?.getText() ?? '')}
+                    disabled={disabled}
+                    aria-label="Save queued prompt"
+                    title="Save queued prompt"
+                  >
+                    <Check />
+                  </Button>
+                </>
               ) : isWorking ? (
                 <Button
                   variant="primary"

--- a/packages/ui/src/react/components/chat-composer/index.tsx
+++ b/packages/ui/src/react/components/chat-composer/index.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@react/primitives/button';
 import { cx } from '@styles/utilities/cx';
-import { ArrowUp, ChevronRight, CircleAlert, Paperclip, ShieldCheck, X } from 'lucide-react';
+import { ArrowUp, Check, ChevronRight, CircleAlert, Paperclip, ShieldCheck, X } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 import { Combobox } from '@/react/primitives/combobox/combobox';
 import { DropdownMenu } from '@/react/primitives/dropdown-menu';
@@ -569,7 +569,45 @@ export function ChatComposer({
   className,
 }: ChatComposerProps) {
   const editorRef = useRef<PromptEditorRef | null>(null);
+  const editingQueuedPromptIdRef = useRef<string | null>(null);
+  const stashedDraftRef = useRef('');
+  const [editingQueuedPromptId, setEditingQueuedPromptId] = useState<string | null>(null);
   const [dragActive, setDragActive] = useState(false);
+
+  const restoreStashedDraft = () => {
+    editingQueuedPromptIdRef.current = null;
+    setEditingQueuedPromptId(null);
+    editorRef.current?.setText(stashedDraftRef.current);
+    editorRef.current?.focus();
+  };
+
+  const beginQueuedPromptEdit = (id: string) => {
+    const prompt = queuedPrompts.find((item) => item.id === id);
+    if (!prompt) return;
+    if (!editingQueuedPromptIdRef.current) {
+      stashedDraftRef.current = editorRef.current?.getText() ?? '';
+    }
+    editingQueuedPromptIdRef.current = id;
+    setEditingQueuedPromptId(id);
+    editorRef.current?.setText(prompt.text);
+    editorRef.current?.focus();
+  };
+
+  const saveQueuedPromptEdit = (text: string) => {
+    const id = editingQueuedPromptIdRef.current;
+    if (!id || !text.trim() || !onEditQueuedPrompt) return;
+    onEditQueuedPrompt(id, text);
+    restoreStashedDraft();
+  };
+
+  useEffect(() => {
+    if (!editingQueuedPromptId) return;
+    if (queuedPrompts.some((prompt) => prompt.id === editingQueuedPromptId)) return;
+    editingQueuedPromptIdRef.current = null;
+    setEditingQueuedPromptId(null);
+    editorRef.current?.setText(stashedDraftRef.current);
+    editorRef.current?.focus();
+  }, [editingQueuedPromptId, queuedPrompts]);
 
   // Retain the last notice so its content stays rendered while the band
   // collapses out, letting the exit transition play before unmount.
@@ -594,6 +632,10 @@ export function ChatComposer({
   }, []);
 
   const handleSubmit = (text: string) => {
+    if (editingQueuedPromptIdRef.current) {
+      saveQueuedPromptEdit(text);
+      return;
+    }
     // Allow image-only sends: a message with attachments but no text is valid.
     const hasImages = attachments.some((a) => a.kind === 'image');
     if (!text.trim() && !hasImages) return;
@@ -725,7 +767,9 @@ export function ChatComposer({
     !!onSendQueuedPromptNow;
   // The permission band takes priority over the notice band.
   const hasBand = canShowQueuedPrompts || !!(permissionRequest ?? notice);
-  const shouldHandleSubmitAttempt = !disabled && (isWorking ? !!onSubmitWhileWorking : canSubmit);
+  const shouldHandleSubmitAttempt =
+    !disabled &&
+    (editingQueuedPromptId ? !!onEditQueuedPrompt : isWorking ? !!onSubmitWhileWorking : canSubmit);
   const resolvedPlaceholder = disabled
     ? 'Session closed'
     : isWorking
@@ -737,7 +781,8 @@ export function ChatComposer({
       {canShowQueuedPrompts && (
         <QueuedPromptsBand
           prompts={queuedPrompts}
-          onEdit={onEditQueuedPrompt}
+          editingPromptId={editingQueuedPromptId}
+          onEdit={beginQueuedPromptEdit}
           onDelete={onDeleteQueuedPrompt}
           onReorder={onReorderQueuedPrompts}
           onSendNow={onSendQueuedPromptNow}
@@ -819,7 +864,9 @@ export function ChatComposer({
             }}
             placeholder={resolvedPlaceholder}
             disabled={disabled}
-            onChange={onInputChange}
+            onChange={(text) => {
+              if (!editingQueuedPromptIdRef.current) onInputChange?.(text);
+            }}
             onSubmit={shouldHandleSubmitAttempt ? handleSubmit : undefined}
             onMentionInsert={onMentionInsert}
             mentionProvider={mentionProvider}
@@ -1007,7 +1054,20 @@ export function ChatComposer({
             )}
 
             {showSubmitButton ? (
-              isWorking ? (
+              editingQueuedPromptId ? (
+                <Button
+                  variant="primary"
+                  size="sm"
+                  icon
+                  className={styles.sendButtonRound}
+                  onClick={() => saveQueuedPromptEdit(editorRef.current?.getText() ?? '')}
+                  disabled={disabled}
+                  aria-label="Save queued prompt"
+                  title="Save queued prompt"
+                >
+                  <Check />
+                </Button>
+              ) : isWorking ? (
                 <Button
                   variant="primary"
                   tone="destructive"

--- a/packages/ui/src/react/components/chat-composer/queued-prompts-band.css.ts
+++ b/packages/ui/src/react/components/chat-composer/queued-prompts-band.css.ts
@@ -77,6 +77,7 @@ export const row = style({
   selectors: {
     '&:hover': { backgroundColor: vars.surfaceHover },
     '&:focus-within': { backgroundColor: vars.surfaceHover },
+    '&[data-editing]': { backgroundColor: vars.surfaceSelected },
     '&:focus-visible': {
       boxShadow: `0 0 0 1px ${vars.border1}`,
     },
@@ -190,36 +191,5 @@ export const actions = style({
   selectors: {
     [`${row}:hover &`]: { opacity: 1, pointerEvents: 'auto' },
     [`${row}:focus-within &`]: { opacity: 1, pointerEvents: 'auto' },
-  },
-});
-
-export const editArea = style({
-  display: 'flex',
-  alignItems: 'center',
-  gap: '0.375rem',
-  minWidth: 0,
-});
-
-export const editInput = style({
-  flex: 1,
-  minWidth: 0,
-  resize: 'vertical',
-  maxHeight: '7rem',
-  border: `1px solid ${vars.border}`,
-  borderRadius: tokenVars.radiusMd,
-  paddingLeft: '0.5rem',
-  paddingRight: '0.5rem',
-  paddingTop: '0.375rem',
-  paddingBottom: '0.375rem',
-  backgroundColor: vars.surfaceBaseEmphasis,
-  color: vars.foreground,
-  font: 'inherit',
-  lineHeight: 1.375,
-  outline: 'none',
-  selectors: {
-    '&:focus': {
-      borderColor: vars.border1,
-      boxShadow: `0 0 0 1px ${vars.border1}`,
-    },
   },
 });

--- a/packages/ui/src/react/components/chat-composer/queued-prompts-band.tsx
+++ b/packages/ui/src/react/components/chat-composer/queued-prompts-band.tsx
@@ -12,7 +12,7 @@ export type ComposerQueuedPrompt = {
 export interface QueuedPromptsBandProps {
   prompts: ComposerQueuedPrompt[];
   editingPromptId?: string | null;
-  onEdit: (id: string) => void;
+  onStartEdit: (id: string) => void;
   onDelete: (id: string) => void;
   onReorder: (ids: string[]) => void;
   onSendNow: (id: string) => void;
@@ -23,7 +23,7 @@ export interface QueuedPromptsBandProps {
 export function QueuedPromptsBand({
   prompts,
   editingPromptId,
-  onEdit,
+  onStartEdit,
   onDelete,
   onReorder,
   onSendNow,
@@ -118,62 +118,62 @@ export function QueuedPromptsBand({
               <button
                 type="button"
                 className={cx(styles.promptText, !prompt.text.trim() && styles.emptyText)}
-                onClick={() => onEdit(prompt.id)}
+                onClick={() => {
+                  if (!isEditing) onStartEdit(prompt.id);
+                }}
                 aria-label={`Edit queued prompt ${index + 1}`}
                 title={isEditing ? 'Editing in composer' : 'Edit queued prompt'}
               >
                 {prompt.text.trim() || 'Image-only prompt'}
               </button>
 
-              <div className={styles.actions}>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  icon
-                  aria-label={`Edit queued prompt ${index + 1}`}
-                  title={isEditing ? 'Editing in composer' : 'Edit queued prompt'}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    onEdit(prompt.id);
-                  }}
-                >
-                  <Pencil />
-                </Button>
-                {!isEditing && (
-                  <>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      icon
-                      aria-label="Send queued prompt now"
-                      title="Send now - cancels the active turn"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        onSendNow(prompt.id);
-                      }}
-                    >
-                      <ArrowUp />
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      tone="destructive"
-                      size="sm"
-                      icon
-                      aria-label="Delete queued prompt"
-                      title="Delete queued prompt"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        onDelete(prompt.id);
-                      }}
-                    >
-                      <Trash2 />
-                    </Button>
-                  </>
-                )}
-              </div>
+              {!isEditing && (
+                <div className={styles.actions}>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    icon
+                    aria-label={`Edit queued prompt ${index + 1}`}
+                    title="Edit queued prompt"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onStartEdit(prompt.id);
+                    }}
+                  >
+                    <Pencil />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    icon
+                    aria-label="Send queued prompt now"
+                    title="Send now - cancels the active turn"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onSendNow(prompt.id);
+                    }}
+                  >
+                    <ArrowUp />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    tone="destructive"
+                    size="sm"
+                    icon
+                    aria-label="Delete queued prompt"
+                    title="Delete queued prompt"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onDelete(prompt.id);
+                    }}
+                  >
+                    <Trash2 />
+                  </Button>
+                </div>
+              )}
             </div>
           );
         })}

--- a/packages/ui/src/react/components/chat-composer/queued-prompts-band.tsx
+++ b/packages/ui/src/react/components/chat-composer/queued-prompts-band.tsx
@@ -118,11 +118,16 @@ export function QueuedPromptsBand({
               <button
                 type="button"
                 className={cx(styles.promptText, !prompt.text.trim() && styles.emptyText)}
-                onClick={() => {
-                  if (!isEditing) onStartEdit(prompt.id);
-                }}
+                onClick={() => onStartEdit(prompt.id)}
+                disabled={!!editingPromptId}
                 aria-label={`Edit queued prompt ${index + 1}`}
-                title={isEditing ? 'Editing in composer' : 'Edit queued prompt'}
+                title={
+                  isEditing
+                    ? 'Editing in composer'
+                    : editingPromptId
+                      ? 'Finish editing the current prompt first'
+                      : 'Edit queued prompt'
+                }
               >
                 {prompt.text.trim() || 'Image-only prompt'}
               </button>
@@ -134,8 +139,13 @@ export function QueuedPromptsBand({
                     variant="ghost"
                     size="sm"
                     icon
+                    disabled={!!editingPromptId}
                     aria-label={`Edit queued prompt ${index + 1}`}
-                    title="Edit queued prompt"
+                    title={
+                      editingPromptId
+                        ? 'Finish editing the current prompt first'
+                        : 'Edit queued prompt'
+                    }
                     onClick={(event) => {
                       event.stopPropagation();
                       onStartEdit(prompt.id);

--- a/packages/ui/src/react/components/chat-composer/queued-prompts-band.tsx
+++ b/packages/ui/src/react/components/chat-composer/queued-prompts-band.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@react/primitives/button';
 import { cx } from '@styles/utilities/cx';
-import { ArrowUp, Check, GripVertical, Trash2, X } from 'lucide-react';
+import { ArrowUp, GripVertical, Pencil, Trash2 } from 'lucide-react';
 import * as React from 'react';
 import * as styles from './queued-prompts-band.css';
 
@@ -11,7 +11,8 @@ export type ComposerQueuedPrompt = {
 
 export interface QueuedPromptsBandProps {
   prompts: ComposerQueuedPrompt[];
-  onEdit: (id: string, text: string) => void;
+  editingPromptId?: string | null;
+  onEdit: (id: string) => void;
   onDelete: (id: string) => void;
   onReorder: (ids: string[]) => void;
   onSendNow: (id: string) => void;
@@ -21,6 +22,7 @@ export interface QueuedPromptsBandProps {
 
 export function QueuedPromptsBand({
   prompts,
+  editingPromptId,
   onEdit,
   onDelete,
   onReorder,
@@ -28,43 +30,10 @@ export function QueuedPromptsBand({
   connectToBandBelow = false,
   className,
 }: QueuedPromptsBandProps) {
-  const [editingId, setEditingId] = React.useState<string | null>(null);
-  const [draft, setDraft] = React.useState('');
   const [draggingId, setDraggingId] = React.useState<string | null>(null);
   const [dragOverId, setDragOverId] = React.useState<string | null>(null);
-  const editInputRef = React.useRef<HTMLTextAreaElement | null>(null);
-
-  React.useEffect(() => {
-    if (!editingId) return;
-    if (prompts.some((prompt) => prompt.id === editingId)) return;
-    setEditingId(null);
-    setDraft('');
-  }, [editingId, prompts]);
-
-  React.useEffect(() => {
-    if (!editingId) return;
-    editInputRef.current?.focus();
-    editInputRef.current?.select();
-  }, [editingId]);
 
   const ids = prompts.map((prompt) => prompt.id);
-
-  const beginEdit = (prompt: ComposerQueuedPrompt) => {
-    setEditingId(prompt.id);
-    setDraft(prompt.text);
-  };
-
-  const cancelEdit = () => {
-    setEditingId(null);
-    setDraft('');
-  };
-
-  const saveEdit = (id: string) => {
-    const next = draft.trim();
-    if (!next) return;
-    onEdit(id, draft);
-    cancelEdit();
-  };
 
   const reorder = (fromId: string, toId: string) => {
     if (fromId === toId) return;
@@ -116,11 +85,12 @@ export function QueuedPromptsBand({
 
       <div className={styles.list}>
         {prompts.map((prompt, index) => {
-          const isEditing = editingId === prompt.id;
+          const isEditing = editingPromptId === prompt.id;
           return (
             <div
               key={prompt.id}
               className={styles.row}
+              data-editing={isEditing || undefined}
               data-dragging={draggingId === prompt.id || undefined}
               data-drag-over={dragOverId === prompt.id || undefined}
               onDragOver={(event) => handleDragOver(event, prompt.id)}
@@ -131,111 +101,79 @@ export function QueuedPromptsBand({
             >
               <span className={styles.indexSlot}>
                 <span className={styles.indexNumber}>{index + 1}</span>
-                {!isEditing && (
-                  <button
-                    type="button"
-                    className={styles.dragHandle}
-                    draggable
-                    aria-label={`Reorder queued prompt ${index + 1}`}
-                    title="Drag to reorder"
-                    onClick={(event) => event.stopPropagation()}
-                    onDragStart={(event) => handleDragStart(event, prompt.id)}
-                    onDragEnd={handleDragEnd}
-                  >
-                    <GripVertical className={styles.dragHandleIcon} aria-hidden />
-                  </button>
-                )}
-              </span>
-
-              {isEditing ? (
-                <div className={styles.editArea}>
-                  <textarea
-                    ref={editInputRef}
-                    className={styles.editInput}
-                    value={draft}
-                    rows={2}
-                    aria-label={`Edit queued prompt ${index + 1}`}
-                    onChange={(event) => setDraft(event.currentTarget.value)}
-                    onKeyDown={(event) => {
-                      if (event.key === 'Escape') {
-                        event.preventDefault();
-                        cancelEdit();
-                      }
-                      if (event.key === 'Enter' && !event.shiftKey) {
-                        event.preventDefault();
-                        saveEdit(prompt.id);
-                      }
-                    }}
-                  />
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    icon
-                    aria-label="Save queued prompt"
-                    title="Save queued prompt"
-                    disabled={!draft.trim()}
-                    onClick={() => saveEdit(prompt.id)}
-                  >
-                    <Check />
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    icon
-                    aria-label="Cancel edit"
-                    title="Cancel edit"
-                    onClick={cancelEdit}
-                  >
-                    <X />
-                  </Button>
-                </div>
-              ) : (
                 <button
                   type="button"
-                  className={cx(styles.promptText, !prompt.text.trim() && styles.emptyText)}
-                  onClick={() => beginEdit(prompt)}
-                  aria-label={`Edit queued prompt ${index + 1}`}
-                  title="Edit queued prompt"
+                  className={styles.dragHandle}
+                  draggable
+                  aria-label={`Reorder queued prompt ${index + 1}`}
+                  title="Drag to reorder"
+                  onClick={(event) => event.stopPropagation()}
+                  onDragStart={(event) => handleDragStart(event, prompt.id)}
+                  onDragEnd={handleDragEnd}
                 >
-                  {prompt.text.trim() || 'Image-only prompt'}
+                  <GripVertical className={styles.dragHandleIcon} aria-hidden />
                 </button>
-              )}
+              </span>
 
-              {!isEditing && (
-                <div className={styles.actions}>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    icon
-                    aria-label="Send queued prompt now"
-                    title="Send now - cancels the active turn"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onSendNow(prompt.id);
-                    }}
-                  >
-                    <ArrowUp />
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    tone="destructive"
-                    size="sm"
-                    icon
-                    aria-label="Delete queued prompt"
-                    title="Delete queued prompt"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onDelete(prompt.id);
-                    }}
-                  >
-                    <Trash2 />
-                  </Button>
-                </div>
-              )}
+              <button
+                type="button"
+                className={cx(styles.promptText, !prompt.text.trim() && styles.emptyText)}
+                onClick={() => onEdit(prompt.id)}
+                aria-label={`Edit queued prompt ${index + 1}`}
+                title={isEditing ? 'Editing in composer' : 'Edit queued prompt'}
+              >
+                {prompt.text.trim() || 'Image-only prompt'}
+              </button>
+
+              <div className={styles.actions}>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  icon
+                  aria-label={`Edit queued prompt ${index + 1}`}
+                  title={isEditing ? 'Editing in composer' : 'Edit queued prompt'}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onEdit(prompt.id);
+                  }}
+                >
+                  <Pencil />
+                </Button>
+                {!isEditing && (
+                  <>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      icon
+                      aria-label="Send queued prompt now"
+                      title="Send now - cancels the active turn"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onSendNow(prompt.id);
+                      }}
+                    >
+                      <ArrowUp />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      tone="destructive"
+                      size="sm"
+                      icon
+                      aria-label="Delete queued prompt"
+                      title="Delete queued prompt"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onDelete(prompt.id);
+                      }}
+                    >
+                      <Trash2 />
+                    </Button>
+                  </>
+                )}
+              </div>
             </div>
           );
         })}

--- a/packages/ui/src/react/components/prompt-editor/extensions/submit-keymap.ts
+++ b/packages/ui/src/react/components/prompt-editor/extensions/submit-keymap.ts
@@ -8,7 +8,7 @@
 
 import { Extension } from '@tiptap/core';
 
-export function buildSubmitKeymap(onSubmit: () => void) {
+export function buildSubmitKeymap(onSubmit: () => void, onCancel: () => boolean) {
   return Extension.create({
     name: 'submitKeymap',
     addKeyboardShortcuts() {
@@ -17,6 +17,8 @@ export function buildSubmitKeymap(onSubmit: () => void) {
           onSubmit();
           return true;
         },
+
+        Escape: onCancel,
 
         'Shift-Enter': ({ editor }) => {
           editor.commands.setHardBreak();

--- a/packages/ui/src/react/components/prompt-editor/prompt-editor.tsx
+++ b/packages/ui/src/react/components/prompt-editor/prompt-editor.tsx
@@ -173,6 +173,7 @@ export const PromptEditor = forwardRef<PromptEditorRef, PromptEditorProps>(funct
     disabled = false,
     onChange,
     onSubmit,
+    onCancel,
     onMentionInsert,
     mentionProvider,
     renderMentionIcon,
@@ -186,6 +187,8 @@ export const PromptEditor = forwardRef<PromptEditorRef, PromptEditorProps>(funct
   // Stable refs so callbacks inside TipTap extensions always see current values.
   const onSubmitRef = useRef(onSubmit);
   onSubmitRef.current = onSubmit;
+  const onCancelRef = useRef(onCancel);
+  onCancelRef.current = onCancel;
   const onMentionInsertRef = useRef(onMentionInsert);
   onMentionInsertRef.current = onMentionInsert;
   const onCommandRef = useRef(onCommand);
@@ -216,10 +219,15 @@ export const PromptEditor = forwardRef<PromptEditorRef, PromptEditorProps>(funct
     const ed = editorRef.current;
     if (!ed) return;
     const text = serializeDoc(ed.state.doc);
-    if (!text.trim()) return;
     if (!onSubmitRef.current) return;
     ed.commands.clearContent(true);
     onSubmitRef.current(text);
+  }, []);
+
+  const handleCancelFromKeymap = useCallback(() => {
+    if (!onCancelRef.current) return false;
+    onCancelRef.current();
+    return true;
   }, []);
 
   const mentionExtension = buildMentionExtension(
@@ -268,7 +276,7 @@ export const PromptEditor = forwardRef<PromptEditorRef, PromptEditorProps>(funct
     }
   );
 
-  const submitKeymap = buildSubmitKeymap(handleSubmitFromKeymap);
+  const submitKeymap = buildSubmitKeymap(handleSubmitFromKeymap, handleCancelFromKeymap);
 
   const editor = useEditor({
     extensions: [

--- a/packages/ui/src/react/components/prompt-editor/types.ts
+++ b/packages/ui/src/react/components/prompt-editor/types.ts
@@ -110,6 +110,8 @@ export interface PromptEditorProps {
   onChange?: (text: string) => void;
   /** Called when the user submits (Enter with no open suggestion). */
   onSubmit?: (text: string) => void;
+  /** Called when the user presses Escape with no open suggestion. */
+  onCancel?: () => void;
   /** Called after a mention node is inserted. Raw insertText entries do not trigger this. */
   onMentionInsert?: (item: MentionItem) => void;
   /**


### PR DESCRIPTION
### Description

Move queued-prompt editing into the main chat composer instead of rendering a separate inline textarea inside the queue.

Selecting a queued prompt now loads its text into the composer, highlights the active queue row, and replaces the send/stop control with a save checkmark. Saving via Enter or the checkmark updates the queued prompt and restores any draft that was in the composer before editing began.

### Screenshot/Recording (if applicable)
https://cap.link/bhrawm7v1kjyrrd

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] Docs were not needed for this interaction change
- [x] Existing component behavior was exercised manually; the package currently has no ChatComposer interaction test harness
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit and PR title

</details>