### PR TITLE
fix(pull-requests): order CI check runs chronologically

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/checks-list.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/checks-list.tsx
@@ -7,6 +7,7 @@ import { EmptyState } from '@renderer/lib/ui/empty-state';
 import {
   computeCheckBucket,
   formatCheckDuration,
+  sortCheckRunsByLatest,
   type CheckRun,
   type CheckRunBucket,
 } from '@renderer/utils/github';
@@ -16,14 +17,6 @@ import { buildPullRequestConversationItems } from './pull-request-conversation';
 import { usePullRequestComments } from './use-pull-request-comments';
 
 const EMPTY_COMMENTS: PullRequestComment[] = [];
-
-const bucketOrder: Record<CheckRunBucket, number> = {
-  fail: 0,
-  pending: 1,
-  pass: 2,
-  skipping: 3,
-  cancel: 4,
-};
 
 export function BucketIcon({ bucket }: { bucket: CheckRunBucket }) {
   switch (bucket) {
@@ -85,13 +78,7 @@ export function CheckRunItem({ check }: { check: CheckRun }) {
 }
 
 export function ChecksList({ checks }: { checks: CheckRun[] }) {
-  const sorted = useMemo(
-    () =>
-      [...checks].sort(
-        (a, b) => bucketOrder[computeCheckBucket(a)] - bucketOrder[computeCheckBucket(b)]
-      ),
-    [checks]
-  );
+  const sorted = useMemo(() => sortCheckRunsByLatest(checks), [checks]);
 
   if (sorted.length === 0) {
     return <div className="px-3 py-2 text-xs text-foreground-passive">No checks available</div>;

--- a/apps/emdash-desktop/src/renderer/utils/github/utils.test.ts
+++ b/apps/emdash-desktop/src/renderer/utils/github/utils.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import type { CheckRun } from './types';
+import { sortCheckRunsByLatest } from './utils';
+
+function makeCheck(overrides: Partial<CheckRun> = {}): CheckRun {
+  return {
+    id: 'check-1',
+    pullRequestUrl: 'https://github.com/acme/repo/pull/1',
+    commitSha: 'head',
+    name: 'CI',
+    status: 'COMPLETED',
+    conclusion: 'SUCCESS',
+    detailsUrl: null,
+    startedAt: null,
+    completedAt: null,
+    workflowName: null,
+    appName: null,
+    appLogoUrl: null,
+    ...overrides,
+  };
+}
+
+describe('sortCheckRunsByLatest', () => {
+  it('orders runs newest first regardless of their result', () => {
+    const oldFailure = makeCheck({
+      id: 'old-failure',
+      name: 'CI (old)',
+      conclusion: 'FAILURE',
+      startedAt: '2026-07-18T08:00:00.000Z',
+    });
+    const latestSuccess = makeCheck({
+      id: 'latest-success',
+      name: 'CI (latest)',
+      startedAt: '2026-07-18T09:00:00.000Z',
+    });
+
+    expect(sortCheckRunsByLatest([oldFailure, latestSuccess])).toEqual([latestSuccess, oldFailure]);
+  });
+
+  it('falls back to completion time and keeps runs without a timestamp last', () => {
+    const unknownTime = makeCheck({ id: 'unknown-time' });
+    const completed = makeCheck({
+      id: 'completed',
+      completedAt: '2026-07-18T09:00:00.000Z',
+    });
+
+    expect(sortCheckRunsByLatest([unknownTime, completed])).toEqual([completed, unknownTime]);
+  });
+
+  it('does not mutate the source list', () => {
+    const older = makeCheck({ id: 'older', startedAt: '2026-07-18T08:00:00.000Z' });
+    const newer = makeCheck({ id: 'newer', startedAt: '2026-07-18T09:00:00.000Z' });
+    const checks = [older, newer];
+
+    sortCheckRunsByLatest(checks);
+
+    expect(checks).toEqual([older, newer]);
+  });
+});

--- a/apps/emdash-desktop/src/renderer/utils/github/utils.ts
+++ b/apps/emdash-desktop/src/renderer/utils/github/utils.ts
@@ -59,6 +59,16 @@ export function computeCheckRunsSummary(checks: CheckRun[]): CheckRunsSummary {
   return summary;
 }
 
+export function sortCheckRunsByLatest(checks: CheckRun[]): CheckRun[] {
+  return [...checks].sort((a, b) => {
+    const aTimestamp = Date.parse(a.startedAt ?? a.completedAt ?? '');
+    const bTimestamp = Date.parse(b.startedAt ?? b.completedAt ?? '');
+    const aTime = Number.isNaN(aTimestamp) ? Number.NEGATIVE_INFINITY : aTimestamp;
+    const bTime = Number.isNaN(bTimestamp) ? Number.NEGATIVE_INFINITY : bTimestamp;
+    return bTime - aTime;
+  });
+}
+
 export function formatRelativeTime(dateStr: string): string {
   const date = new Date(dateStr);
   if (isNaN(date.getTime())) return '';


### PR DESCRIPTION
### Description

Order CI check runs by their latest timestamp instead of grouping failed runs above successful ones. The checks panel now displays newest runs first, falls back from `startedAt` to `completedAt`, and keeps checks without a valid timestamp at the end without mutating the source list.

### Related issues

[ENG-1903](https://linear.app/general-action/issue/ENG-1903/order-ci-check-runs-chronologically)

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [ ] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>