### PR TITLE
fix(view-state): persist task layout across reloads

### DIFF
--- a/apps/emdash-desktop/src/main/app/menu.ts
+++ b/apps/emdash-desktop/src/main/app/menu.ts
@@ -7,6 +7,7 @@ import {
   menuGiveFeedbackChannel,
   menuOpenSettingsChannel,
   menuQuitRequestedChannel,
+  menuReloadRequestedChannel,
   menuRedoChannel,
   menuUndoChannel,
 } from '@shared/events/appEvents';
@@ -35,6 +36,16 @@ function requestQuit(): void {
   win.show();
   win.focus();
   events.emit(menuQuitRequestedChannel, undefined);
+}
+
+function requestReload(): void {
+  const win = getMainWindow();
+  if (!win) return;
+  if (win.webContents.isLoading()) {
+    win.webContents.reload();
+    return;
+  }
+  events.emit(menuReloadRequestedChannel, undefined);
 }
 
 export function setupApplicationMenu(): void {
@@ -132,7 +143,11 @@ export function setupApplicationMenu(): void {
     {
       label: 'View',
       submenu: [
-        { role: 'reload' as const },
+        {
+          label: 'Reload',
+          accelerator: 'CmdOrCtrl+R',
+          click: requestReload,
+        },
         { role: 'forceReload' as const },
         { role: 'toggleDevTools' as const },
         { type: 'separator' as const },

--- a/apps/emdash-desktop/src/main/core/app/controller.ts
+++ b/apps/emdash-desktop/src/main/core/app/controller.ts
@@ -101,6 +101,14 @@ export const appController = createRPCController({
       return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   },
+  reload: () => {
+    try {
+      appService.reload();
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  },
   openIn: async (args: {
     app: OpenInAppId;
     path: string;

--- a/apps/emdash-desktop/src/main/core/app/controller.ts
+++ b/apps/emdash-desktop/src/main/core/app/controller.ts
@@ -103,7 +103,9 @@ export const appController = createRPCController({
   },
   reload: () => {
     try {
-      appService.reload();
+      if (!appService.reload()) {
+        return { success: false, error: 'Main window is not available' };
+      }
       return { success: true };
     } catch (error) {
       return { success: false, error: error instanceof Error ? error.message : String(error) };

--- a/apps/emdash-desktop/src/main/core/app/service.test.ts
+++ b/apps/emdash-desktop/src/main/core/app/service.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
     popup: mocks.menuPopup,
     template,
   })),
+  getMainWindow: vi.fn(),
   eventEmit: vi.fn(),
   clipboardWriteText: vi.fn(),
 }));
@@ -44,7 +45,7 @@ vi.mock('electron', () => ({
 }));
 
 vi.mock('@main/app/window', () => ({
-  getMainWindow: vi.fn(),
+  getMainWindow: mocks.getMainWindow,
 }));
 
 vi.mock('@main/db/client', () => ({
@@ -176,5 +177,16 @@ describe('AppService.showTerminalContextMenu', () => {
     copyItem?.click?.({} as Electron.MenuItem, undefined as never, undefined as never);
 
     expect(mocks.clipboardWriteText).toHaveBeenCalledWith('   ');
+  });
+});
+
+describe('AppService.reload', () => {
+  it('reloads the main window web contents', () => {
+    const reload = vi.fn();
+    mocks.getMainWindow.mockReturnValue({ webContents: { reload } });
+
+    appService.reload();
+
+    expect(reload).toHaveBeenCalledOnce();
   });
 });

--- a/apps/emdash-desktop/src/main/core/app/service.test.ts
+++ b/apps/emdash-desktop/src/main/core/app/service.test.ts
@@ -185,8 +185,15 @@ describe('AppService.reload', () => {
     const reload = vi.fn();
     mocks.getMainWindow.mockReturnValue({ webContents: { reload } });
 
-    appService.reload();
+    const reloaded = appService.reload();
 
+    expect(reloaded).toBe(true);
     expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it('returns false when the main window is unavailable', () => {
+    mocks.getMainWindow.mockReturnValue(null);
+
+    expect(appService.reload()).toBe(false);
   });
 });

--- a/apps/emdash-desktop/src/main/core/app/service.ts
+++ b/apps/emdash-desktop/src/main/core/app/service.ts
@@ -308,8 +308,11 @@ class AppService implements IInitializable, IDisposable {
     app.quit();
   }
 
-  reload(): void {
-    getMainWindow()?.webContents.reload();
+  reload(): boolean {
+    const win = getMainWindow();
+    if (!win) return false;
+    win.webContents.reload();
+    return true;
   }
 
   minimizeWindow(): void {

--- a/apps/emdash-desktop/src/main/core/app/service.ts
+++ b/apps/emdash-desktop/src/main/core/app/service.ts
@@ -308,6 +308,10 @@ class AppService implements IInitializable, IDisposable {
     app.quit();
   }
 
+  reload(): void {
+    getMainWindow()?.webContents.reload();
+  }
+
   minimizeWindow(): void {
     getMainWindow()?.minimize();
   }

--- a/apps/emdash-desktop/src/main/core/projects/operations/deleteProject.test.ts
+++ b/apps/emdash-desktop/src/main/core/projects/operations/deleteProject.test.ts
@@ -92,9 +92,22 @@ describe('deleteProject', () => {
     await deleteProject('project-1');
 
     expect(mocks.closeProject).not.toHaveBeenCalled();
-    expect(mocks.getTasks).not.toHaveBeenCalled();
+    expect(mocks.getTasks).toHaveBeenCalledWith('project-1');
     expect(mocks.teardownTask).not.toHaveBeenCalled();
     expect(mocks.deleteWhere).toHaveBeenCalledTimes(1);
+  });
+
+  it('deletes aggregate and dedicated tab view state for every task', async () => {
+    mocks.getTasks.mockResolvedValue([{ id: 'task-1' }, { id: 'task-2' }]);
+
+    const deletedTaskIds = await deleteProject('project-1');
+
+    expect(mocks.delViewState).toHaveBeenCalledWith('task:task-1');
+    expect(mocks.delViewState).toHaveBeenCalledWith('task:task-1:tabs');
+    expect(mocks.delViewState).toHaveBeenCalledWith('task:task-2');
+    expect(mocks.delViewState).toHaveBeenCalledWith('task:task-2:tabs');
+    expect(mocks.delViewState).toHaveBeenCalledWith('project:project-1');
+    expect(deletedTaskIds).toEqual(['task-1', 'task-2']);
   });
 
   it('cleans PR sync data before deleting the project row', async () => {

--- a/apps/emdash-desktop/src/main/core/projects/operations/deleteProject.test.ts
+++ b/apps/emdash-desktop/src/main/core/projects/operations/deleteProject.test.ts
@@ -108,6 +108,13 @@ describe('deleteProject', () => {
     expect(mocks.delViewState).toHaveBeenCalledWith('task:task-2:tabs');
     expect(mocks.delViewState).toHaveBeenCalledWith('project:project-1');
     expect(deletedTaskIds).toEqual(['task-1', 'task-2']);
+
+    const projectStateDeleteIndex = mocks.delViewState.mock.calls.findIndex(
+      ([key]) => key === 'project:project-1'
+    );
+    expect(mocks.delViewState.mock.invocationCallOrder[projectStateDeleteIndex]).toBeLessThan(
+      mocks.deleteWhere.mock.invocationCallOrder[0]
+    );
   });
 
   it('cleans PR sync data before deleting the project row', async () => {

--- a/apps/emdash-desktop/src/main/core/projects/operations/deleteProject.ts
+++ b/apps/emdash-desktop/src/main/core/projects/operations/deleteProject.ts
@@ -17,16 +17,16 @@ export async function deleteProject(id: string): Promise<string[]> {
     await projectManager.closeProject(id);
   }
 
-  await Promise.allSettled(
-    projectTasks.flatMap((task) => [
+  await Promise.allSettled([
+    viewStateService.del(`project:${id}`),
+    ...projectTasks.flatMap((task) => [
       viewStateService.del(`task:${task.id}`),
       viewStateService.del(`task:${task.id}:tabs`),
-    ])
-  );
+    ]),
+  ]);
 
   await prSyncEngine.deleteProjectData(id);
   await db.delete(projects).where(eq(projects.id, id));
-  await viewStateService.del(`project:${id}`);
   projectEvents._emit('project:deleted', id);
   telemetryService.capture('project_deleted', { project_id: id });
   return projectTasks.map((task) => task.id);

--- a/apps/emdash-desktop/src/main/core/projects/operations/deleteProject.ts
+++ b/apps/emdash-desktop/src/main/core/projects/operations/deleteProject.ts
@@ -9,20 +9,25 @@ import { db } from '@main/db/client';
 import { projects } from '@main/db/schema';
 import { telemetryService } from '@main/lib/telemetry';
 
-export async function deleteProject(id: string): Promise<void> {
+export async function deleteProject(id: string): Promise<string[]> {
   const provider = projectManager.getProject(id);
+  const projectTasks = await getTasks(id);
   if (provider) {
-    const projectTasks = await getTasks(id);
-    await Promise.allSettled([
-      ...projectTasks.map((t) => taskSessionManager.teardownTask(t.id)),
-      ...projectTasks.map((t) => viewStateService.del(`task:${t.id}`)),
-    ]);
+    await Promise.allSettled([...projectTasks.map((t) => taskSessionManager.teardownTask(t.id))]);
     await projectManager.closeProject(id);
   }
 
+  await Promise.allSettled(
+    projectTasks.flatMap((task) => [
+      viewStateService.del(`task:${task.id}`),
+      viewStateService.del(`task:${task.id}:tabs`),
+    ])
+  );
+
   await prSyncEngine.deleteProjectData(id);
   await db.delete(projects).where(eq(projects.id, id));
-  void viewStateService.del(`project:${id}`);
+  await viewStateService.del(`project:${id}`);
   projectEvents._emit('project:deleted', id);
   telemetryService.capture('project_deleted', { project_id: id });
+  return projectTasks.map((task) => task.id);
 }

--- a/apps/emdash-desktop/src/main/core/view-state/view-state-service.ts
+++ b/apps/emdash-desktop/src/main/core/view-state/view-state-service.ts
@@ -5,7 +5,7 @@ import { KV } from '@main/db/kv';
 const viewStateKV = new KV<Record<string, unknown>>('view-state');
 
 export const viewStateService = {
-  save: (key: string, snapshot: unknown): Promise<void> => viewStateKV.set(key, snapshot),
+  save: (key: string, snapshot: unknown): Promise<void> => viewStateKV.setOrThrow(key, snapshot),
 
   get: (key: string): Promise<unknown> => viewStateKV.get(key),
 

--- a/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.ts
@@ -2,6 +2,7 @@ import { err, ok, type Result } from '@emdash/shared';
 import { makeObservable, observable, runInAction } from 'mobx';
 import { events, rpc } from '@renderer/lib/ipc';
 import { appState } from '@renderer/lib/stores/app-state';
+import { snapshotRegistry } from '@renderer/lib/stores/snapshot-registry';
 import { viewStateCache } from '@renderer/lib/stores/view-state-cache';
 import { log } from '@renderer/utils/logger';
 import { captureTelemetry } from '@renderer/utils/telemetryClient';
@@ -370,7 +371,12 @@ export class ProjectManagerStore {
     });
     appState.navigation.revalidate();
     try {
-      await rpc.projects.deleteProject(projectId);
+      const taskIds = await rpc.projects.deleteProject(projectId);
+      snapshotRegistry.evict(`project:${projectId}`);
+      for (const taskId of taskIds) {
+        snapshotRegistry.evict(`task:${taskId}`);
+        snapshotRegistry.evict(`task:${taskId}:tabs`);
+      }
     } catch (err) {
       runInAction(() => {
         if (snapshot) this.projects.set(projectId, snapshot);

--- a/apps/emdash-desktop/src/renderer/features/sidebar/sidebar-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/sidebar/sidebar-store.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
+import { rpc } from '@renderer/lib/ipc';
+import { SnapshotRegistry } from '@renderer/lib/stores/snapshot-registry';
+import { viewStateCache } from '@renderer/lib/stores/view-state-cache';
+import type { SidebarSnapshot } from '@shared/view-state';
 import { SidebarStore } from './sidebar-store';
 
 type SidebarProjectManager = ConstructorParameters<typeof SidebarStore>[0];
@@ -7,11 +11,21 @@ vi.mock('@renderer/lib/ipc', () => ({
   events: {
     on: vi.fn(),
   },
-  rpc: {},
+  rpc: {
+    viewState: {
+      save: vi.fn(),
+    },
+  },
 }));
 
 vi.mock('@renderer/lib/stores/app-state', () => ({
   appState: {},
+}));
+
+vi.mock('@renderer/utils/logger', () => ({
+  log: {
+    error: vi.fn(),
+  },
 }));
 
 vi.mock('@renderer/features/conversations/acp/acp-chat-store', () => ({
@@ -123,5 +137,115 @@ describe('SidebarStore project ordering', () => {
       { projectId: 'project-1', taskId: 'task-1b' },
       { projectId: 'project-2', taskId: 'task-2a' },
     ]);
+  });
+
+  it('synchronously persists and restores manual task order', () => {
+    const projects = projectManagerWithTasks([
+      {
+        id: 'project-1',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        taskIds: ['task-1a', 'task-1b'],
+      },
+    ]);
+    const store = new SidebarStore(projects);
+    const dispose = new SnapshotRegistry().register('sidebar', () => store.snapshot, 0);
+    vi.mocked(rpc.viewState.save).mockClear();
+
+    store.setTaskOrder('project-1', ['task-1b', 'task-1a']);
+
+    expect(rpc.viewState.save).toHaveBeenCalledTimes(1);
+    expect(rpc.viewState.save).toHaveBeenCalledWith(
+      'sidebar',
+      expect.objectContaining({
+        taskOrderByProject: { 'project-1': ['task-1b', 'task-1a'] },
+      })
+    );
+
+    const restored = new SidebarStore(projects);
+    const savedSnapshot = vi.mocked(rpc.viewState.save).mock.calls[0][1] as SidebarSnapshot;
+    expect(() => structuredClone(savedSnapshot)).not.toThrow();
+    restored.restoreSnapshot(savedSnapshot);
+    expect(restored.visibleTaskIdsForProject('project-1')).toEqual(['task-1b', 'task-1a']);
+
+    dispose();
+  });
+
+  it('flushes pending saves before reload and retains cached state after disposal', async () => {
+    const projects = projectManagerWithTasks([
+      {
+        id: 'project-1',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        taskIds: ['task-1a', 'task-1b'],
+      },
+    ]);
+    const store = new SidebarStore(projects);
+    const registry = new SnapshotRegistry();
+    const dispose = registry.register('sidebar', () => store.snapshot, 0);
+    const pending = Promise.withResolvers<void>();
+    vi.mocked(rpc.viewState.save).mockReset();
+    vi.mocked(rpc.viewState.save).mockReturnValueOnce(pending.promise);
+
+    store.setTaskOrder('project-1', ['task-1b', 'task-1a']);
+    const flush = registry.flush();
+    await Promise.resolve();
+
+    expect(rpc.viewState.save).toHaveBeenCalledTimes(1);
+    pending.resolve();
+    await flush;
+    expect(rpc.viewState.save).toHaveBeenCalledTimes(2);
+
+    dispose();
+    expect(viewStateCache.peek('sidebar')).toEqual(store.snapshot);
+    registry.evict('sidebar');
+    expect(viewStateCache.peek('sidebar')).toBeUndefined();
+  });
+
+  it('rejects a flush when the current snapshot cannot be persisted', async () => {
+    const projects = projectManagerWithTasks([
+      {
+        id: 'project-1',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        taskIds: ['task-1a', 'task-1b'],
+      },
+    ]);
+    const store = new SidebarStore(projects);
+    const registry = new SnapshotRegistry();
+    const dispose = registry.register('sidebar', () => store.snapshot, 0);
+    vi.mocked(rpc.viewState.save).mockReset();
+    vi.mocked(rpc.viewState.save).mockRejectedValue(new Error('database is read-only'));
+
+    store.setTaskOrder('project-1', ['task-1b', 'task-1a']);
+
+    await expect(registry.flush()).rejects.toThrow('database is read-only');
+    dispose();
+    registry.evict('sidebar');
+  });
+
+  it('flushes the retained snapshot after its active registration is disposed', async () => {
+    const projects = projectManagerWithTasks([
+      {
+        id: 'project-1',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        taskIds: ['task-1a', 'task-1b'],
+      },
+    ]);
+    const store = new SidebarStore(projects);
+    const registry = new SnapshotRegistry();
+    const dispose = registry.register('sidebar', () => store.snapshot, 0);
+    vi.mocked(rpc.viewState.save).mockReset();
+    vi.mocked(rpc.viewState.save).mockRejectedValue(new Error('database is read-only'));
+
+    store.setTaskOrder('project-1', ['task-1b', 'task-1a']);
+    await Promise.resolve();
+    dispose();
+
+    await expect(registry.flush()).rejects.toThrow('database is read-only');
+    expect(rpc.viewState.save).toHaveBeenLastCalledWith(
+      'sidebar',
+      expect.objectContaining({
+        taskOrderByProject: { 'project-1': ['task-1b', 'task-1a'] },
+      })
+    );
+    registry.evict('sidebar');
   });
 });

--- a/apps/emdash-desktop/src/renderer/features/sidebar/sidebar-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/sidebar/sidebar-store.test.ts
@@ -200,28 +200,7 @@ describe('SidebarStore project ordering', () => {
     expect(viewStateCache.peek('sidebar')).toBeUndefined();
   });
 
-  it('rejects a flush when the current snapshot cannot be persisted', async () => {
-    const projects = projectManagerWithTasks([
-      {
-        id: 'project-1',
-        createdAt: '2026-01-01T00:00:00.000Z',
-        taskIds: ['task-1a', 'task-1b'],
-      },
-    ]);
-    const store = new SidebarStore(projects);
-    const registry = new SnapshotRegistry();
-    const dispose = registry.register('sidebar', () => store.snapshot, 0);
-    vi.mocked(rpc.viewState.save).mockReset();
-    vi.mocked(rpc.viewState.save).mockRejectedValue(new Error('database is read-only'));
-
-    store.setTaskOrder('project-1', ['task-1b', 'task-1a']);
-
-    await expect(registry.flush()).rejects.toThrow('database is read-only');
-    dispose();
-    registry.evict('sidebar');
-  });
-
-  it('flushes the retained snapshot after its active registration is disposed', async () => {
+  it('rejects failed flushes before and after the active registration is disposed', async () => {
     const projects = projectManagerWithTasks([
       {
         id: 'project-1',
@@ -237,7 +216,10 @@ describe('SidebarStore project ordering', () => {
 
     store.setTaskOrder('project-1', ['task-1b', 'task-1a']);
     await Promise.resolve();
+
+    await expect(registry.flush()).rejects.toThrow('database is read-only');
     dispose();
+    vi.mocked(rpc.viewState.save).mockClear();
 
     await expect(registry.flush()).rejects.toThrow('database is read-only');
     expect(rpc.viewState.save).toHaveBeenLastCalledWith(

--- a/apps/emdash-desktop/src/renderer/features/sidebar/sidebar-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/sidebar/sidebar-store.test.ts
@@ -200,6 +200,42 @@ describe('SidebarStore project ordering', () => {
     expect(viewStateCache.peek('sidebar')).toBeUndefined();
   });
 
+  it('waits for reaction saves started during the canonical flush writes', async () => {
+    const projects = projectManagerWithTasks([
+      {
+        id: 'project-1',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        taskIds: ['task-1a', 'task-1b'],
+      },
+    ]);
+    const store = new SidebarStore(projects);
+    const registry = new SnapshotRegistry();
+    registry.register('sidebar', () => store.snapshot, 0);
+    const canonicalSave = Promise.withResolvers<void>();
+    const reactionSave = Promise.withResolvers<void>();
+    vi.mocked(rpc.viewState.save).mockReset();
+    vi.mocked(rpc.viewState.save)
+      .mockReturnValueOnce(canonicalSave.promise)
+      .mockReturnValueOnce(reactionSave.promise);
+
+    let flushed = false;
+    const flush = registry.flush().then(() => {
+      flushed = true;
+    });
+    await vi.waitFor(() => expect(rpc.viewState.save).toHaveBeenCalledTimes(1));
+
+    store.setTaskOrder('project-1', ['task-1b', 'task-1a']);
+    expect(rpc.viewState.save).toHaveBeenCalledTimes(2);
+    canonicalSave.resolve();
+    await Promise.resolve();
+    expect(flushed).toBe(false);
+
+    reactionSave.resolve();
+    await flush;
+    expect(flushed).toBe(true);
+    registry.evict('sidebar');
+  });
+
   it('rejects failed flushes before and after the active registration is disposed', async () => {
     const projects = projectManagerWithTasks([
       {

--- a/apps/emdash-desktop/src/renderer/features/sidebar/sidebar-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/sidebar/sidebar-store.ts
@@ -166,7 +166,12 @@ export class SidebarStore implements Snapshottable<SidebarSnapshot> {
     return {
       expandedProjectIds: [...this.expandedProjectIds],
       projectOrder: [...this.projectOrder],
-      taskOrderByProject: { ...this.taskOrderByProject },
+      taskOrderByProject: Object.fromEntries(
+        Object.entries(this.taskOrderByProject).map(([projectId, taskIds]) => [
+          projectId,
+          [...taskIds],
+        ])
+      ),
       taskSortBy: this.taskSortBy,
     };
   }

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.ts
@@ -11,6 +11,7 @@ import {
 import type { ProjectSettingsStore } from '@renderer/features/projects/stores/project-settings-store';
 import { getTaskGitWorktreeStore } from '@renderer/features/tasks/stores/task-selectors';
 import { events, rpc } from '@renderer/lib/ipc';
+import { snapshotRegistry } from '@renderer/lib/stores/snapshot-registry';
 import { viewStateCache } from '@renderer/lib/stores/view-state-cache';
 import type { Conversation } from '@shared/core/conversations/conversations';
 import { gitWorktreeUpdateChannel } from '@shared/core/git/events';
@@ -666,6 +667,10 @@ export class TaskManagerStore {
         t.dispose();
       });
       await rpc.tasks.deleteTasks(this.projectId, taskIds, opts);
+      for (const id of taskIds) {
+        snapshotRegistry.evict(`task:${id}`);
+        snapshotRegistry.evict(`task:${id}:tabs`);
+      }
     } catch (e) {
       runInAction(() => {
         removed.forEach((t, id) => {

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-store.test.ts
@@ -142,6 +142,17 @@ describe('TaskStore frontend runtime lifecycle', () => {
     expect(order).toEqual(['acquire', 'restore', 'initialize']);
   });
 
+  it('restores dedicated view state when the legacy task snapshot is absent', () => {
+    const task = makeTask();
+    const store = createUnprovisionedTask(task);
+    const viewModel = mocks.viewModels[0];
+
+    store.transitionToProvisioned(task, '/tmp/workspace-1', 'workspace-1', {} as never);
+
+    expect(viewModel.restoreSnapshot).toHaveBeenCalledWith({});
+    expect(viewModel.restoreSnapshot).toHaveBeenCalledBefore(viewModel.initialize);
+  });
+
   it('recreates registered stores before reprovisioning a dry task', () => {
     const task = makeTask();
     const store = createUnprovisionedTask(task);

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-store.ts
@@ -114,7 +114,7 @@ export class TaskStore {
     this.phase = null;
     this.errorMessage = undefined;
     this.provisionProgressMessage = null;
-    if (savedSnapshot) this.viewModel?.restoreSnapshot(savedSnapshot);
+    this.viewModel?.restoreSnapshot(savedSnapshot ?? {});
     this.viewModel?.initialize();
   }
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-tab-view-persistor.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-tab-view-persistor.ts
@@ -3,6 +3,7 @@ import type { TabPersistenceAdapter } from '@renderer/features/tabs/persistence'
 import { rpc } from '@renderer/lib/ipc';
 import { snapshotRegistry } from '@renderer/lib/stores/snapshot-registry';
 import { viewStateCache } from '@renderer/lib/stores/view-state-cache';
+import { log } from '@renderer/utils/logger';
 import type { TabDescriptor, TabGroupsSnapshot, TaskViewSnapshot } from '@shared/view-state';
 import { resolveWorkspacePath } from './workspace-path';
 
@@ -41,13 +42,15 @@ export class TaskTabViewPersistor implements TabPersistenceAdapter {
     // Eager-write so the dedicated key is populated before the next aggregate
     // save (which no longer includes tabGroups).
     viewStateCache.set(this._key, migrated);
-    void rpc.viewState.save(this._key, migrated);
+    void Promise.resolve(rpc.viewState.save(this._key, migrated)).catch((error: unknown) => {
+      log.error(`Failed to migrate tab view state "${this._key}":`, error);
+    });
 
     return normalizeTabGroupsSnapshot(migrated, this._ctx.workspacePath);
   }
 
   start(getSnapshot: () => TabGroupsSnapshot): () => void {
-    return snapshotRegistry.register(this._key, getSnapshot);
+    return snapshotRegistry.register(this._key, getSnapshot, 0);
   }
 }
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.test.ts
@@ -784,6 +784,39 @@ describe('WorkspaceViewModel tab persistence adapter', () => {
     viewModel.dispose();
   });
 
+  it('restores dedicated tabs when the legacy aggregate is absent', () => {
+    conversationRegistry.acquire(PERSISTOR_TASK_ID, 'project-1', [
+      makeConversation({ id: 'pi-conversation', taskId: PERSISTOR_TASK_ID }),
+    ]);
+    viewStateCache.set(`task:${PERSISTOR_TASK_ID}:tabs`, {
+      groups: [
+        {
+          groupId: 'group-1',
+          tabManager: {
+            tabs: [
+              {
+                kind: 'conversation',
+                tabId: 'pi-tab',
+                conversationId: 'pi-conversation',
+                isPreview: false,
+              },
+            ],
+            activeTabId: 'pi-tab',
+          },
+        },
+      ],
+      activeGroupId: 'group-1',
+      paneSizes: [100],
+    });
+    const viewModel = makePersistorViewModel();
+
+    viewModel.restoreSnapshot({});
+
+    expect(conversationTabIds(viewModel)).toEqual(['pi-conversation']);
+    viewModel.dispose();
+    conversationRegistry.release(PERSISTOR_TASK_ID);
+  });
+
   it('gates default-conversation auto-open when tab state is restored', () => {
     const conversations = conversationRegistry.acquire(PERSISTOR_TASK_ID, 'project-1', [
       makeConversation({
@@ -842,4 +875,74 @@ describe('WorkspaceViewModel tab persistence adapter', () => {
     );
     viewModel.dispose();
   });
+
+  it('synchronously dispatches every agent tab snapshot', () => {
+    workspaceRegistry.acquire('project-1', 'workspace-1', '/tmp/emdash-test-workspace', {
+      settings: {},
+    } as never);
+    const conversations = conversationRegistry.acquire('task-1', 'project-1', [
+      makeConversation({ id: 'amp-conversation', providerId: 'amp' }),
+      makeConversation({ id: 'opencode-conversation', providerId: 'opencode' }),
+      makeConversation({ id: 'pi-conversation', providerId: 'pi' }),
+    ]);
+    vi.spyOn(conversations, 'hydrateConversation').mockResolvedValue();
+    vi.spyOn(conversations, 'dehydrateConversation').mockResolvedValue();
+
+    const source = makeProvisionedViewModel();
+    source.restoreSnapshot({
+      focusedRegion: 'main',
+      tabGroups: {
+        groups: [
+          {
+            groupId: 'group-1',
+            tabManager: {
+              tabs: [
+                {
+                  kind: 'conversation',
+                  tabId: 'amp-tab',
+                  conversationId: 'amp-conversation',
+                  isPreview: false,
+                },
+              ],
+              activeTabId: 'amp-tab',
+            },
+          },
+        ],
+        activeGroupId: 'group-1',
+        paneSizes: [100],
+      },
+    });
+    source.initialize();
+    vi.mocked(rpc.viewState.save).mockClear();
+
+    source.activePane.closeTab('amp-tab');
+    expect(rpc.viewState.save).toHaveBeenCalledTimes(1);
+    expect(lastSavedConversationIds()).toEqual([]);
+
+    source.paneLayout.open('conversation', { conversationId: 'opencode-conversation' });
+    expect(rpc.viewState.save).toHaveBeenCalledTimes(2);
+    expect(lastSavedConversationIds()).toEqual(['opencode-conversation']);
+
+    source.paneLayout.open('conversation', { conversationId: 'pi-conversation' });
+    expect(rpc.viewState.save).toHaveBeenCalledTimes(3);
+    expect(lastSavedConversationIds()).toEqual(['opencode-conversation', 'pi-conversation']);
+    expect(conversationTabIds(source)).toEqual(['opencode-conversation', 'pi-conversation']);
+
+    source.dispose();
+  });
 });
+
+function lastSavedConversationIds(): string[] {
+  const snapshot = vi
+    .mocked(rpc.viewState.save)
+    .mock.calls.findLast(([key]) => key === 'task:task-1:tabs')?.[1] as
+    | TaskViewSnapshot['tabGroups']
+    | undefined;
+  return (
+    snapshot?.groups.flatMap((group) =>
+      group.tabManager.tabs.flatMap((tab) =>
+        tab.kind === 'conversation' ? [tab.conversationId] : []
+      )
+    ) ?? []
+  );
+}

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.tsx
@@ -185,7 +185,7 @@ export class WorkspaceViewModel implements ILifecycle {
    * Restore persisted UI state from a saved snapshot. Call this before
    * initialize() so the reaction baseline is correct.
    */
-  restoreSnapshot(savedSnapshot: TaskViewSnapshot): void {
+  restoreSnapshot(savedSnapshot: Partial<TaskViewSnapshot>): void {
     this.sidebarTab = (savedSnapshot.sidebarTab as SidebarTab) ?? 'conversations';
     this.isSidebarCollapsed = savedSnapshot.isSidebarCollapsed ?? true;
     this.focusedRegion = savedSnapshot.focusedRegion === 'bottom' ? 'bottom' : 'main';

--- a/apps/emdash-desktop/src/renderer/lib/stores/app-state.ts
+++ b/apps/emdash-desktop/src/renderer/lib/stores/app-state.ts
@@ -32,7 +32,6 @@ class AppState {
     });
     this.resourceMonitor = new ResourceMonitorStore();
     snapshotRegistry.register('navigation', () => this.navigation.snapshot);
-    snapshotRegistry.register('sidebar', () => this.sidebar.snapshot);
     this.sshConnections.start();
   }
 }

--- a/apps/emdash-desktop/src/renderer/lib/stores/snapshot-registry.ts
+++ b/apps/emdash-desktop/src/renderer/lib/stores/snapshot-registry.ts
@@ -63,7 +63,7 @@ export class SnapshotRegistry {
   }
 
   async flush(): Promise<void> {
-    await Promise.allSettled([...this.pendingSaves]);
+    await this.drainPendingSaves();
     await Promise.all(
       [...this.latestSnapshots].map(([key, latestSnapshot]) => {
         const snapshot = this.snapshots.get(key)?.() ?? latestSnapshot;
@@ -72,6 +72,13 @@ export class SnapshotRegistry {
         return this.save(key, snapshot);
       })
     );
+    await this.drainPendingSaves();
+  }
+
+  private async drainPendingSaves(): Promise<void> {
+    while (this.pendingSaves.size > 0) {
+      await Promise.allSettled([...this.pendingSaves]);
+    }
   }
 
   private save(key: string, snapshot: unknown): Promise<void> {

--- a/apps/emdash-desktop/src/renderer/lib/stores/snapshot-registry.ts
+++ b/apps/emdash-desktop/src/renderer/lib/stores/snapshot-registry.ts
@@ -1,17 +1,21 @@
 import { comparer, reaction } from 'mobx';
 import { rpc } from '@renderer/lib/ipc';
+import { log } from '@renderer/utils/logger';
 import { viewStateCache } from './view-state-cache';
 
 export class SnapshotRegistry {
   private readonly disposers = new Map<string, () => void>();
+  private readonly snapshots = new Map<string, () => unknown>();
+  private readonly latestSnapshots = new Map<string, unknown>();
+  private readonly pendingSaves = new Set<Promise<void>>();
 
   /**
    * Register an entity's snapshot with the registry.
    *
    * A MobX reaction is started that watches `getSnapshot()` and persists the
-   * result via RPC after a 1 second debounce whenever it structurally changes.
-   * The cache is updated immediately on every change so subsequent reads are
-   * instant, and the entry is evicted from the cache when the disposer runs.
+   * result via RPC whenever it structurally changes. Persistence is debounced
+   * by one second by default, but callers can opt into immediate writes for
+   * state that must survive a reload directly after user interaction.
    *
    * Call this AFTER restoring saved state so the initial value does not trigger
    * a spurious write (fireImmediately is false).
@@ -19,29 +23,65 @@ export class SnapshotRegistry {
    * @returns A disposer function — call it when the entity is torn down to stop
    *          the reaction and clean up the entry.
    */
-  register(key: string, getSnapshot: () => unknown): () => void {
+  register(key: string, getSnapshot: () => unknown, delay = 1000): () => void {
     // Clean up any stale reaction for this key before creating a new one.
     this.disposers.get(key)?.();
 
     // Warm the cache with the current snapshot value immediately on register.
-    viewStateCache.set(key, getSnapshot());
+    const initialSnapshot = getSnapshot();
+    viewStateCache.set(key, initialSnapshot);
+    this.latestSnapshots.set(key, initialSnapshot);
+    this.snapshots.set(key, getSnapshot);
 
-    const disposer = reaction(
+    const reactionDisposer = reaction(
       () => getSnapshot(),
       (snapshot) => {
         viewStateCache.set(key, snapshot);
-        void rpc.viewState.save(key, snapshot);
+        this.latestSnapshots.set(key, snapshot);
+        void this.save(key, snapshot).catch((error: unknown) => {
+          log.error(`Failed to persist view state "${key}":`, error);
+        });
       },
-      { equals: comparer.structural, delay: 1000, fireImmediately: false }
+      { equals: comparer.structural, delay, fireImmediately: false }
     );
 
+    const disposer = () => {
+      reactionDisposer();
+      if (this.disposers.get(key) !== disposer) return;
+      this.disposers.delete(key);
+      this.snapshots.delete(key);
+    };
     this.disposers.set(key, disposer);
 
-    return () => {
-      disposer();
-      viewStateCache.delete(key);
-      this.disposers.delete(key);
-    };
+    return disposer;
+  }
+
+  evict(key: string): void {
+    this.disposers.get(key)?.();
+    this.latestSnapshots.delete(key);
+    viewStateCache.delete(key);
+  }
+
+  async flush(): Promise<void> {
+    await Promise.allSettled([...this.pendingSaves]);
+    await Promise.all(
+      [...this.latestSnapshots].map(([key, latestSnapshot]) => {
+        const snapshot = this.snapshots.get(key)?.() ?? latestSnapshot;
+        viewStateCache.set(key, snapshot);
+        this.latestSnapshots.set(key, snapshot);
+        return this.save(key, snapshot);
+      })
+    );
+  }
+
+  private save(key: string, snapshot: unknown): Promise<void> {
+    const save = Promise.resolve(rpc.viewState.save(key, snapshot));
+    this.pendingSaves.add(save);
+    void save.then(
+      () => this.pendingSaves.delete(save),
+      () => this.pendingSaves.delete(save)
+    );
+    return save;
   }
 }
 

--- a/apps/emdash-desktop/src/renderer/lib/stores/view-state-cache.ts
+++ b/apps/emdash-desktop/src/renderer/lib/stores/view-state-cache.ts
@@ -5,8 +5,8 @@ import { rpc } from '@renderer/lib/ipc';
  *
  * After the bulk `getAll()` load at bootstrap, every subsequent `get` call is
  * a synchronous Map lookup (returned as a resolved Promise). Writes update the
- * cache immediately and then fire the async IPC save. Eviction happens when a
- * SnapshotRegistry disposer is called (task or project teardown/deletion).
+ * cache immediately and then fire the async IPC save. Snapshot disposers retain
+ * cached state for suspension; permanent deletion explicitly evicts its keys.
  */
 class ViewStateCache {
   private readonly map = new Map<string, unknown>();
@@ -42,7 +42,7 @@ class ViewStateCache {
     this.map.set(key, value);
   }
 
-  /** Evict a key from the cache (called by SnapshotRegistry disposers). */
+  /** Evict a key from the cache after its owning entity is permanently deleted. */
   delete(key: string): void {
     this.map.delete(key);
   }

--- a/apps/emdash-desktop/src/renderer/main.tsx
+++ b/apps/emdash-desktop/src/renderer/main.tsx
@@ -10,18 +10,37 @@ import { setupAppCommandProvider } from '@renderer/lib/commands/app-commands';
 import { setupViewCommandProvider } from '@renderer/lib/commands/registry';
 import { wireCommitHistoryInvalidation } from '@renderer/lib/commit-history-invalidation';
 import { wireExternalLinkRequests } from '@renderer/lib/external-link-requests';
-import { rpc } from '@renderer/lib/ipc';
+import { events, rpc } from '@renderer/lib/ipc';
 import { wireModelRegistryInvalidation } from '@renderer/lib/monaco/invalidation-bridges';
 import { monacoBootstrap } from '@renderer/lib/monaco/monaco-bootstrap';
 import { modelRegistry } from '@renderer/lib/monaco/monaco-model-registry';
 import { wirePrCacheInvalidation } from '@renderer/lib/pr-cache-invalidation';
+import { snapshotRegistry } from '@renderer/lib/stores/snapshot-registry';
 import { viewStateCache } from '@renderer/lib/stores/view-state-cache';
 import { log } from '@renderer/utils/logger';
 import { initSoundPlayer } from '@renderer/utils/soundPlayer';
+import { menuReloadRequestedChannel } from '@shared/events/appEvents';
 import type { NavigationSnapshot, SidebarSnapshot } from '@shared/view-state';
 import { App } from './App';
 import { ErrorBoundary } from './lib/components/error-boundary';
 import { appState } from './lib/stores/app-state';
+
+let viewStateReady = false;
+let reloadRequested = false;
+
+events.on(menuReloadRequestedChannel, () => {
+  if (reloadRequested) return;
+  reloadRequested = true;
+  void (viewStateReady ? snapshotRegistry.flush() : Promise.resolve())
+    .then(async () => {
+      const result = await rpc.app.reload();
+      if (!result.success) throw new Error(result.error);
+    })
+    .catch((error: unknown) => {
+      reloadRequested = false;
+      log.error('Failed to persist view state before reload:', error);
+    });
+});
 
 async function bootstrap() {
   // Wire invalidation bridges so FS and git events flow into the model registry.
@@ -59,6 +78,8 @@ async function bootstrap() {
   } else {
     appState.sidebar.expandAllProjects();
   }
+  appState.snapshots.register('sidebar', () => appState.sidebar.snapshot, 0);
+  viewStateReady = true;
 
   // Avoid double-mount in dev which can duplicate PTY sessions
   ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(

--- a/apps/emdash-desktop/src/shared/events/appEvents.ts
+++ b/apps/emdash-desktop/src/shared/events/appEvents.ts
@@ -21,6 +21,7 @@ export const menuUndoChannel = defineEvent<void>('menu:undo');
 export const menuRedoChannel = defineEvent<void>('menu:redo');
 export const menuCloseTabChannel = defineEvent<void>('menu:close-tab');
 export const menuQuitRequestedChannel = defineEvent<void>('menu:quit-requested');
+export const menuReloadRequestedChannel = defineEvent<void>('menu:reload-requested');
 export const menuGiveFeedbackChannel = defineEvent<void>('menu:give-feedback');
 
 /** Emitted by main process when the window maximize state changes (Linux custom controls). */


### PR DESCRIPTION
### Description

Fixes view-state restoration races that could reopen a previously closed agent tab, drop the currently open PI/OpenCode tab, or restore an old sidebar task order after Reload.

- Persist task-tab and sidebar snapshots immediately after user changes.
- Flush active and suspended snapshots before a normal Electron Reload, and abort Reload when persistence fails.
- Restore dedicated task-tab state even when the legacy aggregate snapshot is absent.
- Retain snapshots across suspend/reprovision while explicitly evicting them after permanent task or project deletion.
- Send IPC-cloneable sidebar ordering snapshots by copying nested MobX arrays.

### Related issues

Linear: ENG-1838

### Screenshot/Recording (if applicable)
https://cap.link/1g5jg3jpzq13yqz

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] Docs were not needed for this behavior-only fix
- [x] I added or updated tests when behavior changed
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and the PR title

</details>