### PR TITLE
fix(chat): preserve drafts, scroll, and cursor across tabs

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-panel.tsx
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-panel.tsx
@@ -660,6 +660,7 @@ export const AcpChatPanel = observer(function AcpChatPanel() {
     retainedStoreRef.current
   );
   const store = retainedStoreRef.current;
+  const isShowingActiveChat = pane.isVisible && activeStore === store;
 
   const rootRef = useRef<HTMLDivElement | null>(null);
   const viewRef = useRef<ChatView | null>(null);
@@ -737,10 +738,10 @@ export const AcpChatPanel = observer(function AcpChatPanel() {
   }, [agent?.name, cliAuthMethod, providerId, store]);
 
   useEffect(() => {
-    if (conversationStore && !conversationStore.seen) {
+    if (isShowingActiveChat && conversationStore && !conversationStore.seen) {
       conversationStore.markSeen();
     }
-  }, [conversationStore, conversationSeen]);
+  }, [isShowingActiveChat, conversationStore, conversationSeen]);
 
   useEffect(() => {
     if (!store) return;

--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-panel.tsx
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-panel.tsx
@@ -674,16 +674,12 @@ export const AcpChatPanel = observer(function AcpChatPanel() {
   // button does not flash on mount before the first frame fires.
   const [atBottom, setAtBottom] = useState(true);
 
-  const handleReady = useCallback(
-    (view: ChatView) => {
-      viewRef.current = view;
-      store?.bindView(view);
-      setComposerSlot(view.composerSlot);
-      setHeroSlot(view.heroSlot);
-      setOverlaySlot(view.contentOverlay);
-    },
-    [store]
-  );
+  const handleReady = useCallback((view: ChatView) => {
+    viewRef.current = view;
+    setComposerSlot(view.composerSlot);
+    setHeroSlot(view.heroSlot);
+    setOverlaySlot(view.contentOverlay);
+  }, []);
 
   const isConversationEmpty = useObserver(() => store?.isEmpty ?? false);
   const activeConversationId = store?.conversationId ?? null;
@@ -709,7 +705,7 @@ export const AcpChatPanel = observer(function AcpChatPanel() {
     return () => {
       store.bindView(null);
     };
-  }, [store]);
+  }, [store, composerSlot]);
 
   // State-driven notification clearing: mark the active conversation as seen
   // immediately when the panel is showing it. This covers the split-pane case

--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-panel.tsx
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-panel.tsx
@@ -53,6 +53,7 @@ import type { AcpChatStore, AcpPromptAttachment } from './acp-chat-store';
 import type { AcpChatTabResource } from './acp-chat-tab-resource';
 import { chatViewCommandForShortcut, executeChatViewCommand } from './acp-chat-view-commands';
 import { buildIssueMentionHiddenContext } from './issue-mention-context';
+import { selectRetainedChatStore } from './select-retained-chat-store';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -584,6 +585,7 @@ const ComposerForStore = observer(function ComposerForStore({
       <ChatComposer
         isWorking={a.isWorking}
         canSubmit={a.canSubmit}
+        initialValue={store.draftText}
         onSubmit={handleSubmit}
         onInputChange={(text) => store.setDraftText(text)}
         onSubmitWhileWorking={handleSubmitWhileWorking}
@@ -646,9 +648,18 @@ const ComposerForStore = observer(function ComposerForStore({
 
 export const AcpChatPanel = observer(function AcpChatPanel() {
   const { pane } = usePaneContext();
-
+  const retainedStoreRef = useRef<AcpChatStore | null>(null);
   const activeTab = pane.resolvedTabs.find((t) => t.isActive && t.kind === 'acp-chat');
-  const store = activeTab ? (activeTab.resource as AcpChatTabResource).store : null;
+  const openStores = pane.resolvedTabs
+    .filter((tab) => tab.kind === 'acp-chat')
+    .map((tab) => (tab.resource as AcpChatTabResource).store);
+  const activeStore = activeTab ? (activeTab.resource as AcpChatTabResource).store : null;
+  retainedStoreRef.current = selectRetainedChatStore(
+    openStores,
+    activeStore,
+    retainedStoreRef.current
+  );
+  const store = retainedStoreRef.current;
 
   const rootRef = useRef<HTMLDivElement | null>(null);
   const viewRef = useRef<ChatView | null>(null);
@@ -663,12 +674,16 @@ export const AcpChatPanel = observer(function AcpChatPanel() {
   // button does not flash on mount before the first frame fires.
   const [atBottom, setAtBottom] = useState(true);
 
-  const handleReady = useCallback((view: ChatView) => {
-    viewRef.current = view;
-    setComposerSlot(view.composerSlot);
-    setHeroSlot(view.heroSlot);
-    setOverlaySlot(view.contentOverlay);
-  }, []);
+  const handleReady = useCallback(
+    (view: ChatView) => {
+      viewRef.current = view;
+      store?.bindView(view);
+      setComposerSlot(view.composerSlot);
+      setHeroSlot(view.heroSlot);
+      setOverlaySlot(view.contentOverlay);
+    },
+    [store]
+  );
 
   const isConversationEmpty = useObserver(() => store?.isEmpty ?? false);
   const activeConversationId = store?.conversationId ?? null;
@@ -689,7 +704,8 @@ export const AcpChatPanel = observer(function AcpChatPanel() {
   // scrollToItem on submit. Only the active store holds the handle.
   useEffect(() => {
     if (!store) return;
-    store.bindView(viewRef.current);
+    const view = viewRef.current;
+    store.bindView(view?.composerSlot?.isConnected ? view : null);
     return () => {
       store.bindView(null);
     };
@@ -806,6 +822,9 @@ export const AcpChatPanel = observer(function AcpChatPanel() {
 
   const showComposer = !store.historyLoading && store.loadError === null;
   const showHero = showComposer && store.isEmpty;
+  const connectedComposerSlot = composerSlot?.isConnected ? composerSlot : null;
+  const connectedHeroSlot = heroSlot?.isConnected ? heroSlot : null;
+  const connectedOverlaySlot = overlaySlot?.isConnected ? overlaySlot : null;
 
   return (
     <div ref={rootRef} className="relative h-full overflow-hidden bg-background-secondary-1">
@@ -827,7 +846,7 @@ export const AcpChatPanel = observer(function AcpChatPanel() {
           The slot sits at z-index 15 (above pinned, below composer at 20).
           Hide the composer in error state so the overlay owns the whole content area.
           Precedence: error > loading. */}
-      {overlaySlot &&
+      {connectedOverlaySlot &&
         (store.loadError !== null || store.historyLoading) &&
         createPortal(
           <div
@@ -876,29 +895,29 @@ export const AcpChatPanel = observer(function AcpChatPanel() {
               'Loading chat...'
             )}
           </div>,
-          overlaySlot
+          connectedOverlaySlot
         )}
 
       {showHero &&
-        heroSlot &&
+        connectedHeroSlot &&
         createPortal(
           <div className="px-4 text-center">
             <h1 className="text-2xl tracking-tight text-foreground">What are we building today?</h1>
           </div>,
-          heroSlot
+          connectedHeroSlot
         )}
 
-      {showComposer && composerSlot && (
+      {showComposer && connectedComposerSlot && (
         <ComposerForStore
           key={store.conversationId}
           store={store}
-          composerSlot={composerSlot}
+          composerSlot={connectedComposerSlot}
           onViewerOpen={handleViewerOpen}
         />
       )}
 
       {showComposer &&
-        composerSlot &&
+        connectedComposerSlot &&
         !atBottom &&
         createPortal(
           <div className="pointer-events-none absolute inset-x-0 bottom-full mb-2 flex justify-center">
@@ -912,7 +931,7 @@ export const AcpChatPanel = observer(function AcpChatPanel() {
               <ArrowDown />
             </Button>
           </div>,
-          composerSlot
+          connectedComposerSlot
         )}
 
       <ImageViewerDialog

--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/select-retained-chat-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/select-retained-chat-store.test.ts
@@ -17,4 +17,9 @@ describe('selectRetainedChatStore', () => {
     const closed = { id: 'closed' };
     expect(selectRetainedChatStore([], null, closed)).toBeNull();
   });
+
+  it('does not mount a chat that has never been active', () => {
+    const chat = { id: 'chat' };
+    expect(selectRetainedChatStore([chat], null, null)).toBeNull();
+  });
 });

--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/select-retained-chat-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/select-retained-chat-store.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { selectRetainedChatStore } from './select-retained-chat-store';
+
+describe('selectRetainedChatStore', () => {
+  it('keeps the active chat when another tab kind becomes active', () => {
+    const chat = { id: 'chat' };
+    expect(selectRetainedChatStore([chat], null, chat)).toBe(chat);
+  });
+
+  it('switches to a newly active chat', () => {
+    const first = { id: 'first' };
+    const second = { id: 'second' };
+    expect(selectRetainedChatStore([first, second], second, first)).toBe(second);
+  });
+
+  it('releases a retained chat after its tab closes', () => {
+    const closed = { id: 'closed' };
+    expect(selectRetainedChatStore([], null, closed)).toBeNull();
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/select-retained-chat-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/select-retained-chat-store.ts
@@ -5,5 +5,5 @@ export function selectRetainedChatStore<T>(
 ): T | null {
   if (activeStore) return activeStore;
   if (retainedStore && openStores.includes(retainedStore)) return retainedStore;
-  return openStores[0] ?? null;
+  return null;
 }

--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/select-retained-chat-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/select-retained-chat-store.ts
@@ -1,0 +1,9 @@
+export function selectRetainedChatStore<T>(
+  openStores: readonly T[],
+  activeStore: T | null,
+  retainedStore: T | null
+): T | null {
+  if (activeStore) return activeStore;
+  if (retainedStore && openStores.includes(retainedStore)) return retainedStore;
+  return openStores[0] ?? null;
+}

--- a/apps/emdash-desktop/src/renderer/features/tabs/content-focus.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tabs/content-focus.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+
+import { CONTENT_FOCUS_REQUEST_EVENT } from '@emdash/ui/react/components';
+import { describe, expect, it, vi } from 'vitest';
+import { focusActiveContentElement } from './content-focus';
+
+describe('focusActiveContentElement', () => {
+  it('lets an editor handle focus through its own selection-aware command', () => {
+    const container = document.createElement('div');
+    const editor = document.createElement('div');
+    editor.setAttribute('contenteditable', 'true');
+    const nativeFocus = vi.spyOn(editor, 'focus');
+    const handleFocusRequest = vi.fn((event: Event) => event.preventDefault());
+    editor.addEventListener(CONTENT_FOCUS_REQUEST_EVENT, handleFocusRequest);
+    container.appendChild(editor);
+
+    focusActiveContentElement(container);
+
+    expect(handleFocusRequest).toHaveBeenCalledOnce();
+    expect(nativeFocus).not.toHaveBeenCalled();
+  });
+
+  it('uses native focus for content without a custom focus handler', () => {
+    const container = document.createElement('div');
+    const textarea = document.createElement('textarea');
+    container.appendChild(textarea);
+    document.body.appendChild(container);
+
+    focusActiveContentElement(container);
+
+    expect(document.activeElement).toBe(textarea);
+    container.remove();
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/tabs/content-focus.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tabs/content-focus.test.ts
@@ -31,4 +31,21 @@ describe('focusActiveContentElement', () => {
     expect(document.activeElement).toBe(textarea);
     container.remove();
   });
+
+  it('skips a hidden editor that handles the request without taking focus', () => {
+    const container = document.createElement('div');
+    const hiddenEditor = document.createElement('div');
+    hiddenEditor.setAttribute('contenteditable', 'true');
+    hiddenEditor.addEventListener(CONTENT_FOCUS_REQUEST_EVENT, (event) => {
+      event.preventDefault();
+    });
+    const activeInput = document.createElement('textarea');
+    container.append(hiddenEditor, activeInput);
+    document.body.appendChild(container);
+
+    focusActiveContentElement(container);
+
+    expect(document.activeElement).toBe(activeInput);
+    container.remove();
+  });
 });

--- a/apps/emdash-desktop/src/renderer/features/tabs/content-focus.ts
+++ b/apps/emdash-desktop/src/renderer/features/tabs/content-focus.ts
@@ -1,0 +1,16 @@
+import { CONTENT_FOCUS_REQUEST_EVENT } from '@emdash/ui/react/components';
+
+const CONTENT_FOCUS_SELECTOR = 'textarea, webview, [contenteditable="true"]';
+
+export function focusActiveContentElement(container: HTMLElement): void {
+  for (const element of container.querySelectorAll<HTMLElement>(CONTENT_FOCUS_SELECTOR)) {
+    const focusRequest = new Event(CONTENT_FOCUS_REQUEST_EVENT, {
+      bubbles: true,
+      cancelable: true,
+    });
+    if (!element.dispatchEvent(focusRequest)) return;
+
+    element.focus();
+    if (document.activeElement === element) return;
+  }
+}

--- a/apps/emdash-desktop/src/renderer/features/tabs/content-focus.ts
+++ b/apps/emdash-desktop/src/renderer/features/tabs/content-focus.ts
@@ -8,7 +8,10 @@ export function focusActiveContentElement(container: HTMLElement): void {
       bubbles: true,
       cancelable: true,
     });
-    if (!element.dispatchEvent(focusRequest)) return;
+    if (!element.dispatchEvent(focusRequest)) {
+      if (element.contains(document.activeElement)) return;
+      continue;
+    }
 
     element.focus();
     if (document.activeElement === element) return;

--- a/apps/emdash-desktop/src/renderer/features/tabs/pane-content.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tabs/pane-content.tsx
@@ -3,16 +3,8 @@ import { observer } from 'mobx-react-lite';
 import { useCallback, useEffect, useRef, type ReactNode } from 'react';
 import { PaneDimensionProvider } from '@renderer/features/tabs/pane-dimension-provider';
 import { usePaneContext } from '../tabs/pane-context';
+import { focusActiveContentElement } from './content-focus';
 import { TabBar } from './tab-bar';
-
-const CONTENT_FOCUS_SELECTOR = 'textarea, webview, [contenteditable="true"]';
-
-function focusActiveContentElement(container: HTMLElement): void {
-  for (const el of container.querySelectorAll<HTMLElement>(CONTENT_FOCUS_SELECTOR)) {
-    el.focus();
-    if (document.activeElement === el) return;
-  }
-}
 
 /** The content for a single pane: tab bar + content area. */
 export const PaneContent = observer(function PaneContent({

--- a/apps/emdash-desktop/src/renderer/lib/chat/chat-transcript.test.ts
+++ b/apps/emdash-desktop/src/renderer/lib/chat/chat-transcript.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatTranscript } from './chat-transcript';
+
+const chatUi = vi.hoisted(() => {
+  let releaseImport: (() => void) | undefined;
+  const importGate = new Promise<void>((resolve) => {
+    releaseImport = resolve;
+  });
+
+  return {
+    createChatView: vi.fn(() => ({ dispose: vi.fn() })),
+    importGate,
+    releaseImport: () => releaseImport?.(),
+  };
+});
+
+vi.mock('@emdash/chat-ui', async () => {
+  await chatUi.importGate;
+  return { createChatView: chatUi.createChatView };
+});
+
+describe('ChatTranscript', () => {
+  beforeEach(() => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('creates an asynchronously loaded view with the latest props', async () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    const firstState = { id: 'first-state' };
+    const secondState = { id: 'second-state' };
+    const firstCommands = { onViewImage: vi.fn() };
+    const secondCommands = { onViewImage: vi.fn() };
+
+    const renderTranscript = (state: object, commands: object) =>
+      createElement(ChatTranscript, {
+        context: {} as never,
+        state: state as never,
+        commands,
+      });
+
+    await act(async () => {
+      root.render(renderTranscript(firstState, firstCommands));
+    });
+    await act(async () => {
+      root.render(renderTranscript(secondState, secondCommands));
+    });
+    await act(async () => {
+      chatUi.releaseImport();
+      await chatUi.importGate;
+    });
+
+    expect(chatUi.createChatView).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: secondState,
+        commands: secondCommands,
+      })
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
+    host.remove();
+  });
+});

--- a/apps/emdash-desktop/src/renderer/lib/chat/chat-transcript.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/chat/chat-transcript.tsx
@@ -74,12 +74,12 @@ export function ChatTranscript(props: ChatTranscriptProps): React.ReactElement {
 
   useEffect(() => {
     if (!ref.current) return;
-    const p = propsRef.current;
     let disposed = false;
     let createdView: ChatView | null = null;
 
     void import('@emdash/chat-ui').then(({ createChatView }) => {
       if (disposed || !ref.current) return;
+      const p = propsRef.current;
       const view = createChatView({
         context: p.context,
         state: p.state,

--- a/packages/chat-ui/src/ChatRoot.tsx
+++ b/packages/chat-ui/src/ChatRoot.tsx
@@ -1523,7 +1523,10 @@ export function ChatRoot(props: ChatRootProps) {
 
     const roHeight = new ResizeObserver((entries) => {
       const h = entries[0]?.contentRect.height;
-      if (h && h > 0) setViewHeight(h);
+      if (!h || h <= 0 || h === untrack(viewHeight)) return;
+      setViewHeight(h);
+      needsProject = true;
+      scheduler.request();
     });
     roHeight.observe(el);
     onCleanup(() => roHeight.disconnect());
@@ -1545,7 +1548,11 @@ export function ChatRoot(props: ChatRootProps) {
     if (props.composer === 'slot' && composerSlotEl) {
       const roSlot = new ResizeObserver((entries) => {
         const h = entries[0]?.contentRect.height ?? 0;
-        setSlotPadBottom(effectiveComposerPlacement() === 'center' ? 0 : h);
+        const next = effectiveComposerPlacement() === 'center' ? 0 : h;
+        if (next === untrack(slotPadBottom)) return;
+        setSlotPadBottom(next);
+        needsProject = true;
+        scheduler.request();
       });
       roSlot.observe(composerSlotEl);
       onCleanup(() => roSlot.disconnect());

--- a/packages/chat-ui/src/chat-view.contract.test.tsx
+++ b/packages/chat-ui/src/chat-view.contract.test.tsx
@@ -81,6 +81,44 @@ describe('createChatView', () => {
     document.body.removeChild(host);
   });
 
+  it('stays pinned to the bottom when the viewport and composer resize after mount', async () => {
+    const ctx = createChatContext({ theme: DEFAULT_THEME });
+    const state = createChatState(ctx);
+    state.transcript.history.seed(generateMockTranscript(80, 12));
+
+    const host = document.createElement('div');
+    host.style.cssText = 'position:fixed;top:0;left:0;width:800px;height:420px;';
+    document.body.appendChild(host);
+
+    const view = createChatView({
+      context: ctx,
+      state,
+      parent: host,
+      composer: 'slot',
+      stickToBottom: true,
+    });
+    await nextPaint();
+
+    const scrollEl = host.querySelector('[data-chat-scroll]') as HTMLElement | null;
+    expect(scrollEl).not.toBeNull();
+    expect(view.composerSlot).not.toBeNull();
+
+    view.scrollToBottom();
+    await nextPaint();
+
+    host.style.height = '280px';
+    view.composerSlot!.style.height = '140px';
+    await nextPaint();
+    await nextPaint();
+
+    expect(scrollEl!.scrollHeight - scrollEl!.clientHeight - scrollEl!.scrollTop).toBeLessThan(2);
+
+    view.dispose();
+    ctx.dispose();
+    state.dispose();
+    document.body.removeChild(host);
+  });
+
   it('aligns pinned user messages with the measured transcript column', async () => {
     const ctx = createChatContext({ theme: DEFAULT_THEME });
     const state = createChatState(ctx);

--- a/packages/ui/src/react/components/chat-composer/index.tsx
+++ b/packages/ui/src/react/components/chat-composer/index.tsx
@@ -169,6 +169,8 @@ export interface ComposerAgentOption {
 export interface ChatComposerProps {
   disabled?: boolean;
   isWorking?: boolean;
+  /** Initial serialized editor text, applied when this composer instance mounts. */
+  initialValue?: string;
   /** False while the session is still starting up. Blocks Send/Enter but keeps the editor typeable. */
   canSubmit?: boolean;
   /** Hide the submit/stop control for draft-only composer surfaces. */
@@ -523,6 +525,7 @@ function ComposerAgentSelector({
 export function ChatComposer({
   disabled = false,
   isWorking = false,
+  initialValue = '',
   canSubmit = true,
   showSubmitButton = true,
   placeholder,
@@ -818,6 +821,7 @@ export function ChatComposer({
               }
             }}
             placeholder={resolvedPlaceholder}
+            initialValue={initialValue}
             disabled={disabled}
             onChange={onInputChange}
             onSubmit={shouldHandleSubmitAttempt ? handleSubmit : undefined}

--- a/packages/ui/src/react/components/index.ts
+++ b/packages/ui/src/react/components/index.ts
@@ -28,6 +28,7 @@ export type {
   ComposerPermissionRequest,
   ComposerPermissionOption,
 } from './chat-composer/permission-band';
+export { CONTENT_FOCUS_REQUEST_EVENT } from './prompt-editor/focus-request';
 export { ConfirmationDialog, type ConfirmationDialogProps } from './confirmation-dialog';
 export { ImageViewerDialog, type ImageViewerDialogProps } from './image-viewer';
 export { MermaidViewerDialog, type MermaidViewerDialogProps } from './mermaid-viewer';

--- a/packages/ui/src/react/components/prompt-editor/focus-request.ts
+++ b/packages/ui/src/react/components/prompt-editor/focus-request.ts
@@ -1,0 +1,1 @@
+export const CONTENT_FOCUS_REQUEST_EVENT = 'emdash:content-focus-request';

--- a/packages/ui/src/react/components/prompt-editor/prompt-editor.tsx
+++ b/packages/ui/src/react/components/prompt-editor/prompt-editor.tsx
@@ -29,6 +29,7 @@ import {
 import { buildMentionExtension } from './extensions/mention';
 import { buildSlashCommandExtension } from './extensions/slash-command';
 import { buildSubmitKeymap } from './extensions/submit-keymap';
+import { CONTENT_FOCUS_REQUEST_EVENT } from './focus-request';
 import { fileIconClass } from './mention-pill-helpers';
 import { serializeDoc, serializeNode } from './serialize';
 import type {
@@ -211,6 +212,26 @@ export const PromptEditor = forwardRef<PromptEditorRef, PromptEditorProps>(funct
 
   // We capture the editor in a stable ref so the submit handler can read the doc.
   const editorRef = useRef<ReturnType<typeof useEditor> | null>(null);
+  const editorContentRef = useRef<HTMLDivElement | null>(null);
+
+  const handleContentFocusRequest = useCallback((event: Event) => {
+    const currentEditor = editorRef.current;
+    if (!currentEditor) return;
+    event.preventDefault();
+    currentEditor.commands.focus(undefined, { scrollIntoView: false });
+  }, []);
+
+  const setEditorContentRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      editorContentRef.current?.removeEventListener(
+        CONTENT_FOCUS_REQUEST_EVENT,
+        handleContentFocusRequest
+      );
+      editorContentRef.current = element;
+      element?.addEventListener(CONTENT_FOCUS_REQUEST_EVENT, handleContentFocusRequest);
+    },
+    [handleContentFocusRequest]
+  );
 
   // Stable submit callback that reads the doc from the current editor.
   const handleSubmitFromKeymap = useCallback(() => {
@@ -386,7 +407,12 @@ export const PromptEditor = forwardRef<PromptEditorRef, PromptEditorProps>(funct
   return (
     <>
       <div className={cx(styles.editorWrapper, className)}>
-        <EditorContent editor={editor} className={styles.editorContent} aria-disabled={disabled} />
+        <EditorContent
+          ref={setEditorContentRef}
+          editor={editor}
+          className={styles.editorContent}
+          aria-disabled={disabled}
+        />
         {isEmpty && (
           <span aria-hidden className={styles.editorPlaceholder}>
             {placeholder}

--- a/packages/ui/src/react/components/prompt-editor/prompt-editor.tsx
+++ b/packages/ui/src/react/components/prompt-editor/prompt-editor.tsx
@@ -170,6 +170,7 @@ function mentionInsertContent(item: MentionItem) {
 export const PromptEditor = forwardRef<PromptEditorRef, PromptEditorProps>(function PromptEditor(
   {
     placeholder = 'Message…',
+    initialValue = '',
     disabled = false,
     onChange,
     onSubmit,
@@ -200,7 +201,7 @@ export const PromptEditor = forwardRef<PromptEditorRef, PromptEditorProps>(funct
   queryCommandsRef.current = queryCommands;
 
   // Separate suggestion state for @ and / so they don't conflict.
-  const [isEmpty, setIsEmpty] = useState(true);
+  const [isEmpty, setIsEmpty] = useState(() => initialValue.length === 0);
   const [mentionSuggestion, setMentionSuggestion] =
     useState<SuggestionState<MentionItem>>(emptySuggestion());
   const [commandSuggestion, setCommandSuggestion] =
@@ -271,6 +272,7 @@ export const PromptEditor = forwardRef<PromptEditorRef, PromptEditorProps>(funct
   const submitKeymap = buildSubmitKeymap(handleSubmitFromKeymap);
 
   const editor = useEditor({
+    content: plainTextDoc(initialValue),
     extensions: [
       StarterKit.configure({
         // Disable block-level nodes we don't need for a chat input.

--- a/packages/ui/src/react/components/prompt-editor/types.ts
+++ b/packages/ui/src/react/components/prompt-editor/types.ts
@@ -104,6 +104,8 @@ export interface PromptEditorRef {
 export interface PromptEditorProps {
   /** Controlled placeholder text when the editor is empty. */
   placeholder?: string;
+  /** Initial serialized plain text. Later changes should use the imperative editor API. */
+  initialValue?: string;
   /** Whether the editor is disabled (read-only, no input). */
   disabled?: boolean;
   /** Called with the serialized plain-text value on every change. */


### PR DESCRIPTION
### Description

Preserves in-progress ACP chat state when switching between the chat and other task tabs. The chat panel previously unmounted its transcript and composer while inactive, which recreated the editor against stale portal slots, lost live scroll geometry, and refocused the contenteditable without restoring TipTap's selection.

This keeps the active chat store and view mounted while its tab remains open, restores draft content during editor initialization, reprojects bottom anchoring after viewport or composer resizes, and routes pane focus through the prompt editor so the cursor returns to its previous position.

### Screenshot/Recording

[Screen recording](https://cap.so/s/8jyxqmdvmqhnnyt)
