### PR TITLE
fix(chat): preserve transcript text selection

### DIFF
--- a/packages/chat-ui/src/ChatRoot.tsx
+++ b/packages/chat-ui/src/ChatRoot.tsx
@@ -1553,6 +1553,8 @@ export function ChatRoot(props: ChatRootProps) {
 
     const onClick = (e: Event) => {
       const t = e.target as HTMLElement;
+      const selection = window.getSelection();
+      if (selection && !selection.isCollapsed) return;
 
       const userCard = t.closest('[data-user-card]') as HTMLElement | null;
       if (userCard?.dataset.userCard) {

--- a/packages/chat-ui/src/ChatRoot.tsx
+++ b/packages/chat-ui/src/ChatRoot.tsx
@@ -1554,7 +1554,11 @@ export function ChatRoot(props: ChatRootProps) {
     const onClick = (e: Event) => {
       const t = e.target as HTMLElement;
       const selection = window.getSelection();
-      if (selection && !selection.isCollapsed) return;
+      if (selection && !selection.isCollapsed) {
+        for (let i = 0; i < selection.rangeCount; i++) {
+          if (selection.getRangeAt(i).intersectsNode(t)) return;
+        }
+      }
 
       const userCard = t.closest('[data-user-card]') as HTMLElement | null;
       if (userCard?.dataset.userCard) {

--- a/packages/chat-ui/src/chat-view.contract.test.tsx
+++ b/packages/chat-ui/src/chat-view.contract.test.tsx
@@ -28,6 +28,14 @@ async function waitFor<T>(fn: () => T | null, frames = 10): Promise<T | null> {
   return null;
 }
 
+function renderedText(host: HTMLElement, text: string) {
+  const element = Array.from(host.querySelectorAll('span')).find(
+    (candidate) => candidate.textContent === text
+  );
+  if (!element?.firstChild) throw new Error(`Unable to find rendered text: ${text}`);
+  return { element, textNode: element.firstChild };
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('createChatView', () => {
@@ -107,6 +115,85 @@ describe('createChatView', () => {
     const probeRect = probe!.getBoundingClientRect();
     expect(Math.abs(pinRect.left - probeRect.left)).toBeLessThan(1);
     expect(Math.abs(pinRect.width - probeRect.width)).toBeLessThan(1);
+
+    view.dispose();
+    ctx.dispose();
+    state.dispose();
+    document.body.removeChild(host);
+  });
+
+  it('keeps selectable text in visual transcript order', async () => {
+    const ctx = createChatContext({ theme: DEFAULT_THEME });
+    const state = createChatState(ctx);
+    state.transcript.history.seed([
+      {
+        id: 'turn-1',
+        seq: 0,
+        initiator: 'agent',
+        items: [
+          {
+            kind: 'thinking',
+            id: 'thinking-1',
+            seq: 0,
+            segmentId: 'thinking-1',
+            status: 'thinking',
+            text: 'Thinking body',
+            startedAt: Date.now(),
+          },
+          {
+            kind: 'message',
+            id: 'message-1',
+            seq: 1,
+            role: 'assistant',
+            text: [
+              'Text before the selection.',
+              '',
+              '- First selected line',
+              '- Second selected line',
+              '- Third selected line',
+            ].join('\n'),
+          },
+        ],
+      },
+    ]);
+
+    const host = document.createElement('div');
+    host.style.cssText = 'position:fixed;top:0;left:0;width:800px;height:600px;';
+    document.body.appendChild(host);
+
+    const view = createChatView({ context: ctx, state, parent: host });
+    await nextPaint();
+
+    const start = renderedText(host, 'First selected line');
+    const end = renderedText(host, 'Third selected line');
+    const startBlock = start.element.closest('[data-block-id]');
+    const thinkingBlock = renderedText(host, 'Thinking body').element.closest('[data-block-id]');
+    const thinkingWrapper = thinkingBlock?.parentElement;
+    const thinkingStack = thinkingWrapper?.parentElement;
+
+    expect(getComputedStyle(start.element).position).not.toBe('absolute');
+    expect(startBlock).not.toBeNull();
+    expect(getComputedStyle(startBlock!).position).not.toBe('absolute');
+    expect(getComputedStyle(startBlock!.parentElement!).position).not.toBe('absolute');
+    expect(thinkingWrapper).not.toBeNull();
+    expect(thinkingStack).not.toBeNull();
+    expect(
+      thinkingWrapper!.getBoundingClientRect().top - thinkingStack!.getBoundingClientRect().top
+    ).toBe(8);
+
+    const range = document.createRange();
+    range.setStart(start.textNode, 0);
+    range.setEnd(end.textNode, 'Third selected line'.length);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    const selected = selection?.toString() ?? '';
+
+    expect(selected).toContain('First selected line');
+    expect(selected).toContain('Second selected line');
+    expect(selected).toContain('Third selected line');
+    expect(selected).not.toContain('Text before the selection.');
+    selection?.removeAllRanges();
 
     view.dispose();
     ctx.dispose();

--- a/packages/chat-ui/src/chat-view.contract.test.tsx
+++ b/packages/chat-ui/src/chat-view.contract.test.tsx
@@ -200,6 +200,140 @@ describe('createChatView', () => {
     state.dispose();
     document.body.removeChild(host);
   });
+
+  it('preserves an active text selection across streaming updates', async () => {
+    const ctx = createChatContext({ theme: DEFAULT_THEME });
+    const state = createChatState(ctx);
+    const activeTurn = (text: string) => ({
+      id: 'active-turn',
+      seq: 0,
+      initiator: 'agent' as const,
+      items: [
+        {
+          kind: 'message' as const,
+          id: 'streaming-message',
+          seq: 0,
+          role: 'assistant' as const,
+          text,
+        },
+      ],
+    });
+    state.transcript.activeTurn.set(activeTurn('Stable selected text'), 'generating');
+
+    const host = document.createElement('div');
+    host.style.cssText = 'position:fixed;top:0;left:0;width:800px;height:600px;';
+    document.body.appendChild(host);
+
+    const view = createChatView({ context: ctx, state, parent: host });
+    await nextPaint();
+
+    const selectedWord = renderedText(host, 'Stable');
+    const range = document.createRange();
+    range.selectNodeContents(selectedWord.textNode);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    state.transcript.activeTurn.set(
+      activeTurn('Stable selected text with appended streaming content'),
+      'generating'
+    );
+    await nextPaint();
+
+    expect(selection?.toString()).toBe('Stable');
+    selection?.removeAllRanges();
+    view.dispose();
+    ctx.dispose();
+    state.dispose();
+    document.body.removeChild(host);
+  });
+
+  it('updates retained prose fragments when streamed Markdown becomes a link', async () => {
+    const ctx = createChatContext({ theme: DEFAULT_THEME });
+    const state = createChatState(ctx);
+    const activeTurn = (text: string) => ({
+      id: 'active-link-turn',
+      seq: 0,
+      initiator: 'agent' as const,
+      items: [
+        {
+          kind: 'message' as const,
+          id: 'streaming-link-message',
+          seq: 0,
+          role: 'assistant' as const,
+          text,
+        },
+      ],
+    });
+    state.transcript.activeTurn.set(activeTurn('[OpenAI](https://example.com'), 'generating');
+
+    const host = document.createElement('div');
+    host.style.cssText = 'position:fixed;top:0;left:0;width:800px;height:600px;';
+    document.body.appendChild(host);
+
+    const view = createChatView({ context: ctx, state, parent: host });
+    await nextPaint();
+    expect(
+      Array.from(host.querySelectorAll('a')).some((link) => link.textContent === 'OpenAI')
+    ).toBe(false);
+
+    state.transcript.activeTurn.set(activeTurn('[OpenAI](https://example.com)'), 'generating');
+    await nextPaint();
+
+    const link = Array.from(host.querySelectorAll('a')).find(
+      (candidate) => candidate.textContent === 'OpenAI'
+    );
+    expect(link?.href).toBe('https://example.com/');
+
+    view.dispose();
+    ctx.dispose();
+    state.dispose();
+    document.body.removeChild(host);
+  });
+
+  it('does not treat selecting text in a user card as an expand click', async () => {
+    const ctx = createChatContext({ theme: DEFAULT_THEME });
+    const state = createChatState(ctx);
+    state.transcript.history.seed([
+      {
+        id: 'user-turn',
+        seq: 0,
+        initiator: 'user',
+        items: [
+          {
+            kind: 'message',
+            id: 'user-message',
+            seq: 0,
+            role: 'user',
+            text: 'Selectable user message',
+          },
+        ],
+      },
+    ]);
+
+    const host = document.createElement('div');
+    host.style.cssText = 'position:fixed;top:0;left:0;width:800px;height:600px;';
+    document.body.appendChild(host);
+
+    const view = createChatView({ context: ctx, state, parent: host });
+    await nextPaint();
+
+    const selectedText = renderedText(host, 'Selectable user message');
+    const range = document.createRange();
+    range.selectNodeContents(selectedText.textNode);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    selectedText.element.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await nextPaint();
+
+    expect(selection?.toString()).toBe('Selectable user message');
+    selection?.removeAllRanges();
+    view.dispose();
+    ctx.dispose();
+    state.dispose();
+    document.body.removeChild(host);
+  });
 });
 
 describe('ChatView.setModel', () => {

--- a/packages/chat-ui/src/chat-view.contract.test.tsx
+++ b/packages/chat-ui/src/chat-view.contract.test.tsx
@@ -309,6 +309,20 @@ describe('createChatView', () => {
           },
         ],
       },
+      {
+        id: 'other-user-turn',
+        seq: 1,
+        initiator: 'user',
+        items: [
+          {
+            kind: 'message',
+            id: 'other-user-message',
+            seq: 0,
+            role: 'user',
+            text: Array.from({ length: 30 }, (_, i) => `Other message line ${i}`).join('\n\n'),
+          },
+        ],
+      },
     ]);
 
     const host = document.createElement('div');
@@ -328,6 +342,16 @@ describe('createChatView', () => {
     await nextPaint();
 
     expect(selection?.toString()).toBe('Selectable user message');
+
+    const otherCard = host.querySelector(
+      '[data-user-card="other-user-message"]'
+    ) as HTMLElement | null;
+    expect(otherCard).not.toBeNull();
+    const collapsedHeight = otherCard!.getBoundingClientRect().height;
+    otherCard!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await nextPaint();
+
+    expect(otherCard!.getBoundingClientRect().height).toBeGreaterThan(collapsedHeight);
     selection?.removeAllRanges();
     view.dispose();
     ctx.dispose();

--- a/packages/chat-ui/src/components/engine/block-frame.css.ts
+++ b/packages/chat-ui/src/components/engine/block-frame.css.ts
@@ -8,7 +8,8 @@
 import { style } from '@vanilla-extract/css';
 
 export const pblock = style({
-  position: 'absolute',
+  position: 'relative',
+  display: 'flow-root',
   left: 0,
   width: '100%',
   overflow: 'visible',

--- a/packages/chat-ui/src/components/primitives/BlockStackView.tsx
+++ b/packages/chat-ui/src/components/primitives/BlockStackView.tsx
@@ -19,7 +19,14 @@ export type BlockStackViewProps = {
 export function BlockStackView(props: BlockStackViewProps) {
   const placed = () => props.node.layout.placed;
   return (
-    <div style={{ position: 'relative', height: `${props.node.height}px`, width: '100%' }}>
+    <div
+      style={{
+        position: 'relative',
+        display: 'flow-root',
+        height: `${props.node.height}px`,
+        width: '100%',
+      }}
+    >
       {/*
        * Key by reference. stack() rebuilds placed[] with fresh wrapper objects
        * every layout pass, so <For> recreates each row on every streaming chunk.
@@ -32,19 +39,20 @@ export function BlockStackView(props: BlockStackViewProps) {
        * surrounded by blank space until the turn committed.)
        */}
       <For each={placed()}>
-        {(p) => (
-          <div
-            style={{
-              position: 'absolute',
-              top: `${p.top}px`,
-              left: 0,
-              right: 0,
-              height: `${p.child.height}px`,
-            }}
-          >
-            <BlockLeafRender node={p.child as Measured<BlockLeafLayout>} />
-          </div>
-        )}
+        {(p, index) => {
+          const previous = placed()[index() - 1];
+          const previousBottom = previous ? previous.top + previous.child.height : 0;
+          return (
+            <div
+              style={{
+                'margin-top': `${p.top - previousBottom}px`,
+                height: `${p.child.height}px`,
+              }}
+            >
+              <BlockLeafRender node={p.child as Measured<BlockLeafLayout>} />
+            </div>
+          );
+        }}
       </For>
     </div>
   );

--- a/packages/chat-ui/src/components/primitives/BlockStackView.tsx
+++ b/packages/chat-ui/src/components/primitives/BlockStackView.tsx
@@ -2,14 +2,19 @@ import { BLOCK_REGISTRY } from '@components/rows/markdown/block-registry';
 import type { StackLayout } from '@core/compose';
 import type { Measured } from '@core/define';
 import type { BlockLeafLayout } from '@core/layout/layout-types';
-import { For } from 'solid-js';
+import { Index, Show } from 'solid-js';
 import { Dynamic } from 'solid-js/web';
 
 function BlockLeafRender(props: { node: Measured<BlockLeafLayout> }) {
-  const def = BLOCK_REGISTRY[props.node.layout.kind];
-  if (!def) return null;
-  // oxlint-disable-next-line typescript/no-explicit-any -- registry boundary
-  return <Dynamic component={def.Render} node={props.node as any} />;
+  const render = () => BLOCK_REGISTRY[props.node.layout.kind]?.Render;
+  return (
+    <Show when={render()}>
+      {(component) => (
+        // oxlint-disable-next-line typescript/no-explicit-any -- registry boundary
+        <Dynamic component={component()} node={props.node as any} />
+      )}
+    </Show>
+  );
 }
 
 export type BlockStackViewProps = {
@@ -27,33 +32,25 @@ export function BlockStackView(props: BlockStackViewProps) {
         width: '100%',
       }}
     >
-      {/*
-       * Key by reference. stack() rebuilds placed[] with fresh wrapper objects
-       * every layout pass, so <For> recreates each row on every streaming chunk.
-       * That remount is intentional: block defs snapshot props.node.layout at
-       * mount (e.g. `const l = props.node.layout` in code.def / prose.def), so a
-       * growing block's content only stays in sync if its row is recreated when
-       * the layout changes. (A persistent-row optimization keyed by block id was
-       * tried and reverted — it left growing blocks frozen at their first layout
-       * while the reserved height kept growing, producing one-line code blocks
-       * surrounded by blank space until the turn committed.)
-       */}
-      <For each={placed()}>
+      <Index each={placed()}>
         {(p, index) => {
-          const previous = placed()[index() - 1];
-          const previousBottom = previous ? previous.top + previous.child.height : 0;
+          const previous = () => placed()[index - 1];
+          const previousBottom = () => {
+            const value = previous();
+            return value ? value.top + value.child.height : 0;
+          };
           return (
             <div
               style={{
-                'margin-top': `${p.top - previousBottom}px`,
-                height: `${p.child.height}px`,
+                'margin-top': `${p().top - previousBottom()}px`,
+                height: `${p().child.height}px`,
               }}
             >
-              <BlockLeafRender node={p.child as Measured<BlockLeafLayout>} />
+              <BlockLeafRender node={p().child as Measured<BlockLeafLayout>} />
             </div>
           );
         }}
-      </For>
+      </Index>
     </div>
   );
 }

--- a/packages/chat-ui/src/components/rows/markdown/code/Code.tsx
+++ b/packages/chat-ui/src/components/rows/markdown/code/Code.tsx
@@ -24,7 +24,7 @@ import { CopyButton } from '@components/primitives/CopyButton';
 import { applyTokenLines } from '@core/highlight/apply-tokens';
 import type { CodeLaidOut } from '@core/layout/layout-types';
 import type { CodeBlock } from '@core/markdown/document';
-import { For, createEffect, createMemo, onCleanup } from 'solid-js';
+import { Index, createEffect, createMemo, onCleanup } from 'solid-js';
 import { codeLine, codeWrapper } from './code.css';
 import { codeGroup } from '@components/primitives/copy-button.css';
 
@@ -131,20 +131,20 @@ export function Code(props: CodeProps) {
         }}
         class={codeWrapper}
       >
-        <For each={props.block.lines}>
+        <Index each={props.block.lines}>
           {(line, i) => (
             <div
               ref={(el) => {
-                lineElsMap.set(i(), el);
-                onCleanup(() => lineElsMap.delete(i()));
+                lineElsMap.set(i, el);
+                onCleanup(() => lineElsMap.delete(i));
               }}
               class={codeLine}
-              style={{ top: `${line.top}px` }}
+              style={{ top: `${line().top}px` }}
             >
-              {line.text}
+              {line().text}
             </div>
           )}
-        </For>
+        </Index>
       </div>
     </BlockFrame>
   );

--- a/packages/chat-ui/src/components/rows/markdown/code/code.def.tsx
+++ b/packages/chat-ui/src/components/rows/markdown/code/code.def.tsx
@@ -16,7 +16,6 @@ export const codeBlockDef = defineBlock<CodeBlock, CodeLeafLayout>({
   },
 
   Render(props: { node: Measured<CodeLeafLayout> }) {
-    const l = props.node.layout;
-    return <Code block={l} rawBlock={l.raw} />;
+    return <Code block={props.node.layout} rawBlock={props.node.layout.raw} />;
   },
 });

--- a/packages/chat-ui/src/components/rows/markdown/mermaid/mermaid.def.tsx
+++ b/packages/chat-ui/src/components/rows/markdown/mermaid/mermaid.def.tsx
@@ -28,7 +28,6 @@ export const mermaidBlockDef = defineBlock<MermaidBlock, MermaidLeafLayout>({
   },
 
   Render(props: { node: Measured<MermaidLeafLayout> }) {
-    const l = props.node.layout;
-    return <Mermaid block={l} rawBlock={l.raw} />;
+    return <Mermaid block={props.node.layout} rawBlock={props.node.layout.raw} />;
   },
 });

--- a/packages/chat-ui/src/components/rows/markdown/prose/Prose.tsx
+++ b/packages/chat-ui/src/components/rows/markdown/prose/Prose.tsx
@@ -16,7 +16,7 @@ import type {
 } from '@core/layout/layout-types';
 import { mentionDisplayText } from '@core/markdown/document';
 import type { InlineMention, InlineRun } from '@core/markdown/document';
-import { For, Match, Show, Switch, createMemo, onMount } from 'solid-js';
+import { Index, Match, Show, Switch, createEffect, createMemo } from 'solid-js';
 import {
   bulletColor,
   commandChip,
@@ -70,14 +70,18 @@ function fragVisualClass(run: InlineRun, variant: string): string {
 /**
  * Split a fragment's text into alternating word/space runs, preserving
  * `white-space: pre` semantics (no trimming, no merging of spaces).
- * Returns [text, isWord] pairs.
+ * Carries a stable word index so existing word nodes can survive streaming updates.
  */
-function splitFragmentWords(text: string): Array<[string, boolean]> {
+function splitFragmentWords(
+  text: string
+): Array<{ text: string; isWord: boolean; wordIndex: number }> {
   const parts = text.split(/(\s+)/);
-  const result: Array<[string, boolean]> = [];
+  const result: Array<{ text: string; isWord: boolean; wordIndex: number }> = [];
+  let wordIndex = 0;
   for (const p of parts) {
     if (p.length === 0) continue;
-    result.push([p, /\S/.test(p)]);
+    const isWord = /\S/.test(p);
+    result.push({ text: p, isWord, wordIndex: isWord ? wordIndex++ : -1 });
   }
   return result;
 }
@@ -98,155 +102,162 @@ function ProseFragment(props: {
 }) {
   const commands = useCommands();
   const chips = useTheme()().chips;
-  const key = fragKey(props.run, props.variant);
-  const moduleCls = [pf, pfVariants[key]].filter(Boolean).join(' ');
-  const visualCls = fragVisualClass(props.run, props.variant);
-  const cls = visualCls ? `${moduleCls} ${visualCls}` : moduleCls;
-  const fragmentStyle = {
+  const cls = () => {
+    const key = fragKey(props.run, props.variant);
+    const moduleCls = [pf, pfVariants[key]].filter(Boolean).join(' ');
+    const visualCls = fragVisualClass(props.run, props.variant);
+    return visualCls ? `${moduleCls} ${visualCls}` : moduleCls;
+  };
+  const fragmentStyle = () => ({
     'margin-left': `${props.frag.gapBefore}px`,
     width: `${props.frag.occupiedWidth}px`,
+  });
+  const linkHref = () => (props.run.kind === 'text' ? props.run.href : undefined);
+  const mention = () => {
+    if (props.run.kind !== 'mention' || !props.run.mentionKind) return undefined;
+    return props.run as InlineMention;
   };
-
-  if (props.run.kind === 'text' && props.run.href) {
-    const href = props.run.href;
-    const classification = () => commands().classifyLink?.(href);
-
-    const handleClick = (e: MouseEvent) => {
-      const result = classification();
-      if (result?.kind === 'workspace-file') {
-        e.preventDefault();
-        commands().onOpenFile?.({
-          path: result.path,
-          itemId: props.blockId,
-          source: 'prose-link',
-        });
-      }
-      // else: browser follows the <a> normally (new tab via target="_blank")
-    };
-
-    // Links are not word-animated (href spans are not appended incrementally).
-    return (
-      <a
-        class={cls}
-        style={fragmentStyle}
-        href={href}
-        target="_blank"
-        rel="noopener noreferrer"
-        onClick={handleClick}
-      >
-        {props.frag.text}
-      </a>
-    );
-  }
-
-  if (props.run.kind === 'mention' && (props.run as InlineMention).mentionKind) {
-    const mention = props.run as InlineMention;
-    // Mentions are not split; fade as a single unit when streaming.
-    const isNew =
-      props.wordOffset !== undefined &&
-      props.frontier !== undefined &&
-      props.wordOffset >= props.frontier;
-
-    const handleMentionClick = () => {
-      if (!mention.mentionKind) return;
-      commands().onClickMention?.({
-        id: mention.id ?? mention.label,
-        label: mention.label,
-        kind: mention.mentionKind,
-        itemId: props.blockId,
-        source: 'prose-mention',
-      });
-    };
-    const isClickable = () => !!commands().onClickMention;
-
-    return (
-      <span
-        classList={{ [cls]: true, [streamWord]: isNew }}
-        onClick={handleMentionClick}
-        style={{
-          cursor: isClickable() ? 'pointer' : undefined,
-          ...fragmentStyle,
-          display: 'inline-flex',
-          'align-items': 'center',
-          gap: `${chips.mentionIconGap}px`,
-        }}
-      >
-        <span
-          style={{
-            display: 'flex',
-            width: `${chips.mentionIconW}px`,
-            height: `${chips.mentionIconW}px`,
-            'flex-shrink': '0',
-            'align-items': 'center',
-            'justify-content': 'center',
-            overflow: 'hidden',
-          }}
-        >
-          <Show
-            when={mention.iconUrl}
-            fallback={
-              <Show
-                when={mention.iconClass}
-                fallback={
-                  <Switch fallback={<MentionAtIcon />}>
-                    <Match when={mention.mentionKind === 'file'}>
-                      <MentionFileIcon />
-                    </Match>
-                    <Match when={mention.mentionKind === 'issue'}>
-                      <MentionIssueIcon />
-                    </Match>
-                    <Match when={mention.mentionKind === 'symbol'}>
-                      <MentionSymbolIcon />
-                    </Match>
-                  </Switch>
-                }
-              >
-                {(ic) => <i class={`${ic()} leading-none`} style={{ 'font-size': '11px' }} />}
-              </Show>
-            }
-          >
-            {(url) => (
-              <img
-                src={url()}
-                alt=""
-                style={{ width: '100%', height: '100%', 'object-fit': 'contain' }}
-              />
-            )}
-          </Show>
-        </span>
-        <span>{mentionDisplayText(mention)}</span>
-      </span>
-    );
-  }
-
-  // Plain text (body / bold / italic / code chip / plain mention).
-  // When streaming, split into per-word spans and animate the new tail.
-  const isStreaming =
+  const isStreamingText = () =>
+    props.run.kind === 'text' &&
+    !/^\s+$/.test(props.frag.text) &&
     props.wordOffset !== undefined &&
     props.frontier !== undefined &&
     props.totalWords !== undefined;
+  const wordPairs = createMemo(() => splitFragmentWords(props.frag.text));
 
-  if (isStreaming && props.run.kind === 'text' && !/^\s+$/.test(props.frag.text)) {
-    const wordPairs = splitFragmentWords(props.frag.text);
-    let localIdx = props.wordOffset!;
-    return (
-      <span class={cls} style={fragmentStyle}>
-        <For each={wordPairs}>
-          {([chunk, isWord]) => {
-            if (!isWord) return <>{chunk}</>;
-            const idx = localIdx++;
-            const isNew = idx >= props.frontier!;
-            return isNew ? <span class={streamWord}>{chunk}</span> : <>{chunk}</>;
-          }}
-        </For>
-      </span>
-    );
-  }
+  const handleLinkClick = (e: MouseEvent) => {
+    const href = linkHref();
+    if (!href) return;
+    const result = commands().classifyLink?.(href);
+    if (result?.kind === 'workspace-file') {
+      e.preventDefault();
+      commands().onOpenFile?.({
+        path: result.path,
+        itemId: props.blockId,
+        source: 'prose-link',
+      });
+    }
+  };
+
+  const handleMentionClick = () => {
+    const value = mention();
+    if (!value?.mentionKind) return;
+    commands().onClickMention?.({
+      id: value.id ?? value.label,
+      label: value.label,
+      kind: value.mentionKind,
+      itemId: props.blockId,
+      source: 'prose-mention',
+    });
+  };
+
+  const isNewMention = () =>
+    props.wordOffset !== undefined &&
+    props.frontier !== undefined &&
+    props.wordOffset >= props.frontier;
+  const isMentionClickable = () => !!commands().onClickMention;
 
   return (
-    <span class={cls} style={fragmentStyle}>
-      {props.frag.text}
-    </span>
+    <Switch
+      fallback={
+        <span class={cls()} style={fragmentStyle()}>
+          {props.frag.text}
+        </span>
+      }
+    >
+      <Match when={linkHref()}>
+        {(href) => (
+          <a
+            class={cls()}
+            style={fragmentStyle()}
+            href={href()}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={handleLinkClick}
+          >
+            {props.frag.text}
+          </a>
+        )}
+      </Match>
+      <Match when={mention()}>
+        {(value) => (
+          <span
+            class={cls()}
+            classList={{ [streamWord]: isNewMention() }}
+            onClick={handleMentionClick}
+            style={{
+              cursor: isMentionClickable() ? 'pointer' : undefined,
+              ...fragmentStyle(),
+              display: 'inline-flex',
+              'align-items': 'center',
+              gap: `${chips.mentionIconGap}px`,
+            }}
+          >
+            <span
+              style={{
+                display: 'flex',
+                width: `${chips.mentionIconW}px`,
+                height: `${chips.mentionIconW}px`,
+                'flex-shrink': '0',
+                'align-items': 'center',
+                'justify-content': 'center',
+                overflow: 'hidden',
+              }}
+            >
+              <Show
+                when={value().iconUrl}
+                fallback={
+                  <Show
+                    when={value().iconClass}
+                    fallback={
+                      <Switch fallback={<MentionAtIcon />}>
+                        <Match when={value().mentionKind === 'file'}>
+                          <MentionFileIcon />
+                        </Match>
+                        <Match when={value().mentionKind === 'issue'}>
+                          <MentionIssueIcon />
+                        </Match>
+                        <Match when={value().mentionKind === 'symbol'}>
+                          <MentionSymbolIcon />
+                        </Match>
+                      </Switch>
+                    }
+                  >
+                    {(ic) => <i class={`${ic()} leading-none`} style={{ 'font-size': '11px' }} />}
+                  </Show>
+                }
+              >
+                {(url) => (
+                  <img
+                    src={url()}
+                    alt=""
+                    style={{ width: '100%', height: '100%', 'object-fit': 'contain' }}
+                  />
+                )}
+              </Show>
+            </span>
+            <span>{mentionDisplayText(value())}</span>
+          </span>
+        )}
+      </Match>
+      <Match when={isStreamingText()}>
+        <span class={cls()} style={fragmentStyle()}>
+          <Index each={wordPairs()}>
+            {(pair) => (
+              <Show when={pair().isWord} fallback={<>{pair().text}</>}>
+                <span
+                  classList={{
+                    [streamWord]: props.wordOffset! + pair().wordIndex >= props.frontier!,
+                  }}
+                >
+                  {pair().text}
+                </span>
+              </Show>
+            )}
+          </Index>
+        </span>
+      </Match>
+    </Switch>
   );
 }
 
@@ -273,22 +284,25 @@ function ProseLine(props: {
         height: `${props.lineHeight}px`,
       }}
     >
-      <For each={props.line.fragments}>
+      <Index each={props.line.fragments}>
         {(frag, i) => {
-          const run = props.runs[frag.runIndex];
-          return run ? (
-            <ProseFragment
-              run={run}
-              frag={frag}
-              variant={props.variant}
-              blockId={props.blockId}
-              wordOffset={props.fragWordOffsets?.[i()]}
-              totalWords={props.totalWords}
-              frontier={props.frontier}
-            />
-          ) : null;
+          return (
+            <Show when={props.runs[frag().runIndex]}>
+              {(run) => (
+                <ProseFragment
+                  run={run()}
+                  frag={frag()}
+                  variant={props.variant}
+                  blockId={props.blockId}
+                  wordOffset={props.fragWordOffsets?.[i]}
+                  totalWords={props.totalWords}
+                  frontier={props.frontier}
+                />
+              )}
+            </Show>
+          );
         }}
-      </For>
+      </Index>
     </div>
   );
 }
@@ -369,7 +383,7 @@ export function Prose(props: ProseProps) {
 
   // After rendering, advance the frontier so the next chunk only animates
   // words appended after this render.
-  onMount(() => {
+  createEffect(() => {
     if (!streamAnim) return;
     const d = fragData();
     if (d) streamAnim.frontier.set(props.block.id, d.totalWords);
@@ -381,30 +395,36 @@ export function Prose(props: ProseProps) {
         <ProseQuoteRail left={(props.block.lines[0]?.left ?? 18) - 10} />
       </Show>
       <Show when={props.block.bullet}>{(bullet) => <ProseBullet bullet={bullet()} />}</Show>
-      <For each={props.block.lines}>
+      <Index each={props.block.lines}>
         {(line, lineIdx) => {
-          const d = fragData();
-          // Build per-fragment offset array for this line using O(1) prefix lookup.
-          const lineFragOffsets = d
-            ? line.fragments.map((_, fi) => d.fragWordOffsets[d.lineBaseFlat[lineIdx()] + fi] ?? 0)
-            : undefined;
-          const previous = props.block.lines[lineIdx() - 1];
-          const previousBottom = previous ? previous.top + props.block.lineHeight : 0;
+          const lineFragOffsets = () => {
+            const d = fragData();
+            return d
+              ? line().fragments.map(
+                  (_, fi) => d.fragWordOffsets[d.lineBaseFlat[lineIdx] + fi] ?? 0
+                )
+              : undefined;
+          };
+          const previous = () => props.block.lines[lineIdx - 1];
+          const previousBottom = () => {
+            const value = previous();
+            return value ? value.top + props.block.lineHeight : 0;
+          };
           return (
             <ProseLine
-              line={line}
-              gapBefore={line.top - previousBottom}
+              line={line()}
+              gapBefore={line().top - previousBottom()}
               lineHeight={props.block.lineHeight}
               runs={props.runs}
               variant={props.variant}
               blockId={props.block.id}
-              fragWordOffsets={lineFragOffsets}
-              totalWords={d?.totalWords}
-              frontier={d?.frontier}
+              fragWordOffsets={lineFragOffsets()}
+              totalWords={fragData()?.totalWords}
+              frontier={fragData()?.frontier}
             />
           );
         }}
-      </For>
+      </Index>
     </BlockFrame>
   );
 }

--- a/packages/chat-ui/src/components/rows/markdown/prose/Prose.tsx
+++ b/packages/chat-ui/src/components/rows/markdown/prose/Prose.tsx
@@ -102,6 +102,10 @@ function ProseFragment(props: {
   const moduleCls = [pf, pfVariants[key]].filter(Boolean).join(' ');
   const visualCls = fragVisualClass(props.run, props.variant);
   const cls = visualCls ? `${moduleCls} ${visualCls}` : moduleCls;
+  const fragmentStyle = {
+    'margin-left': `${props.frag.gapBefore}px`,
+    width: `${props.frag.occupiedWidth}px`,
+  };
 
   if (props.run.kind === 'text' && props.run.href) {
     const href = props.run.href;
@@ -124,7 +128,7 @@ function ProseFragment(props: {
     return (
       <a
         class={cls}
-        style={{ left: `${props.frag.x}px` }}
+        style={fragmentStyle}
         href={href}
         target="_blank"
         rel="noopener noreferrer"
@@ -161,7 +165,7 @@ function ProseFragment(props: {
         onClick={handleMentionClick}
         style={{
           cursor: isClickable() ? 'pointer' : undefined,
-          left: `${props.frag.x}px`,
+          ...fragmentStyle,
           display: 'inline-flex',
           'align-items': 'center',
           gap: `${chips.mentionIconGap}px`,
@@ -226,7 +230,7 @@ function ProseFragment(props: {
     const wordPairs = splitFragmentWords(props.frag.text);
     let localIdx = props.wordOffset!;
     return (
-      <span class={cls} style={{ left: `${props.frag.x}px` }}>
+      <span class={cls} style={fragmentStyle}>
         <For each={wordPairs}>
           {([chunk, isWord]) => {
             if (!isWord) return <>{chunk}</>;
@@ -240,7 +244,7 @@ function ProseFragment(props: {
   }
 
   return (
-    <span class={cls} style={{ left: `${props.frag.x}px` }}>
+    <span class={cls} style={fragmentStyle}>
       {props.frag.text}
     </span>
   );
@@ -250,6 +254,7 @@ function ProseFragment(props: {
 
 function ProseLine(props: {
   line: LineLayout;
+  gapBefore: number;
   lineHeight: number;
   runs: InlineRun[];
   variant: string;
@@ -263,7 +268,7 @@ function ProseLine(props: {
     <div
       class={pline}
       style={{
-        top: `${props.line.top}px`,
+        'margin-top': `${props.gapBefore}px`,
         left: `${props.line.left}px`,
         height: `${props.lineHeight}px`,
       }}
@@ -383,9 +388,12 @@ export function Prose(props: ProseProps) {
           const lineFragOffsets = d
             ? line.fragments.map((_, fi) => d.fragWordOffsets[d.lineBaseFlat[lineIdx()] + fi] ?? 0)
             : undefined;
+          const previous = props.block.lines[lineIdx() - 1];
+          const previousBottom = previous ? previous.top + props.block.lineHeight : 0;
           return (
             <ProseLine
               line={line}
+              gapBefore={line.top - previousBottom}
               lineHeight={props.block.lineHeight}
               runs={props.runs}
               variant={props.variant}

--- a/packages/chat-ui/src/components/rows/markdown/prose/layout.ts
+++ b/packages/chat-ui/src/components/rows/markdown/prose/layout.ts
@@ -161,7 +161,12 @@ export function layoutProse(
       for (const f of line.fragments) {
         x += f.gapBefore;
         // Map from per-segment item index back to original block.runs index.
-        frags.push({ text: f.text, x, runIndex: indexMap[f.itemIndex] ?? f.itemIndex });
+        frags.push({
+          text: f.text,
+          gapBefore: f.gapBefore,
+          occupiedWidth: f.occupiedWidth,
+          runIndex: indexMap[f.itemIndex] ?? f.itemIndex,
+        });
         x += f.occupiedWidth;
       }
 

--- a/packages/chat-ui/src/components/rows/markdown/prose/prose.css.ts
+++ b/packages/chat-ui/src/components/rows/markdown/prose/prose.css.ts
@@ -5,7 +5,7 @@ import { vars } from '@styles/theme.css';
 
 /** A pre-laid-out line row. Height is set via inline style from the line-height constant. */
 export const pline = style({
-  position: 'absolute',
+  position: 'relative',
   display: 'flex',
   alignItems: 'baseline',
 });
@@ -16,11 +16,13 @@ export const pline = style({
  */
 export const pf = style({
   display: 'inline-block',
+  flexShrink: 0,
   whiteSpace: 'pre',
   lineHeight: 1,
-  position: 'absolute',
+  position: 'relative',
   top: '50%',
   transform: 'translateY(-50%)',
+  boxSizing: 'border-box',
 });
 
 export const pfBody = style({

--- a/packages/chat-ui/src/components/rows/markdown/prose/prose.def.tsx
+++ b/packages/chat-ui/src/components/rows/markdown/prose/prose.def.tsx
@@ -40,7 +40,12 @@ export const proseBlockDef = defineBlock<ProseBlock, ProseLeafLayout>({
   },
 
   Render(props: { node: Measured<ProseLeafLayout> }) {
-    const l = props.node.layout;
-    return <Prose block={l} runs={l.raw.runs} variant={l.raw.variant} />;
+    return (
+      <Prose
+        block={props.node.layout}
+        runs={props.node.layout.raw.runs}
+        variant={props.node.layout.raw.variant}
+      />
+    );
   },
 });

--- a/packages/chat-ui/src/core/layout/layout-types.ts
+++ b/packages/chat-ui/src/core/layout/layout-types.ts
@@ -12,11 +12,13 @@
  * compose trees (core/compose.ts) returned by each ComponentDef.measure().
  */
 
-/** A single fragment on a line: the text to render and its x offset. */
+/** A single fragment on a line with its measured spacing and width. */
 export type FragmentLayout = {
   text: string;
-  /** X offset in px from the block's left edge. */
-  x: number;
+  /** Collapsed whitespace between this fragment and the previous fragment. */
+  gapBefore: number;
+  /** Measured width reserved for the text and any inline chrome. */
+  occupiedWidth: number;
   /** Index into the original `InlineRun[]` array — used to determine styling. */
   runIndex: number;
 };

--- a/packages/core/src/acp/reducer/acp-transcript-parser.test.ts
+++ b/packages/core/src/acp/reducer/acp-transcript-parser.test.ts
@@ -259,6 +259,29 @@ describe('AcpTranscriptParser', () => {
     expect(messages.map((message) => message.seq)).toEqual([0, 1, 3]);
   });
 
+  it('segments reused assistant message ids around tool calls', () => {
+    const p = new AcpTranscriptParser(deps());
+    p.push(userChunk('u1', 'do it'));
+    p.push(assistantChunk('a1', 'before'));
+    p.push(toolCallUpdate('tc1', 'Run command'));
+    p.push(toolUpdateDone('tc1'));
+    p.push(assistantChunk('a1', 'summary '));
+    p.push(assistantChunk('a1', 'at the bottom'));
+
+    const messages = (p.activeTurn?.items ?? []).filter((item) => item.kind === 'message');
+    expect(messages.map((message) => message.text)).toEqual([
+      'do it',
+      'before',
+      'summary at the bottom',
+    ]);
+    expect(messages.map((message) => message.id)).toEqual([
+      makeMessageId(makeTurnId(CID, 0), 'u1', 'user'),
+      makeMessageId(makeTurnId(CID, 0), 'a1', 'assistant'),
+      makeMessageId(makeTurnId(CID, 0), 'a1:segment:1', 'assistant'),
+    ]);
+    expect(messages.map((message) => message.seq)).toEqual([0, 1, 3]);
+  });
+
   it('replay treats id-less user chunks after agent content as new turns', () => {
     const updates: SessionUpdate[] = [
       {

--- a/packages/core/src/acp/reducer/item-fold.ts
+++ b/packages/core/src/acp/reducer/item-fold.ts
@@ -132,6 +132,25 @@ function nextSeq(items: TranscriptItem[]): number {
   return maxSeq(items) + 1;
 }
 
+function resolveAssistantMessageId(
+  items: TranscriptItem[],
+  turnId: string,
+  messageId: string
+): string {
+  const baseId = makeMessageId(turnId, messageId, 'assistant');
+  const segmentPrefix = `${baseId}:segment:`;
+  const messages = items.filter(
+    (item) =>
+      item.kind === 'message' &&
+      item.role === 'assistant' &&
+      (item.id === baseId || item.id.startsWith(segmentPrefix))
+  );
+  const latest = messages.at(-1);
+  if (!latest) return baseId;
+  if (latest === items.at(-1)) return latest.id;
+  return `${segmentPrefix}${messages.length}`;
+}
+
 function baseToolFields(
   id: string,
   seq: number,
@@ -603,8 +622,11 @@ export function foldItem(
   const flatItems = flattenItems(items);
   switch (event.kind) {
     case 'message': {
-      const id = makeMessageId(turnId, event.messageId, event.role);
       const base = finalizeOpenThinking(flatItems, at);
+      const id =
+        event.role === 'assistant'
+          ? resolveAssistantMessageId(base, turnId, event.messageId)
+          : makeMessageId(turnId, event.messageId, event.role);
       const idx = base.findIndex((it) => it.kind === 'message' && it.id === id);
       if (idx >= 0) {
         // Append chunk to existing message.


### PR DESCRIPTION
## Summary

- keep transcript content in visual DOM order so native text selection follows what users see
- preserve selected text nodes while assistant responses continue streaming
- keep streamed Markdown reactive when prose becomes bold, inline code, a mention, or a link
- prevent a selection drag inside a user message from triggering the card's expand behavior

## Root cause

The projected chat layout positioned transcript fragments independently and rebuilt block, line, fragment, and code-line wrappers on streaming updates. Native browser selection is anchored to concrete text nodes, so replacing those nodes cleared the selection after mouse release. The delegated user-card click handler could also interpret the click emitted after a selection drag as an expand action.

## Screen recording

[Selection behavior before the fix](https://cap.link/9w99jfryra0hnxg)
