### PR TITLE
feat(chat): allow switching harness from existing conversations

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-panel.tsx
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-panel.tsx
@@ -550,13 +550,18 @@ const ComposerForStore = observer(function ComposerForStore({
   const agentOptions = useMemo<ComposerAgentOption[]>(
     () =>
       (agents ?? [])
-        .filter((agent) => installedAgentIds.has(agent.id) && agentSupportsAcp(agent.capabilities))
+        .filter(
+          (agent) =>
+            agent.id === providerId ||
+            (installedAgentIds.has(agent.id) && agentSupportsAcp(agent.capabilities))
+        )
         .map((agent) => ({
           id: agent.id,
           name: agent.name,
           icon: <AgentIcon id={agent.id} size={14} className="rounded-sm" />,
+          disabled: !installedAgentIds.has(agent.id),
         })),
-    [agents, installedAgentIds]
+    [agents, installedAgentIds, providerId]
   );
 
   const handleAgentChange = useCallback(

--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-panel.tsx
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-panel.tsx
@@ -1,4 +1,5 @@
 import type { AttachmentMimeType, AttachmentRef } from '@emdash/core/acp/client';
+import type { AgentProviderId } from '@emdash/plugins/agents';
 import { ChatComposer, ImageViewerDialog, MermaidViewerDialog } from '@emdash/ui/react/components';
 import type {
   CommandItem,
@@ -19,6 +20,7 @@ import { useConnectedIssueProviders } from '@renderer/features/integrations/use-
 import { usePromptLibrary } from '@renderer/features/library/prompts/use-prompt-library';
 import {
   asMounted,
+  getProjectSshConnectionId,
   getProjectStore,
   getProjectViewStore,
 } from '@renderer/features/projects/stores/project-selectors';
@@ -45,10 +47,13 @@ import { toast } from '@renderer/lib/hooks/use-toast';
 import { rpc } from '@renderer/lib/ipc';
 import { showModal } from '@renderer/lib/modal/modal-provider';
 import { isHeicLikeFile, isUnstableDropPath } from '@renderer/lib/pty/terminal-image-paths';
+import { useAgentInstallationStatuses } from '@renderer/lib/stores/use-agent-installation-statuses';
 import { useAgents } from '@renderer/lib/stores/use-agents';
 import { Button } from '@renderer/lib/ui/button';
 import { log } from '@renderer/utils/logger';
+import { agentSupportsAcp } from '@shared/core/agents/agent-payload';
 import { linkedIssueMentionName, type LinkedIssue } from '@shared/core/linked-issue';
+import { nextDefaultConversationTitle } from '../conversation-title-utils';
 import type { AcpChatStore, AcpPromptAttachment } from './acp-chat-store';
 import type { AcpChatTabResource } from './acp-chat-tab-resource';
 import { chatViewCommandForShortcut, executeChatViewCommand } from './acp-chat-view-commands';
@@ -230,8 +235,10 @@ const ComposerForStore = observer(function ComposerForStore({
   composerSlot: HTMLElement;
   onViewerOpen: (src?: string, alt?: string) => void;
 }) {
+  const { pane, paneId } = usePaneContext();
   const editorApiRef = useRef<PromptEditorRef | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const isCreatingConversationRef = useRef(false);
   const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
   const { value: promptLibrary } = usePromptLibrary();
 
@@ -524,20 +531,85 @@ const ComposerForStore = observer(function ComposerForStore({
     issueProviderContext.repositoryUrl,
   ]);
 
+  const conversation = conversationRegistry
+    .get(store.taskId)
+    ?.conversations.get(store.conversationId);
+  const providerId = conversation?.data.providerId ?? null;
+  const connectionId = getProjectSshConnectionId(store.projectId);
   const { data: agents } = useAgents();
+  const { data: agentStatuses } = useAgentInstallationStatuses(connectionId);
+  const installedAgentIds = useMemo(
+    () =>
+      new Set(
+        (agentStatuses ?? [])
+          .filter((status) => status.status === 'available')
+          .map((status) => status.id)
+      ),
+    [agentStatuses]
+  );
   const agentOptions = useMemo<ComposerAgentOption[]>(
     () =>
-      (agents ?? []).map((a) => ({
-        id: a.id,
-        name: a.name,
-        icon: <AgentIcon id={a.id} size={14} className="rounded-sm" />,
-      })),
-    [agents]
+      (agents ?? [])
+        .filter((agent) => installedAgentIds.has(agent.id) && agentSupportsAcp(agent.capabilities))
+        .map((agent) => ({
+          id: agent.id,
+          name: agent.name,
+          icon: <AgentIcon id={agent.id} size={14} className="rounded-sm" />,
+        })),
+    [agents, installedAgentIds]
   );
 
-  const providerId =
-    conversationRegistry.get(store.taskId)?.conversations.get(store.conversationId)?.data
-      .providerId ?? null;
+  const handleAgentChange = useCallback(
+    async (nextProviderId: string) => {
+      if (
+        isCreatingConversationRef.current ||
+        nextProviderId === providerId ||
+        !installedAgentIds.has(nextProviderId)
+      ) {
+        return;
+      }
+
+      const nextAgent = agents?.find(
+        (agent) => agent.id === nextProviderId && agentSupportsAcp(agent.capabilities)
+      );
+      const conversationManager = conversationRegistry.get(store.taskId);
+      if (!nextAgent || !conversationManager) return;
+
+      isCreatingConversationRef.current = true;
+      const conversationId = crypto.randomUUID();
+      const title = nextDefaultConversationTitle(
+        nextAgent.id,
+        Array.from(conversationManager.conversations.values(), (item) => item.data)
+      );
+
+      try {
+        await conversationManager.createConversation({
+          projectId: store.projectId,
+          taskId: store.taskId,
+          id: conversationId,
+          autoApprove: conversation?.data.autoApprove,
+          provider: nextAgent.id as AgentProviderId,
+          title,
+          type: 'acp',
+        });
+        pane.open('acp-chat', { conversationId }, { preview: false, target: { paneId } });
+      } catch (error) {
+        log.error('Failed to create conversation when changing agents', {
+          providerId: nextProviderId,
+          error,
+        });
+        toast({
+          title: 'Failed to create conversation',
+          description: `Could not start a new chat with ${nextAgent.name}.`,
+          variant: 'destructive',
+        });
+      } finally {
+        isCreatingConversationRef.current = false;
+      }
+    },
+    [agents, conversation?.data.autoApprove, installedAgentIds, pane, paneId, providerId, store]
+  );
+
   const renderMentionIcon = useCallback(({ id, kind }: { id: string; kind: string }) => {
     if (kind !== 'issue') return null;
     const target = parseIssueMentionToken(id);
@@ -608,8 +680,7 @@ const ComposerForStore = observer(function ComposerForStore({
         onPermissionModeChange={handleModeChange}
         agentOptions={agentOptions}
         selectedAgent={providerId ?? undefined}
-        agentLocked
-        onAgentChange={() => {}}
+        onAgentChange={(agentId) => void handleAgentChange(agentId)}
         contextUsage={
           store.usage
             ? {

--- a/packages/ui/src/react/components/chat-composer/index.tsx
+++ b/packages/ui/src/react/components/chat-composer/index.tsx
@@ -687,6 +687,7 @@ export function ChatComposer({
       ? `${selectedAgentItem.name} — agents can't be switched after a conversation starts`
       : selectedAgentItem.name
     : undefined;
+  const showHarnessSelector = !!agentOptions?.length;
 
   // ── Effort items ─────────────────────────────────────────────────────────────
 
@@ -901,31 +902,69 @@ export function ChatComposer({
                 detailSide="right"
                 detailAlign="start"
                 renderFooter={
-                  effortItems.length > 0
+                  showHarnessSelector || effortItems.length > 0
                     ? () => (
-                        <DropdownMenu.Root>
-                          <DropdownMenu.Trigger className={styles.effortRow}>
-                            <span className={styles.effortRowLabel}>Effort</span>
-                            <span className={styles.effortRowValue}>
-                              {selectedEffortItem?.name ?? 'Default'}
-                              <ChevronRight
-                                style={{ width: '0.75rem', height: '0.75rem', flexShrink: 0 }}
-                              />
-                            </span>
-                          </DropdownMenu.Trigger>
-                          <DropdownMenu.Content side="right" align="start" sideOffset={4}>
-                            <DropdownMenu.RadioGroup
-                              value={selectedEffort}
-                              onValueChange={(v) => onEffortChange?.(String(v))}
-                            >
-                              {effortItems.map((e) => (
-                                <DropdownMenu.RadioItem key={e.id} value={e.id}>
-                                  {e.name}
-                                </DropdownMenu.RadioItem>
-                              ))}
-                            </DropdownMenu.RadioGroup>
-                          </DropdownMenu.Content>
-                        </DropdownMenu.Root>
+                        <>
+                          {effortItems.length > 0 && (
+                            <DropdownMenu.Root>
+                              <DropdownMenu.Trigger className={styles.effortRow}>
+                                <span className={styles.effortRowLabel}>Effort</span>
+                                <span className={styles.effortRowValue}>
+                                  {selectedEffortItem?.name ?? 'Default'}
+                                  <ChevronRight
+                                    style={{ width: '0.75rem', height: '0.75rem', flexShrink: 0 }}
+                                  />
+                                </span>
+                              </DropdownMenu.Trigger>
+                              <DropdownMenu.Content side="right" align="start" sideOffset={4}>
+                                <DropdownMenu.RadioGroup
+                                  value={selectedEffort}
+                                  onValueChange={(v) => onEffortChange?.(String(v))}
+                                >
+                                  {effortItems.map((e) => (
+                                    <DropdownMenu.RadioItem key={e.id} value={e.id}>
+                                      {e.name}
+                                    </DropdownMenu.RadioItem>
+                                  ))}
+                                </DropdownMenu.RadioGroup>
+                              </DropdownMenu.Content>
+                            </DropdownMenu.Root>
+                          )}
+                          {showHarnessSelector && agentOptions && (
+                            <DropdownMenu.Root>
+                              <DropdownMenu.Trigger
+                                className={styles.effortRow}
+                                disabled={agentLocked || disabled}
+                              >
+                                <span className={styles.effortRowLabel}>Harness</span>
+                                <span className={styles.effortRowValue}>
+                                  {selectedAgentItem?.name ?? 'Select'}
+                                  <ChevronRight
+                                    style={{ width: '0.75rem', height: '0.75rem', flexShrink: 0 }}
+                                  />
+                                </span>
+                              </DropdownMenu.Trigger>
+                              <DropdownMenu.Content side="right" align="start" sideOffset={4}>
+                                <DropdownMenu.RadioGroup
+                                  value={selectedAgent}
+                                  onValueChange={(value) => onAgentChange?.(String(value))}
+                                >
+                                  {agentOptions.map((agent) => (
+                                    <DropdownMenu.RadioItem
+                                      key={agent.id}
+                                      value={agent.id}
+                                      disabled={agent.disabled}
+                                      closeOnClick
+                                    >
+                                      {agent.icon}
+                                      {agent.name}
+                                    </DropdownMenu.RadioItem>
+                                  ))}
+                                </DropdownMenu.RadioGroup>
+                              </DropdownMenu.Content>
+                            </DropdownMenu.Root>
+                          )}
+                        </>
                       )
                     : undefined
                 }


### PR DESCRIPTION
### Description

Adds a Harness submenu below Effort in the existing conversation model picker. It lists installed ACP-capable harnesses and opens the selected harness in a new chat while preserving the current conversation and auto-approve setting.

The new chat is opened in the originating pane, and duplicate creation is prevented while the conversation is being created.

### Related issue

Linear: ENG-1899

### Screenshot
<img width="432" height="341" alt="Screenshot 2026-07-21 at 21 18 59" src="https://github.com/user-attachments/assets/4f05d2e8-b3a5-4008-af95-3eb027ceec92" />
