### PR TITLE
fix(diff-view): stop commit input stealing focus when commit card mounts

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/commit-card.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/commit-card.tsx
@@ -160,7 +160,6 @@ export const CommitCard = observer(function CommitCard({ autoStage = false }: Co
     <div className="mx-2 mb-2 flex shrink-0 flex-col items-center justify-between gap-2 rounded-xl border border-border bg-background-1 p-2">
       <Input
         placeholder="Commit message"
-        autoFocus
         className="w-full bg-background"
         value={commitMessage}
         onChange={(e) => setCommitMessage(e.target.value)}


### PR DESCRIPTION
### Description

The commit message input had `autoFocus`, and `CommitCard` mounts and unmounts as git state changes in the background (the agent editing, staging, or committing files). Every mount pulled focus out of the agent chat or terminal and into the commit form. This removes the `autoFocus` prop.

### Related issues

Fixes #2925

### Testing

- `pnpm run format`, `pnpm run lint`, `pnpm run typecheck`, `pnpm run test`
- Reproduced the focus steal on the pre-fix build and confirmed the fix in the running app, both with an automated Electron run and by hand
- No test added: focus behavior needs a real window, so it was verified in the app instead

### Screenshot/Recording (if applicable)

Not applicable.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>
