### PR TITLE
fix(diff): scroll to first file change

### DIFF
--- a/apps/emdash-desktop/src/renderer/lib/monaco/monaco-model-registry.test.ts
+++ b/apps/emdash-desktop/src/renderer/lib/monaco/monaco-model-registry.test.ts
@@ -166,4 +166,20 @@ describe('MonacoModelRegistry', () => {
 
     expect(registry.getModelByUri(headUri)?.getValue()).toBe('');
   });
+
+  it('reports whether it restored a saved diff viewport', () => {
+    const registry = new MonacoModelRegistry();
+    const viewState = { modified: null, original: null };
+    const editor = {
+      saveViewState: () => viewState,
+      restoreViewState: vi.fn(),
+    };
+
+    expect(registry.restoreDiffViewState('original', 'modified', editor as never)).toBe(false);
+
+    registry.saveDiffViewState('original', 'modified', editor as never);
+
+    expect(registry.restoreDiffViewState('original', 'modified', editor as never)).toBe(true);
+    expect(editor.restoreViewState).toHaveBeenCalledWith(viewState);
+  });
 });

--- a/apps/emdash-desktop/src/renderer/lib/monaco/monaco-model-registry.ts
+++ b/apps/emdash-desktop/src/renderer/lib/monaco/monaco-model-registry.ts
@@ -646,15 +646,17 @@ export class MonacoModelRegistry {
   /**
    * Restore a previously saved diff editor viewport state.
    * Call this after editor.setModel() so the editor has a layout target.
-   * No-ops silently if no state was ever saved for this pair.
+   * Returns whether a state was restored so callers can choose an initial viewport.
    */
   restoreDiffViewState(
     originalUri: string,
     modifiedUri: string,
     editor: monaco.editor.IStandaloneDiffEditor
-  ): void {
+  ): boolean {
     const vs = this.diffViewStates.get(this.diffKey(originalUri, modifiedUri));
-    if (vs) editor.restoreViewState(vs);
+    if (!vs) return false;
+    editor.restoreViewState(vs);
+    return true;
   }
 
   /**

--- a/apps/emdash-desktop/src/renderer/lib/monaco/sticky-diff-editor.test.ts
+++ b/apps/emdash-desktop/src/renderer/lib/monaco/sticky-diff-editor.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@renderer/lib/hooks/useTheme', () => ({
+  useTheme: () => ({ effectiveTheme: 'dark' }),
+}));
+
+vi.mock('@renderer/lib/monaco/monaco-bootstrap', () => ({
+  monacoBootstrap: {},
+}));
+
+vi.mock('@renderer/lib/monaco/monaco-model-registry', () => ({
+  modelRegistry: {},
+}));
+
+import { revealFirstDiffChange, revealFirstDiffChangeWhenReady } from './sticky-diff-editor';
+
+describe('revealFirstDiffChange', () => {
+  it('reveals the first changed line near the top of the modified editor', () => {
+    const revealLineNearTop = vi.fn();
+    const editor = {
+      getLineChanges: () => [
+        {
+          originalStartLineNumber: 42,
+          originalEndLineNumber: 42,
+          modifiedStartLineNumber: 47,
+          modifiedEndLineNumber: 49,
+        },
+      ],
+      getModifiedEditor: () => ({ revealLineNearTop }),
+    };
+
+    expect(revealFirstDiffChange(editor as never)).toBe(true);
+    expect(revealLineNearTop).toHaveBeenCalledOnce();
+    expect(revealLineNearTop).toHaveBeenCalledWith(47);
+  });
+
+  it('reveals the first valid modified line for a deletion-only hunk', () => {
+    const revealLineNearTop = vi.fn();
+    const editor = {
+      getLineChanges: () => [
+        {
+          originalStartLineNumber: 1,
+          originalEndLineNumber: 10,
+          modifiedStartLineNumber: 0,
+          modifiedEndLineNumber: 0,
+        },
+      ],
+      getModifiedEditor: () => ({ revealLineNearTop }),
+    };
+
+    expect(revealFirstDiffChange(editor as never)).toBe(true);
+    expect(revealLineNearTop).toHaveBeenCalledWith(1);
+  });
+
+  it('waits when Monaco has not calculated line changes yet', () => {
+    const revealLineNearTop = vi.fn();
+    const editor = {
+      getLineChanges: () => null,
+      getModifiedEditor: () => ({ revealLineNearTop }),
+    };
+
+    expect(revealFirstDiffChange(editor as never)).toBe(false);
+    expect(revealLineNearTop).not.toHaveBeenCalled();
+  });
+
+  it('reveals immediately when cached line changes are already available', () => {
+    const revealLineNearTop = vi.fn();
+    const onDidUpdateDiff = vi.fn();
+    const editor = {
+      getLineChanges: () => [{ modifiedStartLineNumber: 32 }],
+      getModifiedEditor: () => ({ revealLineNearTop }),
+      onDidUpdateDiff,
+    };
+
+    expect(revealFirstDiffChangeWhenReady(editor as never)).toBeNull();
+    expect(revealLineNearTop).toHaveBeenCalledWith(32);
+    expect(onDidUpdateDiff).not.toHaveBeenCalled();
+  });
+
+  it('reveals and disposes its listener when async line changes become available', () => {
+    const revealLineNearTop = vi.fn();
+    const dispose = vi.fn();
+    let lineChanges: Array<{ modifiedStartLineNumber: number }> | null = null;
+    let diffListener: (() => void) | undefined;
+    const editor = {
+      getLineChanges: () => lineChanges,
+      getModifiedEditor: () => ({ revealLineNearTop }),
+      onDidUpdateDiff: vi.fn((listener: () => void) => {
+        diffListener = listener;
+        return { dispose };
+      }),
+    };
+
+    expect(revealFirstDiffChangeWhenReady(editor as never)).toEqual({ dispose });
+    expect(revealLineNearTop).not.toHaveBeenCalled();
+
+    lineChanges = [{ modifiedStartLineNumber: 64 }];
+    diffListener?.();
+
+    expect(revealLineNearTop).toHaveBeenCalledWith(64);
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/emdash-desktop/src/renderer/lib/monaco/sticky-diff-editor.test.ts
+++ b/apps/emdash-desktop/src/renderer/lib/monaco/sticky-diff-editor.test.ts
@@ -12,11 +12,12 @@ vi.mock('@renderer/lib/monaco/monaco-model-registry', () => ({
   modelRegistry: {},
 }));
 
-import { revealFirstDiffChange, revealFirstDiffChangeWhenReady } from './sticky-diff-editor';
+import { revealFirstDiffChangeWhenReady } from './sticky-diff-editor';
 
-describe('revealFirstDiffChange', () => {
-  it('reveals the first changed line near the top of the modified editor', () => {
+describe('revealFirstDiffChangeWhenReady', () => {
+  it('reveals immediately when cached line changes are already available', () => {
     const revealLineNearTop = vi.fn();
+    const onDidUpdateDiff = vi.fn();
     const editor = {
       getLineChanges: () => [
         {
@@ -27,15 +28,18 @@ describe('revealFirstDiffChange', () => {
         },
       ],
       getModifiedEditor: () => ({ revealLineNearTop }),
+      onDidUpdateDiff,
     };
 
-    expect(revealFirstDiffChange(editor as never)).toBe(true);
+    expect(revealFirstDiffChangeWhenReady(editor as never)).toBeNull();
     expect(revealLineNearTop).toHaveBeenCalledOnce();
     expect(revealLineNearTop).toHaveBeenCalledWith(47);
+    expect(onDidUpdateDiff).not.toHaveBeenCalled();
   });
 
   it('reveals the first valid modified line for a deletion-only hunk', () => {
     const revealLineNearTop = vi.fn();
+    const onDidUpdateDiff = vi.fn();
     const editor = {
       getLineChanges: () => [
         {
@@ -46,34 +50,11 @@ describe('revealFirstDiffChange', () => {
         },
       ],
       getModifiedEditor: () => ({ revealLineNearTop }),
-    };
-
-    expect(revealFirstDiffChange(editor as never)).toBe(true);
-    expect(revealLineNearTop).toHaveBeenCalledWith(1);
-  });
-
-  it('waits when Monaco has not calculated line changes yet', () => {
-    const revealLineNearTop = vi.fn();
-    const editor = {
-      getLineChanges: () => null,
-      getModifiedEditor: () => ({ revealLineNearTop }),
-    };
-
-    expect(revealFirstDiffChange(editor as never)).toBe(false);
-    expect(revealLineNearTop).not.toHaveBeenCalled();
-  });
-
-  it('reveals immediately when cached line changes are already available', () => {
-    const revealLineNearTop = vi.fn();
-    const onDidUpdateDiff = vi.fn();
-    const editor = {
-      getLineChanges: () => [{ modifiedStartLineNumber: 32 }],
-      getModifiedEditor: () => ({ revealLineNearTop }),
       onDidUpdateDiff,
     };
 
     expect(revealFirstDiffChangeWhenReady(editor as never)).toBeNull();
-    expect(revealLineNearTop).toHaveBeenCalledWith(32);
+    expect(revealLineNearTop).toHaveBeenCalledWith(1);
     expect(onDidUpdateDiff).not.toHaveBeenCalled();
   });
 

--- a/apps/emdash-desktop/src/renderer/lib/monaco/sticky-diff-editor.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/monaco/sticky-diff-editor.tsx
@@ -6,6 +6,26 @@ import { monacoBootstrap } from '@renderer/lib/monaco/monaco-bootstrap';
 import { modelRegistry } from '@renderer/lib/monaco/monaco-model-registry';
 import { DIFF_EDITOR_BASE_OPTIONS } from './editorConfig';
 
+export function revealFirstDiffChange(editor: monaco.editor.IStandaloneDiffEditor): boolean {
+  const firstChange = editor.getLineChanges()?.[0];
+  if (!firstChange) return false;
+
+  editor.getModifiedEditor().revealLineNearTop(Math.max(1, firstChange.modifiedStartLineNumber));
+  return true;
+}
+
+export function revealFirstDiffChangeWhenReady(
+  editor: monaco.editor.IStandaloneDiffEditor
+): monaco.IDisposable | null {
+  if (revealFirstDiffChange(editor)) return null;
+
+  const disposable = editor.onDidUpdateDiff(() => {
+    if (!revealFirstDiffChange(editor)) return;
+    disposable.dispose();
+  });
+  return disposable;
+}
+
 export interface StickyDiffEditorProps {
   /** URI for the left (original/before) side — typically git:// */
   originalUri: string;
@@ -99,6 +119,8 @@ export function StickyDiffEditor({
   // The autorun waits for both models to be 'ready' in the registry, then calls
   // setModel in-place without remounting the editor component.
   useEffect(() => {
+    let diffUpdateDisposable: monaco.IDisposable | null = null;
+
     // Clear the previously-attached models synchronously on URI change so the
     // editor doesn't keep showing the previous file's content while the new
     // models are still loading.
@@ -136,8 +158,12 @@ export function StickyDiffEditor({
 
       editor.setModel({ original: origModel, modified: modModel });
       editor.layout();
-      // Restore scroll/cursor for the incoming URI pair.
       modelRegistry.restoreDiffViewState(originalUri, modifiedUri, editor);
+
+      // Cached models can already have line changes before onDidUpdateDiff is
+      // subscribed. Try synchronously first, then wait for async diff calculation.
+      diffUpdateDisposable?.dispose();
+      diffUpdateDisposable = revealFirstDiffChangeWhenReady(editor);
       onHeightChangeRef.current?.(editor.getModifiedEditor().getContentHeight());
     });
 
@@ -145,6 +171,7 @@ export function StickyDiffEditor({
       // On unmount or URI change: save the current viewport so it can be restored later.
       const ed = editorBox.get();
       if (ed?.getModel()) modelRegistry.saveDiffViewState(originalUri, modifiedUri, ed);
+      diffUpdateDisposable?.dispose();
       disposer();
     };
     // editorBox is a stable ref created once; only URI changes recreate the autorun.

--- a/apps/emdash-desktop/src/renderer/lib/monaco/sticky-diff-editor.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/monaco/sticky-diff-editor.tsx
@@ -158,12 +158,12 @@ export function StickyDiffEditor({
 
       editor.setModel({ original: origModel, modified: modModel });
       editor.layout();
-      modelRegistry.restoreDiffViewState(originalUri, modifiedUri, editor);
+      const restored = modelRegistry.restoreDiffViewState(originalUri, modifiedUri, editor);
 
       // Cached models can already have line changes before onDidUpdateDiff is
       // subscribed. Try synchronously first, then wait for async diff calculation.
       diffUpdateDisposable?.dispose();
-      diffUpdateDisposable = revealFirstDiffChangeWhenReady(editor);
+      diffUpdateDisposable = restored ? null : revealFirstDiffChangeWhenReady(editor);
       onHeightChangeRef.current?.(editor.getModifiedEditor().getContentHeight());
     });
 

--- a/apps/emdash-desktop/src/renderer/lib/monaco/sticky-diff-editor.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/monaco/sticky-diff-editor.tsx
@@ -6,21 +6,21 @@ import { monacoBootstrap } from '@renderer/lib/monaco/monaco-bootstrap';
 import { modelRegistry } from '@renderer/lib/monaco/monaco-model-registry';
 import { DIFF_EDITOR_BASE_OPTIONS } from './editorConfig';
 
-export function revealFirstDiffChange(editor: monaco.editor.IStandaloneDiffEditor): boolean {
-  const firstChange = editor.getLineChanges()?.[0];
-  if (!firstChange) return false;
-
-  editor.getModifiedEditor().revealLineNearTop(Math.max(1, firstChange.modifiedStartLineNumber));
-  return true;
-}
-
 export function revealFirstDiffChangeWhenReady(
   editor: monaco.editor.IStandaloneDiffEditor
 ): monaco.IDisposable | null {
-  if (revealFirstDiffChange(editor)) return null;
+  const reveal = () => {
+    const firstChange = editor.getLineChanges()?.[0];
+    if (!firstChange) return false;
+
+    editor.getModifiedEditor().revealLineNearTop(Math.max(1, firstChange.modifiedStartLineNumber));
+    return true;
+  };
+
+  if (reveal()) return null;
 
   const disposable = editor.onDidUpdateDiff(() => {
-    if (!revealFirstDiffChange(editor)) return;
+    if (!reveal()) return;
     disposable.dispose();
   });
   return disposable;


### PR DESCRIPTION
### Description

Automatically scroll text diff editors to the first changed line when a file is opened. The implementation handles both cached Monaco diffs whose line changes are immediately available and asynchronously calculated diffs, while cleaning up the one-shot listener after use or model changes.

Deletion-only hunks clamp Monaco's modified boundary to the first valid editor line.

### Related issues

[ENG-1902](https://linear.app/general-action/issue/ENG-1902/automatically-scroll-to-first-change-in-diff-view)

### Screenshot/Recording (if applicable)
https://cap.link/fchby7473wvfv5j

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [ ] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit message and PR title

</details>
