### PR TITLE
fix(editor): preserve scroll position across tab and task switches

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tasks/editor/editor-provider.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/editor/editor-provider.tsx
@@ -124,6 +124,9 @@ export const EditorProvider = observer(function EditorProvider({
     return () => {
       focusDisposable.dispose();
       cleanupActive();
+      // Save the active file's view state before disposal. Must run here, not in
+      // the attachment autorun's cleanup — that fires after the editor is disposed.
+      modelRegistry.detach(editor, prevBufUriRef.current);
       editor.dispose();
       container.remove();
       editorRef.current = null;
@@ -178,7 +181,9 @@ export const EditorProvider = observer(function EditorProvider({
         const newBufUri = entry ? buildMonacoModelPath(editorView.modelRootPath, entry.path) : null;
 
         if (!newBufUri) {
-          editor.setModel(null);
+          // detach saves the file's view state, so the scroll position survives
+          // switching to a non-file tab (conversation, diff, …).
+          modelRegistry.detach(editor, prevBufUriRef.current);
           prevBufUriRef.current = undefined;
           return;
         }

--- a/apps/emdash-desktop/src/renderer/features/tasks/editor/editor-provider.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/editor/editor-provider.tsx
@@ -110,12 +110,6 @@ export const EditorProvider = observer(function EditorProvider({
       paneLayout.setActiveGroup(paneId);
     });
 
-    // Satisfy any focus request that arrived before the editor was ready.
-    if (focusPendingRef.current && editor.getModel()) {
-      focusPendingRef.current = false;
-      editor.focus();
-    }
-
     if (hostRef.current) {
       hostRef.current.appendChild(container);
       editor.layout();
@@ -199,6 +193,12 @@ export const EditorProvider = observer(function EditorProvider({
 
         modelRegistry.attach(editor, newBufUri, prevBufUriRef.current);
         prevBufUriRef.current = newBufUri;
+
+        // Satisfy any focus request that arrived while the model was still loading.
+        if (focusPendingRef.current) {
+          focusPendingRef.current = false;
+          editor.focus();
+        }
       }),
     // oxlint-disable-next-line react/exhaustive-deps
     []

--- a/apps/emdash-desktop/src/renderer/lib/monaco/sticky-diff-editor.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/monaco/sticky-diff-editor.tsx
@@ -26,10 +26,13 @@ export function StickyDiffEditor({
   onEditorChange,
 }: StickyDiffEditorProps) {
   const mountRef = useRef<HTMLDivElement>(null);
-  const originalUriRef = useRef(originalUri);
-  originalUriRef.current = originalUri;
   const modifiedUriRef = useRef(modifiedUri);
   modifiedUriRef.current = modifiedUri;
+
+  // URI pair of the models currently attached to the editor. The unmount save
+  // must key by this, not the URI props: the props can already point at a new
+  // diff whose models never attached.
+  const attachedUrisRef = useRef<{ original: string; modified: string } | null>(null);
 
   // Observable box so the autorun can react to the editor arriving after async mount.
   const editorBox = useRef(
@@ -79,8 +82,9 @@ export function StickyDiffEditor({
       heightDisposable.dispose();
       // Save the viewport before disposal. The URI effect's cleanup can't cover
       // unmount: it runs after this one, when editorBox is already null.
-      if (editor.getModel()) {
-        modelRegistry.saveDiffViewState(originalUriRef.current, modifiedUriRef.current, editor);
+      const attached = attachedUrisRef.current;
+      if (attached) {
+        modelRegistry.saveDiffViewState(attached.original, attached.modified, editor);
       }
       runInAction(() => editorBox.set(null));
       editor.dispose();
@@ -114,6 +118,7 @@ export function StickyDiffEditor({
       const prev = current.getModel();
       if (prev) {
         current.setModel(null);
+        attachedUrisRef.current = null;
         if (prev.original.uri.scheme === 'inmemory') prev.original.dispose();
         if (prev.modified.uri.scheme === 'inmemory') prev.modified.dispose();
       }
@@ -142,6 +147,7 @@ export function StickyDiffEditor({
       }
 
       editor.setModel({ original: origModel, modified: modModel });
+      attachedUrisRef.current = { original: originalUri, modified: modifiedUri };
       editor.layout();
       // Restore scroll/cursor for the incoming URI pair.
       modelRegistry.restoreDiffViewState(originalUri, modifiedUri, editor);

--- a/apps/emdash-desktop/src/renderer/lib/monaco/sticky-diff-editor.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/monaco/sticky-diff-editor.tsx
@@ -26,6 +26,8 @@ export function StickyDiffEditor({
   onEditorChange,
 }: StickyDiffEditorProps) {
   const mountRef = useRef<HTMLDivElement>(null);
+  const originalUriRef = useRef(originalUri);
+  originalUriRef.current = originalUri;
   const modifiedUriRef = useRef(modifiedUri);
   modifiedUriRef.current = modifiedUri;
 
@@ -75,6 +77,11 @@ export function StickyDiffEditor({
     return () => {
       onEditorChangeRef.current?.(null);
       heightDisposable.dispose();
+      // Save the viewport before disposal. The URI effect's cleanup can't cover
+      // unmount: it runs after this one, when editorBox is already null.
+      if (editor.getModel()) {
+        modelRegistry.saveDiffViewState(originalUriRef.current, modifiedUriRef.current, editor);
+      }
       runInAction(() => editorBox.set(null));
       editor.dispose();
     };


### PR DESCRIPTION
### Description

Scroll position was lost when you had a file open, switched to the agent tab or another task, and came back.

The editor was torn down without saving its view state first, so the position had nothing to restore from. This saves the view state before the editor is disposed or its model detached, for both the file editor and the diff editor. Also fixes a queued focus request that was never applied when it arrived while the file was still loading.

### Related issues

Fixes #2927.

### Testing

Typecheck, lint, and format pass. Manually verified in the app: opened a long file, scrolled down, switched to the agent tab and back, and switched tasks and back. The position was restored in both cases. No test updates: nothing covers this component lifecycle today, and a regression test would need Monaco in the browser test harness.

### Screenshot/Recording (if applicable)

https://github.com/user-attachments/assets/a8d981e2-a17c-4021-81da-f23c124338d8

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [ ] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>