### PR TITLE
fix(chat-ui): remove duplicate search label

### DIFF
--- a/packages/chat-ui/src/components/rows/tools/tool/tool.def.test.ts
+++ b/packages/chat-ui/src/components/rows/tools/tool/tool.def.test.ts
@@ -1,0 +1,36 @@
+import type { SegmentCtx } from '@core/units';
+import { describe, expect, it } from 'vitest';
+import type { ToolNode } from '@/model';
+import { toolFromItem } from './tool.def';
+
+function searchItem(query: string) {
+  return {
+    kind: 'search-tool-call',
+    id: 'search-1',
+    seq: 0,
+    toolCallId: 'call-1',
+    title: 'Search',
+    status: 'done',
+    query,
+  } satisfies Extract<ToolNode, { kind: 'search-tool-call' }>;
+}
+
+const ctx = {
+  pendingToolCallIds: () => new Set<string>(),
+} as SegmentCtx;
+
+describe('toolFromItem', () => {
+  it('removes a redundant Search prefix from search summaries', () => {
+    expect(toolFromItem(searchItem("Search for 'toAgentUpdate'"), ctx)).toMatchObject({
+      name: 'Search',
+      inputSummary: "for 'toAgentUpdate'",
+    });
+  });
+
+  it('preserves search summaries without the redundant prefix', () => {
+    expect(toolFromItem(searchItem('SolidJS virtualized list patterns'), ctx)).toMatchObject({
+      name: 'Search',
+      inputSummary: 'SolidJS virtualized list patterns',
+    });
+  });
+});

