### PR TITLE
fix: unify switches in new task modal

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.test.ts
@@ -229,6 +229,20 @@ describe('useInitialConversationState', () => {
     expect(latestState?.prompt).toBe('Keep this automation prompt');
   });
 
+  it('persists the auto-approve preference', async () => {
+    await renderProbe('project-1');
+
+    await act(async () => {
+      latestState?.setAutoApprove(true);
+    });
+
+    await act(async () => root.unmount());
+    root = createRoot(container);
+    await renderProbe('project-2');
+
+    expect(latestState?.autoApprove).toBe(true);
+  });
+
   it('defaults chat UI off when the provider supports ACP', async () => {
     await renderProbe('project-1');
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.tsx
@@ -77,7 +77,10 @@ export function useInitialConversationState(
   const { data: agents } = useAgents();
   const [prompt, setPrompt] = useState('');
   const [issueContext, setIssueContext] = useState<string | null>(null);
-  const [autoApproveOverride, setAutoApproveOverride] = useState<boolean | null>(null);
+  const [autoApprovePreference, setAutoApprovePreference] = useLocalStorage(
+    'initial-conversation:auto-approve-enabled',
+    autoApproveByDefault
+  );
   const [issueContextEditorOpen, setIssueContextEditorOpen] = useState(false);
   const [model, setModel] = useState<string | null>(null);
   const [issueMentionContexts, setIssueMentionContexts] = useState<Record<string, string>>({});
@@ -98,7 +101,6 @@ export function useInitialConversationState(
       setPrompt('');
     }
     setIssueContext(null);
-    setAutoApproveOverride(null);
     setIssueContextEditorOpen(false);
     setModel(null);
     setIssueMentionContexts({});
@@ -109,7 +111,7 @@ export function useInitialConversationState(
 
   const capabilities = agents?.find((agent) => agent.id === providerId)?.capabilities;
   const autoApproveSupported = agentSupportsAutoApprove(capabilities);
-  const autoApprove = autoApproveSupported && (autoApproveOverride ?? autoApproveByDefault);
+  const autoApprove = autoApproveSupported && autoApprovePreference;
   const acpSupported = agentSupportsAcp(capabilities);
   const useChatUi = acpSupported && useChatUiPreference;
 
@@ -122,7 +124,7 @@ export function useInitialConversationState(
     issueContext,
     setIssueContext,
     autoApprove,
-    setAutoApprove: setAutoApproveOverride,
+    setAutoApprove: setAutoApprovePreference,
     issueContextEditorOpen,
     setIssueContextEditorOpen,
     model,

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.tsx
@@ -4,6 +4,7 @@ import type { CommandItem, MentionItem, PromptEditorRef } from '@emdash/ui/react
 import {
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -198,6 +199,8 @@ export function InitialConversationField({
   textareaClassName,
   showAutoApproveToggle = true,
 }: InitialConversationFieldProps) {
+  const autoApproveSwitchId = useId();
+  const chatUiSwitchId = useId();
   const editorApiRef = useRef<PromptEditorRef | null>(null);
   const syncingEditorTextRef = useRef(false);
   const { value: promptLibrary } = usePromptLibrary();
@@ -319,18 +322,23 @@ export function InitialConversationField({
         {showAutoApproveToggle && canToggleAutoApprove ? (
           <div className="flex items-center gap-2">
             <Switch
+              id={autoApproveSwitchId}
               checked={state.autoApprove}
               onCheckedChange={state.setAutoApprove}
               disabled={!state.provider}
             />
-            <FieldLabel>Auto-approve permissions</FieldLabel>
+            <FieldLabel htmlFor={autoApproveSwitchId}>Auto-approve permissions</FieldLabel>
           </div>
         ) : null}
 
         {canToggleChatUi ? (
           <div className="flex items-center gap-2">
-            <Switch checked={state.useChatUi} onCheckedChange={state.setUseChatUi} />
-            <FieldLabel>Use chat UI</FieldLabel>
+            <Switch
+              id={chatUiSwitchId}
+              checked={state.useChatUi}
+              onCheckedChange={state.setUseChatUi}
+            />
+            <FieldLabel htmlFor={chatUiSwitchId}>Use chat UI</FieldLabel>
           </div>
         ) : null}
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.tsx
@@ -17,7 +17,7 @@ import { getProjectSshConnectionId } from '@renderer/features/projects/stores/pr
 import { AgentSelector } from '@renderer/lib/components/agent-selector/agent-selector';
 import { useLocalStorage } from '@renderer/lib/hooks/useLocalStorage';
 import { useAgents } from '@renderer/lib/stores/use-agents';
-import { Field } from '@renderer/lib/ui/field';
+import { Field, FieldLabel } from '@renderer/lib/ui/field';
 import { Switch } from '@renderer/lib/ui/switch';
 import { cn } from '@renderer/utils/utils';
 import {
@@ -285,17 +285,6 @@ export function InitialConversationField({
     [promptLibrary]
   );
 
-  const permissionModeOptions =
-    showAutoApproveToggle && canToggleAutoApprove && !state.useChatUi
-      ? {
-          ask: { name: 'Ask' },
-          bypass: {
-            name: 'Bypass Permissions',
-            description: 'Let the agent approve supported actions automatically.',
-          },
-        }
-      : null;
-
   const handleComposerInputChange = useCallback(
     (text: string) => {
       state.setPrompt(text);
@@ -327,16 +316,21 @@ export function InitialConversationField({
           />
         </div>
 
-        {canToggleChatUi ? (
-          <div className="flex items-center justify-between gap-3 rounded-lg border border-border-1 bg-background-1 px-3 py-2">
-            <div className="min-w-0">
-              <div className="text-xs text-foreground">Use Chat UI (Beta)</div>
-            </div>
+        {showAutoApproveToggle && canToggleAutoApprove ? (
+          <div className="flex items-center gap-2">
             <Switch
-              checked={state.useChatUi}
-              onCheckedChange={state.setUseChatUi}
+              checked={state.autoApprove}
+              onCheckedChange={state.setAutoApprove}
               disabled={!state.provider}
             />
+            <FieldLabel>Auto-approve permissions</FieldLabel>
+          </div>
+        ) : null}
+
+        {canToggleChatUi ? (
+          <div className="flex items-center gap-2">
+            <Switch checked={state.useChatUi} onCheckedChange={state.setUseChatUi} />
+            <FieldLabel>Use chat UI</FieldLabel>
           </div>
         ) : null}
 
@@ -354,11 +348,6 @@ export function InitialConversationField({
           modelOptions={modelOptions}
           selectedModel={state.model ?? undefined}
           onModelChange={(modelId) => state.setModel(modelId || null)}
-          permissionModeOptions={permissionModeOptions}
-          selectedPermissionMode={
-            permissionModeOptions ? (state.autoApprove ? 'bypass' : 'ask') : undefined
-          }
-          onPermissionModeChange={(modeId) => state.setAutoApprove(modeId === 'bypass')}
           className={textareaClassName}
         />
       </div>


### PR DESCRIPTION
Uses matching switches for auto-approve permissions and chat UI in the new task modal.

### Screenshot
before:
<img width="215" height="73" alt="image" src="https://github.com/user-attachments/assets/cc977d34-82f5-4016-88a2-12f7988b2f2f" />

after:
<img width="204" height="64" alt="Screenshot 2026-07-20 at 22 09 43" src="https://github.com/user-attachments/assets/2d9db9b3-e55c-4642-9853-187f2ce1e573" />
