### PR TITLE
fix(ssh): avoid per-entry stat snapshot processes

### DIFF
--- a/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-files.test.ts
+++ b/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-files.test.ts
@@ -140,11 +140,13 @@ describe('LegacySshFilesRuntime', () => {
       snapshot([
         { kind: 'file', path: 'README.md', size: '1', mtime: '1' },
         { kind: 'file', path: 'src/a.ts', size: '1', mtime: '1' },
+        { kind: 'file', path: 'src/stable.ts', size: '1', mtime: '3' },
       ]),
       snapshot([
         { kind: 'file', path: 'src/a.ts', size: '2', mtime: '2.5000000000' },
         { kind: 'file', path: 'src/b.ts', size: '1', mtime: '1' },
         { kind: 'file', path: "src/line\nbreak's.ts", size: '1', mtime: '1' },
+        { kind: 'file', path: 'src/stable.ts', size: '1', mtime: '3.7500000000' },
         { kind: 'file', path: 'node_modules/pkg/index.js', size: '1', mtime: '1' },
       ]),
     ]);

--- a/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-files.test.ts
+++ b/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-files.test.ts
@@ -1,9 +1,13 @@
+import { execFile } from 'node:child_process';
 import { EventEmitter } from 'node:events';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import type { ClientChannel } from 'ssh2';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { SshClientProxy } from '@main/core/ssh/lifecycle/ssh-client-proxy';
 import type { FileWatchEvent } from '@shared/core/fs/fs';
