### PR TITLE
fix(conversations): keep create modal open after app blur

### DIFF
--- a/apps/emdash-desktop/src/renderer/app/modal-registry.ts
+++ b/apps/emdash-desktop/src/renderer/app/modal-registry.ts
@@ -51,7 +51,9 @@ export const modalRegistry = {
   confirmActionModal: createModal(ConfirmActionDialog, { size: 'xs' }),
   confirmExternalLinkModal: createModal(ExternalLinkChoiceDialog, { size: 'sm' }),
   unsavedChangesModal: createModal(UnsavedChangesDialog, { size: 'xs' }),
-  createConversationModal: createModal(CreateConversationModal),
+  createConversationModal: createModal(CreateConversationModal, {
+    ignoreOutsidePressAfterWindowBlur: true,
+  }),
   feedbackModal: createModal(FeedbackModal),
   promptModal: createModal(PromptModal, { size: 'lg' }),
   mcpServerModal: createModal(McpModal),


### PR DESCRIPTION
Keeps the Create Conversation modal open when returning to Emdash by applying the same window-blur guard used by New Task.

[Screen recording](https://cap.link/hq4mr8h6vep4gr8)