### PR TITLE
fix(tasks): restore focus to the last used region on task re-entry

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/browser/browser-pane.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-pane.test.ts
@@ -13,6 +13,7 @@ const browserRpc = vi.hoisted(() => ({
 
 vi.mock('@renderer/features/tasks/task-view-context', () => ({
   usePreviewServers: () => ({ urls: [] }),
+  useWorkspaceViewModel: () => ({ focusedRegion: 'main' }),
 }));
 
 vi.mock('@renderer/features/tabs/pane-context', () => ({

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-pane.tsx
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-pane.tsx
@@ -1,7 +1,10 @@
 import { observer } from 'mobx-react-lite';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { usePaneContext } from '@renderer/features/tabs/pane-context';
-import { usePreviewServers } from '@renderer/features/tasks/task-view-context';
+import {
+  usePreviewServers,
+  useWorkspaceViewModel,
+} from '@renderer/features/tasks/task-view-context';
 import { events, rpc } from '@renderer/lib/ipc';
 import { Button } from '@renderer/lib/ui/button';
 import { normalizeBrowserUrl, normalizeBrowserZoomFactor } from '@shared/browser';
@@ -36,6 +39,7 @@ export const BrowserPane = observer(function BrowserPane({
   const session = browserSessionStore.getSession(browserId);
   const { pane } = usePaneContext();
   const previewServers = usePreviewServers();
+  const taskView = useWorkspaceViewModel();
   const webviewRef = useRef<BrowserWebviewElement | null>(null);
   const focusUrlRef = useRef<() => void>(() => {});
   const [adapter, setAdapter] = useState<BrowserWebviewAdapter | null>(null);
@@ -242,6 +246,16 @@ export const BrowserPane = observer(function BrowserPane({
     });
   }, [adapter, sessionBrowserId]);
 
+  // Clicking into the guest page focuses the <webview> element itself, but the
+  // event doesn't reliably reach the region-tracking onFocus on the ancestor
+  // panel; claim the region directly so typing in the page counts as 'main'.
+  useEffect(() => {
+    if (!webviewElement) return;
+    const claimRegion = () => taskView.setFocusedRegion('main');
+    webviewElement.addEventListener('focus', claimRegion);
+    return () => webviewElement.removeEventListener('focus', claimRegion);
+  }, [webviewElement, taskView]);
+
   if (!session) {
     return (
       <div className="flex h-full min-h-0 items-center justify-center bg-background text-sm text-foreground-muted">
@@ -255,7 +269,9 @@ export const BrowserPane = observer(function BrowserPane({
       <BrowserToolbar
         session={session}
         adapter={adapter}
-        autoFocusUrl={showStartPage}
+        // Gated on the region so a restored start page doesn't steal focus
+        // from the terminal drawer.
+        autoFocusUrl={showStartPage && taskView.focusedRegion === 'main'}
         onNavigate={navigateTo}
         onGoBack={goBack}
         onGoForward={goForward}

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-toolbar.tsx
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-toolbar.tsx
@@ -15,6 +15,7 @@ import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
 import { rpc } from '@renderer/lib/ipc';
 import { useNavigate } from '@renderer/lib/layout/navigation-provider';
+import { shouldSkipAutofocus } from '@renderer/lib/region-focus';
 import { Button } from '@renderer/lib/ui/button';
 import {
   DropdownMenu,
@@ -114,6 +115,7 @@ export function BrowserToolbar({
   useEffect(() => {
     if (!autoFocusUrl) return;
     const timer = window.setTimeout(() => {
+      if (shouldSkipAutofocus(null)) return;
       urlInputRef.current?.focus();
       urlInputRef.current?.select();
     }, 0);

--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-panel.tsx
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-panel.tsx
@@ -34,6 +34,8 @@ import {
   getRegisteredTaskData,
   getTaskStore,
 } from '@renderer/features/tasks/stores/task-selectors';
+// TODO(conversations-extraction): Pass task focus state into ACP chat instead of importing task hooks.
+import { useWorkspaceViewModel } from '@renderer/features/tasks/task-view-context';
 import {
   issueMentionToken,
   parseIssueMentionToken,
@@ -45,6 +47,7 @@ import { toast } from '@renderer/lib/hooks/use-toast';
 import { rpc } from '@renderer/lib/ipc';
 import { showModal } from '@renderer/lib/modal/modal-provider';
 import { isHeicLikeFile, isUnstableDropPath } from '@renderer/lib/pty/terminal-image-paths';
+import { shouldSkipAutofocus } from '@renderer/lib/region-focus';
 import { useAgents } from '@renderer/lib/stores/use-agents';
 import { Button } from '@renderer/lib/ui/button';
 import { log } from '@renderer/utils/logger';
@@ -234,11 +237,24 @@ const ComposerForStore = observer(function ComposerForStore({
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
   const { value: promptLibrary } = usePromptLibrary();
+  const taskView = useWorkspaceViewModel();
 
-  // Autofocus when the slot becomes available.
+  // Autofocus the composer when the slot becomes available, only while the main
+  // region owns focus. One focus() call is not enough: Tiptap's focus() no-ops
+  // until EditorContent mounts the view DOM, and the chat view re-parents the
+  // slot during placement, blurring a just-focused editor — hence the retry.
   useEffect(() => {
-    editorApiRef.current?.focus();
-  }, []);
+    if (taskView.focusedRegion !== 'main') return;
+    let attempts = 0;
+    let timer = setTimeout(function tryFocus() {
+      if (taskView.focusedRegion !== 'main') return;
+      if (shouldSkipAutofocus(composerSlot)) return;
+      editorApiRef.current?.focus();
+      if (composerSlot.contains(document.activeElement)) return;
+      if (++attempts < 10) timer = setTimeout(tryFocus, 50);
+    }, 0);
+    return () => clearTimeout(timer);
+  }, [taskView, composerSlot]);
 
   useEffect(() => {
     const editor = editorApiRef.current;

--- a/apps/emdash-desktop/src/renderer/features/conversations/conversations-panel.tsx
+++ b/apps/emdash-desktop/src/renderer/features/conversations/conversations-panel.tsx
@@ -17,6 +17,7 @@ import { PaneSizingContextProvider } from '@renderer/lib/pty/pane-sizing-context
 import { PtyPane } from '@renderer/lib/pty/pty-pane';
 import { TerminalSearchOverlay } from '@renderer/lib/pty/terminal-search-overlay';
 import { useTerminalSearch } from '@renderer/lib/pty/use-terminal-search';
+import { shouldSkipAutofocus } from '@renderer/lib/region-focus';
 import type { ConversationTabResource } from './conversation-tab-resource';
 import {
   activeConversationResource,
@@ -74,6 +75,7 @@ export const ConversationsPanel = observer(function ConversationsPanel() {
 
   useEffect(() => {
     if (!autoFocus) return;
+    if (shouldSkipAutofocus(containerRef.current)) return;
     if (terminalRef.current) {
       terminalRef.current.focus();
       focusPendingRef.current = false;
@@ -131,14 +133,6 @@ export const ConversationsPanel = observer(function ConversationsPanel() {
           ref={containerRef}
           tabIndex={-1}
           className="flex h-full min-w-0 flex-1 flex-col outline-none"
-          onFocus={() => {
-            if (isActive) taskView.setFocusedRegion('main');
-          }}
-          onBlur={(e) => {
-            if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-              // focus left the panel — no region change needed
-            }
-          }}
         >
           <PaneSizingContextProvider sessionIds={allSessionIds} bottomPadding={contextBarHeight}>
             <div className="flex min-h-0 flex-1 flex-col">

--- a/apps/emdash-desktop/src/renderer/features/conversations/sidebar-conversations-list.tsx
+++ b/apps/emdash-desktop/src/renderer/features/conversations/sidebar-conversations-list.tsx
@@ -56,7 +56,15 @@ const ConversationRow = observer(function ConversationRow({
   const conversation = conversations.conversations.get(conversationId);
 
   const tabKind = conversationTabKind(conversation?.data.type);
-  const { isActive, open: openConversation } = useTabSelection(tabKind, conversationId);
+  const { isActive, open: openTab } = useTabSelection(tabKind, conversationId);
+  const taskView = useWorkspaceViewModel();
+
+  // Committed opens claim the region so the composer's region-gated autofocus
+  // fires; previews (single click / arrow-key browsing) must not move focus.
+  const openConversation = (args: { conversationId: string }, config: { preview: boolean }) => {
+    openTab(args, config);
+    if (!config.preview) taskView.setFocusedRegion('main');
+  };
 
   if (!conversation) return null;
   const displayTitle = formatConversationTitleForDisplay(
@@ -229,6 +237,7 @@ export const SidebarConversationsList = observer(function SidebarConversationsLi
         } else {
           paneLayout.open('conversation', { conversationId }, { preview: false });
         }
+        taskView.setFocusedRegion('main');
       },
     });
   };

--- a/apps/emdash-desktop/src/renderer/features/tasks/commands.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/commands.test.ts
@@ -149,6 +149,7 @@ describe('createTaskCommandProvider', () => {
       isSidebarCollapsed: false,
       isTerminalDrawerOpen: false,
       openNewTerminal: vi.fn(),
+      openTerminalDrawer: vi.fn(),
       setFocusedRegion: vi.fn(),
       setSidebarCollapsed: vi.fn(),
       setSidebarTab: vi.fn(),

--- a/apps/emdash-desktop/src/renderer/features/tasks/commands.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/commands.ts
@@ -174,7 +174,7 @@ export function createTaskCommandProvider(projectId: string, taskId: string): Co
           description: viewTerminalsDef.description,
           group: viewTerminalsDef.group,
           execute() {
-            taskView?.setTerminalDrawerOpen(true);
+            taskView?.openTerminalDrawer();
           },
         },
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/editor/editor-provider.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/editor/editor-provider.tsx
@@ -15,6 +15,7 @@ import {
 } from '@renderer/lib/monaco/monaco-config';
 import { modelRegistry } from '@renderer/lib/monaco/monaco-model-registry';
 import { buildMonacoModelPath } from '@renderer/lib/monaco/monacoModelPath';
+import { shouldSkipAutofocus } from '@renderer/lib/region-focus';
 import { useIsActiveTask } from '../hooks/use-is-active-task';
 import { useTaskViewContext } from '../task-view-context';
 import {
@@ -106,7 +107,8 @@ export const EditorProvider = observer(function EditorProvider({
     });
 
     const focusDisposable = editor.onDidFocusEditorWidget(() => {
-      taskView.setFocusedRegion('main');
+      // Region tracking is owned by the main-content panel in TaskMainColumn;
+      // Monaco's focusin bubbles to it, so only the pane group needs updating.
       paneLayout.setActiveGroup(paneId);
     });
 
@@ -239,6 +241,7 @@ export const EditorProvider = observer(function EditorProvider({
     if (!isActive || focusedRegion !== 'main') return;
     // Only the focused pane should attempt to focus.
     if (paneLayout.activePaneId !== paneId) return;
+    if (shouldSkipAutofocus(containerRef.current)) return;
     const editor = editorRef.current;
     if (editor?.getModel()) {
       editor.focus();

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.test.ts
@@ -384,6 +384,71 @@ describe('WorkspaceViewModel terminal drawer snapshot', () => {
   });
 });
 
+describe('WorkspaceViewModel focused region', () => {
+  it('moves focusedRegion only on real drawer open/close transitions', () => {
+    const viewModel = makeViewModel();
+
+    viewModel.setTerminalDrawerOpen(true);
+    expect(viewModel.focusedRegion).toBe('bottom');
+
+    viewModel.setTerminalDrawerOpen(false);
+    expect(viewModel.focusedRegion).toBe('main');
+
+    viewModel.setTerminalDrawerOpen(true);
+    expect(viewModel.focusedRegion).toBe('bottom');
+
+    // Programmatic drawer expand echoes the current state back through
+    // TaskMainColumn's onResize; it must not clobber the remembered region.
+    viewModel.setFocusedRegion('main');
+    viewModel.setTerminalDrawerOpen(true);
+    expect(viewModel.focusedRegion).toBe('main');
+
+    viewModel.dispose();
+  });
+
+  it('openTerminalDrawer focuses the drawer even when it is already open', () => {
+    const viewModel = makeViewModel();
+
+    viewModel.openTerminalDrawer();
+    expect(viewModel.isTerminalDrawerOpen).toBe(true);
+    expect(viewModel.focusedRegion).toBe('bottom');
+
+    viewModel.setFocusedRegion('main');
+    viewModel.openTerminalDrawer();
+    expect(viewModel.focusedRegion).toBe('bottom');
+
+    viewModel.dispose();
+  });
+
+  it('round-trips focusedRegion "bottom" through the snapshot while the drawer is open', () => {
+    const source = makeViewModel();
+    source.setTerminalDrawerOpen(true);
+    expect(source.focusedRegion).toBe('bottom');
+
+    const restored = makeViewModel();
+    restored.restoreSnapshot(source.snapshot);
+
+    expect(restored.isTerminalDrawerOpen).toBe(true);
+    expect(restored.focusedRegion).toBe('bottom');
+
+    source.dispose();
+    restored.dispose();
+  });
+
+  it('normalizes a restored "bottom" region to "main" when the drawer is closed', () => {
+    const viewModel = makeViewModel();
+    viewModel.restoreSnapshot({
+      focusedRegion: 'bottom',
+      isTerminalDrawerOpen: false,
+    });
+
+    expect(viewModel.isTerminalDrawerOpen).toBe(false);
+    expect(viewModel.focusedRegion).toBe('main');
+
+    viewModel.dispose();
+  });
+});
+
 describe('WorkspaceViewModel default conversation tab', () => {
   it('opens the initial conversation for a new task without restored tab state', async () => {
     const conversations = conversationRegistry.acquire('task-1', 'project-1', []);

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.tsx
@@ -188,8 +188,11 @@ export class WorkspaceViewModel implements ILifecycle {
   restoreSnapshot(savedSnapshot: TaskViewSnapshot): void {
     this.sidebarTab = (savedSnapshot.sidebarTab as SidebarTab) ?? 'conversations';
     this.isSidebarCollapsed = savedSnapshot.isSidebarCollapsed ?? true;
-    this.focusedRegion = savedSnapshot.focusedRegion === 'bottom' ? 'bottom' : 'main';
     this.isTerminalDrawerOpen = savedSnapshot.isTerminalDrawerOpen ?? false;
+    // 'bottom' is only meaningful while the drawer is open; a stale snapshot
+    // with {drawer closed, region 'bottom'} would gate off every autofocus.
+    this.focusedRegion =
+      savedSnapshot.focusedRegion === 'bottom' && this.isTerminalDrawerOpen ? 'bottom' : 'main';
     this.terminalDrawerActiveItem = savedSnapshot.terminalDrawerActiveItem;
 
     // Pass the aggregate blob as fallback so the persistor can migrate legacy
@@ -391,15 +394,28 @@ export class WorkspaceViewModel implements ILifecycle {
   }
 
   setFocusedRegion(region: 'main' | 'bottom'): void {
-    if (this.focusedRegion !== region) {
-      focusTracker.transition({ focusedRegion: region }, 'region_switch');
-    }
+    if (this.focusedRegion === region) return;
+    focusTracker.transition({ focusedRegion: region }, 'region_switch');
     this.focusedRegion = region;
   }
 
   setTerminalDrawerOpen(open: boolean): void {
+    // TaskMainColumn's drawer onResize echoes programmatic expand/collapse back
+    // here; only real transitions may move focusedRegion, or the echo clobbers
+    // the remembered region on every task switch.
+    if (this.isTerminalDrawerOpen === open) return;
     this.isTerminalDrawerOpen = open;
     this.setFocusedRegion(open ? 'bottom' : 'main');
+  }
+
+  /**
+   * Opens the terminal drawer and claims the bottom region so the drawer
+   * terminal autofocuses. A no-op when the drawer is already open with the
+   * region already 'bottom'.
+   */
+  openTerminalDrawer(): void {
+    this.isTerminalDrawerOpen = true;
+    this.setFocusedRegion('bottom');
   }
 
   setTerminalDrawerActiveItem(item: TerminalDrawerActiveItem): void {
@@ -408,8 +424,7 @@ export class WorkspaceViewModel implements ILifecycle {
 
   /** Opens the terminal drawer and always creates a new terminal session. */
   async openNewTerminal(shell?: TerminalShellId): Promise<string | undefined> {
-    this.isTerminalDrawerOpen = true;
-    this.setFocusedRegion('bottom');
+    this.openTerminalDrawer();
 
     const terminalId = await this._createDefaultTerminal(shell);
     if (!terminalId) return undefined;

--- a/apps/emdash-desktop/src/renderer/features/tasks/terminals/terminal-panel.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/terminals/terminal-panel.tsx
@@ -149,8 +149,15 @@ export const TerminalsPanel = observer(function TerminalsPanel() {
       orientation="horizontal"
       id="terminal-drawer-inner"
       className="h-full"
-      onFocus={() => {
+      onFocus={(e) => {
+        // Skip popups portaled to document.body (e.g. the shell picker menu);
+        // their React onFocus bubbles here but shouldn't move the region.
+        if (!e.currentTarget.contains(e.target as Node)) return;
         setIsPanelFocused(true);
+        // Focus can land here while the drawer is collapsed (e.g. the resize
+        // handle restores focus after a drag-collapse); 'bottom' is only a
+        // meaningful region while the drawer is open.
+        if (!taskView.isTerminalDrawerOpen) return;
         taskView.setFocusedRegion('bottom');
       }}
       onBlur={(e) => {

--- a/apps/emdash-desktop/src/renderer/features/tasks/terminals/terminal-pty-content.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/terminals/terminal-pty-content.tsx
@@ -9,6 +9,7 @@ import { PtyPane } from '@renderer/lib/pty/pty-pane';
 import { type PtySession } from '@renderer/lib/pty/pty-session';
 import { TerminalSearchOverlay } from '@renderer/lib/pty/terminal-search-overlay';
 import { useTerminalSearch } from '@renderer/lib/pty/use-terminal-search';
+import { shouldSkipAutofocus } from '@renderer/lib/region-focus';
 import { cssVar } from '@renderer/utils/cssVars';
 import { cn } from '@renderer/utils/utils';
 
@@ -64,6 +65,7 @@ export const TerminalPtyContent = observer(function TerminalPtyContent({
   // Fire when autoFocus becomes true or the active session changes.
   useEffect(() => {
     if (!autoFocus) return;
+    if (shouldSkipAutofocus(containerRef.current)) return;
     if (terminalRef.current) {
       terminalRef.current.focus();
       focusPendingRef.current = false;

--- a/apps/emdash-desktop/src/renderer/features/tasks/terminals/terminal-tab-provider.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/terminals/terminal-tab-provider.tsx
@@ -17,6 +17,7 @@ import {
   GenericTabDragPreview,
   GenericTabItem,
 } from '@renderer/features/tabs/tab-bar/generic-tab-item';
+import { useWorkspaceViewModel } from '@renderer/features/tasks/task-view-context';
 import type { PtySession } from '@renderer/lib/pty/pty-session';
 import { EmptyState } from '@renderer/lib/ui/empty-state';
 import { terminalRegistry } from '../stores/terminal-registry';
@@ -128,6 +129,7 @@ const TerminalTabBarItemDragPreview = observer(function TerminalTabBarItemDragPr
 
 const TerminalTabContent = observer(function TerminalTabContent({ host, ctx }: TabContentProps) {
   const taskCtx = ctx as TaskTabContext;
+  const taskView = useWorkspaceViewModel();
   const terminalManager = terminalRegistry.get(taskCtx.taskId);
   const terminalTabs = host.resolvedTabs.filter(
     (tab): tab is ResolvedTab<TerminalTabResourceView> => tab.kind === 'terminal'
@@ -145,7 +147,13 @@ const TerminalTabContent = observer(function TerminalTabContent({ host, ctx }: T
       className="h-full"
       activeSession={activeSession}
       allSessionIds={allSessionIds}
-      autoFocus={activeTerminal !== null && host.resolvedActiveTabId === activeTab?.tabId}
+      // Gated on the region so a restored main-pane terminal doesn't race the
+      // drawer terminal for focus when the user left off in the drawer.
+      autoFocus={
+        activeTerminal !== null &&
+        host.resolvedActiveTabId === activeTab?.tabId &&
+        taskView.focusedRegion === 'main'
+      }
       emptyState={
         <EmptyState
           icon={<Terminal className="text-muted-foreground h-5 w-5" />}

--- a/apps/emdash-desktop/src/renderer/features/tasks/view/task-main-column.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/view/task-main-column.tsx
@@ -15,6 +15,7 @@ import { PaneContent } from '@renderer/features/tabs/pane-content';
 import { PaneProvider } from '@renderer/features/tabs/pane-context';
 import type { Pane as PaneGroup } from '@renderer/features/tabs/pane-layout-store';
 import { TabDragPreview } from '@renderer/features/tabs/tab-bar/tab-drag-preview';
+import { TASK_FOCUS_REGION_ATTR } from '@renderer/lib/region-focus';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@renderer/lib/ui/resizable';
 import { PaneEmptyState } from '../pane-empty-state';
 import { TabBarActions } from '../tab-bar-actions';
@@ -64,6 +65,9 @@ export const TaskMainColumn = observer(function TaskMainColumn() {
         { terminalId: terminalDragData.terminalId },
         { target: { paneId } }
       );
+      // The drag started in the drawer (region 'bottom'); the dropped terminal's
+      // autofocus is gated on region 'main', so move the region explicitly.
+      taskView.setFocusedRegion('main');
       return;
     }
 
@@ -79,12 +83,23 @@ export const TaskMainColumn = observer(function TaskMainColumn() {
       onDragCancel={() => setActiveDrag(null)}
     >
       <ResizablePanelGroup orientation="vertical" id="task-main-vertical">
-        <ResizablePanel id="task-main-content" minSize="30%">
+        <ResizablePanel
+          id="task-main-content"
+          minSize="30%"
+          {...{ [TASK_FOCUS_REGION_ATTR]: 'main' }}
+          // Region-level focus tracking for every main-pane tab kind. contains()
+          // skips popups portaled to document.body (menus, popovers), whose React
+          // onFocus still bubbles here but shouldn't move the region.
+          onFocus={(e) => {
+            if (e.currentTarget.contains(e.target as Node)) taskView.setFocusedRegion('main');
+          }}
+        >
           <SplitPaneLayout />
         </ResizablePanel>
         <ResizableHandle className={taskView.isTerminalDrawerOpen ? 'flex' : 'hidden'} />
         <ResizablePanel
           id="task-terminal-drawer"
+          {...{ [TASK_FOCUS_REGION_ATTR]: 'bottom' }}
           panelRef={bottomPanelRef}
           collapsible
           collapsedSize="0%"

--- a/apps/emdash-desktop/src/renderer/lib/region-focus.test.ts
+++ b/apps/emdash-desktop/src/renderer/lib/region-focus.test.ts
@@ -1,0 +1,88 @@
+import { JSDOM } from 'jsdom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { shouldSkipAutofocus, TASK_FOCUS_REGION_ATTR } from './region-focus';
+
+describe('shouldSkipAutofocus', () => {
+  let dom: JSDOM;
+
+  const build = () => {
+    const doc = dom.window.document;
+    doc.body.innerHTML = `
+      <div id="main" ${TASK_FOCUS_REGION_ATTR}="main">
+        <div id="pane-a"><textarea id="main-terminal"></textarea></div>
+        <div id="pane-b"><div id="composer" contenteditable="true" tabindex="0"></div></div>
+        <button id="tab-button"></button>
+      </div>
+      <div id="bottom" ${TASK_FOCUS_REGION_ATTR}="bottom">
+        <textarea id="drawer-terminal"></textarea>
+        <input id="rename-input" />
+        <div id="drawer-row" role="button" tabindex="0"></div>
+      </div>
+      <div id="app-sidebar"><div id="task-row" role="button" tabindex="0"></div></div>
+    `;
+    return doc;
+  };
+
+  beforeEach(() => {
+    dom = new JSDOM('<body></body>');
+    vi.stubGlobal('document', dom.window.document);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    dom.window.close();
+  });
+
+  it('does not skip when nothing meaningful has focus', () => {
+    const doc = build();
+    expect(shouldSkipAutofocus(doc.getElementById('pane-a'))).toBe(false);
+    doc.body.focus();
+    expect(shouldSkipAutofocus(doc.getElementById('pane-a'))).toBe(false);
+  });
+
+  it('skips for a typing surface in the same region outside the caller', () => {
+    const doc = build();
+    doc.getElementById('composer')!.focus();
+    expect(shouldSkipAutofocus(doc.getElementById('pane-a'))).toBe(true);
+  });
+
+  it('does not skip when the typing surface is inside ownContainer', () => {
+    const doc = build();
+    doc.getElementById('main-terminal')!.focus();
+    expect(shouldSkipAutofocus(doc.getElementById('pane-a'))).toBe(false);
+  });
+
+  it('does not skip for a typing surface in the other region', () => {
+    const doc = build();
+    doc.getElementById('drawer-terminal')!.focus();
+    expect(shouldSkipAutofocus(doc.getElementById('pane-a'))).toBe(false);
+  });
+
+  it('skips for a typing surface in the drawer for drawer-region callers', () => {
+    const doc = build();
+    doc.getElementById('rename-input')!.focus();
+    expect(shouldSkipAutofocus(doc.getElementById('drawer-terminal'))).toBe(true);
+  });
+
+  it('does not skip for non-typing controls', () => {
+    const doc = build();
+    doc.getElementById('tab-button')!.focus();
+    expect(shouldSkipAutofocus(doc.getElementById('pane-a'))).toBe(false);
+    doc.getElementById('drawer-row')!.focus();
+    expect(shouldSkipAutofocus(doc.getElementById('drawer-terminal'))).toBe(false);
+  });
+
+  it('does not skip for focus outside any region (app sidebar, palette)', () => {
+    const doc = build();
+    doc.getElementById('task-row')!.focus();
+    expect(shouldSkipAutofocus(doc.getElementById('pane-a'))).toBe(false);
+  });
+
+  it('with ownContainer null, skips for any focused typing surface in a region', () => {
+    const doc = build();
+    doc.getElementById('composer')!.focus();
+    expect(shouldSkipAutofocus(null)).toBe(true);
+    doc.getElementById('task-row')!.focus();
+    expect(shouldSkipAutofocus(null)).toBe(false);
+  });
+});

--- a/apps/emdash-desktop/src/renderer/lib/region-focus.test.ts
+++ b/apps/emdash-desktop/src/renderer/lib/region-focus.test.ts
@@ -78,6 +78,15 @@ describe('shouldSkipAutofocus', () => {
     expect(shouldSkipAutofocus(doc.getElementById('pane-a'))).toBe(false);
   });
 
+  it('does not skip for a typing surface that is not visible', () => {
+    const doc = build();
+    const composer = doc.getElementById('composer')!;
+    composer.focus();
+    Object.defineProperty(composer, 'checkVisibility', { value: () => false });
+    expect(shouldSkipAutofocus(doc.getElementById('pane-a'))).toBe(false);
+    expect(shouldSkipAutofocus(null)).toBe(false);
+  });
+
   it('with ownContainer null, skips for any focused typing surface in a region', () => {
     const doc = build();
     doc.getElementById('composer')!.focus();

--- a/apps/emdash-desktop/src/renderer/lib/region-focus.ts
+++ b/apps/emdash-desktop/src/renderer/lib/region-focus.ts
@@ -30,6 +30,10 @@ const TYPING_SURFACE_SELECTOR = 'input, textarea, select, [contenteditable="true
 export function shouldSkipAutofocus(ownContainer: Element | null): boolean {
   const active = document.activeElement;
   if (!active || active === document.body) return false;
+  // A hidden element can linger as activeElement (e.g. a view hidden instead of
+  // unmounted); it is not a place the user can type, so it never blocks.
+  // Feature-detected because jsdom lacks checkVisibility.
+  if (typeof active.checkVisibility === 'function' && !active.checkVisibility()) return false;
   if (ownContainer?.contains(active)) return false;
   if (!active.matches(TYPING_SURFACE_SELECTOR)) return false;
   const activeRegion = active.closest(`[${TASK_FOCUS_REGION_ATTR}]`);

--- a/apps/emdash-desktop/src/renderer/lib/region-focus.ts
+++ b/apps/emdash-desktop/src/renderer/lib/region-focus.ts
@@ -1,0 +1,38 @@
+/**
+ * Marks the DOM container of a task focus region ('main' panes vs 'bottom'
+ * terminal drawer). Set on the region roots in task-main-column.tsx and read
+ * by {@link shouldSkipAutofocus}.
+ */
+export const TASK_FOCUS_REGION_ATTR = 'data-task-focus-region';
+
+const TYPING_SURFACE_SELECTOR = 'input, textarea, select, [contenteditable="true"]';
+
+/**
+ * True when an autofocus effect should skip focusing because the user is
+ * already in a typing surface (input, textarea, contenteditable — e.g. Monaco,
+ * xterm, the chat composer) in the same task region, outside `ownContainer`.
+ *
+ * `focusedRegion` is tracked passively — focusing anything inside a region
+ * claims it, which is what keeps the region restored on task re-entry
+ * accurate. The cost is that region-gated autofocus effects also re-fire when
+ * the user merely focuses another element, and answering that would steal
+ * focus from the element they just chose. This check tells the cases apart at
+ * fire time. Non-typing controls (tab buttons, sidebar rows) are deliberately
+ * not protected: clicking them is how users hand focus to a pane's content. A
+ * typing surface in the other region doesn't block either: cross-region
+ * transitions (task re-entry, closing the drawer) are exactly when focus must
+ * move between regions.
+ *
+ * Pass the caller's own container so focus already inside it never suppresses
+ * the autofocus; pass null when even refocusing self would be destructive
+ * (e.g. a URL input whose autofocus also select-alls).
+ */
+export function shouldSkipAutofocus(ownContainer: Element | null): boolean {
+  const active = document.activeElement;
+  if (!active || active === document.body) return false;
+  if (ownContainer?.contains(active)) return false;
+  if (!active.matches(TYPING_SURFACE_SELECTOR)) return false;
+  const activeRegion = active.closest(`[${TASK_FOCUS_REGION_ATTR}]`);
+  if (!activeRegion) return false;
+  return ownContainer ? activeRegion.contains(ownContainer) : true;
+}


### PR DESCRIPTION
### Description

Switching back to a task always focused the drawer terminal, even if you left off in the chat composer: both autofocus on task activation and the terminal wins.

Task views now remember which region owned focus (main panes vs terminal drawer) and restore it on re-entry. Autofocus effects gate on that region and skip when the user is already in a typing surface ([`shouldSkipAutofocus`](https://github.com/generalaction/emdash/blob/815d5ff020d8c8f1a1913fd457b85a9664b594c9/apps/emdash-desktop/src/renderer/lib/region-focus.ts#L10-L38), rationale in its doc comment).

### Related issues

Fixes #2930

### Testing

- 10 new tests covering the skip logic and snapshot restore
- Manual dev build: task switching, drawer open/close, dragging a terminal to a main pane, clicking into inputs

### Screenshot/Recording (if applicable)

https://github.com/user-attachments/assets/c5c3db36-9aab-4db0-abb5-27d5f8032ea0

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>