### PR TITLE
fix(app): open remote VS Code workspaces in new windows

### DIFF
--- a/apps/emdash-desktop/src/main/core/app/service.test.ts
+++ b/apps/emdash-desktop/src/main/core/app/service.test.ts
@@ -4,6 +4,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   exec: vi.fn(),
+  execFile: vi.fn(),
+  dbLimit: vi.fn(),
+  dbSelect: vi.fn(),
   getVersion: vi.fn(() => '1.1.27'),
   openExternal: vi.fn(),
   openPath: vi.fn(),
@@ -19,6 +22,11 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('node:child_process', () => ({
   exec: mocks.exec,
+  execFile: mocks.execFile,
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn(),
 }));
 
 vi.mock('electron', () => ({
@@ -48,7 +56,9 @@ vi.mock('@main/app/window', () => ({
 }));
 
 vi.mock('@main/db/client', () => ({
-  db: {},
+  db: {
+    select: mocks.dbSelect,
+  },
 }));
 
 vi.mock('@main/db/schema', () => ({
@@ -88,6 +98,19 @@ describe('AppService.openIn', () => {
     vi.clearAllMocks();
     setPlatform('win32');
     mocks.openPath.mockResolvedValue('');
+    mocks.openExternal.mockResolvedValue(undefined);
+    mocks.execFile.mockImplementation(
+      (_file: string, _args: string[], _options: object, callback: (error: Error | null) => void) =>
+        callback(null)
+    );
+    mocks.dbLimit.mockResolvedValue([
+      { id: 'connection-1', host: 'example.com', username: 'alice', port: 22 },
+    ]);
+    mocks.dbSelect.mockReturnValue({
+      from: () => ({
+        where: () => ({ limit: mocks.dbLimit }),
+      }),
+    });
     mocks.exec.mockImplementation(
       (_command: string, _options: object, callback: (error: Error | null) => void) => {
         callback(null);
@@ -117,6 +140,80 @@ describe('AppService.openIn', () => {
     );
     expect(mocks.openPath).toHaveBeenCalledWith(target);
     expect(mocks.exec).not.toHaveBeenCalled();
+  });
+
+  it('opens remote VS Code workspaces in a new window via the macOS bundle', async () => {
+    setPlatform('darwin');
+
+    await appService.openIn({
+      app: 'vscode',
+      path: '/repo with space',
+      isRemote: true,
+      sshConnectionId: 'connection-1',
+    });
+
+    expect(mocks.execFile).toHaveBeenCalledTimes(1);
+    expect(mocks.execFile.mock.calls[0]?.slice(0, 2)).toEqual([
+      'open',
+      [
+        '-n',
+        '-b',
+        'com.microsoft.VSCode',
+        '--args',
+        '--new-window',
+        '--remote',
+        'ssh-remote+7b22686f73744e616d65223a226578616d706c652e636f6d222c2275736572223a22616c696365227d',
+        '/repo with space',
+      ],
+    ]);
+    expect(mocks.openExternal).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the registered VS Code URI when command launchers are unavailable', async () => {
+    setPlatform('darwin');
+    mocks.execFile.mockImplementation(
+      (_file: string, _args: string[], _options: object, callback: (error: Error | null) => void) =>
+        callback(new Error('not installed'))
+    );
+
+    await appService.openIn({
+      app: 'vscode',
+      path: '/repo',
+      isRemote: true,
+      sshConnectionId: 'connection-1',
+    });
+
+    const vscodeArgs = [
+      '--new-window',
+      '--remote',
+      'ssh-remote+7b22686f73744e616d65223a226578616d706c652e636f6d222c2275736572223a22616c696365227d',
+      '/repo',
+    ];
+    expect(mocks.execFile.mock.calls.map(([file, args]) => [file, args])).toEqual([
+      ['open', ['-n', '-b', 'com.microsoft.VSCode', '--args', ...vscodeArgs]],
+      ['open', ['-n', '-b', 'com.microsoft.VSCodeInsiders', '--args', ...vscodeArgs]],
+      ['open', ['-n', '-a', 'Visual Studio Code', '--args', ...vscodeArgs]],
+      ['open', ['-n', '-a', 'Visual Studio Code - Insiders', '--args', ...vscodeArgs]],
+    ]);
+    expect(mocks.openExternal).toHaveBeenCalledWith(
+      'vscode://vscode-remote/ssh-remote+7b22686f73744e616d65223a226578616d706c652e636f6d222c2275736572223a22616c696365227d/repo'
+    );
+  });
+
+  it('keeps other remote editor launches on their registered URI', async () => {
+    setPlatform('darwin');
+
+    await appService.openIn({
+      app: 'vscodium',
+      path: '/repo',
+      isRemote: true,
+      sshConnectionId: 'connection-1',
+    });
+
+    expect(mocks.execFile).not.toHaveBeenCalled();
+    expect(mocks.openExternal).toHaveBeenCalledWith(
+      'vscodium://vscode-remote/ssh-remote+7b22686f73744e616d65223a226578616d706c652e636f6d222c2275736572223a22616c696365227d/repo'
+    );
   });
 });
 

--- a/apps/emdash-desktop/src/main/core/app/service.ts
+++ b/apps/emdash-desktop/src/main/core/app/service.ts
@@ -15,6 +15,7 @@ import {
   buildRemoteEditorUrl,
   buildRemoteSshCommand,
   buildRemoteTerminalExecArgs,
+  buildRemoteVsCodeCliArgs,
 } from '@main/utils/remoteOpenIn';
 import {
   appPasteChannel,
@@ -78,7 +79,7 @@ async function resolveHomeJailedPath(rawPath: string): Promise<string> {
   return realPath;
 }
 
-type RemoteTerminalLaunchAttempt = {
+type LaunchAttempt = {
   file: string;
   args: string[];
 };
@@ -381,7 +382,42 @@ class AppService implements IInitializable, IDisposable {
 
     const { host, username, port } = connection;
 
-    if (appId === 'vscode' || appId === 'vscodium' || appId === 'cursor' || appId === 'zed') {
+    if (appId === 'vscode') {
+      const vscodeArgs = buildRemoteVsCodeCliArgs(host, username, target);
+      const attempts =
+        platform === 'darwin'
+          ? [
+              {
+                file: 'open',
+                args: ['-n', '-b', 'com.microsoft.VSCode', '--args', ...vscodeArgs],
+              },
+              {
+                file: 'open',
+                args: ['-n', '-b', 'com.microsoft.VSCodeInsiders', '--args', ...vscodeArgs],
+              },
+              {
+                file: 'open',
+                args: ['-n', '-a', 'Visual Studio Code', '--args', ...vscodeArgs],
+              },
+              {
+                file: 'open',
+                args: ['-n', '-a', 'Visual Studio Code - Insiders', '--args', ...vscodeArgs],
+              },
+            ]
+          : [
+              { file: 'code', args: vscodeArgs },
+              { file: 'code-insiders', args: vscodeArgs },
+            ];
+
+      try {
+        await this.launchCommandAttempts('VS Code', attempts);
+      } catch {
+        await shell.openExternal(buildRemoteEditorUrl(appId, host, username, target, port));
+      }
+      return;
+    }
+
+    if (appId === 'vscodium' || appId === 'cursor' || appId === 'zed') {
       await shell.openExternal(buildRemoteEditorUrl(appId, host, username, target, port));
       return;
     }
@@ -428,7 +464,7 @@ class AppService implements IInitializable, IDisposable {
             ]
           : [{ file: 'ghostty', args: ['-e', ...remoteExecArgs] }];
 
-      await this.launchRemoteTerminal('Ghostty', attempts);
+      await this.launchCommandAttempts('Ghostty', attempts);
       return;
     }
 
@@ -451,7 +487,7 @@ class AppService implements IInitializable, IDisposable {
             ]
           : [{ file: 'kitty', args: remoteExecArgs }];
 
-      await this.launchRemoteTerminal('Kitty', attempts);
+      await this.launchCommandAttempts('Kitty', attempts);
       return;
     }
 
@@ -474,7 +510,7 @@ class AppService implements IInitializable, IDisposable {
             ]
           : [{ file: 'alacritty', args: ['-e', ...remoteExecArgs] }];
 
-      await this.launchRemoteTerminal('Alacritty', attempts);
+      await this.launchCommandAttempts('Alacritty', attempts);
       return;
     }
 
@@ -493,7 +529,7 @@ class AppService implements IInitializable, IDisposable {
             ]
           : [{ file: 'kaku', args: ['start', '--', ...remoteExecArgs] }];
 
-      await this.launchRemoteTerminal('Kaku', attempts);
+      await this.launchCommandAttempts('Kaku', attempts);
       return;
     }
 
@@ -502,10 +538,7 @@ class AppService implements IInitializable, IDisposable {
     }
   }
 
-  private async launchRemoteTerminal(
-    label: string,
-    attempts: RemoteTerminalLaunchAttempt[]
-  ): Promise<void> {
+  private async launchCommandAttempts(label: string, attempts: LaunchAttempt[]): Promise<void> {
     let lastError: unknown = null;
     for (const attempt of attempts) {
       try {

--- a/apps/emdash-desktop/src/main/utils/remoteOpenIn.test.ts
+++ b/apps/emdash-desktop/src/main/utils/remoteOpenIn.test.ts
@@ -3,6 +3,7 @@ import {
   buildRemoteEditorUrl,
   buildRemoteSshAuthority,
   buildRemoteTerminalExecArgs,
+  buildRemoteVsCodeCliArgs,
 } from './remoteOpenIn';
 
 describe('remoteOpenIn', () => {
@@ -41,6 +42,17 @@ describe('remoteOpenIn', () => {
       expect(buildRemoteEditorUrl('zed', 'localhost', 'dev', '/repo with space/#1')).toBe(
         'zed://ssh/dev@localhost/repo%20with%20space/%231'
       );
+    });
+  });
+
+  describe('buildRemoteVsCodeCliArgs', () => {
+    it('requests a new window for the selected remote SSH workspace', () => {
+      expect(buildRemoteVsCodeCliArgs('example.com', 'alice', '/repo with space')).toEqual([
+        '--new-window',
+        '--remote',
+        'ssh-remote+7b22686f73744e616d65223a226578616d706c652e636f6d222c2275736572223a22616c696365227d',
+        '/repo with space',
+      ]);
     });
   });
 

--- a/apps/emdash-desktop/src/main/utils/remoteOpenIn.ts
+++ b/apps/emdash-desktop/src/main/utils/remoteOpenIn.ts
@@ -51,6 +51,21 @@ function buildVsCodeRemoteAuthority(host: string, username: string): string {
   ).toString('hex');
 }
 
+/**
+ * Builds VS Code argv tokens for a remote SSH workspace.
+ *
+ * Callers pass these tokens through execFile (shell disabled), so the remote path stays an
+ * individual argument and does not require shell quoting.
+ */
+export function buildRemoteVsCodeCliArgs(
+  host: string,
+  username: string,
+  targetPath: string
+): string[] {
+  const remoteAuthority = `ssh-remote+${buildVsCodeRemoteAuthority(host, username)}`;
+  return ['--new-window', '--remote', remoteAuthority, targetPath];
+}
+
 export function buildRemoteEditorUrl(
   scheme: RemoteEditorScheme,
   host: string,


### PR DESCRIPTION
### Description

- launch remote VS Code workspaces with `--new-window --remote <authority> <path>`
- target the VS Code and VS Code Insiders bundles directly on macOS so a generic `code` shim cannot open a different editor
- preserve the existing `vscode://` URI fallback when command launchers are unavailable, without changing Cursor, VSCodium, or Zed behavior

### Related issues

Fixes #2904.

### Testing

- `pnpm exec vitest run --project node src/main/utils/remoteOpenIn.test.ts src/main/core/app/service.test.ts` (18 tests)
- `pnpm run test` in `apps/emdash-desktop` (317 files, 2,225 tests)
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run typecheck`
- `git diff --check origin/main...HEAD`

All commands ran with Node 24.14.0 and pnpm 10.28.2.

### Screenshot/Recording (if applicable)

Not applicable. This environment does not have a VS Code bundle or a remote SSH target, so the launcher order, argv, fallback, and unchanged non-VS-Code paths are covered by unit tests instead.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] Documentation changes are not needed for this targeted launcher fix
- [x] I added or updated tests when behavior changed
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit message and PR title

</details>
