### PR TITLE
fix(sidebar): toggle task panels from shortcuts

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tasks/commands.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/commands.test.ts
@@ -147,6 +147,7 @@ describe('createTaskCommandProvider', () => {
     });
     mocks.getTaskView.mockReturnValue({
       isSidebarCollapsed: false,
+      sidebarTab: 'changes',
       isTerminalDrawerOpen: false,
       openNewTerminal: vi.fn(),
       setFocusedRegion: vi.fn(),
@@ -199,6 +200,40 @@ describe('createTaskCommandProvider', () => {
         expect(command.shortcutKey in APP_SHORTCUTS).toBe(true);
       }
     }
+  });
+
+  it.each([
+    ['task.sidebarChanges', 'changes'],
+    ['task.sidebarFiles', 'files'],
+    ['task.sidebarConversations', 'conversations'],
+  ] as const)('collapses the selected sidebar panel from %s', (commandId, sidebarTab) => {
+    const taskView = mocks.getTaskView();
+    taskView.sidebarTab = sidebarTab;
+    mocks.getTaskView.mockReturnValue(taskView);
+    const provider = createTaskCommandProvider('project-1', 'task-1');
+
+    provider
+      .getCommands()
+      .find((candidate) => candidate.id === commandId)
+      ?.execute();
+
+    expect(taskView.setSidebarCollapsed).toHaveBeenCalledWith(true);
+    expect(taskView.setSidebarTab).not.toHaveBeenCalled();
+  });
+
+  it('switches to a different sidebar panel without collapsing the sidebar', () => {
+    const taskView = mocks.getTaskView();
+    taskView.sidebarTab = 'changes';
+    mocks.getTaskView.mockReturnValue(taskView);
+    const provider = createTaskCommandProvider('project-1', 'task-1');
+
+    provider
+      .getCommands()
+      .find((candidate) => candidate.id === 'task.sidebarFiles')
+      ?.execute();
+
+    expect(taskView.setSidebarTab).toHaveBeenCalledWith('files');
+    expect(taskView.setSidebarCollapsed).toHaveBeenCalledWith(false);
   });
 
   it('opens a new conversation in a right split from the split command', () => {

--- a/apps/emdash-desktop/src/renderer/features/tasks/commands.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/commands.test.ts
@@ -221,6 +221,25 @@ describe('createTaskCommandProvider', () => {
     expect(taskView.setSidebarTab).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['task.sidebarChanges', 'changes'],
+    ['task.sidebarFiles', 'files'],
+    ['task.sidebarConversations', 'conversations'],
+  ] as const)('expands the selected sidebar panel from %s', (commandId, sidebarTab) => {
+    const taskView = mocks.getTaskView();
+    taskView.isSidebarCollapsed = true;
+    mocks.getTaskView.mockReturnValue(taskView);
+    const provider = createTaskCommandProvider('project-1', 'task-1');
+
+    provider
+      .getCommands()
+      .find((candidate) => candidate.id === commandId)
+      ?.execute();
+
+    expect(taskView.setSidebarTab).toHaveBeenCalledWith(sidebarTab);
+    expect(taskView.setSidebarCollapsed).toHaveBeenCalledWith(false);
+  });
+
   it('switches to a different sidebar panel without collapsing the sidebar', () => {
     const taskView = mocks.getTaskView();
     taskView.sidebarTab = 'changes';

--- a/apps/emdash-desktop/src/renderer/features/tasks/commands.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/commands.ts
@@ -142,8 +142,13 @@ export function createTaskCommandProvider(projectId: string, taskId: string): Co
           shortcutKey: sidebarChangesDef.shortcutKey,
           group: sidebarChangesDef.group,
           execute() {
-            taskView?.setSidebarTab('changes');
-            taskView?.setSidebarCollapsed(false);
+            if (!taskView) return;
+            if (!taskView.isSidebarCollapsed && taskView.sidebarTab === 'changes') {
+              taskView.setSidebarCollapsed(true);
+              return;
+            }
+            taskView.setSidebarTab('changes');
+            taskView.setSidebarCollapsed(false);
           },
         },
         {
@@ -153,8 +158,13 @@ export function createTaskCommandProvider(projectId: string, taskId: string): Co
           shortcutKey: sidebarConversationsDef.shortcutKey,
           group: sidebarConversationsDef.group,
           execute() {
-            taskView?.setSidebarTab('conversations');
-            taskView?.setSidebarCollapsed(false);
+            if (!taskView) return;
+            if (!taskView.isSidebarCollapsed && taskView.sidebarTab === 'conversations') {
+              taskView.setSidebarCollapsed(true);
+              return;
+            }
+            taskView.setSidebarTab('conversations');
+            taskView.setSidebarCollapsed(false);
           },
         },
         {
@@ -164,8 +174,13 @@ export function createTaskCommandProvider(projectId: string, taskId: string): Co
           shortcutKey: sidebarFilesDef.shortcutKey,
           group: sidebarFilesDef.group,
           execute() {
-            taskView?.setSidebarTab('files');
-            taskView?.setSidebarCollapsed(false);
+            if (!taskView) return;
+            if (!taskView.isSidebarCollapsed && taskView.sidebarTab === 'files') {
+              taskView.setSidebarCollapsed(true);
+              return;
+            }
+            taskView.setSidebarTab('files');
+            taskView.setSidebarCollapsed(false);
           },
         },
         {


### PR DESCRIPTION
### Description

Make `Cmd+Shift+1`, `Cmd+Shift+2`, and `Cmd+Shift+3` toggle their corresponding right-sidebar panels instead of only expanding them. Repeating a shortcut now collapses the active panel, while selecting a different panel keeps the sidebar open and switches tabs.

### Related issues

Fixes ENG-1908.

### Screenshot/Recording (if applicable)

https://cap.link/sjvm9a8jtv90qht

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>