--- a/packages/chat-ui/src/components/rows/tools/tool/tool.def.test.ts
+++ b/packages/chat-ui/src/components/rows/tools/tool/tool.def.test.ts
@@ -20,10 +20,10 @@ const ctx = {
 } as SegmentCtx;
 
 describe('toolFromItem', () => {
-  it('removes a redundant Search prefix from search summaries', () => {
-    expect(toolFromItem(searchItem("Search for 'toAgentUpdate'"), ctx)).toMatchObject({
+  it('preserves raw search queries that begin with search', () => {
+    expect(toolFromItem(searchItem('search engine optimization'), ctx)).toMatchObject({
       name: 'Search',
-      inputSummary: "for 'toAgentUpdate'",
+      inputSummary: 'search engine optimization',
     });
   });
 

--- a/packages/chat-ui/src/components/rows/tools/tool/tool.def.tsx
+++ b/packages/chat-ui/src/components/rows/tools/tool/tool.def.tsx
@@ -25,9 +25,7 @@ export function toolFromItem(item: ToolNode, ctx: SegmentCtx): ChatToolCall {
                 : 'Tool';
   const inputSummary =
     item.kind === 'search-tool-call'
-      ? `${item.query.replace(/^search\s+/i, '')}${
-          item.matchCount !== undefined ? ` (${item.matchCount} matches)` : ''
-        }`
+      ? `${item.query}${item.matchCount !== undefined ? ` (${item.matchCount} matches)` : ''}`
       : item.kind === 'mcp-tool-call'
         ? [item.server, item.tool].filter(Boolean).join('.')
         : item.kind === 'web-fetch-tool-call'

--- a/packages/chat-ui/src/components/rows/tools/tool/tool.def.tsx
+++ b/packages/chat-ui/src/components/rows/tools/tool/tool.def.tsx
@@ -25,7 +25,9 @@ export function toolFromItem(item: ToolNode, ctx: SegmentCtx): ChatToolCall {
                 : 'Tool';
   const inputSummary =
     item.kind === 'search-tool-call'
-      ? `${item.query}${item.matchCount !== undefined ? ` (${item.matchCount} matches)` : ''}`
+      ? `${item.query.replace(/^search\s+/i, '')}${
+          item.matchCount !== undefined ? ` (${item.matchCount} matches)` : ''
+        }`
       : item.kind === 'mcp-tool-call'
         ? [item.server, item.tool].filter(Boolean).join('.')
         : item.kind === 'web-fetch-tool-call'

--- a/packages/core/src/acp/reducer/acp-transcript-parser.test.ts
+++ b/packages/core/src/acp/reducer/acp-transcript-parser.test.ts
@@ -403,7 +403,7 @@ describe('AcpTranscriptParser', () => {
   it('tool kinds can materialize richer tool rows', () => {
     const p = new AcpTranscriptParser(deps());
     p.push(userChunk('u1', 'use tools'));
-    p.push(toolCallUpdate('search-1', 'Find symbols', 'search'));
+    p.push(toolCallUpdate('search-1', "Search for 'symbols'", 'search'));
     p.push(toolCallUpdate('mcp-1', 'linear.searchIssues', 'mcp-tool'));
     p.push(toolCallUpdate('fetch-1', 'https://example.test', 'web-fetch'));
     p.push(toolCallUpdate('subagent-1', 'Investigate failure', 'subagent'));
@@ -411,7 +411,7 @@ describe('AcpTranscriptParser', () => {
     const items = p.activeTurn?.items ?? [];
     expect(items.find((i) => i.kind === 'search-tool-call')).toMatchObject({
       id: makeToolId(makeTurnId(CID, 0), 'search-1'),
-      query: 'Find symbols',
+      query: "for 'symbols'",
       status: 'running',
     });
     expect(items.find((i) => i.kind === 'mcp-tool-call')).toMatchObject({
@@ -431,14 +431,14 @@ describe('AcpTranscriptParser', () => {
     p.pushEvent({
       kind: 'search',
       toolCallId: 'search-1',
-      query: 'NormalizedEvent',
+      query: 'search engine optimization',
       status: 'completed',
       parentToolCallId: null,
       matchCount: 3,
     });
 
     expect(p.activeTurn?.items.find((i) => i.kind === 'search-tool-call')).toMatchObject({
-      query: 'NormalizedEvent',
+      query: 'search engine optimization',
       status: 'done',
       matchCount: 3,
     });

--- a/packages/core/src/acp/reducer/item-fold.ts
+++ b/packages/core/src/acp/reducer/item-fold.ts
@@ -71,6 +71,10 @@ function isSearchKind(toolKind: string | null | undefined): boolean {
   return toolKind === 'search' || toolKind === 'grep';
 }
 
+function searchQueryFromTitle(title: string): string {
+  return title.replace(/^search\s+/i, '');
+}
+
 function isReadKind(toolKind: string | null | undefined, title?: string | null): boolean {
   return toolKind === 'read' || toolKind === 'read_file' || title?.startsWith('Read ') === true;
 }
@@ -178,7 +182,7 @@ export function createToolCallItem(params: {
     return { kind: 'spawn-subagent-tool-call', ...base, name: title };
   }
   if (isSearchKind(toolKind)) {
-    return { kind: 'search-tool-call', ...base, query: title };
+    return { kind: 'search-tool-call', ...base, query: searchQueryFromTitle(title) };
   }
   if (isMcpToolKind(toolKind)) {
     return { kind: 'mcp-tool-call', ...base, tool: title };
@@ -239,7 +243,10 @@ function updateToolCallItem(
     case 'delete-file-tool-call':
       return common;
     case 'search-tool-call':
-      return { ...common, ...(title !== null ? { query: nextTitle } : {}) };
+      return {
+        ...common,
+        ...(title !== null ? { query: searchQueryFromTitle(nextTitle) } : {}),
+      };
     case 'mcp-tool-call':
       return { ...common, ...(title !== null ? { tool: nextTitle } : {}) };
     case 'web-fetch-tool-call':


### PR DESCRIPTION
### Description

Search tool rows currently render the static \`Search\` label beside provider queries that may already begin with \`Search\`, producing duplicated text such as \`Search Search for …\`.

Strip one case-insensitive leading \`Search \` prefix when building the compact search summary. Queries without that prefix remain unchanged. Regression tests cover both cases.

### Screenshot/Recording (if applicable)
before:
<img width="114" height="32" alt="ea74b0991379a6ae280eae96370c63f0859a8c304b042fd71133f24f4ee357ee" src="https://github.com/user-attachments/assets/d3a048b2-b11e-4818-bc1d-16b151965524" />

after:
<img width="341" height="38" alt="Screenshot 2026-07-18 at 17 53 24" src="https://github.com/user-attachments/assets/7c4632d2-736d-4363-a5c1-0af1ceecfeb2" />


<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] Docs were not needed for this behavior-only fix
- [x] I added or updated tests when behavior changed
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit and PR title

</details>