-import { LegacySshFilesRuntime } from './ssh-files';
+import { buildRecursiveSnapshotCommand, LegacySshFilesRuntime } from './ssh-files';
 import { SshFileSystem } from './ssh-legacy-fs';
 
 type SnapshotRecord = {
@@ -22,6 +26,77 @@ describe('LegacySshFilesRuntime', () => {
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
+
+  it('uses GNU find metadata without per-entry stat processes when supported', () => {
+    const command = buildRecursiveSnapshotCommand("/repo/it's here");
+    const [gnuBranch, portableBranch] = command.split('\nelse\n');
+
+    expect(gnuBranch).toContain("cd '/repo/it'\\''s here' || exit 1");
+    expect(gnuBranch).toContain(
+      "if find . -maxdepth 0 -printf '%s\\0%T@\\0%P\\0' >/dev/null 2>&1; then"
+    );
+    expect(gnuBranch).toContain("-type f -printf 'file\\0%s\\0%T@\\0%P\\0'");
+    expect(gnuBranch).toContain("-type d -printf 'directory\\0%s\\0%T@\\0%P\\0'");
+    expect(gnuBranch).toContain("-name 'node_modules'");
+    expect(gnuBranch).not.toContain('stat ');
+    expect(portableBranch).toBeDefined();
+  });
+
+  it('keeps the NUL-safe stat fallback for non-GNU find implementations', () => {
+    const command = buildRecursiveSnapshotCommand('/repo');
+    const portableBranch = command.split('\nelse\n')[1];
+
+    expect(portableBranch).toContain("stat -c '%s %Y'");
+    expect(portableBranch).toContain("stat -f '%z %m'");
+    expect(portableBranch).toContain('-exec sh -c');
+    expect(portableBranch).toContain('%s\\0%s\\0%s\\0%s\\0');
+    expect(portableBranch).toContain('sh "$stat_style" {} +');
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'emits recursive snapshot records with the available POSIX find implementation',
+    async () => {
+      const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'emdash-ssh-snapshot-'));
+      const rootPath = path.join(tempRoot, "repo with ' quote");
+      const bulkFileCount = 128;
+
+      try {
+        await mkdir(path.join(rootPath, 'src'), { recursive: true });
+        await mkdir(path.join(rootPath, 'bulk'), { recursive: true });
+        await mkdir(path.join(rootPath, 'node_modules', 'ignored'), { recursive: true });
+        await writeFile(path.join(rootPath, 'README.md'), 'readme');
+        await writeFile(path.join(rootPath, 'src', "line\nbreak's.ts"), 'source');
+        await writeFile(path.join(rootPath, 'node_modules', 'ignored', 'index.js'), 'ignored');
+        await Promise.all(
+          Array.from({ length: bulkFileCount }, (_, index) =>
+            writeFile(path.join(rootPath, 'bulk', `${index}.txt`), String(index))
+          )
+        );
+
+        const stdout = await execLocalShell(buildRecursiveSnapshotCommand(rootPath));
+        const records = parseSnapshotRecords(stdout);
+
+        expect(records).toHaveLength(bulkFileCount + 4);
+        expect(records.map((record) => record.path)).toEqual(
+          expect.arrayContaining(['README.md', 'bulk', 'src', "src/line\nbreak's.ts"])
+        );
+        expect(records.filter((record) => record.path.startsWith('bulk/'))).toHaveLength(
+          bulkFileCount
+        );
+        expect(records.some((record) => record.path.includes('node_modules'))).toBe(false);
+        expect(records.find((record) => record.path === 'README.md')).toMatchObject({
+          kind: 'file',
+          size: '6',
+        });
+        expect(records.find((record) => record.path === 'src')).toMatchObject({
+          kind: 'directory',
+        });
+        expect(records.every((record) => /^\d+(?:\.\d+)?$/.test(record.mtime ?? ''))).toBe(true);
+      } finally {
+        await rm(tempRoot, { recursive: true, force: true });
+      }
+    }
+  );
 
   it('keeps scoped watches on the existing SSH polling watcher', async () => {
     let emitLegacyEvents: ((events: FileWatchEvent[]) => void) | undefined;
@@ -67,8 +142,9 @@ describe('LegacySshFilesRuntime', () => {
         { kind: 'file', path: 'src/a.ts', size: '1', mtime: '1' },
       ]),
       snapshot([
-        { kind: 'file', path: 'src/a.ts', size: '2', mtime: '2' },
+        { kind: 'file', path: 'src/a.ts', size: '2', mtime: '2.5000000000' },
         { kind: 'file', path: 'src/b.ts', size: '1', mtime: '1' },
+        { kind: 'file', path: "src/line\nbreak's.ts", size: '1', mtime: '1' },
         { kind: 'file', path: 'node_modules/pkg/index.js', size: '1', mtime: '1' },
       ]),
     ]);
@@ -96,6 +172,7 @@ describe('LegacySshFilesRuntime', () => {
         changes: [
           { kind: 'update', path: '/repo/src/a.ts', entryType: 'file' },
           { kind: 'create', path: '/repo/src/b.ts', entryType: 'file' },
+          { kind: 'create', path: "/repo/src/line\nbreak's.ts", entryType: 'file' },
           { kind: 'delete', path: '/repo/README.md', entryType: 'file' },
         ],
       },
@@ -145,6 +222,36 @@ async function collect(iterable: AsyncIterable<string>): Promise<string[]> {
   const paths: string[] = [];
   for await (const relPath of iterable) paths.push(relPath);
   return paths;
+}
+
+function execLocalShell(command: string): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    execFile('/bin/sh', ['-c', command], { encoding: 'buffer' }, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(stderr.toString('utf8') || error.message));
+        return;
+      }
+      resolve(stdout);
+    });
+  });
+}
+
+function parseSnapshotRecords(stdout: Buffer): SnapshotRecord[] {
+  const fields = stdout.toString('utf8').split('\0');
+  const records: SnapshotRecord[] = [];
+
+  for (let index = 0; index + 3 < fields.length; index += 4) {
+    const kind = fields[index];
+    if (kind !== 'file' && kind !== 'directory') continue;
+    records.push({
+      kind,
+      size: fields[index + 1],
+      mtime: fields[index + 2],
+      path: fields[index + 3],
+    });
+  }
+
+  return records;
 }
 
 function snapshot(records: SnapshotRecord[]): Buffer {

--- a/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-files.ts
+++ b/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-files.ts
@@ -869,7 +869,7 @@ function parseRecursiveSnapshot(
     if (!entryType) continue;
 
     const size = fields[index + 1];
-    const mtime = fields[index + 2];
+    const mtime = normalizeSnapshotMtime(fields[index + 2]);
     const absPath = toRemoteAbsolutePath(rootPath, fields[index + 3]);
     if (isIgnoredRemotePath(rootPath, absPath)) continue;
 
@@ -881,6 +881,11 @@ function parseRecursiveSnapshot(
   }
 
   return entries;
+}
+
+function normalizeSnapshotMtime(raw: string): string {
+  const fractionalSeparator = raw.indexOf('.');
+  return fractionalSeparator === -1 ? raw : raw.slice(0, fractionalSeparator);
 }
 
 function parseSnapshotEntryType(raw: string): Exclude<FileEntryType, 'unknown'> | null {

--- a/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-files.ts
+++ b/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-files.ts
@@ -817,8 +817,12 @@ function readExecStream(
   });
 }
 
