### PR TITLE
fix(telemetry): report application crashes to PostHog

### DIFF
--- a/apps/emdash-desktop/package.json
+++ b/apps/emdash-desktop/package.json
@@ -79,6 +79,7 @@
     "nbranch": "^0.1.1",
     "node-pty": "1.1.0",
     "pidusage": "^4.0.1",
+    "posthog-node": "^5.45.2",
     "smol-toml": "^1.6.0",
     "ssh2": "^1.17.0",
     "ts-pattern": "^5.9.0",

--- a/apps/emdash-desktop/src/main/app/shutdown.ts
+++ b/apps/emdash-desktop/src/main/app/shutdown.ts
@@ -39,8 +39,6 @@ async function withDeadline<T>(promise: Promise<T>, ms: number): Promise<T> {
  * - best effort phase — voided, abandoned after GRACE_WINDOW_MS
  */
 export async function runQuitCleanup(): Promise<void> {
-  telemetryService.capture('app_closed');
-
   // synchronous stops
   automationsService.stop();
   agentHookService.dispose();
@@ -51,13 +49,13 @@ export async function runQuitCleanup(): Promise<void> {
 
   // critical phase
   const criticalSteps: Array<[string, () => Promise<void>]> = [
+    ['telemetryService.dispose', () => telemetryService.dispose()],
     ['acpAgentStatusBridge.dispose', async () => acpAgentStatusBridge.dispose()],
     ['projectManager.release', () => projectManager.release()],
     ['runtimeManager.dispose', () => runtimeManager.dispose()],
     ['disposeAcpRuntimeProcess', () => disposeAcpRuntimeProcess()],
     ['disposeAgentConfigRuntimeProcess', () => disposeAgentConfigRuntimeProcess()],
     ['appScope.dispose', () => appScope.dispose()],
-    ['telemetryService.dispose', () => telemetryService.dispose()],
   ];
   await withDeadline(
     (async () => {

--- a/apps/emdash-desktop/src/main/app/window.ts
+++ b/apps/emdash-desktop/src/main/app/window.ts
@@ -90,6 +90,21 @@ export function createMainWindow(): BrowserWindow {
     telemetryService.capture('app_window_unfocused');
   });
 
+  mainWindow.webContents.on('render-process-gone', (_event, details) => {
+    if (details.reason === 'clean-exit') return;
+    telemetryService.captureException(
+      new Error(
+        `Electron renderer process exited unexpectedly: ${details.reason} (${details.exitCode})`
+      ),
+      {
+        process_type: 'renderer',
+        reason: details.reason,
+        exit_code: details.exitCode,
+        mechanism: 'render_process_gone',
+      }
+    );
+  });
+
   // Keep the renderer's custom window controls (Linux) in sync with the
   // actual maximize state so the maximize/restore icon stays correct.
   mainWindow.on('maximize', () => {

--- a/apps/emdash-desktop/src/main/core/telemetry/controller.ts
+++ b/apps/emdash-desktop/src/main/core/telemetry/controller.ts
@@ -1,16 +1,24 @@
 import { telemetryService } from '@main/lib/telemetry';
 import { createRPCController } from '@shared/lib/ipc/rpc';
-import type { TelemetryEvent } from '@shared/telemetry';
+import type { TelemetryEvent, TelemetryExceptionReport } from '@shared/telemetry';
 
 export const telemetryController = createRPCController({
   capture: (args: { event: TelemetryEvent; properties?: Record<string, unknown> }) => {
     telemetryService.capture(args.event, args.properties);
   },
+  captureException: (report: TelemetryExceptionReport) => {
+    const error = new Error(report.message);
+    error.name = report.name;
+    if (report.stack) error.stack = report.stack;
+    telemetryService.captureException(error, {
+      process_type: 'renderer',
+      mechanism: report.mechanism,
+      ...(report.componentStack ? { component_stack: report.componentStack } : {}),
+    });
+  },
   getStatus: () => {
     return { status: telemetryService.getTelemetryStatus() };
   },
-  setEnabled: (enabled: boolean) => {
-    telemetryService.setTelemetryEnabledViaUser(enabled);
-  },
+  setEnabled: (enabled: boolean) => telemetryService.setTelemetryEnabledViaUser(enabled),
   getFeatureFlags: () => telemetryService.getFeatureFlags(),
 });

--- a/apps/emdash-desktop/src/main/db/kv.ts
+++ b/apps/emdash-desktop/src/main/db/kv.ts
@@ -11,6 +11,14 @@ export class KV<TSchema extends Record<string, unknown>> {
   }
 
   async get<K extends keyof TSchema & string>(key: K): Promise<TSchema[K] | null> {
+    try {
+      return await this.getOrThrow(key);
+    } catch {
+      return null;
+    }
+  }
+
+  async getOrThrow<K extends keyof TSchema & string>(key: K): Promise<TSchema[K] | null> {
     const rows = await db
       .select({ value: kv.value })
       .from(kv)
@@ -19,12 +27,7 @@ export class KV<TSchema extends Record<string, unknown>> {
 
     const raw = rows[0]?.value;
     if (raw === undefined || raw === null) return null;
-
-    try {
-      return JSON.parse(raw) as TSchema[K];
-    } catch {
-      return null;
-    }
+    return JSON.parse(raw) as TSchema[K];
   }
 
   async set<K extends keyof TSchema & string>(key: K, value: TSchema[K]): Promise<void> {

--- a/apps/emdash-desktop/src/main/index.ts
+++ b/apps/emdash-desktop/src/main/index.ts
@@ -71,6 +71,17 @@ if (process.platform === 'linux') {
 registerAppScheme();
 
 initializeFileLogger();
+let resolveTelemetryInitialization = () => {};
+const telemetryInitialization = new Promise<void>((resolve) => {
+  resolveTelemetryInitialization = resolve;
+});
+registerProcessErrorLogging(log, async (error, mechanism) => {
+  await telemetryInitialization;
+  await telemetryService.captureExceptionImmediate(error, {
+    process_type: 'main',
+    mechanism,
+  });
+});
 registerRendererLogHandler(ipcMain);
 
 app.on('child-process-gone', (_event, details) => {
@@ -129,13 +140,9 @@ void app.whenReady().then(async () => {
       await telemetryService.initialize({ installSource: app.isPackaged ? 'dmg' : 'dev' });
     } catch (e) {
       log.warn('telemetry init failed:', e);
+    } finally {
+      resolveTelemetryInitialization();
     }
-    registerProcessErrorLogging(log, (error, mechanism) =>
-      telemetryService.captureExceptionImmediate(error, {
-        process_type: 'main',
-        mechanism,
-      })
-    );
 
     await resetStaleAcpAgentStatuses();
     searchService.initialize();

--- a/apps/emdash-desktop/src/main/index.ts
+++ b/apps/emdash-desktop/src/main/index.ts
@@ -71,12 +71,6 @@ if (process.platform === 'linux') {
 registerAppScheme();
 
 initializeFileLogger();
-registerProcessErrorLogging(log, (error, mechanism) =>
-  telemetryService.captureExceptionImmediate(error, {
-    process_type: 'main',
-    mechanism,
-  })
-);
 registerRendererLogHandler(ipcMain);
 
 app.on('child-process-gone', (_event, details) => {
@@ -130,6 +124,19 @@ void app.whenReady().then(async () => {
 
   try {
     await initializeDatabase();
+
+    try {
+      await telemetryService.initialize({ installSource: app.isPackaged ? 'dmg' : 'dev' });
+    } catch (e) {
+      log.warn('telemetry init failed:', e);
+    }
+    registerProcessErrorLogging(log, (error, mechanism) =>
+      telemetryService.captureExceptionImmediate(error, {
+        process_type: 'main',
+        mechanism,
+      })
+    );
+
     await resetStaleAcpAgentStatuses();
     searchService.initialize();
     workspaceFileIndexService.initialize();
@@ -148,12 +155,6 @@ void app.whenReady().then(async () => {
     );
     app.quit();
     return;
-  }
-
-  try {
-    await telemetryService.initialize({ installSource: app.isPackaged ? 'dmg' : 'dev' });
-  } catch (e) {
-    log.warn('telemetry init failed:', e);
   }
 
   emdashAccountService.on('accountChanged', (username, userId, email) => {

--- a/apps/emdash-desktop/src/main/index.ts
+++ b/apps/emdash-desktop/src/main/index.ts
@@ -71,8 +71,28 @@ if (process.platform === 'linux') {
 registerAppScheme();
 
 initializeFileLogger();
-registerProcessErrorLogging(log);
+registerProcessErrorLogging(log, (error, mechanism) =>
+  telemetryService.captureExceptionImmediate(error, {
+    process_type: 'main',
+    mechanism,
+  })
+);
 registerRendererLogHandler(ipcMain);
+
+app.on('child-process-gone', (_event, details) => {
+  if (details.reason === 'clean-exit') return;
+  telemetryService.captureException(
+    new Error(
+      `Electron ${details.type} process exited unexpectedly: ${details.reason} (${details.exitCode})`
+    ),
+    {
+      process_type: details.type,
+      reason: details.reason,
+      exit_code: details.exitCode,
+      mechanism: 'child_process_gone',
+    }
+  );
+});
 
 app.on('second-instance', () => {
   const win = BrowserWindow.getAllWindows()[0];

--- a/apps/emdash-desktop/src/main/lib/file-logger.ts
+++ b/apps/emdash-desktop/src/main/lib/file-logger.ts
@@ -12,7 +12,7 @@ const RETAINED_LOG_FILES = 5;
 const LOG_FILE_NAME = 'emdash.log';
 const DIAGNOSTIC_ATTACHMENT_FILENAME = 'emdash-diagnostics.log';
 const RENDERER_LOG_PAYLOAD_LIMIT = 64 * 1024;
-const PROCESS_EXIT_FLUSH_TIMEOUT_MS = 1000;
+const PROCESS_EXIT_FLUSH_TIMEOUT_MS = 2_500;
 
 type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 let logFilePath: string | undefined;
@@ -85,21 +85,43 @@ export async function getDiagnosticLogAttachment() {
   };
 }
 
-export function registerProcessErrorLogging(logger: { error(...input: unknown[]): void }) {
+type FatalErrorReporter = (
+  error: unknown,
+  mechanism: 'uncaught_exception' | 'unhandled_rejection'
+) => void | Promise<void>;
+
+export function registerProcessErrorLogging(
+  logger: { error(...input: unknown[]): void },
+  reportFatalError?: FatalErrorReporter
+) {
   process.on('uncaughtException', (error) => {
     logger.error('Uncaught exception', error);
-    flushAndExit();
+    handleFatalError(error, 'uncaught_exception', reportFatalError);
   });
 
   process.on('unhandledRejection', (reason) => {
     logger.error('Unhandled rejection', reason);
-    flushAndExit();
+    handleFatalError(reason, 'unhandled_rejection', reportFatalError);
   });
 }
 
-function flushAndExit() {
+let fatalExitStarted = false;
+
+function handleFatalError(
+  error: unknown,
+  mechanism: 'uncaught_exception' | 'unhandled_rejection',
+  reportFatalError?: FatalErrorReporter
+) {
+  if (fatalExitStarted) return;
+  fatalExitStarted = true;
+  let reportPromise: void | Promise<void>;
+  try {
+    reportPromise = reportFatalError?.(error, mechanism);
+  } catch {
+    reportPromise = undefined;
+  }
   const flush = Promise.race([
-    flushLogWrites(),
+    Promise.allSettled([flushLogWrites(), Promise.resolve(reportPromise)]),
     new Promise<void>((resolve) => setTimeout(resolve, PROCESS_EXIT_FLUSH_TIMEOUT_MS)),
   ]);
   void flush.finally(() => process.exit(1));

--- a/apps/emdash-desktop/src/main/lib/telemetry.test.ts
+++ b/apps/emdash-desktop/src/main/lib/telemetry.test.ts
@@ -1,0 +1,311 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  store: new Map<string, unknown>(),
+  readFailures: new Set<string>(),
+  writeFailures: new Set<string>(),
+  transportError: false,
+  captureHandler: undefined as
+    | ((event: { event: string; uuid?: string }) => Promise<void>)
+    | undefined,
+  env: {
+    build: {
+      VITE_BUILD: 'production',
+      VITE_POSTHOG_KEY: 'phc_test',
+      VITE_POSTHOG_HOST: 'https://posthog.example.com',
+    },
+    dev: {},
+    runtime: {} as { TELEMETRY_ENABLED?: string },
+  },
+  clients: [] as Array<{
+    captureImmediate: ReturnType<typeof vi.fn>;
+    captureExceptionImmediate: ReturnType<typeof vi.fn>;
+    disable: ReturnType<typeof vi.fn>;
+    enable: ReturnType<typeof vi.fn>;
+    getAllFlags: ReturnType<typeof vi.fn>;
+    identifyImmediate: ReturnType<typeof vi.fn>;
+    on: ReturnType<typeof vi.fn>;
+    _shutdown: ReturnType<typeof vi.fn>;
+  }>,
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    getVersion: () => '1.2.3',
+    isPackaged: true,
+  },
+}));
+
+vi.mock('@main/lib/env', () => ({
+  env: mocks.env,
+}));
+
+vi.mock('@main/db/kv', () => ({
+  KV: class {
+    async get(key: string) {
+      return mocks.store.get(key) ?? null;
+    }
+
+    async getOrThrow(key: string) {
+      if (mocks.readFailures.has(key)) throw new Error('Invalid stored value');
+      return mocks.store.get(key) ?? null;
+    }
+
+    async set(key: string, value: unknown) {
+      mocks.store.set(key, value);
+    }
+
+    async setOrThrow(key: string, value: unknown) {
+      if (mocks.writeFailures.has(key)) throw new Error('Write failed');
+      mocks.store.set(key, value);
+    }
+
+    async del(key: string) {
+      mocks.store.delete(key);
+    }
+  },
+}));
+
+vi.mock('posthog-node', () => ({
+  PostHog: class {
+    private errorHandlers = new Set<() => void>();
+    captureImmediate = vi.fn(async (event: { event: string; uuid?: string }) => {
+      await (mocks.captureHandler ? mocks.captureHandler(event) : Promise.resolve());
+      if (mocks.transportError) {
+        for (const handler of this.errorHandlers) handler();
+      }
+    });
+    captureExceptionImmediate = vi.fn().mockResolvedValue(undefined);
+    disable = vi.fn().mockResolvedValue(undefined);
+    enable = vi.fn().mockResolvedValue(undefined);
+    getAllFlags = vi.fn().mockResolvedValue({});
+    identifyImmediate = vi.fn().mockResolvedValue(undefined);
+    on = vi.fn((event: string, handler: () => void) => {
+      if (event === 'error') this.errorHandlers.add(handler);
+      return () => this.errorHandlers.delete(handler);
+    });
+    _shutdown = vi.fn().mockResolvedValue(undefined);
+
+    constructor() {
+      mocks.clients.push(this as (typeof mocks.clients)[number]);
+    }
+  },
+}));
+
+import { TelemetryService } from './telemetry';
+
+describe('TelemetryService', () => {
+  beforeEach(() => {
+    mocks.store.clear();
+    mocks.readFailures.clear();
+    mocks.writeFailures.clear();
+    mocks.clients.length = 0;
+    mocks.captureHandler = undefined;
+    mocks.transportError = false;
+    delete mocks.env.runtime.TELEMETRY_ENABLED;
+  });
+
+  it('does not initialize PostHog when telemetry is disabled by the environment', async () => {
+    mocks.env.runtime.TELEMETRY_ENABLED = 'false';
+
+    const service = new TelemetryService(false);
+    await service.initialize();
+
+    expect(mocks.clients).toHaveLength(0);
+    expect(service.getTelemetryStatus()).toMatchObject({
+      enabled: false,
+      envDisabled: true,
+    });
+  });
+
+  it('does not initialize PostHog and clears stale sessions after opt-out', async () => {
+    mocks.store.set('enabled', 'false');
+    mocks.store.set('sessionState', {
+      sessionId: 'disabled-session',
+      lastHeartbeatTs: new Date().toISOString(),
+    });
+
+    const service = new TelemetryService(false);
+    await service.initialize();
+
+    expect(mocks.clients).toHaveLength(0);
+    expect(mocks.store.has('sessionState')).toBe(false);
+    expect(service.getTelemetryStatus().enabled).toBe(false);
+  });
+
+  it('fails closed when stored telemetry consent cannot be parsed', async () => {
+    mocks.readFailures.add('enabled');
+
+    const service = new TelemetryService(false);
+    await service.initialize();
+
+    expect(mocks.clients).toHaveLength(0);
+    expect(service.getTelemetryStatus().enabled).toBe(false);
+  });
+
+  it('records session state immediately and removes it when telemetry is disabled', async () => {
+    const service = new TelemetryService(false);
+    await service.initialize();
+
+    expect(mocks.store.get('sessionState')).toMatchObject({
+      active: { sessionId: service.getTelemetryStatus().session_id },
+      pendingRecoveries: [],
+    });
+
+    service.capture('app_window_focused');
+    await service.setTelemetryEnabledViaUser(false);
+
+    expect(mocks.store.has('sessionState')).toBe(false);
+    expect(mocks.clients[0]?.disable).toHaveBeenCalledOnce();
+    expect(
+      mocks.clients[0]?.captureImmediate.mock.calls.some(
+        ([event]) => event.event === 'app_window_focused'
+      )
+    ).toBe(false);
+  });
+
+  it('keeps runtime telemetry disabled when persisting opt-out fails', async () => {
+    const service = new TelemetryService(false);
+    await service.initialize();
+    mocks.writeFailures.add('enabled');
+
+    await expect(service.setTelemetryEnabledViaUser(false)).rejects.toThrow('Write failed');
+    service.capture('app_window_focused');
+    await Promise.resolve();
+
+    expect(service.getTelemetryStatus().enabled).toBe(false);
+    expect(mocks.clients[0]?.disable).toHaveBeenCalledOnce();
+    expect(
+      mocks.clients[0]?.captureImmediate.mock.calls.some(
+        ([event]) => event.event === 'app_window_focused'
+      )
+    ).toBe(false);
+  });
+
+  it('keeps runtime telemetry disabled when arming an opted-in session fails', async () => {
+    mocks.store.set('enabled', 'false');
+    const service = new TelemetryService(false);
+    await service.initialize();
+    mocks.writeFailures.add('sessionState');
+
+    await expect(service.setTelemetryEnabledViaUser(true)).rejects.toThrow('Write failed');
+
+    expect(service.getTelemetryStatus().enabled).toBe(false);
+    expect(mocks.clients[0]?.disable).toHaveBeenCalledOnce();
+  });
+
+  it('preserves an existing recovery when the current session marker cannot be written', async () => {
+    const previousState = {
+      active: {
+        sessionId: '72ce17d2-037a-4b53-bf84-01d680f2dbb7',
+        lastHeartbeatTs: '2026-07-20T10:00:00.000Z',
+      },
+      pendingRecoveries: [],
+    };
+    mocks.store.set('sessionState', previousState);
+    mocks.writeFailures.add('sessionState');
+
+    const service = new TelemetryService(false);
+    await service.initialize();
+
+    expect(mocks.store.get('sessionState')).toEqual(previousState);
+    expect(mocks.clients).toHaveLength(0);
+    expect(service.getTelemetryStatus().enabled).toBe(false);
+  });
+
+  it('uses PostHog exception capture with redacted error data', async () => {
+    const service = new TelemetryService(false);
+    await service.initialize();
+
+    const error = new Error('token: ghp_123456');
+    await service.captureExceptionImmediate(error, {
+      mechanism: 'uncaught_exception',
+      process_type: 'main',
+    });
+
+    const capture = mocks.clients[0]?.captureExceptionImmediate;
+    expect(capture).toHaveBeenCalledOnce();
+    const [reportedError, distinctId, properties] = capture!.mock.calls[0]!;
+    expect(reportedError.message).not.toContain('ghp_123456');
+    expect(reportedError.stack).not.toContain('ghp_123456');
+    expect(distinctId).toBe(service.getInstanceId());
+    expect(properties).toMatchObject({
+      mechanism: 'uncaught_exception',
+      process_type: 'main',
+    });
+
+    await service.dispose();
+    expect(mocks.clients[0]?._shutdown).toHaveBeenCalledWith(1_000);
+  });
+
+  it('persists the current session and a stable recovery ID before reporting an unclean exit', async () => {
+    const previousSession = {
+      sessionId: '72ce17d2-037a-4b53-bf84-01d680f2dbb7',
+      lastHeartbeatTs: '2026-07-20T10:00:00.000Z',
+    };
+    mocks.store.set('sessionState', previousSession);
+    let finishRecovery: (() => void) | undefined;
+    mocks.captureHandler = ({ event }) =>
+      event === 'app_closed'
+        ? new Promise<void>((resolve) => {
+            finishRecovery = resolve;
+          })
+        : Promise.resolve();
+
+    const service = new TelemetryService(false);
+    const initializing = service.initialize();
+    await vi.waitFor(() => expect(finishRecovery).toBeTypeOf('function'));
+
+    const persisted = mocks.store.get('sessionState') as {
+      active: { sessionId: string };
+      pendingRecoveries: Array<{ eventId: string; sessionId: string }>;
+    };
+    expect(persisted.active.sessionId).toBe(service.getTelemetryStatus().session_id);
+    expect(persisted.pendingRecoveries).toHaveLength(1);
+    expect(persisted.pendingRecoveries[0]).toMatchObject({ sessionId: previousSession.sessionId });
+    const recoveryEventId = persisted.pendingRecoveries[0]!.eventId;
+
+    finishRecovery!();
+    await initializing;
+    await vi.waitFor(() => {
+      expect(
+        (mocks.store.get('sessionState') as { pendingRecoveries: unknown[] }).pendingRecoveries
+      ).toHaveLength(0);
+    });
+    expect(mocks.clients[0]?.captureImmediate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'app_closed',
+        uuid: recoveryEventId,
+        timestamp: new Date(previousSession.lastHeartbeatTs),
+        properties: expect.objectContaining({ was_unclean_exit: true }),
+      })
+    );
+
+    mocks.captureHandler = undefined;
+    await service.dispose();
+  });
+
+  it('retains a pending recovery when the PostHog SDK reports a transport error', async () => {
+    const previousSession = {
+      sessionId: '72ce17d2-037a-4b53-bf84-01d680f2dbb7',
+      lastHeartbeatTs: '2026-07-20T10:00:00.000Z',
+    };
+    mocks.store.set('sessionState', previousSession);
+    mocks.transportError = true;
+
+    const service = new TelemetryService(false);
+    await service.initialize();
+
+    expect(mocks.store.get('sessionState')).toMatchObject({
+      pendingRecoveries: [
+        {
+          eventId: previousSession.sessionId,
+          sessionId: previousSession.sessionId,
+        },
+      ],
+    });
+
+    mocks.transportError = false;
+    await service.dispose();
+  });
+});

--- a/apps/emdash-desktop/src/main/lib/telemetry.test.ts
+++ b/apps/emdash-desktop/src/main/lib/telemetry.test.ts
@@ -211,6 +211,25 @@ describe('TelemetryService', () => {
     expect(mocks.store.get('sessionState')).toEqual(previousState);
     expect(mocks.clients).toHaveLength(0);
     expect(service.getTelemetryStatus().enabled).toBe(false);
+
+    mocks.writeFailures.delete('sessionState');
+    await service.setTelemetryEnabledViaUser(true);
+    service.capture('app_window_focused');
+    await vi.waitFor(() => {
+      expect(
+        mocks.clients[0]?.captureImmediate.mock.calls.some(
+          ([event]) => event.event === 'app_window_focused'
+        )
+      ).toBe(true);
+    });
+
+    expect(service.getTelemetryStatus()).toMatchObject({
+      enabled: true,
+      envDisabled: false,
+      userOptOut: false,
+    });
+
+    await service.dispose();
   });
 
   it('uses PostHog exception capture with redacted error data', async () => {

--- a/apps/emdash-desktop/src/main/lib/telemetry.test.ts
+++ b/apps/emdash-desktop/src/main/lib/telemetry.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
   writeFailures: new Set<string>(),
   transportError: false,
   captureHandler: undefined as
-    | ((event: { event: string; uuid?: string }) => Promise<void>)
+    | ((event: { event: string; timestamp?: Date; uuid?: string }) => Promise<void>)
     | undefined,
   env: {
     build: {
@@ -69,7 +69,7 @@ vi.mock('@main/db/kv', () => ({
 vi.mock('posthog-node', () => ({
   PostHog: class {
     private errorHandlers = new Set<() => void>();
-    captureImmediate = vi.fn(async (event: { event: string; uuid?: string }) => {
+    captureImmediate = vi.fn(async (event: { event: string; timestamp?: Date; uuid?: string }) => {
       await (mocks.captureHandler ? mocks.captureHandler(event) : Promise.resolve());
       if (mocks.transportError) {
         for (const handler of this.errorHandlers) handler();
@@ -307,5 +307,68 @@ describe('TelemetryService', () => {
 
     mocks.transportError = false;
     await service.dispose();
+  });
+
+  it('removes a pending recovery with an invalid timestamp', async () => {
+    mocks.store.set('sessionState', {
+      active: null,
+      pendingRecoveries: [
+        {
+          eventId: '72ce17d2-037a-4b53-bf84-01d680f2dbb7',
+          sessionId: '72ce17d2-037a-4b53-bf84-01d680f2dbb7',
+          lastHeartbeatTs: 'not-a-timestamp',
+        },
+      ],
+    });
+
+    const service = new TelemetryService(false);
+    await service.initialize();
+
+    expect(mocks.store.get('sessionState')).toMatchObject({ pendingRecoveries: [] });
+    expect(
+      mocks.clients[0]?.captureImmediate.mock.calls.some(([event]) => event.event === 'app_closed')
+    ).toBe(false);
+
+    await service.dispose();
+  });
+
+  it('retains the active session when the clean close event fails', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-07-20T10:00:00.000Z'));
+      const service = new TelemetryService(false);
+      await service.initialize();
+      const sessionId = service.getTelemetryStatus().session_id;
+      let closeEvent: { timestamp?: Date } | undefined;
+      let finishClose: (() => void) | undefined;
+      mocks.captureHandler = (event) => {
+        if (event.event !== 'app_closed') return Promise.resolve();
+        closeEvent = event;
+        return new Promise<void>((resolve) => {
+          finishClose = resolve;
+        });
+      };
+      mocks.transportError = true;
+
+      const disposing = service.dispose();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(finishClose).toBeTypeOf('function');
+      await vi.advanceTimersByTimeAsync(60_000);
+      finishClose!();
+      await disposing;
+
+      expect(mocks.store.get('sessionState')).toMatchObject({
+        active: null,
+        pendingRecoveries: [
+          {
+            eventId: sessionId,
+            sessionId,
+            lastHeartbeatTs: closeEvent?.timestamp?.toISOString(),
+          },
+        ],
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/emdash-desktop/src/main/lib/telemetry.test.ts
+++ b/apps/emdash-desktop/src/main/lib/telemetry.test.ts
@@ -191,6 +191,21 @@ describe('TelemetryService', () => {
     await expect(service.setTelemetryEnabledViaUser(true)).rejects.toThrow('Write failed');
 
     expect(service.getTelemetryStatus().enabled).toBe(false);
+    expect(mocks.store.get('enabled')).toBe('false');
+    expect(mocks.clients[0]?.disable).toHaveBeenCalledOnce();
+  });
+
+  it('rolls back an opted-in session when persisting consent fails', async () => {
+    mocks.store.set('enabled', 'false');
+    const service = new TelemetryService(false);
+    await service.initialize();
+    mocks.writeFailures.add('enabled');
+
+    await expect(service.setTelemetryEnabledViaUser(true)).rejects.toThrow('Write failed');
+
+    expect(service.getTelemetryStatus().enabled).toBe(false);
+    expect(mocks.store.get('enabled')).toBe('false');
+    expect(mocks.store.has('sessionState')).toBe(false);
     expect(mocks.clients[0]?.disable).toHaveBeenCalledOnce();
   });
 

--- a/apps/emdash-desktop/src/main/lib/telemetry.ts
+++ b/apps/emdash-desktop/src/main/lib/telemetry.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'node:crypto';
 import type { IDisposable, IInitializable } from '@emdash/shared';
+import { redactAll } from '@emdash/shared/logger';
 import { app } from 'electron';
+import { PostHog } from 'posthog-node';
 import { KV } from '@main/db/kv';
 import { env as appEnv } from '@main/lib/env';
 import type { TelemetryEnvelope, TelemetryEvent, TelemetryProperties } from '@shared/telemetry';
@@ -9,10 +11,25 @@ interface InitOptions {
   installSource?: string;
 }
 
+type SessionSnapshot = {
+  sessionId: string;
+  lastHeartbeatTs: string;
+};
+
+type PendingRecovery = SessionSnapshot & {
+  eventId: string;
+};
+
+type PersistedSessionState = {
+  active: SessionSnapshot | null;
+  pendingRecoveries: PendingRecovery[];
+};
+
 type TelemetryKVSchema = {
   instanceId: string;
   enabled: string;
   lastActiveDate: string;
+  sessionState: PersistedSessionState | SessionSnapshot;
   lastSessionId: string;
   lastHeartbeatTs: string;
 };
@@ -22,8 +39,28 @@ const isViteDevBuild = import.meta.env.DEV;
 const MAX_EVENT_TS_MS = 9_999_999_999_999;
 const MAX_DURATION_MS = 30 * 24 * 60 * 60 * 1_000;
 const MAX_GENERIC_NUMBER = 1_000_000;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-class TelemetryService implements IInitializable, IDisposable {
+function isSessionSnapshot(value: unknown): value is SessionSnapshot {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.sessionId === 'string' && typeof record.lastHeartbeatTs === 'string';
+}
+
+function isPersistedSessionState(value: unknown): value is PersistedSessionState {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  return (
+    (record.active === null || isSessionSnapshot(record.active)) &&
+    Array.isArray(record.pendingRecoveries)
+  );
+}
+
+function recoveryEventId(sessionId: string): string {
+  return UUID_PATTERN.test(sessionId) ? sessionId : randomUUID();
+}
+
+export class TelemetryService implements IInitializable, IDisposable {
   private enabled = true;
   private apiKey: string | undefined;
   private host: string | undefined;
@@ -37,7 +74,17 @@ class TelemetryService implements IInitializable, IDisposable {
   private cachedEmail: string | null = null;
   private cachedFeatureFlags: Record<string, boolean> = {};
   private heartbeatInterval: ReturnType<typeof setInterval> | undefined;
+  private heartbeatGeneration = 0;
+  private sessionState: PersistedSessionState | undefined;
+  private sessionWriteQueue = Promise.resolve();
+  private consentGeneration = 0;
+  private lifecycle: 'active' | 'disposing' | 'disposed' = 'active';
+  private requestController = new AbortController();
+  private client: PostHog | undefined;
+  private readonly pendingRequests = new Set<Promise<void>>();
   private readonly kv = new KV<TelemetryKVSchema>('telemetry');
+
+  constructor(private readonly devBuild = isViteDevBuild) {}
 
   // ---------------------------------------------------------------------------
   // Internal helpers
@@ -45,7 +92,8 @@ class TelemetryService implements IInitializable, IDisposable {
 
   private isEnabled(): boolean {
     return (
-      !isViteDevBuild &&
+      !this.devBuild &&
+      this.lifecycle === 'active' &&
       this.enabled === true &&
       this.userOptOut !== true &&
       !!this.apiKey &&
@@ -53,6 +101,48 @@ class TelemetryService implements IInitializable, IDisposable {
       typeof this.instanceId === 'string' &&
       this.instanceId.length > 0
     );
+  }
+
+  private async ensureClient(): Promise<PostHog | undefined> {
+    if (!this.isEnabled()) return undefined;
+    if (!this.client) {
+      this.client = new PostHog(this.apiKey!, {
+        host: this.host,
+        disableGeoip: true,
+        fetchRetryCount: 0,
+        flushInterval: 0,
+        isServer: false,
+        preloadFeatureFlags: false,
+        requestTimeout: 2_000,
+        fetch: (url, options) =>
+          fetch(url, {
+            ...options,
+            signal: options.signal
+              ? AbortSignal.any([options.signal, this.requestController.signal])
+              : this.requestController.signal,
+          }),
+      });
+    }
+    return this.client;
+  }
+
+  private trackRequest(request: Promise<unknown>): Promise<void> {
+    const tracked = request.then(
+      () => undefined,
+      () => undefined
+    );
+    this.pendingRequests.add(tracked);
+    void tracked.finally(() => this.pendingRequests.delete(tracked));
+    return tracked;
+  }
+
+  private async flushPendingRequests(timeoutMs: number): Promise<void> {
+    const pending = [...this.pendingRequests];
+    if (pending.length === 0) return;
+    await Promise.race([
+      Promise.allSettled(pending).then(() => undefined),
+      new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
+    ]);
   }
 
   private getVersionSafe(): string {
@@ -84,10 +174,7 @@ class TelemetryService implements IInitializable, IDisposable {
    * Sanitize event properties to prevent PII leakage.
    * Simple allowlist approach: only allow safe property names and primitive types.
    */
-  private sanitizeEventAndProps(
-    _event: TelemetryEvent,
-    props: Record<string, unknown> | undefined
-  ) {
+  private sanitizeEventAndProps(_event: string, props: Record<string, unknown> | undefined) {
     const sanitized: Record<string, unknown> = {};
 
     const allowedProps = new Set([
@@ -144,7 +231,7 @@ class TelemetryService implements IInitializable, IDisposable {
       'conflicts',
       'count',
       'terminal_id',
-      'was_crash',
+      'was_unclean_exit',
       'type',
       'status',
       'automation_id',
@@ -152,21 +239,20 @@ class TelemetryService implements IInitializable, IDisposable {
       'duration_ms',
       'error_step',
       'error_code',
+      'process_type',
+      'mechanism',
+      'reason',
+      'component_stack',
     ]);
-    const passthroughProps = new Set([
-      '$exception_message',
-      '$exception_type',
-      '$exception_stack_trace_raw',
-      '$exception_fingerprint',
-    ]);
+    const longTextProps = new Set(['component_stack']);
 
     if (props) {
       for (const [key, value] of Object.entries(props)) {
-        if (!allowedProps.has(key) && !passthroughProps.has(key)) continue;
+        if (!allowedProps.has(key)) continue;
 
         if (typeof value === 'string') {
-          const maxLength = passthroughProps.has(key) ? 2_000 : 100;
-          sanitized[key] = value.trim().slice(0, maxLength);
+          const maxLength = longTextProps.has(key) ? 4_000 : 100;
+          sanitized[key] = redactAll(value).trim().slice(0, maxLength);
         } else if (typeof value === 'number') {
           if (key === 'event_ts_ms') {
             sanitized[key] = Math.max(0, Math.min(Math.trunc(value), MAX_EVENT_TS_MS));
@@ -201,52 +287,66 @@ class TelemetryService implements IInitializable, IDisposable {
 
   private async posthogCapture(
     event: TelemetryEvent,
-    properties?: Record<string, unknown>
-  ): Promise<void> {
-    if (!this.isEnabled()) return;
+    properties?: Record<string, unknown>,
+    delivery?: { uuid: string; timestamp: Date; confirmTransport: boolean }
+  ): Promise<boolean> {
+    if (!this.isEnabled()) return false;
+    const consentGeneration = this.consentGeneration;
     try {
-      const u = (this.host ?? '').replace(/\/$/, '') + '/capture/';
-      const body = {
-        api_key: this.apiKey,
-        event,
-        properties: {
-          distinct_id: this.instanceId,
-          ...this.getBaseProps(),
-          ...this.sanitizeEventAndProps(event, properties),
-        },
-      };
-      await fetch(u, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-        signal: AbortSignal.timeout(5_000),
-      }).catch(() => undefined);
+      const client = await this.ensureClient();
+      if (
+        !client ||
+        !this.instanceId ||
+        consentGeneration !== this.consentGeneration ||
+        !this.isEnabled()
+      )
+        return false;
+      let transportFailed = false;
+      const unsubscribe = delivery?.confirmTransport
+        ? client.on('error', () => {
+            transportFailed = true;
+          })
+        : undefined;
+      try {
+        await client.captureImmediate({
+          distinctId: this.instanceId,
+          event,
+          uuid: delivery?.uuid,
+          timestamp: delivery?.timestamp,
+          properties: {
+            ...this.getBaseProps(),
+            ...this.sanitizeEventAndProps(event, properties),
+          },
+        });
+        return !transportFailed;
+      } finally {
+        unsubscribe?.();
+      }
     } catch {
       // swallow errors; telemetry must never crash the app
+      return false;
     }
   }
 
   private async posthogIdentify(username: string, email?: string): Promise<void> {
     if (!this.isEnabled() || !username) return;
+    const consentGeneration = this.consentGeneration;
     try {
-      const u = (this.host ?? '').replace(/\/$/, '') + '/capture/';
-      const body = {
-        api_key: this.apiKey,
-        event: '$identify',
+      const client = await this.ensureClient();
+      if (
+        !client ||
+        !this.instanceId ||
+        consentGeneration !== this.consentGeneration ||
+        !this.isEnabled()
+      )
+        return;
+      await client.identifyImmediate({
+        distinctId: this.instanceId,
         properties: {
-          distinct_id: this.instanceId,
-          $set: {
-            ...(email ? { email } : {}),
-            ...this.getBaseProps(),
-          },
+          ...(email ? { email } : {}),
+          ...this.getBaseProps(),
         },
-      };
-      await fetch(u, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-        signal: AbortSignal.timeout(5_000),
-      }).catch(() => undefined);
+      });
     } catch {
       // swallow errors; telemetry must never crash the app
     }
@@ -254,35 +354,26 @@ class TelemetryService implements IInitializable, IDisposable {
 
   private async posthogDecide(): Promise<void> {
     if (!this.isEnabled() || !this.instanceId) return;
+    const consentGeneration = this.consentGeneration;
     try {
-      const u = (this.host ?? '').replace(/\/$/, '') + '/decide/?v=3';
-      const body = {
-        api_key: this.apiKey,
-        distinct_id: this.instanceId,
-        person_properties: {
+      const client = await this.ensureClient();
+      if (!client || consentGeneration !== this.consentGeneration || !this.isEnabled()) return;
+      const flags = await client.getAllFlags(this.instanceId, {
+        personProperties: {
           ...(this.cachedGithubUsername ? { github_username: this.cachedGithubUsername } : {}),
           ...(this.cachedAccountId ? { account_id: this.cachedAccountId } : {}),
           ...(this.cachedEmail ? { email: this.cachedEmail } : {}),
         },
-      };
-      const response = await fetch(u, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
       });
-      if (response.ok) {
-        const data = (await response.json()) as { featureFlags?: Record<string, unknown> };
-        const flags = data.featureFlags ?? {};
-        const parsed: Record<string, boolean> = {};
-        for (const [key, value] of Object.entries(flags)) {
-          if (typeof value === 'boolean') {
-            parsed[key] = value;
-          } else if (value === 'true' || value === 'false') {
-            parsed[key] = value === 'true';
-          }
+      const parsed: Record<string, boolean> = {};
+      for (const [key, value] of Object.entries(flags)) {
+        if (typeof value === 'boolean') {
+          parsed[key] = value;
+        } else if (value === 'true' || value === 'false') {
+          parsed[key] = value === 'true';
         }
-        this.cachedFeatureFlags = parsed;
       }
+      this.cachedFeatureFlags = parsed;
     } catch {
       // swallow errors; telemetry must never crash the app
     }
@@ -298,15 +389,167 @@ class TelemetryService implements IInitializable, IDisposable {
       const today = new Date().toISOString().split('T')[0]!;
       if (this.lastActiveDate === today) return;
 
-      void this.posthogCapture('daily_active_user', {
-        date: today,
-        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'unknown',
-      });
+      void this.trackRequest(
+        this.posthogCapture('daily_active_user', {
+          date: today,
+          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'unknown',
+        })
+      );
 
       this.lastActiveDate = today;
       void this.kv.set('lastActiveDate', today);
     } catch {
       // Never let telemetry errors crash the app
+    }
+  }
+
+  private async clearSessionState(): Promise<void> {
+    await this.disarmSessionState();
+    await Promise.all([
+      this.kv.del('sessionState'),
+      this.kv.del('lastSessionId'),
+      this.kv.del('lastHeartbeatTs'),
+    ]);
+  }
+
+  private async disarmSessionState(): Promise<void> {
+    this.heartbeatGeneration += 1;
+    if (this.heartbeatInterval !== undefined) {
+      clearInterval(this.heartbeatInterval);
+      this.heartbeatInterval = undefined;
+    }
+    this.sessionState = undefined;
+    await this.sessionWriteQueue.catch(() => undefined);
+  }
+
+  private async closeSessionState(): Promise<void> {
+    const generation = ++this.heartbeatGeneration;
+    if (this.heartbeatInterval !== undefined) {
+      clearInterval(this.heartbeatInterval);
+      this.heartbeatInterval = undefined;
+    }
+    await this.sessionWriteQueue.catch(() => undefined);
+    if (this.sessionState?.pendingRecoveries.length) {
+      this.sessionState.active = null;
+      await this.writeSessionState(generation);
+    } else {
+      await this.kv.del('sessionState');
+    }
+    this.sessionState = undefined;
+    await Promise.all([this.kv.del('lastSessionId'), this.kv.del('lastHeartbeatTs')]);
+  }
+
+  private writeSessionState(generation: number): Promise<void> {
+    this.sessionWriteQueue = this.sessionWriteQueue
+      .catch(() => undefined)
+      .then(async () => {
+        if (generation !== this.heartbeatGeneration || !this.sessionState) return;
+        await this.kv.setOrThrow('sessionState', this.sessionState);
+      });
+    return this.sessionWriteQueue;
+  }
+
+  private async armSessionState(pendingRecoveries: PendingRecovery[] = []): Promise<void> {
+    if (!this.isEnabled() || !this.sessionId) return;
+    if (this.heartbeatInterval !== undefined) {
+      clearInterval(this.heartbeatInterval);
+      this.heartbeatInterval = undefined;
+    }
+    const generation = ++this.heartbeatGeneration;
+    this.sessionState = {
+      active: {
+        sessionId: this.sessionId,
+        lastHeartbeatTs: new Date().toISOString(),
+      },
+      pendingRecoveries,
+    };
+    const writeHeartbeat = async () => {
+      if (
+        generation !== this.heartbeatGeneration ||
+        !this.isEnabled() ||
+        !this.sessionState?.active
+      )
+        return;
+      this.sessionState.active.lastHeartbeatTs = new Date().toISOString();
+      await this.writeSessionState(generation);
+      if (generation !== this.heartbeatGeneration || !this.isEnabled()) {
+        await this.kv.del('sessionState');
+      }
+    };
+
+    await writeHeartbeat();
+    if (generation !== this.heartbeatGeneration || !this.isEnabled()) return;
+    this.heartbeatInterval = setInterval(() => {
+      void writeHeartbeat().catch(() => undefined);
+    }, 60_000);
+  }
+
+  private async reportPendingRecoveries(generation: number): Promise<void> {
+    const pendingRecoveries = [...(this.sessionState?.pendingRecoveries ?? [])];
+    for (const recovery of pendingRecoveries) {
+      const lastHeartbeatMs = Date.parse(recovery.lastHeartbeatTs);
+      if (Number.isNaN(lastHeartbeatMs)) continue;
+      const sent = await this.posthogCapture(
+        'app_closed',
+        {
+          was_unclean_exit: true,
+          event_ts_ms: lastHeartbeatMs,
+          session_id: recovery.sessionId,
+        },
+        {
+          uuid: recovery.eventId,
+          timestamp: new Date(recovery.lastHeartbeatTs),
+          confirmTransport: true,
+        }
+      );
+      if (
+        !sent ||
+        generation !== this.heartbeatGeneration ||
+        !this.sessionState ||
+        !this.isEnabled()
+      )
+        continue;
+      this.sessionState.pendingRecoveries = this.sessionState.pendingRecoveries.filter(
+        ({ eventId }) => eventId !== recovery.eventId
+      );
+      await this.writeSessionState(generation);
+    }
+  }
+
+  private sanitizeError(error: Error | unknown): Error {
+    const source = error instanceof Error ? error : new Error(String(error));
+    const sanitized = new Error(redactAll(source.message || 'Unknown error').slice(0, 2_000));
+    sanitized.name = redactAll(source.name || 'Error').slice(0, 100);
+    sanitized.stack = redactAll(source.stack || `${sanitized.name}: ${sanitized.message}`).slice(
+      0,
+      10_000
+    );
+    return sanitized;
+  }
+
+  private async posthogCaptureException(
+    error: Error | unknown,
+    additionalProperties?: Record<string, unknown>
+  ): Promise<void> {
+    if (!this.isEnabled()) return;
+    const consentGeneration = this.consentGeneration;
+    try {
+      const client = await this.ensureClient();
+      if (
+        !client ||
+        !this.instanceId ||
+        consentGeneration !== this.consentGeneration ||
+        !this.isEnabled()
+      )
+        return;
+      await client.captureExceptionImmediate(this.sanitizeError(error), this.instanceId, {
+        ...this.getBaseProps(),
+        ...this.sanitizeEventAndProps('$exception', additionalProperties),
+        event_ts_ms: Date.now(),
+        session_id: this.sessionId,
+      });
+    } catch {
+      // swallow errors; telemetry must never crash the app
     }
   }
 
@@ -317,7 +560,7 @@ class TelemetryService implements IInitializable, IDisposable {
   async initialize(options?: InitOptions): Promise<void> {
     const enabledEnv = (appEnv.runtime.TELEMETRY_ENABLED ?? 'true').toLowerCase();
     this.enabled =
-      !isViteDevBuild && enabledEnv !== 'false' && enabledEnv !== '0' && enabledEnv !== 'no';
+      !this.devBuild && enabledEnv !== 'false' && enabledEnv !== '0' && enabledEnv !== 'no';
     // build value wins (prod); dev fallback used locally without VITE_ vars set
     this.apiKey = appEnv.build.VITE_POSTHOG_KEY ?? appEnv.dev.POSTHOG_PROJECT_API_KEY;
     this.host = this.normalizeHost(appEnv.build.VITE_POSTHOG_HOST ?? appEnv.dev.POSTHOG_HOST);
@@ -328,70 +571,111 @@ class TelemetryService implements IInitializable, IDisposable {
     let storedInstanceId: string | null = null;
     let storedEnabled: string | null = null;
     let storedActiveDate: string | null = null;
+    let storedSessionState: TelemetryKVSchema['sessionState'] | null = null;
     let storedLastSessionId: string | null = null;
     let storedLastHeartbeatTs: string | null = null;
+    let consentReadFailed = false;
     try {
       [
         storedInstanceId,
         storedEnabled,
         storedActiveDate,
+        storedSessionState,
         storedLastSessionId,
         storedLastHeartbeatTs,
       ] = await Promise.all([
         this.kv.get('instanceId'),
-        this.kv.get('enabled'),
+        this.kv.getOrThrow('enabled'),
         this.kv.get('lastActiveDate'),
+        this.kv.get('sessionState'),
         this.kv.get('lastSessionId'),
         this.kv.get('lastHeartbeatTs'),
       ]);
     } catch {
-      // KV unavailable during startup (e.g. DB migration not yet applied) — use in-memory defaults
+      // Consent cannot be established safely when its store is unavailable.
+      consentReadFailed = true;
+    }
+    if (storedEnabled !== null && storedEnabled !== 'true' && storedEnabled !== 'false') {
+      consentReadFailed = true;
     }
 
-    this.instanceId = storedInstanceId ?? (randomUUID().toString() as string);
+    this.instanceId = storedInstanceId ?? randomUUID();
     if (!storedInstanceId) {
-      void this.kv.set('instanceId', this.instanceId);
+      await this.kv.set('instanceId', this.instanceId);
     }
 
-    this.userOptOut = storedEnabled === 'false' ? true : undefined;
+    this.userOptOut = consentReadFailed || storedEnabled === 'false' ? true : undefined;
     this.lastActiveDate = storedActiveDate ?? undefined;
 
-    // Detect unclean exit from the previous session: if we have a recorded session ID
-    // that was never cleared by a clean shutdown, emit a synthetic app_closed so that
-    // session duration queries remain accurate.
-    if (storedLastSessionId && storedLastHeartbeatTs) {
-      const lastHeartbeatMs = Date.parse(storedLastHeartbeatTs);
-      if (!Number.isNaN(lastHeartbeatMs)) {
-        void this.posthogCapture('app_closed', {
-          was_crash: true,
-          event_ts_ms: lastHeartbeatMs,
-          session_id: storedLastSessionId,
+    if (!this.isEnabled()) {
+      await this.clearSessionState();
+      return;
+    }
+
+    const pendingRecoveries = new Map<string, PendingRecovery>();
+    if (isPersistedSessionState(storedSessionState)) {
+      for (const recovery of storedSessionState.pendingRecoveries) {
+        if (isSessionSnapshot(recovery) && typeof recovery.eventId === 'string') {
+          pendingRecoveries.set(recovery.sessionId, recovery);
+        }
+      }
+      if (
+        storedSessionState.active &&
+        !pendingRecoveries.has(storedSessionState.active.sessionId)
+      ) {
+        pendingRecoveries.set(storedSessionState.active.sessionId, {
+          ...storedSessionState.active,
+          eventId: recoveryEventId(storedSessionState.active.sessionId),
         });
       }
+    } else if (isSessionSnapshot(storedSessionState)) {
+      pendingRecoveries.set(storedSessionState.sessionId, {
+        ...storedSessionState,
+        eventId: recoveryEventId(storedSessionState.sessionId),
+      });
     }
-    // Record the current session ID so the next startup can detect a crash.
-    // sessionId is guaranteed non-undefined at this point (set to randomUUID() above).
-    void this.kv.set('lastSessionId', this.sessionId!);
+    if (
+      storedLastSessionId &&
+      storedLastHeartbeatTs &&
+      !pendingRecoveries.has(storedLastSessionId)
+    ) {
+      pendingRecoveries.set(storedLastSessionId, {
+        sessionId: storedLastSessionId,
+        lastHeartbeatTs: storedLastHeartbeatTs,
+        eventId: recoveryEventId(storedLastSessionId),
+      });
+    }
 
-    void this.posthogCapture('app_started');
+    try {
+      await this.armSessionState([...pendingRecoveries.values()]);
+    } catch {
+      this.enabled = false;
+      await this.client?.disable();
+      await this.disarmSessionState();
+      return;
+    }
+    await Promise.all([this.kv.del('lastSessionId'), this.kv.del('lastHeartbeatTs')]);
+    await this.ensureClient();
+    const heartbeatGeneration = this.heartbeatGeneration;
+    await this.trackRequest(this.reportPendingRecoveries(heartbeatGeneration));
+
+    void this.trackRequest(this.posthogCapture('app_started'));
     void this.checkDailyActiveUser();
-
-    // Heartbeat: write lastHeartbeatTs to KV every 60 s so crash recovery can
-    // estimate session duration without firing any PostHog events.
-    this.heartbeatInterval = setInterval(() => {
-      void this.kv.set('lastHeartbeatTs', new Date().toISOString());
-    }, 60_000);
   }
 
   async dispose(): Promise<void> {
-    if (this.heartbeatInterval !== undefined) {
-      clearInterval(this.heartbeatInterval);
-      this.heartbeatInterval = undefined;
-    }
-    // Await both deletes so the process cannot exit before they complete.
-    // If these are fire-and-forget, the next startup will see lastSessionId still
-    // in KV and incorrectly emit a synthetic app_closed with was_crash: true.
-    await Promise.all([this.kv.del('lastSessionId'), this.kv.del('lastHeartbeatTs')]);
+    if (this.lifecycle !== 'active') return;
+    await this.posthogCapture('app_closed', {
+      event_ts_ms: Date.now(),
+      session_id: this.sessionId,
+    });
+    await this.flushPendingRequests(2_000);
+    this.lifecycle = 'disposing';
+    this.consentGeneration += 1;
+    await this.closeSessionState().catch(() => undefined);
+    await this.client?._shutdown(1_000).catch(() => undefined);
+    this.client = undefined;
+    this.lifecycle = 'disposed';
   }
 
   /**
@@ -430,32 +714,32 @@ class TelemetryService implements IInitializable, IDisposable {
       event_ts_ms: Date.now(),
       session_id: captureSessionId,
     };
-    void this.posthogCapture(event, {
-      ...(properties as Record<string, unknown> | undefined),
-      ...envelope,
-    });
+    void this.trackRequest(
+      this.posthogCapture(event, {
+        ...(properties as Record<string, unknown> | undefined),
+        ...envelope,
+      })
+    );
   }
 
   /**
    * Capture an exception for PostHog error tracking.
    */
   captureException(error: Error | unknown, additionalProperties?: Record<string, unknown>): void {
-    if (!this.isEnabled()) return;
+    void this.trackRequest(this.posthogCaptureException(error, additionalProperties));
+  }
 
-    const errorObj = error instanceof Error ? error : new Error(String(error));
-
-    void this.posthogCapture('$exception', {
-      $exception_message: errorObj.message || 'Unknown error',
-      $exception_type: errorObj.name || 'Error',
-      $exception_stack_trace_raw: errorObj.stack || '',
-      ...additionalProperties,
-    });
+  async captureExceptionImmediate(
+    error: Error | unknown,
+    additionalProperties?: Record<string, unknown>
+  ): Promise<void> {
+    await this.trackRequest(this.posthogCaptureException(error, additionalProperties));
   }
 
   getTelemetryStatus() {
     return {
       enabled: this.isEnabled(),
-      envDisabled: isViteDevBuild || !this.enabled,
+      envDisabled: this.devBuild || !this.enabled,
       userOptOut: this.userOptOut === true,
       hasKeyAndHost: !!this.apiKey && !!this.host,
       session_id: this.sessionId ?? null,
@@ -467,9 +751,53 @@ class TelemetryService implements IInitializable, IDisposable {
     return this.instanceId;
   }
 
-  setTelemetryEnabledViaUser(enabledFlag: boolean): void {
+  async setTelemetryEnabledViaUser(enabledFlag: boolean): Promise<void> {
+    if (this.lifecycle !== 'active') return;
+    const previousOptOut = this.userOptOut;
     this.userOptOut = !enabledFlag;
-    void this.kv.set('enabled', String(enabledFlag));
+    if (!enabledFlag) {
+      this.consentGeneration += 1;
+      this.requestController.abort();
+      await this.client?.disable();
+    }
+    try {
+      await this.kv.setOrThrow('enabled', String(enabledFlag));
+    } catch (error) {
+      if (!enabledFlag) {
+        this.cachedFeatureFlags = {};
+        await this.clearSessionState();
+        await this.flushPendingRequests(2_000);
+        throw error;
+      }
+      this.userOptOut = previousOptOut;
+      if (!this.userOptOut) {
+        this.requestController = new AbortController();
+        await this.client?.enable();
+      }
+      throw error;
+    }
+
+    if (!enabledFlag) {
+      this.cachedFeatureFlags = {};
+      await this.clearSessionState();
+      await this.flushPendingRequests(2_000);
+      return;
+    }
+
+    this.consentGeneration += 1;
+    this.requestController = new AbortController();
+    await this.client?.enable();
+    await this.ensureClient();
+    try {
+      await this.armSessionState();
+    } catch (error) {
+      this.userOptOut = true;
+      this.consentGeneration += 1;
+      this.requestController.abort();
+      await this.client?.disable();
+      await this.disarmSessionState();
+      throw error;
+    }
   }
 
   async checkAndReportDailyActiveUser(): Promise<void> {
@@ -481,7 +809,7 @@ class TelemetryService implements IInitializable, IDisposable {
    * environment variables (e.g. FLAG_my_flag=true) override any PostHog values.
    */
   getFeatureFlags(): Record<string, boolean> {
-    if (!isViteDevBuild) return this.cachedFeatureFlags;
+    if (!this.devBuild) return this.cachedFeatureFlags;
 
     const overrides: Record<string, boolean> = {};
     for (const [key, value] of Object.entries(process.env)) {

--- a/apps/emdash-desktop/src/main/lib/telemetry.ts
+++ b/apps/emdash-desktop/src/main/lib/telemetry.ts
@@ -488,7 +488,10 @@ export class TelemetryService implements IInitializable, IDisposable {
     const pendingRecoveries = [...(this.sessionState?.pendingRecoveries ?? [])];
     for (const recovery of pendingRecoveries) {
       const lastHeartbeatMs = Date.parse(recovery.lastHeartbeatTs);
-      if (Number.isNaN(lastHeartbeatMs)) continue;
+      if (Number.isNaN(lastHeartbeatMs)) {
+        await this.removePendingRecovery(recovery.eventId, generation);
+        continue;
+      }
       const sent = await this.posthogCapture(
         'app_closed',
         {
@@ -509,11 +512,16 @@ export class TelemetryService implements IInitializable, IDisposable {
         !this.isEnabled()
       )
         continue;
-      this.sessionState.pendingRecoveries = this.sessionState.pendingRecoveries.filter(
-        ({ eventId }) => eventId !== recovery.eventId
-      );
-      await this.writeSessionState(generation);
+      await this.removePendingRecovery(recovery.eventId, generation);
     }
+  }
+
+  private async removePendingRecovery(eventId: string, generation: number): Promise<void> {
+    if (generation !== this.heartbeatGeneration || !this.sessionState || !this.isEnabled()) return;
+    this.sessionState.pendingRecoveries = this.sessionState.pendingRecoveries.filter(
+      (recovery) => recovery.eventId !== eventId
+    );
+    await this.writeSessionState(generation);
   }
 
   private sanitizeError(error: Error | unknown): Error {
@@ -665,10 +673,44 @@ export class TelemetryService implements IInitializable, IDisposable {
 
   async dispose(): Promise<void> {
     if (this.lifecycle !== 'active') return;
-    await this.posthogCapture('app_closed', {
-      event_ts_ms: Date.now(),
-      session_id: this.sessionId,
-    });
+    const closeGeneration = ++this.heartbeatGeneration;
+    if (this.heartbeatInterval !== undefined) {
+      clearInterval(this.heartbeatInterval);
+      this.heartbeatInterval = undefined;
+    }
+    await this.sessionWriteQueue.catch(() => undefined);
+    const closeTimestamp = new Date();
+    const activeSession = this.sessionState?.active;
+    let closeStatePersisted = !activeSession;
+    if (activeSession) {
+      activeSession.lastHeartbeatTs = closeTimestamp.toISOString();
+      closeStatePersisted = await this.writeSessionState(closeGeneration).then(
+        () => true,
+        () => false
+      );
+    }
+    const closeSent = closeStatePersisted
+      ? await this.posthogCapture(
+          'app_closed',
+          {
+            event_ts_ms: closeTimestamp.getTime(),
+            session_id: this.sessionId,
+          },
+          activeSession
+            ? {
+                uuid: recoveryEventId(activeSession.sessionId),
+                timestamp: closeTimestamp,
+                confirmTransport: true,
+              }
+            : undefined
+        )
+      : false;
+    if (!closeSent && activeSession && this.sessionState) {
+      const eventId = recoveryEventId(activeSession.sessionId);
+      if (!this.sessionState.pendingRecoveries.some((recovery) => recovery.eventId === eventId)) {
+        this.sessionState.pendingRecoveries.push({ ...activeSession, eventId });
+      }
+    }
     await this.flushPendingRequests(2_000);
     this.lifecycle = 'disposing';
     this.consentGeneration += 1;

--- a/apps/emdash-desktop/src/main/lib/telemetry.ts
+++ b/apps/emdash-desktop/src/main/lib/telemetry.ts
@@ -657,7 +657,7 @@ export class TelemetryService implements IInitializable, IDisposable {
     try {
       await this.armSessionState([...pendingRecoveries.values()]);
     } catch {
-      this.enabled = false;
+      this.userOptOut = true;
       await this.client?.disable();
       await this.disarmSessionState();
       return;

--- a/apps/emdash-desktop/src/main/lib/telemetry.ts
+++ b/apps/emdash-desktop/src/main/lib/telemetry.ts
@@ -797,6 +797,22 @@ export class TelemetryService implements IInitializable, IDisposable {
     if (this.lifecycle !== 'active') return;
     const previousOptOut = this.userOptOut;
     this.userOptOut = !enabledFlag;
+    if (enabledFlag) {
+      this.consentGeneration += 1;
+      this.requestController = new AbortController();
+      await this.client?.enable();
+      await this.ensureClient();
+      try {
+        await this.armSessionState();
+      } catch (error) {
+        this.userOptOut = true;
+        this.consentGeneration += 1;
+        this.requestController.abort();
+        await this.client?.disable();
+        await this.disarmSessionState();
+        throw error;
+      }
+    }
     if (!enabledFlag) {
       this.consentGeneration += 1;
       this.requestController.abort();
@@ -812,9 +828,12 @@ export class TelemetryService implements IInitializable, IDisposable {
         throw error;
       }
       this.userOptOut = previousOptOut;
-      if (!this.userOptOut) {
-        this.requestController = new AbortController();
-        await this.client?.enable();
+      if (this.userOptOut) {
+        this.consentGeneration += 1;
+        this.requestController.abort();
+        await this.client?.disable();
+        await this.clearSessionState();
+        await this.flushPendingRequests(2_000);
       }
       throw error;
     }
@@ -824,21 +843,6 @@ export class TelemetryService implements IInitializable, IDisposable {
       await this.clearSessionState();
       await this.flushPendingRequests(2_000);
       return;
-    }
-
-    this.consentGeneration += 1;
-    this.requestController = new AbortController();
-    await this.client?.enable();
-    await this.ensureClient();
-    try {
-      await this.armSessionState();
-    } catch (error) {
-      this.userOptOut = true;
-      this.consentGeneration += 1;
-      this.requestController.abort();
-      await this.client?.disable();
-      await this.disarmSessionState();
-      throw error;
     }
   }
 

--- a/apps/emdash-desktop/src/renderer/features/settings/components/TelemetryCard.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/TelemetryCard.tsx
@@ -4,6 +4,7 @@ import { useTelemetryConsent } from '@renderer/lib/hooks/useTelemetryConsent';
 import { rpc } from '@renderer/lib/ipc';
 import { Button } from '@renderer/lib/ui/button';
 import { Switch } from '@renderer/lib/ui/switch';
+import { captureTelemetry } from '@renderer/utils/telemetryClient';
 import { PRODUCT_NAME } from '@shared/app-identity';
 import { SettingRow } from './SettingRow';
 
@@ -40,10 +41,10 @@ const TelemetryCard: React.FC = () => {
           <Switch
             checked={prefEnabled}
             onCheckedChange={async (checked) => {
-              void import('../../../utils/telemetryClient').then(({ captureTelemetry }) => {
+              await setTelemetryEnabled(checked);
+              if (checked) {
                 captureTelemetry('setting_changed', { setting: 'telemetry' });
-              });
-              void setTelemetryEnabled(checked);
+              }
             }}
             disabled={loading || envDisabled}
             aria-label="Enable anonymous telemetry"

--- a/apps/emdash-desktop/src/renderer/lib/components/error-boundary.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/error-boundary.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { captureException } from '@renderer/utils/telemetryClient';
 import { rpc } from '../ipc';
 import { Button } from '../ui/button';
 
@@ -33,6 +34,10 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
 
   static getDerivedStateFromError(error: Error): ErrorBoundaryState {
     return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    captureException(error, 'react', info.componentStack ?? undefined);
   }
 
   handleReload = () => {

--- a/apps/emdash-desktop/src/renderer/main.tsx
+++ b/apps/emdash-desktop/src/renderer/main.tsx
@@ -18,10 +18,19 @@ import { wirePrCacheInvalidation } from '@renderer/lib/pr-cache-invalidation';
 import { viewStateCache } from '@renderer/lib/stores/view-state-cache';
 import { log } from '@renderer/utils/logger';
 import { initSoundPlayer } from '@renderer/utils/soundPlayer';
+import { captureException } from '@renderer/utils/telemetryClient';
 import type { NavigationSnapshot, SidebarSnapshot } from '@shared/view-state';
 import { App } from './App';
 import { ErrorBoundary } from './lib/components/error-boundary';
 import { appState } from './lib/stores/app-state';
+
+window.addEventListener('error', (event) => {
+  captureException(event.error ?? event.message, 'window_error');
+});
+
+window.addEventListener('unhandledrejection', (event) => {
+  captureException(event.reason, 'unhandled_rejection');
+});
 
 async function bootstrap() {
   // Wire invalidation bridges so FS and git events flow into the model registry.
@@ -70,4 +79,5 @@ async function bootstrap() {
 
 bootstrap().catch((error: unknown) => {
   log.error('Renderer bootstrap failed:', error);
+  captureException(error, 'bootstrap');
 });

--- a/apps/emdash-desktop/src/renderer/utils/telemetryClient.ts
+++ b/apps/emdash-desktop/src/renderer/utils/telemetryClient.ts
@@ -2,7 +2,11 @@
  * Simple telemetry client for renderer process.
  * Captures events and sends them to the main process via IPC.
  */
-import type { TelemetryEvent, TelemetryProperties } from '@shared/telemetry';
+import type {
+  TelemetryEvent,
+  TelemetryExceptionReport,
+  TelemetryProperties,
+} from '@shared/telemetry';
 import { rpc } from '../lib/ipc';
 import { focusTracker } from './focus-tracker';
 import { getTelemetryScope } from './telemetry-scope';
@@ -55,6 +59,25 @@ export function captureTelemetry<E extends TelemetryEvent>(
   }).catch(() => {
     // Telemetry failures never break the app
   });
+}
+
+export function captureException(
+  error: unknown,
+  mechanism: TelemetryExceptionReport['mechanism'],
+  componentStack?: string
+): void {
+  const normalized = error instanceof Error ? error : new Error(String(error));
+  void rpc.telemetry
+    .captureException({
+      name: normalized.name || 'Error',
+      message: normalized.message || 'Unknown error',
+      stack: normalized.stack,
+      componentStack,
+      mechanism,
+    })
+    .catch(() => {
+      // Error reporting must never break the renderer.
+    });
 }
 
 focusTracker.setTransitionEmitter((properties) => {

--- a/apps/emdash-desktop/src/shared/telemetry.ts
+++ b/apps/emdash-desktop/src/shared/telemetry.ts
@@ -32,6 +32,14 @@ export interface TelemetryEnvelope {
   conversation_id?: string;
 }
 
+export type TelemetryExceptionReport = {
+  name: string;
+  message: string;
+  stack?: string;
+  componentStack?: string;
+  mechanism: 'react' | 'window_error' | 'unhandled_rejection' | 'bootstrap';
+};
+
 export interface FocusContext {
   active_view: FocusView | null;
   active_main_panel: FocusMainPanel | null;
@@ -42,7 +50,7 @@ export type SettingName = 'theme' | 'default_provider' | 'telemetry' | 'notifica
 
 export type TelemetryEventProperties = {
   app_started: EmptyProps;
-  app_closed: { was_crash?: boolean };
+  app_closed: { was_unclean_exit?: boolean };
   app_window_focused: EmptyProps;
   app_window_unfocused: EmptyProps;
   daily_active_user: { date: string; timezone: string };
@@ -159,21 +167,6 @@ export type TelemetryEventProperties = {
   setting_changed: { setting: SettingName };
   sidebar_toggled: { side: 'left' | 'right'; state: 'open' | 'closed' };
 
-  $exception: {
-    $exception_message: string;
-    $exception_type: string;
-    $exception_stack_trace_raw: string;
-    $exception_fingerprint?: string;
-    severity?: 'low' | 'medium' | 'high' | 'critical';
-    component?: string;
-    action?: string;
-    user_action?: string;
-    operation?: string;
-    endpoint?: string;
-    session_errors?: number;
-    error_timestamp?: string;
-    error_type?: string;
-  };
   error: { error_type: string; scope: string };
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       pidusage:
         specifier: ^4.0.1
         version: 4.0.1
+      posthog-node:
+        specifier: ^5.45.2
+        version: 5.45.2(rxjs@7.8.2)
       smol-toml:
         specifier: ^1.6.0
         version: 1.6.1
@@ -2888,6 +2891,12 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@posthog/core@1.43.1':
+    resolution: {integrity: sha512-hGM8f5sp3we6Em/RQHXbmyYm554hUx9+9jhf92ZQgDS4/xW72KHyZiO9wcFye+qAx2cJAOhOCDIznmO1FV8IbA==}
+
+  '@posthog/types@1.397.0':
+    resolution: {integrity: sha512-Pa7FtsBo3V0XrhY4y8Xquwp8U07syuZ2IGQdlsRyxhz0yejQLceFjI58UssCXE5zDCDj3km5l7H3ufD6rHChCg==}
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
@@ -7534,6 +7543,15 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-node@5.45.2:
+    resolution: {integrity: sha512-QhHw/xL0ntMG/DzqA/qdiKu8JY8ChK5Obm8m1nMJor5sjJ7+pfVJSx1yAynC7iUAJfJ9V+OhBNhDCyi5IFWC0Q==}
+    engines: {node: ^20.20.0 || >=22.22.0}
+    peerDependencies:
+      rxjs: ^7.0.0
+    peerDependenciesMeta:
+      rxjs:
+        optional: true
+
   postject@1.0.0-alpha.6:
     resolution: {integrity: sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==}
     engines: {node: '>=14.0.0'}
@@ -10923,6 +10941,12 @@ snapshots:
   '@pkgr/core@0.3.6': {}
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@posthog/core@1.43.1':
+    dependencies:
+      '@posthog/types': 1.397.0
+
+  '@posthog/types@1.397.0': {}
 
   '@quansync/fs@1.0.0':
     dependencies:
@@ -16393,6 +16417,12 @@ snapshots:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  posthog-node@5.45.2(rxjs@7.8.2):
+    dependencies:
+      '@posthog/core': 1.43.1
+    optionalDependencies:
+      rxjs: 7.8.2
 
   postject@1.0.0-alpha.6:
     dependencies:


### PR DESCRIPTION
### Description

Report main-process, renderer, React, and Electron child-process crashes through PostHog's structured exception API when telemetry is enabled.

This adds bounded fatal-error delivery, redaction for exception data, atomic session recovery for unclean exits, deterministic retry deduplication, and a strict opt-out barrier that aborts in-flight requests and stays disabled when preference persistence fails. Clean shutdown now flushes telemetry before the remaining teardown, while malformed consent state fails closed.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed, or confirmed existing telemetry disclosure remains accurate
- [x] I added or updated tests when behavior changed
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit message and PR title

</details>