-function buildRecursiveSnapshotCommand(rootPath: string): string {
+export function buildRecursiveSnapshotCommand(rootPath: string): string {
   const pruneExpression = buildFindPruneExpression();
+  // GNU find can stream metadata without starting a stat process for every entry.
+  const gnuFindSnapshotCommand = `find . -mindepth 1 ${pruneExpression}\\( -type f -printf ${quoteShellArg(
+    'file\\0%s\\0%T@\\0%P\\0'
+  )} -o -type d -printf ${quoteShellArg('directory\\0%s\\0%T@\\0%P\\0')} \\)`;
   const snapshotScript = `
 stat_style=$1
 shift
@@ -836,13 +840,20 @@ for p do
   printf '%s\\0%s\\0%s\\0%s\\0' "$kind" "$size" "$mtime" "$rel"
 done
 `.trim();
-
-  return [
-    `cd ${quoteShellArg(rootPath)} || exit 1`,
+  const portableSnapshotCommand = [
     "if stat -c '%s %Y' . >/dev/null 2>&1; then stat_style=gnu; elif stat -f '%z %m' . >/dev/null 2>&1; then stat_style=bsd; else exit 2; fi",
     `find . ${pruneExpression}\\( -type f -o -type d \\) -exec sh -c ${quoteShellArg(
       snapshotScript
     )} sh "$stat_style" {} +`,
+  ].join('\n');
+
+  return [
+    `cd ${quoteShellArg(rootPath)} || exit 1`,
+    `if find . -maxdepth 0 -printf ${quoteShellArg('%s\\0%T@\\0%P\\0')} >/dev/null 2>&1; then`,
+    `  ${gnuFindSnapshotCommand}`,
+    'else',
+    portableSnapshotCommand,
+    'fi',
   ].join('\n');
 }
 


### PR DESCRIPTION
### Description

- use GNU `find -printf` to stream file type, size, mtime, and NUL-delimited relative paths in one recursive scan
- avoid spawning one `stat` process per entry on GNU/Linux hosts
- retain the existing GNU/BSD `stat` implementation as the portable fallback when `find -printf` is unavailable
- preserve ignored-directory pruning, shell escaping, and the existing NUL snapshot parser contract

For a 132-record fixture, the GNU fast path executed two `find` processes (capability probe plus scan) and zero `stat` processes.

### Related issues

Fixes #2853.

### Testing

- `pnpm exec vitest run --project node src/main/core/runtime/legacy/ssh-files.test.ts` (7 tests)
- POSIX integration fixture with 128 files plus directories, quote/newline paths, and ignored-directory pruning on the macOS/BSD fallback
- the same fixture with GNU findutils 4.11, with a wrapper measurement of 2 `find` and 0 `stat` processes for 132 records
- app Node suite (280 files, 1,992 tests)
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run typecheck`
- `git diff --check origin/main...HEAD`

All commands ran with Node 24.14.0 and pnpm 10.28.2. A full workspace test run also completed, but the workspace remains red in unchanged session-manager, UI serialization, plugin ACP, and browser xterm test areas; the affected SSH test suite and all static checks pass. Docker and a real remote SSH target were unavailable.

### Screenshot/Recording (if applicable)

Not applicable; this is a remote filesystem process-spawn optimization with automated command, parser, fallback, and integration coverage.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] Documentation changes are not needed because the external behavior and setup are unchanged
- [x] I added or updated tests when behavior changed
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit message and PR title

</details>
