### PR TITLE
feat(mcp): add mcp support for emdash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -400,7 +400,8 @@ pnpm run test
   `pushRemote`, `tmux`, and `workspaceProvider` are DB-backed, not `.emdash.json`.
 - Optional environment variables include `TELEMETRY_ENABLED`, `EMDASH_DB_FILE`,
   `EMDASH_DISABLE_NATIVE_DB`, `EMDASH_DISABLE_CLONE_CACHE`, `EMDASH_DISABLE_PTY`,
-  `CODEX_SANDBOX_MODE`, and `CODEX_APPROVAL_POLICY`.
+  `EMDASH_MCP_SERVER` (set to `false` to disable the built-in MCP server),
+  `EMDASH_MCP_PORT`, `CODEX_SANDBOX_MODE`, and `CODEX_APPROVAL_POLICY`.
 - Build-time telemetry configuration may use `VITE_POSTHOG_KEY` and `VITE_POSTHOG_HOST`.
 - Runtime feature flags are read through telemetry-backed feature flag helpers.
 - App path aliases are defined in `tsconfig.json` and mirrored in `electron.vite.config.ts`:

--- a/apps/emdash-desktop/package.json
+++ b/apps/emdash-desktop/package.json
@@ -62,6 +62,7 @@
     "@gitbeaker/rest": "^43.8.0",
     "@linear/sdk": "^77.0.0",
     "@llamaduck/forgejo-ts": "^14.0.3",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@octokit/auth-oauth-device": "^8.0.3",
     "@octokit/rest": "^22.0.1",
     "@parcel/watcher": "^2.5.6",

--- a/apps/emdash-desktop/src/assets/images/mcp/emdash.svg
+++ b/apps/emdash-desktop/src/assets/images/mcp/emdash.svg
@@ -1,0 +1,4 @@
+<svg role="img" viewBox="8 4.6985 23.4459 23.4459" fill="none" xmlns="http://www.w3.org/2000/svg">
+<title>emdash</title>
+<path d="M13.2625 13.2642H31.4459L26.1835 19.5786H8L13.2625 13.2642Z" fill="currentColor"/>
+</svg>

--- a/apps/emdash-desktop/src/main/core/git/repository/service.ts
+++ b/apps/emdash-desktop/src/main/core/git/repository/service.ts
@@ -53,8 +53,10 @@ export class GitRepositoryService {
     return (await this.getConfiguredRemotes()).pushRemote;
   }
 
-  async getDefaultBranch(): Promise<string> {
-    return this.gitRepository.getDefaultBranch(await this.getBaseRemote());
+  async getDefaultBranch(baseRemote?: string): Promise<string> {
+    // Callers that already resolved the base remote can pass it to avoid a
+    // redundant settings + `git remote` round trip.
+    return this.gitRepository.getDefaultBranch(baseRemote ?? (await this.getBaseRemote()));
   }
 
   async getRemotes(): Promise<{ name: string; url: string }[]> {

--- a/apps/emdash-desktop/src/main/core/mcp/controller.test.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/controller.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EMDASH_SELF_SERVER_NAME, type McpServer } from '@shared/core/mcp/types';
+import type * as SelfRegistration from './server/self-registration';
+
+const mocks = vi.hoisted(() => ({
+  loadAll: vi.fn(),
+  saveServer: vi.fn(),
+  listForAgent: vi.fn(),
+  resolveSelfServer: vi.fn(),
+  getConnectionInfo: vi.fn(),
+}));
+
+vi.mock('@emdash/plugins/agents', () => ({
+  pluginRegistry: { getAll: () => [] },
+}));
+
+vi.mock('@main/core/dependencies/dependency-managers', () => ({
+  localDependencyManager: { get: vi.fn(), probeCategory: vi.fn() },
+}));
+
+vi.mock('@main/lib/logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// Keep the real isSelfServerEntry (the controller's ownership check) and mock
+// only the connection-info-dependent resolveSelfServer.
+vi.mock('./server/self-registration', async (importOriginal) => {
+  const actual = await importOriginal<typeof SelfRegistration>();
+  return { ...actual, resolveSelfServer: mocks.resolveSelfServer };
+});
+
+vi.mock('./server/mcp-http-server', () => ({
+  mcpHttpServer: { getConnectionInfo: mocks.getConnectionInfo },
+}));
+
+vi.mock('./services/McpService', () => ({
+  mcpService: {
+    loadAll: mocks.loadAll,
+    saveServer: mocks.saveServer,
+    removeServer: vi.fn(),
+    listForAgent: mocks.listForAgent,
+  },
+}));
+
+const { mcpController } = await import('./controller');
+
+function selfEntry(): McpServer {
+  return {
+    name: EMDASH_SELF_SERVER_NAME,
+    transport: 'http',
+    url: 'http://127.0.0.1:8212/mcp',
+    headers: { Authorization: 'Bearer secret-token' },
+    providers: ['claude'],
+  };
+}
+
+function customServer(overrides: Partial<McpServer> = {}): McpServer {
+  return {
+    name: 'linear',
+    transport: 'http',
+    url: 'https://mcp.linear.app/mcp',
+    headers: { Authorization: 'Bearer linear-token' },
+    providers: ['claude'],
+    ...overrides,
+  };
+}
+
+/** A user's own server that happens to use the managed "emdash" name. */
+function foreignEmdashServer(): McpServer {
+  return {
+    name: EMDASH_SELF_SERVER_NAME,
+    transport: 'http',
+    url: 'https://mcp.example.com/mcp',
+    headers: { Authorization: 'Bearer user-token' },
+    providers: ['claude'],
+  };
+}
+
+const managedEntry = {
+  key: EMDASH_SELF_SERVER_NAME,
+  name: EMDASH_SELF_SERVER_NAME,
+  description: 'Built-in server',
+  docsUrl: '',
+  defaultConfig: { type: 'http' },
+  credentialKeys: [],
+  managed: true,
+};
+
+const plainEntry = {
+  key: 'linear',
+  name: 'Linear',
+  description: 'Issue tracking',
+  docsUrl: 'https://linear.app',
+  defaultConfig: { type: 'http', url: 'https://mcp.linear.app/mcp' },
+  credentialKeys: [],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.saveServer.mockResolvedValue(undefined);
+  mocks.loadAll.mockResolvedValue({ installed: [], catalog: [] });
+  mocks.getConnectionInfo.mockReturnValue({
+    url: 'http://127.0.0.1:8212/mcp',
+    token: 'live-token',
+  });
+});
+
+describe('loadAll', () => {
+  it('redacts and flags the emdash entry, leaving other servers untouched', async () => {
+    mocks.loadAll.mockResolvedValue({ installed: [selfEntry(), customServer()], catalog: [] });
+    const result = await mcpController.loadAll();
+    expect(result).toEqual({
+      success: true,
+      data: {
+        installed: [{ ...selfEntry(), headers: undefined, managed: true }, customServer()],
+        catalog: [],
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain('secret-token');
+  });
+
+  it('leaves an unrelated emdash-named server unredacted and unmanaged', async () => {
+    mocks.loadAll.mockResolvedValue({ installed: [foreignEmdashServer()], catalog: [] });
+    const result = await mcpController.loadAll();
+    expect(result).toEqual({
+      success: true,
+      data: { installed: [foreignEmdashServer()], catalog: [] },
+    });
+  });
+
+  it('fills the live url into managed catalog entries', async () => {
+    mocks.loadAll.mockResolvedValue({ installed: [], catalog: [managedEntry, plainEntry] });
+    const result = await mcpController.loadAll();
+    expect(result).toEqual({
+      success: true,
+      data: {
+        installed: [],
+        catalog: [
+          {
+            ...managedEntry,
+            defaultConfig: { type: 'http', url: 'http://127.0.0.1:8212/mcp' },
+          },
+          plainEntry,
+        ],
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain('live-token');
+  });
+
+  it('omits managed catalog entries when the server is not running', async () => {
+    mocks.getConnectionInfo.mockReturnValue(null);
+    mocks.loadAll.mockResolvedValue({ installed: [], catalog: [managedEntry, plainEntry] });
+    const result = await mcpController.loadAll();
+    expect(result).toEqual({
+      success: true,
+      data: { installed: [], catalog: [plainEntry] },
+    });
+  });
+
+  it('returns a failure result when the service throws', async () => {
+    mocks.loadAll.mockRejectedValue(new Error('config unreadable'));
+    const result = await mcpController.loadAll();
+    expect(result).toEqual({ success: false, error: 'config unreadable' });
+  });
+});
+
+describe('saveServer', () => {
+  it('passes ordinary servers through unchanged', async () => {
+    const server = customServer();
+    const result = await mcpController.saveServer(server);
+    expect(result).toEqual({ success: true });
+    expect(mocks.saveServer).toHaveBeenCalledWith(server);
+    expect(mocks.resolveSelfServer).not.toHaveBeenCalled();
+  });
+
+  it('replaces an emdash-named save with the resolved managed entry', async () => {
+    const resolved = selfEntry();
+    mocks.resolveSelfServer.mockReturnValue(resolved);
+    const result = await mcpController.saveServer({
+      name: EMDASH_SELF_SERVER_NAME,
+      transport: 'http',
+      providers: ['claude', 'codex'],
+    });
+    expect(result).toEqual({ success: true });
+    expect(mocks.resolveSelfServer).toHaveBeenCalledWith(['claude', 'codex']);
+    expect(mocks.saveServer).toHaveBeenCalledWith(resolved);
+  });
+
+  it('preserves user-set fields from the installed emdash entry', async () => {
+    mocks.loadAll.mockResolvedValue({
+      installed: [{ ...selfEntry(), enabled: false, timeout: 30_000 }],
+      catalog: [],
+    });
+    mocks.resolveSelfServer.mockReturnValue(selfEntry());
+    const result = await mcpController.saveServer({
+      name: EMDASH_SELF_SERVER_NAME,
+      transport: 'http',
+      providers: ['claude'],
+    });
+    expect(result).toEqual({ success: true });
+    expect(mocks.saveServer).toHaveBeenCalledWith({
+      ...selfEntry(),
+      enabled: false,
+      timeout: 30_000,
+    });
+  });
+
+  it('saves an unrelated emdash-named server as-is instead of hijacking it', async () => {
+    mocks.loadAll.mockResolvedValue({ installed: [foreignEmdashServer()], catalog: [] });
+    const edited = { ...foreignEmdashServer(), providers: ['claude', 'codex'] };
+    const result = await mcpController.saveServer(edited);
+    expect(result).toEqual({ success: true });
+    expect(mocks.saveServer).toHaveBeenCalledWith(edited);
+    expect(mocks.resolveSelfServer).not.toHaveBeenCalled();
+  });
+
+  it('fails without writing when the emdash server is not running', async () => {
+    mocks.resolveSelfServer.mockImplementation(() => {
+      throw new Error('The emdash MCP server is not running');
+    });
+    const result = await mcpController.saveServer({
+      name: EMDASH_SELF_SERVER_NAME,
+      transport: 'http',
+      providers: ['claude'],
+    });
+    expect(result).toEqual({ success: false, error: 'The emdash MCP server is not running' });
+    expect(mocks.saveServer).not.toHaveBeenCalled();
+  });
+});
+
+describe('listForAgent', () => {
+  it('redacts and flags the emdash entry, leaving other servers untouched', async () => {
+    mocks.listForAgent.mockResolvedValue([selfEntry(), customServer()]);
+    const result = await mcpController.listForAgent('claude');
+    expect(result).toEqual({
+      success: true,
+      data: [{ ...selfEntry(), headers: undefined, managed: true }, customServer()],
+    });
+    expect(JSON.stringify(result)).not.toContain('secret-token');
+  });
+});

--- a/apps/emdash-desktop/src/main/core/mcp/controller.test.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/controller.test.ts
@@ -205,6 +205,14 @@ describe('saveServer', () => {
     });
   });
 
+  it('saves a new custom emdash-named server as-is instead of hijacking it', async () => {
+    const submitted = foreignEmdashServer();
+    const result = await mcpController.saveServer(submitted);
+    expect(result).toEqual({ success: true });
+    expect(mocks.saveServer).toHaveBeenCalledWith(submitted);
+    expect(mocks.resolveSelfServer).not.toHaveBeenCalled();
+  });
+
   it('saves an unrelated emdash-named server as-is instead of hijacking it', async () => {
     mocks.loadAll.mockResolvedValue({ installed: [foreignEmdashServer()], catalog: [] });
     const edited = { ...foreignEmdashServer(), providers: ['claude', 'codex'] };

--- a/apps/emdash-desktop/src/main/core/mcp/controller.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/controller.ts
@@ -40,16 +40,17 @@ function redactManagedServer(server: McpServer): McpServer {
 
 /**
  * The managed emdash entry's connection details come from the live server,
- * not the caller — callers only choose providers. But only when the installed
- * entry (if any) is actually ours: a user's own server that happens to use
- * the managed name is saved as-is instead of being overwritten with loopback
- * connection details.
+ * not the caller — callers only choose providers. But only when the entry is
+ * actually ours: a user's own server that happens to use the managed name,
+ * whether already installed or newly submitted with its own URL, is saved
+ * as-is instead of being overwritten with loopback connection details.
  */
 async function resolveServerForSave(server: McpServer): Promise<McpServer> {
   if (!isManagedCatalogKey(server.name)) return server;
   const { installed } = await mcpService.loadAll();
   const existing = installed.find((entry) => entry.name === server.name);
   if (existing && !isSelfServerEntry(existing)) return server;
+  if (!existing && server.url && !isSelfServerEntry(server)) return server;
   // Spread the existing entry first so user-set fields (enabled, timeout,
   // cwd) survive; connection details are always replaced.
   return { ...existing, ...resolveSelfServer(server.providers) };

--- a/apps/emdash-desktop/src/main/core/mcp/controller.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/controller.ts
@@ -5,7 +5,10 @@ import { localDependencyManager } from '@main/core/dependencies/dependency-manag
 import { log } from '@main/lib/logger';
 import type { McpProvidersResponse, McpServer } from '@shared/core/mcp/types';
 import { createRPCController } from '@shared/lib/ipc/rpc';
+import { mcpHttpServer } from './server/mcp-http-server';
+import { isSelfServerEntry, resolveSelfServer } from './server/self-registration';
 import { mcpService } from './services/McpService';
+import { isManagedCatalogKey } from './utils/catalog';
 
 function mapProviders(): McpProvidersResponse[] {
   return pluginRegistry
@@ -24,11 +27,48 @@ function mapProviders(): McpProvidersResponse[] {
     });
 }
 
+/**
+ * Managed entries carry the local bearer token in their Authorization header;
+ * never send it to the renderer. The `managed` annotation tells the renderer
+ * to treat the entry's connection details as read-only. An unrelated server
+ * that happens to use a managed name is passed through untouched.
+ */
+function redactManagedServer(server: McpServer): McpServer {
+  if (!isManagedCatalogKey(server.name) || !isSelfServerEntry(server)) return server;
+  return { ...server, headers: undefined, managed: true };
+}
+
+/**
+ * The managed emdash entry's connection details come from the live server,
+ * not the caller — callers only choose providers. But only when the installed
+ * entry (if any) is actually ours: a user's own server that happens to use
+ * the managed name is saved as-is instead of being overwritten with loopback
+ * connection details.
+ */
+async function resolveServerForSave(server: McpServer): Promise<McpServer> {
+  if (!isManagedCatalogKey(server.name)) return server;
+  const { installed } = await mcpService.loadAll();
+  const existing = installed.find((entry) => entry.name === server.name);
+  if (existing && !isSelfServerEntry(existing)) return server;
+  // Spread the existing entry first so user-set fields (enabled, timeout,
+  // cwd) survive; connection details are always replaced.
+  return { ...existing, ...resolveSelfServer(server.providers) };
+}
+
 export const mcpController = createRPCController({
   loadAll: async () => {
     try {
       const data = await mcpService.loadAll();
-      return { success: true, data };
+      const installed = data.installed.map(redactManagedServer);
+      // Managed entries are only offered while the local server is running,
+      // and their static catalog config has no URL — fill in the live address.
+      const info = mcpHttpServer.getConnectionInfo();
+      const catalog = data.catalog.flatMap((entry) => {
+        if (!entry.managed) return [entry];
+        if (!info) return [];
+        return [{ ...entry, defaultConfig: { ...entry.defaultConfig, url: info.url } }];
+      });
+      return { success: true, data: { installed, catalog } };
     } catch (error) {
       log.error('Failed to load MCP servers:', error);
       return { success: false, error: error instanceof Error ? error.message : String(error) };
@@ -37,7 +77,7 @@ export const mcpController = createRPCController({
 
   saveServer: async (server: McpServer) => {
     try {
-      await mcpService.saveServer(server);
+      await mcpService.saveServer(await resolveServerForSave(server));
       return { success: true };
     } catch (error) {
       log.error('Failed to save MCP server:', error);
@@ -77,7 +117,7 @@ export const mcpController = createRPCController({
   listForAgent: async (agentId: string) => {
     try {
       const data = await mcpService.listForAgent(agentId);
-      return { success: true, data };
+      return { success: true, data: data.map(redactManagedServer) };
     } catch (error) {
       log.error('Failed to list MCP servers for agent:', error);
       return { success: false, error: error instanceof Error ? error.message : String(error) };

--- a/apps/emdash-desktop/src/main/core/mcp/server/create-task-from-prompt.test.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/server/create-task-from-prompt.test.ts
@@ -1,0 +1,386 @@
+import { err, ok } from '@emdash/shared';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GitRepositoryService } from '@main/core/git/repository/service';
+
+const mocks = vi.hoisted(() => ({
+  getAcpRuntimeClient: vi.fn(),
+  startSession: vi.fn(),
+  getPlugin: vi.fn(),
+  isValidProviderId: vi.fn(),
+  listPlugins: vi.fn(),
+  createConversation: vi.fn(),
+  openProject: vi.fn(),
+  getProject: vi.fn(),
+  settingsGet: vi.fn(),
+  generateRandom: vi.fn(),
+  generateTaskName: vi.fn(),
+  prepareCreateTask: vi.fn(),
+  commitCreateTask: vi.fn(),
+  finalizeCreateTask: vi.fn(),
+  notifyTaskCreated: vi.fn(),
+  launch: vi.fn(),
+  transaction: vi.fn(),
+}));
+
+vi.mock('@main/core/acp/controller', () => ({
+  getAcpRuntimeClient: mocks.getAcpRuntimeClient,
+}));
+
+vi.mock('@main/core/agents/plugin-registry', () => ({
+  getPlugin: mocks.getPlugin,
+  isValidProviderId: mocks.isValidProviderId,
+  listPlugins: mocks.listPlugins,
+}));
+
+vi.mock('@main/core/conversations/createConversation', () => ({
+  createConversation: mocks.createConversation,
+}));
+
+vi.mock('@main/core/projects/operations/openProject', () => ({
+  openProject: mocks.openProject,
+}));
+
+vi.mock('@main/core/projects/project-manager', () => ({
+  projectManager: { getProject: mocks.getProject },
+}));
+
+vi.mock('@main/core/settings/settings-registry', () => ({
+  DEFAULT_AGENT_ID: 'claude',
+}));
+
+vi.mock('@main/core/settings/settings-service', () => ({
+  appSettingsService: { get: mocks.settingsGet },
+}));
+
+vi.mock('@main/core/tasks/name-generation/generateTaskName', () => ({
+  generateRandom: mocks.generateRandom,
+  generateTaskName: mocks.generateTaskName,
+}));
+
+vi.mock('@main/core/tasks/operations/createTask', () => ({
+  prepareCreateTask: mocks.prepareCreateTask,
+  commitCreateTask: mocks.commitCreateTask,
+  finalizeCreateTask: mocks.finalizeCreateTask,
+}));
+
+vi.mock('@main/core/tasks/task-service', () => ({
+  taskService: { notifyTaskCreated: mocks.notifyTaskCreated, launch: mocks.launch },
+}));
+
+vi.mock('@main/db/client', () => ({
+  db: { transaction: mocks.transaction },
+}));
+
+const { createTaskFromPrompt, isValidBranchName, resolveFromBranch, resolveModel } =
+  await import('./create-task-from-prompt');
+
+const ORIGIN = { name: 'origin', url: 'git@example.com:owner/repo.git' };
+const UPSTREAM = { name: 'upstream', url: 'git@example.com:upstream/repo.git' };
+
+function fakeGitRepository(
+  overrides: {
+    defaultBranch?: string;
+    remotes?: { name: string; url: string }[];
+    baseRemote?: string;
+    branches?: unknown[];
+  } = {}
+): GitRepositoryService {
+  const branches = overrides.branches ?? [
+    { type: 'local', branch: 'main' },
+    { type: 'remote', branch: 'main', remote: ORIGIN },
+    { type: 'local', branch: 'local-only' },
+    { type: 'remote', branch: 'remote-only', remote: ORIGIN },
+    { type: 'remote', branch: 'upstream-only', remote: UPSTREAM },
+  ];
+  return {
+    getDefaultBranch: async () => overrides.defaultBranch ?? 'main',
+    getRemotes: async () => overrides.remotes ?? [ORIGIN, UPSTREAM],
+    getBaseRemote: async () => overrides.baseRemote ?? 'origin',
+    getSnapshot: async () => ({ refs: { value: { branches } } }),
+  } as unknown as GitRepositoryService;
+}
+
+const SELECTABLE_MODELS = {
+  kind: 'selectable',
+  modelOptions: { 'claude-fable-5': { name: 'Fable' }, 'claude-sonnet-5': { name: 'Sonnet' } },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getPlugin.mockReturnValue({
+    capabilities: { models: SELECTABLE_MODELS, acp: { kind: 'supported' } },
+  });
+  mocks.isValidProviderId.mockImplementation((id: string) => id === 'claude' || id === 'codex');
+  mocks.listPlugins.mockReturnValue([
+    { metadata: { id: 'claude' } },
+    { metadata: { id: 'codex' } },
+  ]);
+});
+
+describe('resolveModel', () => {
+  it('accepts an omitted or blank model', () => {
+    expect(resolveModel('claude', undefined)).toEqual(ok(undefined));
+    expect(resolveModel('claude', '   ')).toEqual(ok(undefined));
+  });
+
+  it('accepts a known model id, trimmed', () => {
+    expect(resolveModel('claude', ' claude-sonnet-5 ')).toEqual(ok('claude-sonnet-5'));
+  });
+
+  it('rejects providers without selectable models', () => {
+    mocks.getPlugin.mockReturnValue({ capabilities: { models: { kind: 'none' } } });
+    const result = resolveModel('claude', 'claude-sonnet-5');
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('does not support model selection');
+  });
+
+  it('rejects an unknown model and lists valid ids', () => {
+    const result = resolveModel('claude', 'gpt-4');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('Unknown model "gpt-4"');
+      expect(result.error).toContain('claude-fable-5, claude-sonnet-5');
+    }
+  });
+
+  it('rejects prototype-chain property names as model ids', () => {
+    expect(resolveModel('claude', 'toString').success).toBe(false);
+    expect(resolveModel('claude', 'constructor').success).toBe(false);
+  });
+});
+
+describe('resolveFromBranch', () => {
+  it('defaults to the default branch on the base remote', async () => {
+    const result = await resolveFromBranch(fakeGitRepository(), undefined);
+    expect(result).toEqual(ok({ type: 'remote', branch: 'main', remote: ORIGIN }));
+  });
+
+  it('falls back to a local default-branch ref when the base remote is missing', async () => {
+    const result = await resolveFromBranch(fakeGitRepository({ remotes: [] }), undefined);
+    expect(result).toEqual(ok({ type: 'local', branch: 'main' }));
+  });
+
+  it('treats a blank request like the default branch', async () => {
+    const result = await resolveFromBranch(fakeGitRepository(), '   ');
+    expect(result).toEqual(ok({ type: 'remote', branch: 'main', remote: ORIGIN }));
+  });
+
+  it('resolves a local-only branch to a local ref', async () => {
+    const result = await resolveFromBranch(fakeGitRepository(), 'local-only');
+    expect(result).toEqual(ok({ type: 'local', branch: 'local-only' }));
+  });
+
+  it('resolves a branch known only on the base remote to a remote ref', async () => {
+    const result = await resolveFromBranch(fakeGitRepository(), 'remote-only');
+    expect(result).toEqual(ok({ type: 'remote', branch: 'remote-only', remote: ORIGIN }));
+  });
+
+  it('falls back to any remote when the branch is not on the base remote', async () => {
+    const result = await resolveFromBranch(fakeGitRepository(), 'upstream-only');
+    expect(result).toEqual(ok({ type: 'remote', branch: 'upstream-only', remote: UPSTREAM }));
+  });
+
+  it('rejects an unknown branch', async () => {
+    const result = await resolveFromBranch(fakeGitRepository(), 'nope');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('Branch "nope" not found');
+      expect(result.error).not.toContain('remote prefix');
+    }
+  });
+
+  it('hints when the request looks remote-prefixed', async () => {
+    const result = await resolveFromBranch(fakeGitRepository(), 'origin/main');
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('without a remote prefix');
+  });
+});
+
+describe('isValidBranchName', () => {
+  it.each(['feat/mcp', 'my-branch', 'a', 'v1.2.3', 'chung/feat-mcp'])('accepts %s', (name) =>
+    expect(isValidBranchName(name)).toBe(true)
+  );
+
+  it.each([
+    '',
+    '@',
+    'bad name',
+    '-leading-dash',
+    '/leading-slash',
+    'trailing-slash/',
+    'trailing-dot.',
+    '.hidden',
+    'double//slash',
+    'dots..dots',
+    'at@{brace',
+    'ref.lock',
+    'seg/.hidden',
+    'colon:name',
+    'star*name',
+    'question?name',
+    'tilde~name',
+    'caret^name',
+    'back\\slash',
+    'bracket[name',
+  ])('rejects %j', (name) => expect(isValidBranchName(name)).toBe(false));
+});
+
+describe('createTaskFromPrompt', () => {
+  const INPUT = { projectId: 'p1', prompt: 'do the thing', provider: 'claude' };
+
+  beforeEach(() => {
+    mocks.getProject.mockReturnValue({ gitRepository: fakeGitRepository() });
+    mocks.generateRandom.mockReturnValue('breezy-otter');
+    mocks.generateTaskName.mockReturnValue('breezy-otter-branch');
+    mocks.prepareCreateTask.mockResolvedValue(ok({ params: true }));
+    mocks.transaction.mockImplementation((fn: (tx: unknown) => void) => fn({}));
+    mocks.commitCreateTask.mockReturnValue({ taskRow: { id: 'row' }, convRow: undefined });
+    mocks.finalizeCreateTask.mockReturnValue({ task: { id: 'row' } });
+    mocks.launch.mockResolvedValue(ok({ workspaceId: 'ws1', path: '/tmp/worktree' }));
+    mocks.createConversation.mockResolvedValue(undefined);
+    mocks.startSession.mockResolvedValue(ok(undefined));
+    mocks.getAcpRuntimeClient.mockResolvedValue({ startSession: mocks.startSession });
+    mocks.settingsGet.mockResolvedValue('claude');
+  });
+
+  it('rejects an empty prompt', async () => {
+    const result = await createTaskFromPrompt({ ...INPUT, prompt: '  ' });
+    expect(result).toEqual(err('prompt must not be empty'));
+    expect(mocks.prepareCreateTask).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown project after trying to open it', async () => {
+    mocks.getProject.mockReturnValue(undefined);
+    mocks.openProject.mockResolvedValue(err({ type: 'not-found' }));
+    const result = await createTaskFromPrompt(INPUT);
+    expect(result).toEqual(err('Project not found: p1'));
+  });
+
+  it('rejects an unknown provider and lists valid ids', async () => {
+    const result = await createTaskFromPrompt({ ...INPUT, provider: 'not-a-provider' });
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('claude, codex');
+  });
+
+  it('rejects an invalid explicit branch name before creating anything', async () => {
+    const result = await createTaskFromPrompt({ ...INPUT, branchName: 'bad name' });
+    expect(result).toEqual(err('Invalid branch name: "bad name"'));
+    expect(mocks.prepareCreateTask).not.toHaveBeenCalled();
+  });
+
+  it('rejects a task name that derives an unusable branch name', async () => {
+    mocks.generateTaskName.mockReturnValue('');
+    const result = await createTaskFromPrompt({ ...INPUT, name: '!!!' });
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('pass branchName explicitly');
+    expect(mocks.prepareCreateTask).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the default agent when no provider is given', async () => {
+    mocks.settingsGet.mockResolvedValue('codex');
+    const result = await createTaskFromPrompt({ projectId: 'p1', prompt: 'go' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.provider).toBe('codex');
+  });
+
+  it('starts a terminal (pty) conversation by default', async () => {
+    const result = await createTaskFromPrompt(INPUT);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.conversationType).toBe('pty');
+    expect(mocks.createConversation).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'pty', initialPrompt: 'do the thing' })
+    );
+    expect(mocks.startSession).not.toHaveBeenCalled();
+  });
+
+  it('starts an acp conversation when chatUi is set and the provider supports it', async () => {
+    const result = await createTaskFromPrompt({ ...INPUT, chatUi: true });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.conversationType).toBe('acp');
+    expect(mocks.createConversation).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'acp', initialQueue: [{ text: 'do the thing' }] })
+    );
+    expect(mocks.startSession).toHaveBeenCalledWith({
+      input: expect.objectContaining({ providerId: 'claude', cwd: '/tmp/worktree', model: null }),
+    });
+  });
+
+  it('falls back to pty when chatUi is set but the provider lacks acp support', async () => {
+    mocks.getPlugin.mockReturnValue({
+      capabilities: { models: SELECTABLE_MODELS, acp: { kind: 'unsupported' } },
+    });
+    const result = await createTaskFromPrompt({ ...INPUT, chatUi: true });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.conversationType).toBe('pty');
+  });
+
+  it('passes a validated model through to the conversation', async () => {
+    const result = await createTaskFromPrompt({ ...INPUT, model: 'claude-sonnet-5' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.model).toBe('claude-sonnet-5');
+    expect(mocks.createConversation).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'claude-sonnet-5' })
+    );
+  });
+
+  it('reports a provisioning failure with the task id', async () => {
+    mocks.launch.mockResolvedValue(
+      err({ type: 'setup-failed', message: 'setup script exploded', stepErrorType: 'script' })
+    );
+    const result = await createTaskFromPrompt(INPUT);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('workspace provisioning failed');
+      expect(result.error).toContain('setup script exploded');
+    }
+    expect(mocks.createConversation).not.toHaveBeenCalled();
+  });
+
+  it('returns a structured error when the pty conversation fails to spawn', async () => {
+    mocks.createConversation.mockRejectedValue(new Error('spawn ENOENT'));
+    const result = await createTaskFromPrompt(INPUT);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('agent session failed to start');
+      expect(result.error).toContain('spawn ENOENT');
+    }
+  });
+
+  it('returns a structured error when the acp session fails to start', async () => {
+    mocks.startSession.mockResolvedValue(err({ type: 'spawn-failed', message: 'no binary' }));
+    const result = await createTaskFromPrompt({ ...INPUT, chatUi: true });
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('no binary');
+  });
+
+  it('returns the created task details on success', async () => {
+    const result = await createTaskFromPrompt({ ...INPUT, name: 'My Task', branchName: 'my-br' });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toEqual({
+      taskId: expect.any(String),
+      taskName: 'My Task',
+      branchName: 'my-br',
+      provider: 'claude',
+      model: null,
+      conversationType: 'pty',
+      workspacePath: '/tmp/worktree',
+    });
+    expect(mocks.notifyTaskCreated).toHaveBeenCalled();
+  });
+
+  it('builds the workspace config from the new-worktree preset without pushing', async () => {
+    await createTaskFromPrompt(INPUT);
+    const params = mocks.prepareCreateTask.mock.calls[0]?.[0];
+    expect(params.workspaceConfig).toEqual({
+      version: '2',
+      git: {
+        kind: 'create-branch',
+        fromBranch: { type: 'remote', branch: 'main', remote: ORIGIN },
+        branchName: 'breezy-otter-branch',
+        pushBranch: false,
+      },
+      workspace: { kind: 'new-worktree' },
+    });
+  });
+});

--- a/apps/emdash-desktop/src/main/core/mcp/server/create-task-from-prompt.test.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/server/create-task-from-prompt.test.ts
@@ -243,10 +243,36 @@ describe('createTaskFromPrompt', () => {
     mocks.settingsGet.mockResolvedValue('claude');
   });
 
-  it('rejects an empty prompt', async () => {
+  it('creates an idle task without a conversation when no prompt is given', async () => {
+    const result = await createTaskFromPrompt({ projectId: 'p1' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toMatchObject({
+        conversationType: 'none',
+        provider: null,
+        model: null,
+        workspacePath: '/tmp/worktree',
+      });
+    }
+    // The task and worktree are still created, but no agent is started.
+    expect(mocks.prepareCreateTask).toHaveBeenCalled();
+    expect(mocks.launch).toHaveBeenCalled();
+    expect(mocks.createConversation).not.toHaveBeenCalled();
+    expect(mocks.startSession).not.toHaveBeenCalled();
+  });
+
+  it('treats a whitespace-only prompt as no prompt', async () => {
     const result = await createTaskFromPrompt({ ...INPUT, prompt: '  ' });
-    expect(result).toEqual(err('prompt must not be empty'));
-    expect(mocks.prepareCreateTask).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.conversationType).toBe('none');
+    expect(mocks.createConversation).not.toHaveBeenCalled();
+  });
+
+  it('does not resolve or validate a provider for a promptless task', async () => {
+    const result = await createTaskFromPrompt({ projectId: 'p1', provider: 'not-a-provider' });
+    // Provider is ignored when there is no prompt, so this does not error.
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.provider).toBe(null);
   });
 
   it('rejects an unknown project after trying to open it', async () => {

--- a/apps/emdash-desktop/src/main/core/mcp/server/create-task-from-prompt.test.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/server/create-task-from-prompt.test.ts
@@ -108,7 +108,11 @@ const SELECTABLE_MODELS = {
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.getPlugin.mockReturnValue({
-    capabilities: { models: SELECTABLE_MODELS, acp: { kind: 'supported' } },
+    capabilities: {
+      models: SELECTABLE_MODELS,
+      acp: { kind: 'supported' },
+      autoApprove: { kind: 'supported' },
+    },
   });
   mocks.isValidProviderId.mockImplementation((id: string) => id === 'claude' || id === 'codex');
   mocks.listPlugins.mockReturnValue([
@@ -240,8 +244,18 @@ describe('createTaskFromPrompt', () => {
     mocks.createConversation.mockResolvedValue(undefined);
     mocks.startSession.mockResolvedValue(ok(undefined));
     mocks.getAcpRuntimeClient.mockResolvedValue({ startSession: mocks.startSession });
-    mocks.settingsGet.mockResolvedValue('claude');
+    mockSettings();
   });
+
+  /** Stubs the two app settings the flow reads: the default agent and task defaults. */
+  function mockSettings({
+    defaultAgent = 'claude',
+    autoApproveByDefault = false,
+  }: { defaultAgent?: string; autoApproveByDefault?: boolean } = {}) {
+    mocks.settingsGet.mockImplementation(async (key: string) =>
+      key === 'tasks' ? { autoApproveByDefault } : defaultAgent
+    );
+  }
 
   it('creates an idle task without a conversation when no prompt is given', async () => {
     const result = await createTaskFromPrompt({ projectId: 'p1' });
@@ -251,6 +265,7 @@ describe('createTaskFromPrompt', () => {
         conversationType: 'none',
         provider: null,
         model: null,
+        autoApprove: null,
         workspacePath: '/tmp/worktree',
       });
     }
@@ -303,7 +318,7 @@ describe('createTaskFromPrompt', () => {
   });
 
   it('falls back to the default agent when no provider is given', async () => {
-    mocks.settingsGet.mockResolvedValue('codex');
+    mockSettings({ defaultAgent: 'codex' });
     const result = await createTaskFromPrompt({ projectId: 'p1', prompt: 'go' });
     expect(result.success).toBe(true);
     if (result.success) expect(result.data.provider).toBe('codex');
@@ -333,7 +348,11 @@ describe('createTaskFromPrompt', () => {
 
   it('falls back to pty when chatUi is set but the provider lacks acp support', async () => {
     mocks.getPlugin.mockReturnValue({
-      capabilities: { models: SELECTABLE_MODELS, acp: { kind: 'unsupported' } },
+      capabilities: {
+        models: SELECTABLE_MODELS,
+        acp: { kind: 'unsupported' },
+        autoApprove: { kind: 'supported' },
+      },
     });
     const result = await createTaskFromPrompt({ ...INPUT, chatUi: true });
     expect(result.success).toBe(true);
@@ -346,6 +365,55 @@ describe('createTaskFromPrompt', () => {
     if (result.success) expect(result.data.model).toBe('claude-sonnet-5');
     expect(mocks.createConversation).toHaveBeenCalledWith(
       expect.objectContaining({ model: 'claude-sonnet-5' })
+    );
+  });
+
+  it('starts the agent with permission prompts when autoApprove is not given', async () => {
+    const result = await createTaskFromPrompt(INPUT);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.autoApprove).toBe(false);
+    expect(mocks.createConversation).toHaveBeenCalledWith(
+      expect.objectContaining({ autoApprove: false })
+    );
+  });
+
+  it('skips permission prompts when autoApprove is set', async () => {
+    const result = await createTaskFromPrompt({ ...INPUT, autoApprove: true });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.autoApprove).toBe(true);
+    expect(mocks.createConversation).toHaveBeenCalledWith(
+      expect.objectContaining({ autoApprove: true })
+    );
+  });
+
+  it('falls back to the auto-approve-by-default task setting', async () => {
+    mockSettings({ autoApproveByDefault: true });
+    const result = await createTaskFromPrompt(INPUT);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.autoApprove).toBe(true);
+  });
+
+  it('lets an explicit autoApprove override the app default', async () => {
+    mockSettings({ autoApproveByDefault: true });
+    const result = await createTaskFromPrompt({ ...INPUT, autoApprove: false });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.autoApprove).toBe(false);
+  });
+
+  it('ignores autoApprove for a provider without an auto-approve mode', async () => {
+    mocks.getPlugin.mockReturnValue({
+      capabilities: {
+        models: SELECTABLE_MODELS,
+        acp: { kind: 'supported' },
+        autoApprove: { kind: 'unsupported' },
+      },
+    });
+    const result = await createTaskFromPrompt({ ...INPUT, autoApprove: true });
+    expect(result.success).toBe(true);
+    // Reported back as false so the caller can see the request was dropped.
+    if (result.success) expect(result.data.autoApprove).toBe(false);
+    expect(mocks.createConversation).toHaveBeenCalledWith(
+      expect.objectContaining({ autoApprove: false })
     );
   });
 
@@ -390,6 +458,7 @@ describe('createTaskFromPrompt', () => {
       provider: 'claude',
       model: null,
       conversationType: 'pty',
+      autoApprove: false,
       workspacePath: '/tmp/worktree',
     });
     expect(mocks.notifyTaskCreated).toHaveBeenCalled();

--- a/apps/emdash-desktop/src/main/core/mcp/server/create-task-from-prompt.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/server/create-task-from-prompt.ts
@@ -1,0 +1,293 @@
+import { randomUUID } from 'node:crypto';
+import type { GitBranchRef } from '@emdash/core/git';
+import type { AgentProviderId } from '@emdash/plugins/agents';
+import { err, ok, type Result } from '@emdash/shared';
+import { getAcpRuntimeClient } from '@main/core/acp/controller';
+import { getPlugin, isValidProviderId, listPlugins } from '@main/core/agents/plugin-registry';
+import { createConversation } from '@main/core/conversations/createConversation';
+import type { GitRepositoryService } from '@main/core/git/repository/service';
+import { openProject } from '@main/core/projects/operations/openProject';
+import { projectManager } from '@main/core/projects/project-manager';
+import { DEFAULT_AGENT_ID } from '@main/core/settings/settings-registry';
+import { appSettingsService } from '@main/core/settings/settings-service';
+import {
+  generateRandom,
+  generateTaskName,
+} from '@main/core/tasks/name-generation/generateTaskName';
+import {
+  commitCreateTask,
+  finalizeCreateTask,
+  prepareCreateTask,
+} from '@main/core/tasks/operations/createTask';
+import { taskService } from '@main/core/tasks/task-service';
+import { db } from '@main/db/client';
+import type { ConversationRow, TaskRow } from '@main/db/schema';
+import type { ConversationType } from '@shared/core/conversations/conversations';
+import type { CreateTaskParams } from '@shared/core/tasks/tasks';
+import { buildWorkspaceConfigFromPreset } from '@shared/core/workspaces/build-workspace-config-from-preset';
+import type { WorkspaceConfig } from '@shared/core/workspaces/workspace-config';
+
+export type McpCreateTaskInput = {
+  projectId: string;
+  prompt: string;
+  name?: string;
+  provider?: string;
+  model?: string;
+  branchName?: string;
+  baseBranch?: string;
+  chatUi?: boolean;
+};
+
+export type McpCreateTaskResult = {
+  taskId: string;
+  taskName: string;
+  branchName: string;
+  provider: AgentProviderId;
+  model: string | null;
+  conversationType: ConversationType;
+  workspacePath: string;
+};
+
+export async function ensureProjectOpen(projectId: string) {
+  let project = projectManager.getProject(projectId);
+  if (!project) {
+    const openResult = await openProject(projectId);
+    if (!openResult.success) return undefined;
+    project = projectManager.getProject(projectId);
+  }
+  return project;
+}
+
+/** Comma-separated provider ids, for error messages and tool descriptions. */
+export function validProviderIds(): string {
+  return listPlugins()
+    .map((plugin) => plugin.metadata.id)
+    .join(', ');
+}
+
+async function resolveProvider(
+  requested: string | undefined
+): Promise<Result<AgentProviderId, string>> {
+  if (requested) {
+    if (!isValidProviderId(requested)) {
+      return err(`Unknown provider "${requested}". Valid providers: ${validProviderIds()}`);
+    }
+    return ok(requested);
+  }
+  const configured = await appSettingsService.get('defaultAgent');
+  return ok(isValidProviderId(configured) ? configured : DEFAULT_AGENT_ID);
+}
+
+/**
+ * Practical subset of `git check-ref-format --branch`: rejects names git would
+ * refuse, so task creation fails here with a clear message instead of deep in
+ * worktree provisioning after the task row already exists.
+ */
+export function isValidBranchName(name: string): boolean {
+  if (!name || name === '@') return false;
+  if (/[\s~^:?*[\\\x00-\x1f\x7f]/.test(name)) return false;
+  if (name.startsWith('-') || name.startsWith('/') || name.endsWith('/')) return false;
+  if (name.includes('..') || name.includes('@{') || name.includes('//')) return false;
+  return !name
+    .split('/')
+    .some(
+      (segment) => segment.startsWith('.') || segment.endsWith('.') || segment.endsWith('.lock')
+    );
+}
+
+export function resolveModel(
+  provider: AgentProviderId,
+  requested: string | undefined
+): Result<string | undefined, string> {
+  const model = requested?.trim();
+  if (!model) return ok(undefined);
+  const models = getPlugin(provider).capabilities.models;
+  if (models.kind !== 'selectable') {
+    return err(`Provider "${provider}" does not support model selection`);
+  }
+  if (!Object.hasOwn(models.modelOptions, model)) {
+    const valid = Object.keys(models.modelOptions).join(', ');
+    return err(`Unknown model "${model}" for provider "${provider}". Valid models: ${valid}`);
+  }
+  return ok(model);
+}
+
+/**
+ * Builds the create-branch ref, matching what the renderer's new-task modal
+ * resolves for the "new worktree" preset: the base remote's ref when the
+ * branch is known there, a local ref otherwise.
+ */
+export async function resolveFromBranch(
+  gitRepository: GitRepositoryService,
+  requested: string | undefined
+): Promise<Result<GitBranchRef, string>> {
+  // Resolve the base remote once and reuse it: getDefaultBranch would
+  // otherwise repeat the settings + `git remote` lookups internally.
+  const [remotes, baseRemote] = await Promise.all([
+    gitRepository.getRemotes(),
+    gitRepository.getBaseRemote(),
+  ]);
+  const defaultBranch = await gitRepository.getDefaultBranch(baseRemote);
+
+  const branch = requested?.trim() || defaultBranch;
+  if (branch === defaultBranch) {
+    const remote = remotes.find((r) => r.name === baseRemote);
+    return ok(
+      remote
+        ? { type: 'remote', branch, remote: { name: remote.name, url: remote.url } }
+        : { type: 'local', branch }
+    );
+  }
+
+  const snapshot = await gitRepository.getSnapshot();
+  const candidates = snapshot.refs.value.branches.filter((b) => b.branch === branch);
+  const picked =
+    candidates.find((b) => b.type === 'remote' && b.remote.name === baseRemote) ??
+    candidates.find((b) => b.type === 'local') ??
+    candidates[0];
+  if (!picked) {
+    const hint = branch.includes('/')
+      ? ' Pass the branch name without a remote prefix (e.g. "main" instead of "origin/main").'
+      : '';
+    return err(`Branch "${branch}" not found in the repository.${hint}`);
+  }
+  return picked.type === 'remote'
+    ? ok({
+        type: 'remote',
+        branch: picked.branch,
+        remote: { name: picked.remote.name, url: picked.remote.url },
+      })
+    : ok({ type: 'local', branch: picked.branch });
+}
+
+function sessionStartFailure(taskId: string, detail: string): string {
+  return `Task ${taskId} was created but the agent session failed to start: ${detail}`;
+}
+
+/**
+ * Creates a task with a new worktree, provisions it, and starts the initial
+ * agent conversation from a prompt. Mirrors the automation task-create flow
+ * (`executeTaskCreate`) but is driven by the local MCP server instead of an
+ * automation run.
+ */
+export async function createTaskFromPrompt(
+  input: McpCreateTaskInput
+): Promise<Result<McpCreateTaskResult, string>> {
+  const prompt = input.prompt.trim();
+  if (!prompt) return err('prompt must not be empty');
+
+  const project = await ensureProjectOpen(input.projectId);
+  if (!project) return err(`Project not found: ${input.projectId}`);
+
+  const providerResult = await resolveProvider(input.provider);
+  if (!providerResult.success) return providerResult;
+  const provider = providerResult.data;
+
+  const modelResult = resolveModel(provider, input.model);
+  if (!modelResult.success) return modelResult;
+  const model = modelResult.data;
+
+  const taskName = input.name?.trim() || generateRandom();
+  const branchName = input.branchName?.trim() || generateTaskName({ title: taskName });
+  if (!isValidBranchName(branchName)) {
+    return input.branchName?.trim()
+      ? err(`Invalid branch name: "${branchName}"`)
+      : err(
+          `Could not derive a valid branch name from task name "${taskName}"; pass branchName explicitly`
+        );
+  }
+
+  const fromBranchResult = await resolveFromBranch(project.gitRepository, input.baseBranch);
+  if (!fromBranchResult.success) return fromBranchResult;
+  const fromBranch = fromBranchResult.data;
+
+  const workspaceConfig: WorkspaceConfig = buildWorkspaceConfigFromPreset(
+    'new-worktree',
+    {},
+    { fromBranch, branchName, pushBranch: false }
+  );
+
+  const taskId = randomUUID();
+  const createTaskParams: CreateTaskParams = {
+    id: taskId,
+    projectId: input.projectId,
+    taskConfig: { version: '1', name: taskName },
+    workspaceConfig,
+  };
+
+  const prepared = await prepareCreateTask(createTaskParams);
+  if (!prepared.success) return err(`Failed to create task: ${prepared.error.type}`);
+
+  let taskRow!: TaskRow;
+  let convRow: ConversationRow | undefined;
+  db.transaction((tx) => {
+    ({ taskRow, convRow } = commitCreateTask(prepared.data, tx));
+  });
+  const created = finalizeCreateTask(prepared.data, taskRow, convRow);
+  taskService.notifyTaskCreated(created.task, createTaskParams);
+
+  const provision = await taskService.launch(taskId);
+  if (!provision.success) {
+    const detail =
+      provision.error.type === 'setup-failed'
+        ? (provision.error.message ?? provision.error.stepErrorType)
+        : provision.error.type;
+    return err(`Task ${taskId} was created but workspace provisioning failed: ${detail}`);
+  }
+
+  // Matches the new-task modal: chat UI is opt-in and only available when the
+  // provider supports ACP; otherwise the agent runs in a terminal session.
+  const acpSupported = getPlugin(provider).capabilities.acp.kind === 'supported';
+  const conversationType: ConversationType =
+    (input.chatUi ?? false) && acpSupported ? 'acp' : 'pty';
+  const conversationId = randomUUID();
+  const initialQueue = [{ text: prompt }];
+
+  try {
+    await createConversation({
+      id: conversationId,
+      projectId: input.projectId,
+      taskId,
+      provider,
+      title: taskName,
+      isInitialConversation: true,
+      type: conversationType,
+      ...(model && { model }),
+      ...(conversationType === 'acp' ? { initialQueue } : { initialPrompt: prompt }),
+    });
+  } catch (error) {
+    // PTY conversations spawn eagerly and createConversation rethrows on spawn
+    // failure; surface it as a structured error like the ACP branch below.
+    return err(sessionStartFailure(taskId, error instanceof Error ? error.message : String(error)));
+  }
+
+  if (conversationType === 'acp') {
+    const acpClient = await getAcpRuntimeClient();
+    const startResult = await acpClient.startSession({
+      input: {
+        conversationId,
+        projectId: input.projectId,
+        taskId,
+        providerId: provider,
+        workspaceId: provision.data.workspaceId,
+        cwd: provision.data.path,
+        sessionId: null,
+        model: model ?? null,
+        initialQueue,
+      },
+    });
+    if (!startResult.success) {
+      return err(sessionStartFailure(taskId, startResult.error.message ?? startResult.error.type));
+    }
+  }
+
+  return ok({
+    taskId,
+    taskName,
+    branchName,
+    provider,
+    model: model ?? null,
+    conversationType,
+    workspacePath: provision.data.path,
+  });
+}

--- a/apps/emdash-desktop/src/main/core/mcp/server/create-task-from-prompt.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/server/create-task-from-prompt.ts
@@ -29,7 +29,7 @@ import type { WorkspaceConfig } from '@shared/core/workspaces/workspace-config';
 
 export type McpCreateTaskInput = {
   projectId: string;
-  prompt: string;
+  prompt?: string;
   name?: string;
   provider?: string;
   model?: string;
@@ -42,9 +42,11 @@ export type McpCreateTaskResult = {
   taskId: string;
   taskName: string;
   branchName: string;
-  provider: AgentProviderId;
+  // Null when the task was created without a prompt: no agent conversation is
+  // started, so no provider/model is chosen and conversationType is 'none'.
+  provider: AgentProviderId | null;
   model: string | null;
-  conversationType: ConversationType;
+  conversationType: ConversationType | 'none';
   workspacePath: string;
 };
 
@@ -173,19 +175,26 @@ function sessionStartFailure(taskId: string, detail: string): string {
 export async function createTaskFromPrompt(
   input: McpCreateTaskInput
 ): Promise<Result<McpCreateTaskResult, string>> {
-  const prompt = input.prompt.trim();
-  if (!prompt) return err('prompt must not be empty');
+  // Prompt is optional: with one, we start an agent conversation; without one,
+  // the task is provisioned and left idle for the user to drive later.
+  const prompt = input.prompt?.trim() ?? '';
 
   const project = await ensureProjectOpen(input.projectId);
   if (!project) return err(`Project not found: ${input.projectId}`);
 
-  const providerResult = await resolveProvider(input.provider);
-  if (!providerResult.success) return providerResult;
-  const provider = providerResult.data;
+  // Provider/model only matter when a prompt starts a conversation; skip
+  // resolving (and validating) them for a promptless task.
+  let provider: AgentProviderId | null = null;
+  let model: string | undefined;
+  if (prompt) {
+    const providerResult = await resolveProvider(input.provider);
+    if (!providerResult.success) return providerResult;
+    provider = providerResult.data;
 
-  const modelResult = resolveModel(provider, input.model);
-  if (!modelResult.success) return modelResult;
-  const model = modelResult.data;
+    const modelResult = resolveModel(provider, input.model);
+    if (!modelResult.success) return modelResult;
+    model = modelResult.data;
+  }
 
   const taskName = input.name?.trim() || generateRandom();
   const branchName = input.branchName?.trim() || generateTaskName({ title: taskName });
@@ -233,6 +242,20 @@ export async function createTaskFromPrompt(
         ? (provision.error.message ?? provision.error.stepErrorType)
         : provision.error.type;
     return err(`Task ${taskId} was created but workspace provisioning failed: ${detail}`);
+  }
+
+  // No prompt: the worktree is provisioned and the task exists, but no agent
+  // conversation is started. The user drives it later from the UI.
+  if (!prompt || !provider) {
+    return ok({
+      taskId,
+      taskName,
+      branchName,
+      provider: null,
+      model: null,
+      conversationType: 'none',
+      workspacePath: provision.data.path,
+    });
   }
 
   // Matches the new-task modal: chat UI is opt-in and only available when the

--- a/apps/emdash-desktop/src/main/core/mcp/server/create-task-from-prompt.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/server/create-task-from-prompt.ts
@@ -36,6 +36,7 @@ export type McpCreateTaskInput = {
   branchName?: string;
   baseBranch?: string;
   chatUi?: boolean;
+  autoApprove?: boolean;
 };
 
 export type McpCreateTaskResult = {
@@ -47,6 +48,10 @@ export type McpCreateTaskResult = {
   provider: AgentProviderId | null;
   model: string | null;
   conversationType: ConversationType | 'none';
+  // Null when no conversation is started. False when the caller asked for
+  // auto-approve but the provider has no such mode, so the caller can tell that
+  // the request was dropped.
+  autoApprove: boolean | null;
   workspacePath: string;
 };
 
@@ -78,6 +83,20 @@ async function resolveProvider(
   }
   const configured = await appSettingsService.get('defaultAgent');
   return ok(isValidProviderId(configured) ? configured : DEFAULT_AGENT_ID);
+}
+
+/**
+ * Mirrors the new-task modal: an explicit request wins over the app default,
+ * and both are ignored for providers without an auto-approve mode.
+ */
+async function resolveAutoApprove(
+  provider: AgentProviderId,
+  requested: boolean | undefined
+): Promise<boolean> {
+  if (getPlugin(provider).capabilities.autoApprove.kind !== 'supported') return false;
+  if (requested !== undefined) return requested;
+  const tasks = await appSettingsService.get('tasks');
+  return tasks.autoApproveByDefault;
 }
 
 /**
@@ -254,6 +273,7 @@ export async function createTaskFromPrompt(
       provider: null,
       model: null,
       conversationType: 'none',
+      autoApprove: null,
       workspacePath: provision.data.path,
     });
   }
@@ -265,6 +285,7 @@ export async function createTaskFromPrompt(
     (input.chatUi ?? false) && acpSupported ? 'acp' : 'pty';
   const conversationId = randomUUID();
   const initialQueue = [{ text: prompt }];
+  const autoApprove = await resolveAutoApprove(provider, input.autoApprove);
 
   try {
     await createConversation({
@@ -275,6 +296,7 @@ export async function createTaskFromPrompt(
       title: taskName,
       isInitialConversation: true,
       type: conversationType,
+      autoApprove,
       ...(model && { model }),
       ...(conversationType === 'acp' ? { initialQueue } : { initialPrompt: prompt }),
     });
@@ -311,6 +333,7 @@ export async function createTaskFromPrompt(
     provider,
     model: model ?? null,
     conversationType,
+    autoApprove,
     workspacePath: provision.data.path,
   });
 }

--- a/apps/emdash-desktop/src/main/core/mcp/server/mcp-http-server.test.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/server/mcp-http-server.test.ts
@@ -1,0 +1,298 @@
+import { promises as fs } from 'node:fs';
+import http from 'node:http';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  userDataDir: '',
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => mocks.userDataDir,
+    getVersion: () => '0.0.0-test',
+  },
+}));
+
+vi.mock('@main/lib/logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// Replace the real tool registry with a minimal echo server so these tests
+// exercise the HTTP layer (auth, allowlists, body handling) end to end without
+// pulling in the app's db/task services.
+vi.mock('./register-tools', async () => {
+  const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js');
+  const { z } = await import('zod');
+  return {
+    buildEmdashMcpServer: () => {
+      const server = new McpServer({ name: 'test', version: '0.0.0' });
+      server.registerTool(
+        'echo',
+        { description: 'echoes its input', inputSchema: { text: z.string() } },
+        async ({ text }: { text: string }) => ({
+          content: [{ type: 'text' as const, text }],
+        })
+      );
+      return server;
+    },
+  };
+});
+
+const { McpHttpServer } = await import('./mcp-http-server');
+
+type RawResponse = { status: number; body: string };
+
+function rawRequest(options: {
+  port: number;
+  path?: string;
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+  splitBodyAt?: number;
+}): Promise<RawResponse> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: '127.0.0.1',
+        port: options.port,
+        path: options.path ?? '/mcp',
+        method: options.method ?? 'POST',
+        headers: options.headers,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () =>
+          resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString('utf8') })
+        );
+      }
+    );
+    req.on('error', reject);
+    if (options.body === undefined) {
+      req.end();
+      return;
+    }
+    const buffer = Buffer.from(options.body, 'utf8');
+    if (options.splitBodyAt === undefined) {
+      req.end(buffer);
+      return;
+    }
+    req.write(buffer.subarray(0, options.splitBodyAt));
+    setTimeout(() => req.end(buffer.subarray(options.splitBodyAt)), 10);
+  });
+}
+
+function jsonRpcHeaders(token: string): Record<string, string> {
+  return {
+    'content-type': 'application/json',
+    accept: 'application/json, text/event-stream',
+    authorization: `Bearer ${token}`,
+  };
+}
+
+describe('McpHttpServer', () => {
+  let server: InstanceType<typeof McpHttpServer>;
+
+  beforeEach(async () => {
+    mocks.userDataDir = await fs.mkdtemp(path.join(tmpdir(), 'emdash-mcp-test-'));
+    server = new McpHttpServer(0);
+  });
+
+  afterEach(async () => {
+    await server.stop();
+    await fs.rm(mocks.userDataDir, { recursive: true, force: true });
+  });
+
+  function connectionInfo(): { port: number; token: string } {
+    const info = server.getConnectionInfo();
+    if (!info) throw new Error('server not running');
+    return { port: Number(new URL(info.url).port), token: info.token };
+  }
+
+  describe('lifecycle', () => {
+    it('reports not-running before start and after stop', async () => {
+      expect(server.getConnectionInfo()).toBeNull();
+      await server.start();
+      expect(server.getConnectionInfo()).not.toBeNull();
+      await server.stop();
+      expect(server.getConnectionInfo()).toBeNull();
+    });
+
+    it('shares one listener across concurrent start calls', async () => {
+      await Promise.all([server.start(), server.start()]);
+      const info = server.getConnectionInfo();
+      expect(info).not.toBeNull();
+      await server.stop();
+      expect(server.getConnectionInfo()).toBeNull();
+    });
+
+    it('binds an ephemeral port and reports the real port in the url', async () => {
+      await server.start();
+      const info = server.getConnectionInfo();
+      expect(info).not.toBeNull();
+      const url = new URL(info!.url);
+      expect(url.hostname).toBe('127.0.0.1');
+      expect(url.pathname).toBe('/mcp');
+      expect(Number(url.port)).toBeGreaterThan(0);
+    });
+
+    it('is a no-op when started twice', async () => {
+      await server.start();
+      const first = server.getConnectionInfo();
+      await server.start();
+      expect(server.getConnectionInfo()).toEqual(first);
+    });
+
+    it('reports not-running when the port is already in use', async () => {
+      await server.start();
+      const { port } = connectionInfo();
+      const second = new McpHttpServer(port);
+      await expect(second.start()).rejects.toThrow();
+      expect(second.getConnectionInfo()).toBeNull();
+    });
+  });
+
+  describe('token persistence', () => {
+    it('generates a hex token and persists it with owner-only permissions', async () => {
+      await server.start();
+      const { token } = connectionInfo();
+      expect(token).toMatch(/^[0-9a-f]{64}$/);
+      const tokenPath = path.join(mocks.userDataDir, 'mcp-server-token');
+      expect((await fs.readFile(tokenPath, 'utf8')).trim()).toBe(token);
+      if (process.platform !== 'win32') {
+        const stat = await fs.stat(tokenPath);
+        expect(stat.mode & 0o777).toBe(0o600);
+      }
+    });
+
+    it('reuses the persisted token across restarts', async () => {
+      await server.start();
+      const { token } = connectionInfo();
+      await server.stop();
+      await server.start();
+      expect(connectionInfo().token).toBe(token);
+    });
+  });
+
+  describe('request filtering', () => {
+    let port = 0;
+    let token = '';
+
+    beforeEach(async () => {
+      await server.start();
+      ({ port, token } = connectionInfo());
+    });
+
+    it('returns 404 for paths other than /mcp', async () => {
+      const res = await rawRequest({ port, path: '/other', headers: jsonRpcHeaders(token) });
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 403 for a non-local Host header (DNS rebinding)', async () => {
+      const res = await rawRequest({
+        port,
+        headers: { ...jsonRpcHeaders(token), host: 'evil.example.com' },
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 403 for a non-local Origin header', async () => {
+      const res = await rawRequest({
+        port,
+        headers: { ...jsonRpcHeaders(token), origin: 'https://evil.example.com' },
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it('accepts a local Origin header', async () => {
+      const res = await rawRequest({
+        port,
+        headers: { ...jsonRpcHeaders(token), origin: `http://127.0.0.1:${port}` },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 401 without an Authorization header', async () => {
+      const headers = jsonRpcHeaders(token);
+      delete headers.authorization;
+      const res = await rawRequest({ port, headers });
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 401 for a wrong bearer token', async () => {
+      const res = await rawRequest({ port, headers: jsonRpcHeaders('0'.repeat(64)) });
+      expect(res.status).toBe(401);
+    });
+
+    it('accepts a lowercase "bearer" auth scheme', async () => {
+      const res = await rawRequest({
+        port,
+        headers: { ...jsonRpcHeaders(token), authorization: `bearer ${token}` },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 405 for non-POST methods', async () => {
+      const res = await rawRequest({ port, method: 'GET', headers: jsonRpcHeaders(token) });
+      expect(res.status).toBe(405);
+    });
+
+    it('returns 400 for a body that is not valid JSON', async () => {
+      const res = await rawRequest({ port, headers: jsonRpcHeaders(token), body: 'not json' });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects bodies over the size cap with 413', async () => {
+      const oversized = `"${'a'.repeat(4_000_001)}"`;
+      const res = await rawRequest({ port, headers: jsonRpcHeaders(token), body: oversized });
+      expect(res.status).toBe(413);
+    });
+  });
+
+  describe('MCP requests', () => {
+    let port = 0;
+    let token = '';
+
+    beforeEach(async () => {
+      await server.start();
+      ({ port, token } = connectionInfo());
+    });
+
+    it('serves tools/list for an authorized request', async () => {
+      const res = await rawRequest({
+        port,
+        headers: jsonRpcHeaders(token),
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+      });
+      expect(res.status).toBe(200);
+      const parsed = JSON.parse(res.body);
+      expect(parsed.result.tools.map((tool: { name: string }) => tool.name)).toEqual(['echo']);
+    });
+
+    it('round-trips multibyte input split across body chunks', async () => {
+      const text = 'héllo 🚀 wörld — 日本語';
+      const body = JSON.stringify({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'echo', arguments: { text } },
+      });
+      // Split mid-way through the rocket emoji's 4-byte UTF-8 sequence so the
+      // two writes arrive as separate chunks; per-chunk decoding would corrupt it.
+      const splitBodyAt = Buffer.from(body, 'utf8').indexOf(Buffer.from('🚀', 'utf8')) + 2;
+      const res = await rawRequest({
+        port,
+        headers: jsonRpcHeaders(token),
+        body,
+        splitBodyAt,
+      });
+      expect(res.status).toBe(200);
+      const parsed = JSON.parse(res.body);
+      expect(parsed.result.content).toEqual([{ type: 'text', text }]);
+    });
+  });
+});

--- a/apps/emdash-desktop/src/main/core/mcp/server/mcp-http-server.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/server/mcp-http-server.ts
@@ -1,0 +1,242 @@
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { app } from 'electron';
+import { log } from '@main/lib/logger';
+import { buildEmdashMcpServer } from './register-tools';
+
+/** 8212 = U+2014 EM DASH. Override with EMDASH_MCP_PORT. */
+const DEFAULT_PORT = 8212;
+const MAX_BODY_BYTES = 4_000_000;
+const TOKEN_FILE = 'mcp-server-token';
+
+// Loopback only: requests are rejected unless both the Host header and, when a
+// browser sends one, the Origin header resolve to these hostnames. This blocks
+// DNS-rebinding attacks where a web page tricks the browser into hitting the
+// local port with an attacker-controlled Host/Origin.
+const ALLOWED_HOSTNAMES = new Set(['127.0.0.1', 'localhost', '[::1]', '::1']);
+
+function hostnameOf(value: string | undefined): string | null {
+  if (!value) return null;
+  try {
+    return new URL(value.includes('://') ? value : `http://${value}`).hostname;
+  } catch {
+    return null;
+  }
+}
+
+function tokensMatch(expected: string, presented: string): boolean {
+  // Hash before comparing so timingSafeEqual gets equal-length buffers.
+  const a = createHash('sha256').update(expected).digest();
+  const b = createHash('sha256').update(presented).digest();
+  return timingSafeEqual(a, b);
+}
+
+/**
+ * Local HTTP server exposing emdash as an MCP server (Streamable HTTP transport,
+ * stateless mode). Binds to 127.0.0.1 and requires a bearer token persisted in
+ * the app's userData directory.
+ */
+type ParsedBody = { kind: 'ok'; body: unknown } | { kind: 'invalid' } | { kind: 'too-large' };
+
+export class McpHttpServer {
+  private server: http.Server | null = null;
+  private startPromise: Promise<void> | null = null;
+  private port = 0;
+  private token = '';
+
+  /** `portOverride` (0 = ephemeral) bypasses EMDASH_MCP_PORT/default resolution; for tests. */
+  constructor(private readonly portOverride?: number) {}
+
+  async start(): Promise<void> {
+    if (this.server) return;
+    // Share one in-flight start: a concurrent second call would otherwise race
+    // token loading and double-listen, and must not resolve before listen does.
+    this.startPromise ??= this.doStart().finally(() => {
+      this.startPromise = null;
+    });
+    return this.startPromise;
+  }
+
+  private async doStart(): Promise<void> {
+    this.token = await this.loadOrCreateToken();
+    const envPort = Number(process.env.EMDASH_MCP_PORT);
+    const port =
+      this.portOverride ?? (Number.isInteger(envPort) && envPort > 0 ? envPort : DEFAULT_PORT);
+
+    const server = http.createServer((req, res) => {
+      this.handleRequest(req, res).catch((error) => {
+        log.error('McpHttpServer: request handler error', { error: String(error) });
+        if (!res.headersSent) {
+          res.writeHead(500).end();
+        }
+      });
+    });
+    this.server = server;
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const onError = (error: Error) => reject(error);
+        server.once('error', onError);
+        server.listen(port, '127.0.0.1', () => {
+          server.removeListener('error', onError);
+          const address = server.address();
+          this.port = typeof address === 'object' && address ? address.port : port;
+          resolve();
+        });
+      });
+    } catch (error) {
+      // Reset fully so getConnectionInfo() reports not-running instead of a
+      // port-0 URL that self-registration would write into agent configs.
+      server.close();
+      this.server = null;
+      this.port = 0;
+      throw error;
+    }
+
+    // Without a listener, a post-startup server 'error' event would crash the
+    // main process (unhandled EventEmitter error).
+    server.on('error', (error) => {
+      log.error('McpHttpServer: server error', { error: String(error) });
+    });
+
+    log.info(`McpHttpServer: listening at ${this.getUrl()}`);
+  }
+
+  async stop(): Promise<void> {
+    const server = this.server;
+    if (!server) return;
+    this.server = null;
+    this.port = 0;
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+      server.closeAllConnections();
+    });
+  }
+
+  getUrl(): string {
+    return `http://127.0.0.1:${this.port}/mcp`;
+  }
+
+  /** Connection details for registering emdash in agent configs; null when not running. */
+  getConnectionInfo(): { url: string; token: string } | null {
+    // `this.server` is assigned before listen() resolves; the port check keeps
+    // a caller in that window from seeing a port-0 URL.
+    if (!this.server || this.port === 0) return null;
+    return { url: this.getUrl(), token: this.token };
+  }
+
+  private async loadOrCreateToken(): Promise<string> {
+    const tokenPath = path.join(app.getPath('userData'), TOKEN_FILE);
+    try {
+      const existing = (await fs.readFile(tokenPath, 'utf8')).trim();
+      if (existing) return existing;
+    } catch {
+      // Missing or unreadable — generate a fresh token below.
+    }
+    const token = randomBytes(32).toString('hex');
+    // 0o600 restricts access on POSIX only; on Windows the file inherits the
+    // userData directory ACL (per-user), which is the best Node's fs offers.
+    await fs.writeFile(tokenPath, `${token}\n`, { mode: 0o600 });
+    return token;
+  }
+
+  private async handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const pathname = new URL(req.url ?? '/', 'http://127.0.0.1').pathname;
+    if (pathname !== '/mcp') {
+      res.writeHead(404).end();
+      return;
+    }
+
+    const hostName = hostnameOf(req.headers.host);
+    if (!hostName || !ALLOWED_HOSTNAMES.has(hostName)) {
+      log.warn('McpHttpServer: rejected request with non-local Host header');
+      res.writeHead(403).end();
+      return;
+    }
+    const origin = req.headers.origin;
+    if (origin) {
+      const originHost = hostnameOf(origin);
+      if (!originHost || !ALLOWED_HOSTNAMES.has(originHost)) {
+        log.warn('McpHttpServer: rejected request with non-local Origin header');
+        res.writeHead(403).end();
+        return;
+      }
+    }
+
+    const auth = req.headers.authorization ?? '';
+    // The auth scheme is case-insensitive (RFC 7235), so accept "bearer" etc.
+    const presented = /^Bearer\s+(.+)$/i.exec(auth)?.[1]?.trim() ?? '';
+    if (!presented || !tokensMatch(this.token, presented)) {
+      log.warn('McpHttpServer: rejected request with missing or invalid bearer token');
+      res.writeHead(401).end();
+      return;
+    }
+
+    if (req.method !== 'POST') {
+      res.writeHead(405, { Allow: 'POST' }).end();
+      return;
+    }
+
+    const parsed = await this.readBody(req);
+    if (parsed.kind === 'too-large') {
+      // Respond before dropping the connection so the client sees a clean 413
+      // instead of a connection reset mid-upload.
+      res.writeHead(413, { Connection: 'close' }).end(() => req.destroy());
+      return;
+    }
+    if (parsed.kind === 'invalid') {
+      res.writeHead(400).end();
+      return;
+    }
+    const body = parsed.body;
+
+    // Stateless mode: a fresh server + transport per request, torn down when the
+    // response closes. Avoids session bookkeeping for this local, single-user server.
+    const mcpServer = buildEmdashMcpServer();
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true,
+    });
+    res.on('close', () => {
+      void transport.close();
+      void mcpServer.close();
+    });
+    await mcpServer.connect(transport);
+    await transport.handleRequest(req, res, body);
+  }
+
+  private readBody(req: http.IncomingMessage): Promise<ParsedBody> {
+    return new Promise((resolve) => {
+      // Collect raw buffers and decode once: per-chunk toString() would corrupt
+      // multibyte UTF-8 split across chunk boundaries, and the size cap must
+      // count bytes, not UTF-16 code units.
+      const chunks: Buffer[] = [];
+      let totalBytes = 0;
+      req.on('data', (chunk: Buffer) => {
+        totalBytes += chunk.length;
+        if (totalBytes > MAX_BODY_BYTES) {
+          // Stop consuming but leave the socket alive so the caller can still
+          // write a 413 response; the caller drops the connection afterwards.
+          req.removeAllListeners('data');
+          req.pause();
+          resolve({ kind: 'too-large' });
+          return;
+        }
+        chunks.push(chunk);
+      });
+      req.on('end', () => {
+        try {
+          resolve({ kind: 'ok', body: JSON.parse(Buffer.concat(chunks).toString('utf8')) });
+        } catch {
+          resolve({ kind: 'invalid' });
+        }
+      });
+      req.on('error', () => resolve({ kind: 'invalid' }));
+    });
+  }
+}
+
+export const mcpHttpServer = new McpHttpServer();

--- a/apps/emdash-desktop/src/main/core/mcp/server/register-tools.test.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/server/register-tools.test.ts
@@ -1,0 +1,390 @@
+import { err, ok } from '@emdash/shared';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  select: vi.fn(),
+  archiveTask: vi.fn(),
+  renameTask: vi.fn(),
+  deleteTask: vi.fn(),
+  getDeletePreflight: vi.fn(),
+  createTaskFromPrompt: vi.fn(),
+  ensureProjectOpen: vi.fn(),
+  logError: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  app: { getVersion: () => '0.0.0-test' },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn(),
+  desc: vi.fn(),
+  eq: vi.fn(),
+  inArray: vi.fn(),
+}));
+
+vi.mock('@main/db/client', () => ({
+  db: { select: mocks.select },
+}));
+
+vi.mock('@main/db/schema', () => ({
+  projects: {},
+  tasks: {},
+  workspaces: {},
+}));
+
+vi.mock('@main/core/agents/plugin-registry', () => ({
+  listPlugins: () => [{ metadata: { id: 'claude' } }, { metadata: { id: 'codex' } }],
+}));
+
+vi.mock('@main/core/tasks/task-service', () => ({
+  taskService: {
+    archiveTask: mocks.archiveTask,
+    renameTask: mocks.renameTask,
+    deleteTask: mocks.deleteTask,
+    getDeletePreflight: mocks.getDeletePreflight,
+  },
+}));
+
+vi.mock('@main/lib/logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: mocks.logError },
+}));
+
+vi.mock('./create-task-from-prompt', () => ({
+  createTaskFromPrompt: mocks.createTaskFromPrompt,
+  ensureProjectOpen: mocks.ensureProjectOpen,
+  validProviderIds: () => 'claude, codex',
+}));
+
+const { buildEmdashMcpServer } = await import('./register-tools');
+
+/**
+ * Minimal stand-in for drizzle's fluent select builder: every step returns
+ * itself and awaiting it yields the queued rows, one queue entry per
+ * `db.select()` call.
+ */
+function queueSelectResults(...results: unknown[][]): void {
+  const queue = [...results];
+  mocks.select.mockImplementation(() => {
+    const rows = queue.shift() ?? [];
+    const chain = {
+      from: () => chain,
+      where: () => chain,
+      orderBy: () => chain,
+      limit: () => chain,
+      then: (onFulfilled: (rows: unknown) => unknown, onRejected?: (error: unknown) => unknown) =>
+        Promise.resolve(rows).then(onFulfilled, onRejected),
+    };
+    return chain;
+  });
+}
+
+async function connectClient(): Promise<Client> {
+  const server = buildEmdashMcpServer();
+  const client = new Client({ name: 'test-client', version: '0.0.0' });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+  return client;
+}
+
+type ToolResult = { isError?: boolean; content: { type: string; text: string }[] };
+
+async function callTool(
+  client: Client,
+  name: string,
+  args: Record<string, unknown>
+): Promise<{ isError: boolean; text: string }> {
+  const result = (await client.callTool({ name, arguments: args })) as ToolResult;
+  return { isError: result.isError === true, text: result.content[0]?.text ?? '' };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  queueSelectResults();
+});
+
+describe('tool registry', () => {
+  it('exposes exactly the six emdash tools', async () => {
+    const client = await connectClient();
+    const { tools } = await client.listTools();
+    expect(tools.map((tool) => tool.name).sort()).toEqual([
+      'archive_task',
+      'create_task',
+      'delete_task',
+      'list_projects',
+      'list_tasks',
+      'rename_task',
+    ]);
+  });
+
+  it('marks the list tools read-only and only delete_task destructive', async () => {
+    const client = await connectClient();
+    const { tools } = await client.listTools();
+    const byName = new Map(tools.map((tool) => [tool.name, tool.annotations]));
+    expect(byName.get('list_projects')).toMatchObject({ readOnlyHint: true });
+    expect(byName.get('list_tasks')).toMatchObject({ readOnlyHint: true });
+    expect(byName.get('delete_task')).toMatchObject({ destructiveHint: true });
+    for (const name of ['create_task', 'archive_task', 'rename_task']) {
+      expect(byName.get(name)).toMatchObject({ destructiveHint: false });
+    }
+    for (const [, annotations] of byName) {
+      expect(annotations).toMatchObject({ openWorldHint: false });
+    }
+  });
+});
+
+describe('error guarding', () => {
+  it('hides internal error details from the client and logs them instead', async () => {
+    mocks.select.mockImplementation(() => {
+      throw new Error('SQLITE_BUSY: /Users/x/secret.db is locked');
+    });
+    const client = await connectClient();
+    const result = await callTool(client, 'list_tasks', { projectId: 'p1' });
+    expect(result.isError).toBe(true);
+    expect(result.text).toBe('emdash hit an internal error while handling list_tasks');
+    expect(result.text).not.toContain('SQLITE_BUSY');
+    expect(mocks.logError).toHaveBeenCalledWith(
+      'McpHttpServer: list_tasks failed',
+      expect.objectContaining({ error: expect.stringContaining('SQLITE_BUSY') })
+    );
+  });
+});
+
+describe('list_projects', () => {
+  it('returns the project rows', async () => {
+    queueSelectResults([{ id: 'p1', name: 'emdash', path: '/repo' }]);
+    const client = await connectClient();
+    const result = await callTool(client, 'list_projects', {});
+    expect(result.isError).toBe(false);
+    expect(JSON.parse(result.text)).toEqual([{ id: 'p1', name: 'emdash', path: '/repo' }]);
+  });
+});
+
+describe('list_tasks', () => {
+  it('enriches tasks with branch and worktree path from their workspace', async () => {
+    queueSelectResults(
+      [
+        {
+          id: 't1',
+          name: 'With workspace',
+          status: 'running',
+          updatedAt: 2,
+          archivedAt: null,
+          workspaceId: 'ws1',
+        },
+        {
+          id: 't2',
+          name: 'No workspace',
+          status: 'archived',
+          updatedAt: 1,
+          archivedAt: 99,
+          workspaceId: null,
+        },
+      ],
+      [{ id: 'ws1', path: '/worktrees/t1', branchName: 'feat/t1' }]
+    );
+    const client = await connectClient();
+    const result = await callTool(client, 'list_tasks', { projectId: 'p1' });
+    expect(result.isError).toBe(false);
+    expect(JSON.parse(result.text)).toEqual([
+      {
+        id: 't1',
+        name: 'With workspace',
+        status: 'running',
+        updatedAt: 2,
+        isArchived: false,
+        branchName: 'feat/t1',
+        workspacePath: '/worktrees/t1',
+      },
+      {
+        id: 't2',
+        name: 'No workspace',
+        status: 'archived',
+        updatedAt: 1,
+        isArchived: true,
+        branchName: null,
+        workspacePath: null,
+      },
+    ]);
+  });
+});
+
+describe('create_task', () => {
+  it('returns the creation result on success', async () => {
+    mocks.createTaskFromPrompt.mockResolvedValue(ok({ taskId: 't1', branchName: 'b1' }));
+    const client = await connectClient();
+    const result = await callTool(client, 'create_task', { projectId: 'p1', prompt: 'go' });
+    expect(result.isError).toBe(false);
+    expect(JSON.parse(result.text)).toEqual({ taskId: 't1', branchName: 'b1' });
+  });
+
+  it('surfaces validation errors as tool errors', async () => {
+    mocks.createTaskFromPrompt.mockResolvedValue(err('Unknown provider "x"'));
+    const client = await connectClient();
+    const result = await callTool(client, 'create_task', {
+      projectId: 'p1',
+      prompt: 'go',
+      provider: 'x',
+    });
+    expect(result.isError).toBe(true);
+    expect(result.text).toBe('Unknown provider "x"');
+  });
+});
+
+describe('archive_task', () => {
+  it('rejects a task that is not in the project', async () => {
+    queueSelectResults([]);
+    const client = await connectClient();
+    const result = await callTool(client, 'archive_task', { projectId: 'p1', taskId: 't1' });
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain('Task not found in project p1: t1');
+    expect(mocks.archiveTask).not.toHaveBeenCalled();
+  });
+
+  it('opens the project before archiving so live sessions get torn down', async () => {
+    queueSelectResults([{ id: 't1' }]);
+    mocks.ensureProjectOpen.mockResolvedValue({});
+    mocks.archiveTask.mockResolvedValue(undefined);
+    const client = await connectClient();
+    const result = await callTool(client, 'archive_task', { projectId: 'p1', taskId: 't1' });
+    expect(result.isError).toBe(false);
+    expect(JSON.parse(result.text)).toEqual({ taskId: 't1', archived: true });
+    expect(mocks.ensureProjectOpen).toHaveBeenCalledWith('p1');
+    expect(mocks.archiveTask).toHaveBeenCalledWith('p1', 't1');
+    const openOrder = mocks.ensureProjectOpen.mock.invocationCallOrder[0] ?? 0;
+    const archiveOrder = mocks.archiveTask.mock.invocationCallOrder[0] ?? 0;
+    expect(openOrder).toBeLessThan(archiveOrder);
+  });
+
+  it('archives but warns when the project cannot be opened', async () => {
+    queueSelectResults([{ id: 't1' }]);
+    mocks.ensureProjectOpen.mockResolvedValue(undefined);
+    mocks.archiveTask.mockResolvedValue(undefined);
+    const client = await connectClient();
+    const result = await callTool(client, 'archive_task', { projectId: 'p1', taskId: 't1' });
+    expect(result.isError).toBe(false);
+    expect(JSON.parse(result.text)).toEqual({
+      taskId: 't1',
+      archived: true,
+      warning: expect.stringContaining('live agent sessions'),
+    });
+    expect(mocks.archiveTask).toHaveBeenCalledWith('p1', 't1');
+  });
+});
+
+describe('rename_task', () => {
+  it('rejects an empty name', async () => {
+    const client = await connectClient();
+    const result = await callTool(client, 'rename_task', {
+      projectId: 'p1',
+      taskId: 't1',
+      name: '   ',
+    });
+    expect(result.isError).toBe(true);
+    expect(result.text).toBe('name must not be empty');
+    expect(mocks.renameTask).not.toHaveBeenCalled();
+  });
+
+  it('renames with the trimmed name', async () => {
+    mocks.renameTask.mockResolvedValue(ok({ task: { name: 'New name' } }));
+    const client = await connectClient();
+    const result = await callTool(client, 'rename_task', {
+      projectId: 'p1',
+      taskId: 't1',
+      name: '  New name  ',
+    });
+    expect(result.isError).toBe(false);
+    expect(JSON.parse(result.text)).toEqual({ taskId: 't1', name: 'New name' });
+    expect(mocks.renameTask).toHaveBeenCalledWith('p1', 't1', 'New name');
+  });
+
+  it('reports a missing task as an error', async () => {
+    mocks.renameTask.mockResolvedValue(err({ taskId: 't1' }));
+    const client = await connectClient();
+    const result = await callTool(client, 'rename_task', {
+      projectId: 'p1',
+      taskId: 't1',
+      name: 'x',
+    });
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain('Task not found in project p1: t1');
+  });
+});
+
+describe('delete_task', () => {
+  it('rejects a task that is not in the project', async () => {
+    queueSelectResults([]);
+    const client = await connectClient();
+    const result = await callTool(client, 'delete_task', { projectId: 'p1', taskId: 't1' });
+    expect(result.isError).toBe(true);
+    expect(mocks.deleteTask).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the project cannot be opened to verify the worktree', async () => {
+    queueSelectResults([{ id: 't1' }]);
+    mocks.ensureProjectOpen.mockResolvedValue(undefined);
+    const client = await connectClient();
+    const result = await callTool(client, 'delete_task', { projectId: 'p1', taskId: 't1' });
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain('could not be opened');
+    expect(mocks.deleteTask).not.toHaveBeenCalled();
+  });
+
+  it('asks for confirmation instead of deleting when the worktree has uncommitted changes', async () => {
+    queueSelectResults([{ id: 't1' }]);
+    mocks.ensureProjectOpen.mockResolvedValue({});
+    mocks.getDeletePreflight.mockResolvedValue({
+      tasks: [{ taskId: 't1', hasUncommittedChanges: true }],
+    });
+    const client = await connectClient();
+    const result = await callTool(client, 'delete_task', { projectId: 'p1', taskId: 't1' });
+    expect(result.isError).toBe(false);
+    expect(JSON.parse(result.text)).toMatchObject({
+      taskId: 't1',
+      deleted: false,
+      requiresConfirmation: true,
+      instructions: expect.stringContaining('confirm: true'),
+    });
+    expect(mocks.deleteTask).not.toHaveBeenCalled();
+  });
+
+  it('deletes a dirty worktree once the user has confirmed', async () => {
+    queueSelectResults([{ id: 't1' }]);
+    mocks.ensureProjectOpen.mockResolvedValue({});
+    mocks.getDeletePreflight.mockResolvedValue({
+      tasks: [{ taskId: 't1', hasUncommittedChanges: true }],
+    });
+    mocks.deleteTask.mockResolvedValue(undefined);
+    const client = await connectClient();
+    const result = await callTool(client, 'delete_task', {
+      projectId: 'p1',
+      taskId: 't1',
+      confirm: true,
+    });
+    expect(result.isError).toBe(false);
+    expect(JSON.parse(result.text)).toEqual({ taskId: 't1', deleted: true, branchKept: true });
+    expect(mocks.deleteTask).toHaveBeenCalledWith('p1', 't1', {
+      deleteWorktree: true,
+      deleteBranch: false,
+    });
+  });
+
+  it('deletes the worktree but keeps the branch when the worktree is clean', async () => {
+    queueSelectResults([{ id: 't1' }]);
+    mocks.ensureProjectOpen.mockResolvedValue({});
+    mocks.getDeletePreflight.mockResolvedValue({
+      tasks: [{ taskId: 't1', hasUncommittedChanges: false }],
+    });
+    mocks.deleteTask.mockResolvedValue(undefined);
+    const client = await connectClient();
+    const result = await callTool(client, 'delete_task', { projectId: 'p1', taskId: 't1' });
+    expect(result.isError).toBe(false);
+    expect(JSON.parse(result.text)).toEqual({ taskId: 't1', deleted: true, branchKept: true });
+    expect(mocks.deleteTask).toHaveBeenCalledWith('p1', 't1', {
+      deleteWorktree: true,
+      deleteBranch: false,
+    });
+  });
+});

--- a/apps/emdash-desktop/src/main/core/mcp/server/register-tools.test.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/server/register-tools.test.ts
@@ -11,6 +11,8 @@ const mocks = vi.hoisted(() => ({
   getDeletePreflight: vi.fn(),
   createTaskFromPrompt: vi.fn(),
   ensureProjectOpen: vi.fn(),
+  runTaskScript: vi.fn(),
+  stopTaskScript: vi.fn(),
   logError: vi.fn(),
 }));
 
@@ -56,6 +58,11 @@ vi.mock('./create-task-from-prompt', () => ({
   createTaskFromPrompt: mocks.createTaskFromPrompt,
   ensureProjectOpen: mocks.ensureProjectOpen,
   validProviderIds: () => 'claude, codex',
+}));
+
+vi.mock('./run-task-script', () => ({
+  runTaskScript: mocks.runTaskScript,
+  stopTaskScript: mocks.stopTaskScript,
 }));
 
 const { buildEmdashMcpServer } = await import('./register-tools');
@@ -106,7 +113,7 @@ beforeEach(() => {
 });
 
 describe('tool registry', () => {
-  it('exposes exactly the six emdash tools', async () => {
+  it('exposes exactly the eight emdash tools', async () => {
     const client = await connectClient();
     const { tools } = await client.listTools();
     expect(tools.map((tool) => tool.name).sort()).toEqual([
@@ -116,6 +123,8 @@ describe('tool registry', () => {
       'list_projects',
       'list_tasks',
       'rename_task',
+      'run_task_script',
+      'stop_task_script',
     ]);
   });
 
@@ -126,7 +135,13 @@ describe('tool registry', () => {
     expect(byName.get('list_projects')).toMatchObject({ readOnlyHint: true });
     expect(byName.get('list_tasks')).toMatchObject({ readOnlyHint: true });
     expect(byName.get('delete_task')).toMatchObject({ destructiveHint: true });
-    for (const name of ['create_task', 'archive_task', 'rename_task']) {
+    for (const name of [
+      'create_task',
+      'archive_task',
+      'rename_task',
+      'run_task_script',
+      'stop_task_script',
+    ]) {
       expect(byName.get(name)).toMatchObject({ destructiveHint: false });
     }
     for (const [, annotations] of byName) {
@@ -310,6 +325,109 @@ describe('rename_task', () => {
     });
     expect(result.isError).toBe(true);
     expect(result.text).toContain('Task not found in project p1: t1');
+  });
+});
+
+describe('run_task_script', () => {
+  it('returns the started result and forwards the type', async () => {
+    mocks.runTaskScript.mockResolvedValue({ status: 'started', type: 'setup' });
+    const client = await connectClient();
+    const result = await callTool(client, 'run_task_script', {
+      projectId: 'p1',
+      taskId: 't1',
+      type: 'setup',
+    });
+    expect(result.isError).toBe(false);
+    expect(JSON.parse(result.text)).toEqual({ status: 'started', type: 'setup' });
+    expect(mocks.runTaskScript).toHaveBeenCalledWith({
+      projectId: 'p1',
+      taskId: 't1',
+      type: 'setup',
+    });
+  });
+
+  it('reports a started dev server without waiting for it to exit', async () => {
+    mocks.runTaskScript.mockResolvedValue({ status: 'started', type: 'run' });
+    const client = await connectClient();
+    const result = await callTool(client, 'run_task_script', {
+      projectId: 'p1',
+      taskId: 't1',
+      type: 'run',
+    });
+    expect(result.isError).toBe(false);
+    expect(JSON.parse(result.text)).toEqual({ status: 'started', type: 'run' });
+  });
+
+  it('surfaces a missing task or workspace as a tool error', async () => {
+    mocks.runTaskScript.mockResolvedValue({
+      status: 'not_found',
+      message: 'Task not found in project p1: t1',
+    });
+    const client = await connectClient();
+    const result = await callTool(client, 'run_task_script', {
+      projectId: 'p1',
+      taskId: 't1',
+      type: 'teardown',
+    });
+    expect(result.isError).toBe(true);
+    expect(result.text).toBe('Task not found in project p1: t1');
+  });
+
+  it('rejects an unknown script type before dispatching', async () => {
+    const client = await connectClient();
+    const result = await callTool(client, 'run_task_script', {
+      projectId: 'p1',
+      taskId: 't1',
+      type: 'bogus',
+    });
+    expect(result.isError).toBe(true);
+    expect(mocks.runTaskScript).not.toHaveBeenCalled();
+  });
+});
+
+describe('stop_task_script', () => {
+  it('stops the given script type for the task', async () => {
+    mocks.stopTaskScript.mockResolvedValue({ status: 'stopped', type: 'run' });
+    const client = await connectClient();
+    const result = await callTool(client, 'stop_task_script', {
+      projectId: 'p1',
+      taskId: 't1',
+      type: 'run',
+    });
+    expect(result.isError).toBe(false);
+    expect(JSON.parse(result.text)).toEqual({ status: 'stopped', type: 'run' });
+    expect(mocks.stopTaskScript).toHaveBeenCalledWith({
+      projectId: 'p1',
+      taskId: 't1',
+      type: 'run',
+    });
+  });
+
+  it('reports not_running when the script is not up', async () => {
+    mocks.stopTaskScript.mockResolvedValue({ status: 'not_running', type: 'setup' });
+    const client = await connectClient();
+    const result = await callTool(client, 'stop_task_script', {
+      projectId: 'p1',
+      taskId: 't1',
+      type: 'setup',
+    });
+    expect(result.isError).toBe(false);
+    expect(JSON.parse(result.text)).toEqual({ status: 'not_running', type: 'setup' });
+  });
+
+  it('surfaces a missing task or workspace as a tool error', async () => {
+    mocks.stopTaskScript.mockResolvedValue({
+      status: 'not_found',
+      message: 'Task not found in project p1: t1',
+    });
+    const client = await connectClient();
+    const result = await callTool(client, 'stop_task_script', {
+      projectId: 'p1',
+      taskId: 't1',
+      type: 'run',
+    });
+    expect(result.isError).toBe(true);
+    expect(result.text).toBe('Task not found in project p1: t1');
   });
 });
 

--- a/apps/emdash-desktop/src/main/core/mcp/server/register-tools.test.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/server/register-tools.test.ts
@@ -235,6 +235,15 @@ describe('create_task', () => {
     expect(JSON.parse(result.text)).toEqual({ taskId: 't1', branchName: 'b1' });
   });
 
+  it('forwards autoApprove to the create flow', async () => {
+    mocks.createTaskFromPrompt.mockResolvedValue(ok({ taskId: 't1', branchName: 'b1' }));
+    const client = await connectClient();
+    await callTool(client, 'create_task', { projectId: 'p1', prompt: 'go', autoApprove: true });
+    expect(mocks.createTaskFromPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({ autoApprove: true })
+    );
+  });
+
   it('surfaces validation errors as tool errors', async () => {
     mocks.createTaskFromPrompt.mockResolvedValue(err('Unknown provider "x"'));
     const client = await connectClient();

--- a/apps/emdash-desktop/src/main/core/mcp/server/register-tools.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/server/register-tools.ts
@@ -1,0 +1,293 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { and, desc, eq, inArray } from 'drizzle-orm';
+import { app } from 'electron';
+import z from 'zod';
+import { taskService } from '@main/core/tasks/task-service';
+import { db } from '@main/db/client';
+import { projects, tasks, workspaces } from '@main/db/schema';
+import { log } from '@main/lib/logger';
+import {
+  createTaskFromPrompt,
+  ensureProjectOpen,
+  validProviderIds,
+} from './create-task-from-prompt';
+
+function textResult(value: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }] };
+}
+
+function errorResult(message: string) {
+  return { content: [{ type: 'text' as const, text: message }], isError: true };
+}
+
+/**
+ * The SDK forwards a thrown exception's message verbatim to the MCP client;
+ * catch here so internal errors (db, git runtime) are logged but only a
+ * generic message leaves the process.
+ */
+function guarded<Args extends unknown[]>(
+  toolName: string,
+  fn: (...args: Args) => Promise<ReturnType<typeof textResult> | ReturnType<typeof errorResult>>
+) {
+  return async (...args: Args) => {
+    try {
+      return await fn(...args);
+    } catch (error) {
+      log.error(`McpHttpServer: ${toolName} failed`, { error: String(error) });
+      return errorResult(`emdash hit an internal error while handling ${toolName}`);
+    }
+  };
+}
+
+async function findTaskInProject(projectId: string, taskId: string) {
+  const [row] = await db
+    .select({ id: tasks.id })
+    .from(tasks)
+    .where(and(eq(tasks.id, taskId), eq(tasks.projectId, projectId)))
+    .limit(1);
+  return row;
+}
+
+/** Builds a fresh MCP server instance exposing emdash's tools (one per request in stateless HTTP mode). */
+export function buildEmdashMcpServer(): McpServer {
+  const server = new McpServer({ name: 'emdash', version: app.getVersion() });
+
+  server.registerTool(
+    'list_projects',
+    {
+      title: 'List projects',
+      description:
+        'Lists the projects registered in emdash. Use the returned project id with create_task and list_tasks.',
+      inputSchema: {},
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    guarded('list_projects', async () => {
+      const rows = await db
+        .select({ id: projects.id, name: projects.name, path: projects.path })
+        .from(projects);
+      return textResult(rows);
+    })
+  );
+
+  server.registerTool(
+    'list_tasks',
+    {
+      title: 'List tasks',
+      description: 'Lists tasks in an emdash project, most recently updated first.',
+      inputSchema: {
+        projectId: z.string().describe('Project id from list_projects'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    guarded('list_tasks', async ({ projectId }) => {
+      // Query directly instead of taskService.getTasks(): that fetches every
+      // task plus conversation/diff-stat aggregates the tool output never uses.
+      const projectTasks = await db
+        .select({
+          id: tasks.id,
+          name: tasks.name,
+          status: tasks.status,
+          updatedAt: tasks.updatedAt,
+          archivedAt: tasks.archivedAt,
+          workspaceId: tasks.workspaceId,
+        })
+        .from(tasks)
+        .where(eq(tasks.projectId, projectId))
+        .orderBy(desc(tasks.updatedAt))
+        .limit(50);
+      const workspaceIds = projectTasks
+        .map((task) => task.workspaceId)
+        .filter((id): id is string => Boolean(id));
+      const workspaceRows = workspaceIds.length
+        ? await db
+            .select({ id: workspaces.id, path: workspaces.path, branchName: workspaces.branchName })
+            .from(workspaces)
+            .where(inArray(workspaces.id, workspaceIds))
+        : [];
+      const workspaceById = new Map(workspaceRows.map((row) => [row.id, row]));
+      return textResult(
+        projectTasks.map((task) => {
+          const workspace = task.workspaceId ? workspaceById.get(task.workspaceId) : undefined;
+          return {
+            id: task.id,
+            name: task.name,
+            status: task.status,
+            updatedAt: task.updatedAt,
+            isArchived: task.archivedAt != null,
+            branchName: workspace?.branchName ?? null,
+            workspacePath: workspace?.path ?? null,
+          };
+        })
+      );
+    })
+  );
+
+  server.registerTool(
+    'create_task',
+    {
+      title: 'Create task',
+      description:
+        'Creates a new emdash task in an isolated git worktree and starts a coding agent on the given prompt. ' +
+        'Returns the task id, branch name, and worktree path.',
+      inputSchema: {
+        projectId: z.string().describe('Project id from list_projects'),
+        prompt: z.string().describe('The prompt the coding agent starts with'),
+        name: z.string().optional().describe('Task name; generated when omitted'),
+        provider: z
+          .string()
+          .optional()
+          .describe(
+            `Agent provider id (${validProviderIds()}); defaults to the app's default agent`
+          ),
+        model: z
+          .string()
+          .optional()
+          .describe(
+            "Model id for the agent; must be one of the provider's selectable models. " +
+              "Defaults to the provider CLI's default model"
+          ),
+        branchName: z
+          .string()
+          .optional()
+          .describe('Branch name; derived from the task name when omitted'),
+        baseBranch: z
+          .string()
+          .optional()
+          .describe(
+            "Existing branch to base the new task branch on; defaults to the project's " +
+              'default branch'
+          ),
+        chatUi: z
+          .boolean()
+          .optional()
+          .describe(
+            'Start the conversation in the chat UI instead of a terminal (requires an ' +
+              'ACP-capable provider); defaults to false, matching the new-task modal'
+          ),
+      },
+      annotations: { destructiveHint: false, openWorldHint: false },
+    },
+    guarded('create_task', async (input) => {
+      const result = await createTaskFromPrompt(input);
+      if (!result.success) return errorResult(result.error);
+      return textResult(result.data);
+    })
+  );
+
+  server.registerTool(
+    'archive_task',
+    {
+      title: 'Archive task',
+      description:
+        'Archives an emdash task: stops its agent sessions but keeps the worktree and branch. ' +
+        'Can be restored from the emdash UI.',
+      inputSchema: {
+        projectId: z.string().describe('Project id from list_projects'),
+        taskId: z.string().describe('Task id from list_tasks or create_task'),
+      },
+      annotations: { destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    },
+    guarded('archive_task', async ({ projectId, taskId }) => {
+      const row = await findTaskInProject(projectId, taskId);
+      if (!row) return errorResult(`Task not found in project ${projectId}: ${taskId}`);
+      // Open the project so archiveTask's session teardown can actually reap
+      // the task's live agent/tmux sessions instead of silently no-opping.
+      const project = await ensureProjectOpen(projectId);
+      await taskService.archiveTask(projectId, taskId);
+      return textResult({
+        taskId,
+        archived: true,
+        ...(project
+          ? {}
+          : {
+              warning:
+                'The project could not be opened, so any live agent sessions for this task were not stopped.',
+            }),
+      });
+    })
+  );
+
+  server.registerTool(
+    'rename_task',
+    {
+      title: 'Rename task',
+      description: 'Renames an emdash task. Does not change its branch or worktree.',
+      inputSchema: {
+        projectId: z.string().describe('Project id from list_projects'),
+        taskId: z.string().describe('Task id from list_tasks or create_task'),
+        name: z.string().describe('New task name'),
+      },
+      annotations: { destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    },
+    guarded('rename_task', async ({ projectId, taskId, name }) => {
+      const trimmed = name.trim();
+      if (!trimmed) return errorResult('name must not be empty');
+      const result = await taskService.renameTask(projectId, taskId, trimmed);
+      if (!result.success) {
+        return errorResult(`Task not found in project ${projectId}: ${result.error.taskId}`);
+      }
+      return textResult({ taskId, name: result.data.task.name });
+    })
+  );
+
+  server.registerTool(
+    'delete_task',
+    {
+      title: 'Delete task',
+      description:
+        'Deletes an emdash task and removes its worktree. The task branch is always kept, so ' +
+        'committed work stays recoverable. If the worktree has uncommitted changes the tool ' +
+        'returns requiresConfirmation instead of deleting; get the user’s explicit approval, ' +
+        'then retry with confirm: true.',
+      inputSchema: {
+        projectId: z.string().describe('Project id from list_projects'),
+        taskId: z.string().describe('Task id from list_tasks or create_task'),
+        confirm: z
+          .boolean()
+          .optional()
+          .describe(
+            'Required (true) to delete a task whose worktree has uncommitted changes. Only set ' +
+              'this after the user has explicitly approved losing those changes; never set it ' +
+              'preemptively.'
+          ),
+      },
+      annotations: { destructiveHint: true, openWorldHint: false },
+    },
+    guarded('delete_task', async ({ projectId, taskId, confirm }) => {
+      const row = await findTaskInProject(projectId, taskId);
+      if (!row) return errorResult(`Task not found in project ${projectId}: ${taskId}`);
+
+      // The uncommitted-changes preflight needs the project's git runtime; fail
+      // closed rather than delete a worktree whose state could not be verified.
+      const project = await ensureProjectOpen(projectId);
+      if (!project) {
+        return errorResult(`Project ${projectId} could not be opened to verify worktree state`);
+      }
+      const preflight = await taskService.getDeletePreflight(projectId, [taskId]);
+      const item = preflight.tasks.find((task) => task.taskId === taskId);
+      if (item?.hasUncommittedChanges && confirm !== true) {
+        // A normal (non-error) result: the agent is expected to relay this to
+        // its user and retry with confirm, not to treat it as a failure and
+        // work around the check by touching the worktree itself.
+        return textResult({
+          taskId,
+          deleted: false,
+          requiresConfirmation: true,
+          reason: 'The task worktree has uncommitted changes that will be permanently lost.',
+          instructions:
+            'Ask the user to confirm deleting this task, then call delete_task again with ' +
+            "confirm: true. Do not set confirm without the user's explicit approval, and do " +
+            'not commit, discard, or delete anything in the worktree to get around this check.',
+        });
+      }
+
+      await taskService.deleteTask(projectId, taskId, {
+        deleteWorktree: true,
+        deleteBranch: false,
+      });
+      return textResult({ taskId, deleted: true, branchKept: true });
+    })
+  );
+
+  return server;
+}

--- a/apps/emdash-desktop/src/main/core/mcp/server/register-tools.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/server/register-tools.ts
@@ -128,11 +128,18 @@ export function buildEmdashMcpServer(): McpServer {
     {
       title: 'Create task',
       description:
-        'Creates a new emdash task in an isolated git worktree and starts a coding agent on the given prompt. ' +
-        'Returns the task id, branch name, and worktree path.',
+        'Creates a new emdash task in an isolated git worktree. With a prompt, it also starts a ' +
+        'coding agent on that prompt; without one, the task is left idle for the user to drive ' +
+        'later. Returns the task id, branch name, and worktree path.',
       inputSchema: {
         projectId: z.string().describe('Project id from list_projects'),
-        prompt: z.string().describe('The prompt the coding agent starts with'),
+        prompt: z
+          .string()
+          .optional()
+          .describe(
+            'The prompt the coding agent starts with. Omit to create the task without starting ' +
+              'an agent'
+          ),
         name: z.string().optional().describe('Task name; generated when omitted'),
         provider: z
           .string()

--- a/apps/emdash-desktop/src/main/core/mcp/server/register-tools.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/server/register-tools.ts
@@ -11,6 +11,7 @@ import {
   ensureProjectOpen,
   validProviderIds,
 } from './create-task-from-prompt';
+import { runTaskScript, stopTaskScript } from './run-task-script';
 
 function textResult(value: unknown) {
   return { content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }] };
@@ -286,6 +287,57 @@ export function buildEmdashMcpServer(): McpServer {
         deleteBranch: false,
       });
       return textResult({ taskId, deleted: true, branchKept: true });
+    })
+  );
+
+  server.registerTool(
+    'run_task_script',
+    {
+      title: 'Run task script',
+      description:
+        "Starts one of a task's configured worktree lifecycle scripts (setup, run, or teardown), " +
+        'the same scripts the Scripts panel in the emdash UI runs, and returns as soon as it has ' +
+        'started rather than waiting for it to finish. Watch the Scripts panel for progress and ' +
+        'stop a still-running script with stop_task_script. Reports already_running when a script ' +
+        'of that type is already running, or no_script when none is configured for the type.',
+      inputSchema: {
+        projectId: z.string().describe('Project id from list_projects'),
+        taskId: z.string().describe('Task id from list_tasks or create_task'),
+        type: z
+          .enum(['setup', 'run', 'teardown'])
+          .describe(
+            'Which lifecycle script to run: setup (prepare the worktree), run (start the dev ' +
+              'server), or teardown (clean up)'
+          ),
+      },
+      annotations: { destructiveHint: false, openWorldHint: false },
+    },
+    guarded('run_task_script', async ({ projectId, taskId, type }) => {
+      const result = await runTaskScript({ projectId, taskId, type });
+      if (result.status === 'not_found') return errorResult(result.message);
+      return textResult(result);
+    })
+  );
+
+  server.registerTool(
+    'stop_task_script',
+    {
+      title: 'Stop task script',
+      description:
+        "Stops a task's running lifecycle script (setup, run, or teardown) started by " +
+        'run_task_script, the same as clicking Stop in the emdash Scripts panel. Reports ' +
+        'not_running when no script of that type is currently running for the task.',
+      inputSchema: {
+        projectId: z.string().describe('Project id from list_projects'),
+        taskId: z.string().describe('Task id from list_tasks or create_task'),
+        type: z.enum(['setup', 'run', 'teardown']).describe('Which lifecycle script to stop'),
+      },
+      annotations: { destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    },
+    guarded('stop_task_script', async ({ projectId, taskId, type }) => {
+      const result = await stopTaskScript({ projectId, taskId, type });
+      if (result.status === 'not_found') return errorResult(result.message);
+      return textResult(result);
     })
   );
 

--- a/apps/emdash-desktop/src/main/core/mcp/server/register-tools.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/server/register-tools.ts
@@ -172,6 +172,15 @@ export function buildEmdashMcpServer(): McpServer {
             'Start the conversation in the chat UI instead of a terminal (requires an ' +
               'ACP-capable provider); defaults to false, matching the new-task modal'
           ),
+        autoApprove: z
+          .boolean()
+          .optional()
+          .describe(
+            'Run the agent with permission prompts skipped, so it executes commands and edits ' +
+              "without asking. Defaults to the app's auto-approve-by-default task setting, and " +
+              'is ignored for providers without an auto-approve mode. The response reports the ' +
+              'value that was applied'
+          ),
       },
       annotations: { destructiveHint: false, openWorldHint: false },
     },

--- a/apps/emdash-desktop/src/main/core/mcp/server/run-task-script.test.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/server/run-task-script.test.ts
@@ -1,0 +1,217 @@
+import { err, ok } from '@emdash/shared';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  select: vi.fn(),
+  ensureProjectOpen: vi.fn(),
+  resolveLifecycleScript: vi.fn(),
+  runLifecycleScriptWithPolicy: vi.fn(),
+  stopLifecycleScriptSession: vi.fn(),
+  isLifecycleScriptSessionActive: vi.fn(),
+  logError: vi.fn(),
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn(),
+  eq: vi.fn(),
+}));
+
+vi.mock('@main/db/client', () => ({
+  db: { select: mocks.select },
+}));
+
+vi.mock('@main/db/schema', () => ({
+  tasks: {},
+}));
+
+vi.mock('@main/lib/logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: mocks.logError },
+}));
+
+vi.mock('./create-task-from-prompt', () => ({
+  ensureProjectOpen: mocks.ensureProjectOpen,
+}));
+
+vi.mock('@main/core/terminals/lifecycle-script-settings', () => ({
+  resolveLifecycleScript: mocks.resolveLifecycleScript,
+}));
+
+vi.mock('@main/core/terminals/lifecycle-script-coordinator', () => ({
+  runLifecycleScriptWithPolicy: mocks.runLifecycleScriptWithPolicy,
+  stopLifecycleScriptSession: mocks.stopLifecycleScriptSession,
+  isLifecycleScriptSessionActive: mocks.isLifecycleScriptSessionActive,
+}));
+
+const { runTaskScript, stopTaskScript } = await import('./run-task-script');
+
+/** One queued row-set per `db.select()` call; mirrors register-tools.test.ts. */
+function queueTaskRow(row: { id: string; workspaceId: string | null } | undefined): void {
+  mocks.select.mockImplementation(() => {
+    const chain = {
+      from: () => chain,
+      where: () => chain,
+      limit: () => chain,
+      then: (onFulfilled: (rows: unknown) => unknown) =>
+        Promise.resolve(row ? [row] : []).then(onFulfilled),
+    };
+    return chain;
+  });
+}
+
+const workspace = { id: 'ws1' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  queueTaskRow({ id: 't1', workspaceId: 'ws1' });
+  mocks.ensureProjectOpen.mockResolvedValue({});
+  mocks.isLifecycleScriptSessionActive.mockReturnValue(false);
+  mocks.resolveLifecycleScript.mockResolvedValue(
+    ok({ workspace, script: 'npm run dev', shellSetup: undefined })
+  );
+});
+
+describe('runTaskScript resolution', () => {
+  it('reports a task that is not in the project', async () => {
+    queueTaskRow(undefined);
+    const result = await runTaskScript({ projectId: 'p1', taskId: 't1', type: 'setup' });
+    expect(result).toEqual({
+      status: 'not_found',
+      message: 'Task not found in project p1: t1',
+    });
+    expect(mocks.runLifecycleScriptWithPolicy).not.toHaveBeenCalled();
+  });
+
+  it('reports a task whose worktree is not provisioned', async () => {
+    queueTaskRow({ id: 't1', workspaceId: null });
+    const result = await runTaskScript({ projectId: 'p1', taskId: 't1', type: 'setup' });
+    expect(result.status).toBe('not_found');
+    expect(mocks.runLifecycleScriptWithPolicy).not.toHaveBeenCalled();
+  });
+
+  it('opens the project before resolving the workspace script', async () => {
+    mocks.runLifecycleScriptWithPolicy.mockResolvedValue({
+      kind: 'succeeded',
+      result: { kind: 'exited', exitCode: 0, outputTail: '' },
+    });
+    await runTaskScript({ projectId: 'p1', taskId: 't1', type: 'setup' });
+    expect(mocks.ensureProjectOpen).toHaveBeenCalledWith('p1');
+    const openOrder = mocks.ensureProjectOpen.mock.invocationCallOrder[0] ?? 0;
+    const resolveOrder = mocks.resolveLifecycleScript.mock.invocationCallOrder[0] ?? 0;
+    expect(openOrder).toBeLessThan(resolveOrder);
+  });
+
+  it('fails when the project cannot be opened', async () => {
+    mocks.ensureProjectOpen.mockResolvedValue(undefined);
+    const result = await runTaskScript({ projectId: 'p1', taskId: 't1', type: 'setup' });
+    expect(result).toEqual({
+      status: 'not_found',
+      message: 'Project p1 could not be opened',
+    });
+    expect(mocks.runLifecycleScriptWithPolicy).not.toHaveBeenCalled();
+  });
+
+  it('reports no_script when the type has no configured script', async () => {
+    mocks.resolveLifecycleScript.mockResolvedValue(ok({ workspace, script: undefined }));
+    const result = await runTaskScript({ projectId: 'p1', taskId: 't1', type: 'teardown' });
+    expect(result).toEqual({ status: 'no_script', type: 'teardown' });
+    expect(mocks.runLifecycleScriptWithPolicy).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a lifecycle settings error', async () => {
+    mocks.resolveLifecycleScript.mockResolvedValue(
+      err({ type: 'not_found', entity: 'workspace', workspaceId: 'ws1' })
+    );
+    const result = await runTaskScript({ projectId: 'p1', taskId: 't1', type: 'setup' });
+    expect(result.status).toBe('not_found');
+    expect(mocks.runLifecycleScriptWithPolicy).not.toHaveBeenCalled();
+  });
+});
+
+describe('runTaskScript execution', () => {
+  // A never-resolving promise stands in for a script still running when the tool
+  // returns; runTaskScript must resolve to 'started' without awaiting it.
+  const pending = () => new Promise(() => {});
+
+  it.each(['setup', 'run', 'teardown'] as const)(
+    'starts a %s script without waiting for it to finish',
+    async (type) => {
+      mocks.runLifecycleScriptWithPolicy.mockReturnValue(pending());
+      const result = await runTaskScript({ projectId: 'p1', taskId: 't1', type });
+      expect(result).toEqual({ status: 'started', type });
+      const policy = mocks.runLifecycleScriptWithPolicy.mock.calls[0][0].policy;
+      // Fire-and-forget: never block the caller, never throw into the void.
+      expect(policy.waitForExit).toBeUndefined();
+      expect(policy.timeoutMs).toBeUndefined();
+      expect(policy.continueOnFailure).toBe(true);
+    }
+  );
+
+  it.each(['setup', 'run', 'teardown'] as const)(
+    'reports already_running when a %s script is already active',
+    async (type) => {
+      mocks.isLifecycleScriptSessionActive.mockReturnValue(true);
+      const result = await runTaskScript({ projectId: 'p1', taskId: 't1', type });
+      expect(result).toEqual({ status: 'already_running', type });
+      expect(mocks.runLifecycleScriptWithPolicy).not.toHaveBeenCalled();
+    }
+  );
+
+  it('does not leak an unhandled rejection when a backgrounded script fails', async () => {
+    mocks.runLifecycleScriptWithPolicy.mockRejectedValue(new Error('spawn failed'));
+    const result = await runTaskScript({ projectId: 'p1', taskId: 't1', type: 'setup' });
+    expect(result).toEqual({ status: 'started', type: 'setup' });
+    // Let the rejected background promise settle so the .catch handler runs.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mocks.logError).toHaveBeenCalledWith(
+      'McpHttpServer: setup script failed',
+      expect.objectContaining({ error: expect.stringContaining('spawn failed') })
+    );
+  });
+});
+
+describe('stopTaskScript', () => {
+  it('reports stopped when a session was killed', async () => {
+    mocks.stopLifecycleScriptSession.mockReturnValue(true);
+    const result = await stopTaskScript({ projectId: 'p1', taskId: 't1', type: 'run' });
+    expect(result).toEqual({ status: 'stopped', type: 'run' });
+    expect(mocks.stopLifecycleScriptSession).toHaveBeenCalledWith({
+      projectId: 'p1',
+      taskId: 't1',
+      workspaceId: 'ws1',
+      type: 'run',
+      origin: 'manual',
+    });
+  });
+
+  it('reports not_running when nothing was stopped', async () => {
+    mocks.stopLifecycleScriptSession.mockReturnValue(false);
+    const result = await stopTaskScript({ projectId: 'p1', taskId: 't1', type: 'run' });
+    expect(result).toEqual({ status: 'not_running', type: 'run' });
+  });
+
+  it('can stop a non-run script such as setup', async () => {
+    mocks.stopLifecycleScriptSession.mockReturnValue(true);
+    const result = await stopTaskScript({ projectId: 'p1', taskId: 't1', type: 'setup' });
+    expect(result).toEqual({ status: 'stopped', type: 'setup' });
+    expect(mocks.stopLifecycleScriptSession).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'setup' })
+    );
+  });
+
+  it('reports a task that is not in the project without touching the session', async () => {
+    queueTaskRow(undefined);
+    const result = await stopTaskScript({ projectId: 'p1', taskId: 't1', type: 'run' });
+    expect(result.status).toBe('not_found');
+    expect(mocks.stopLifecycleScriptSession).not.toHaveBeenCalled();
+  });
+
+  it('does not open the project as a side effect of stopping', async () => {
+    // Stopping works off the PTY registry by session id; opening the project
+    // would mount workspaces and run hooks just to stop a script.
+    mocks.stopLifecycleScriptSession.mockReturnValue(true);
+    const result = await stopTaskScript({ projectId: 'p1', taskId: 't1', type: 'run' });
+    expect(result).toEqual({ status: 'stopped', type: 'run' });
+    expect(mocks.ensureProjectOpen).not.toHaveBeenCalled();
+  });
+});

--- a/apps/emdash-desktop/src/main/core/mcp/server/run-task-script.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/server/run-task-script.ts
@@ -1,0 +1,176 @@
+import { and, eq } from 'drizzle-orm';
+import {
+  isLifecycleScriptSessionActive,
+  runLifecycleScriptWithPolicy,
+  stopLifecycleScriptSession,
+} from '@main/core/terminals/lifecycle-script-coordinator';
+import { resolveLifecycleScript } from '@main/core/terminals/lifecycle-script-settings';
+import { db } from '@main/db/client';
+import { tasks } from '@main/db/schema';
+import { log } from '@main/lib/logger';
+import type { LifecycleScriptType } from '@shared/core/tasks/taskEvents';
+import { ensureProjectOpen } from './create-task-from-prompt';
+
+export type RunTaskScriptInput = {
+  projectId: string;
+  taskId: string;
+  type: LifecycleScriptType;
+};
+
+export type StopTaskScriptInput = {
+  projectId: string;
+  taskId: string;
+  type: LifecycleScriptType;
+};
+
+export type StopTaskScriptResult =
+  | { status: 'not_found'; message: string }
+  | { status: 'stopped'; type: LifecycleScriptType }
+  | { status: 'not_running'; type: LifecycleScriptType };
+
+type ResolveTaskWorkspaceResult =
+  | { ok: true; workspaceId: string }
+  | { ok: false; message: string };
+
+/**
+ * Looks up a task's `workspaceId` from the db, scoped to its project.
+ * `openProject` mounts the project's workspace registry (needed before
+ * resolving a live workspace); stopping a script does not need it, since
+ * stopLifecycleScriptSession works off the PTY registry by id alone — so
+ * callers opt in rather than mounting a whole project as a side effect.
+ */
+async function resolveTaskWorkspace(
+  projectId: string,
+  taskId: string,
+  { openProject }: { openProject: boolean }
+): Promise<ResolveTaskWorkspaceResult> {
+  const [taskRow] = await db
+    .select({ id: tasks.id, workspaceId: tasks.workspaceId })
+    .from(tasks)
+    .where(and(eq(tasks.id, taskId), eq(tasks.projectId, projectId)))
+    .limit(1);
+  if (!taskRow) {
+    return { ok: false, message: `Task not found in project ${projectId}: ${taskId}` };
+  }
+  if (!taskRow.workspaceId) {
+    return {
+      ok: false,
+      message: `Task ${taskId} has no workspace; its worktree may not be provisioned yet.`,
+    };
+  }
+
+  if (openProject) {
+    const project = await ensureProjectOpen(projectId);
+    if (!project) {
+      return { ok: false, message: `Project ${projectId} could not be opened` };
+    }
+  }
+  return { ok: true, workspaceId: taskRow.workspaceId };
+}
+
+export type RunTaskScriptResult =
+  | { status: 'not_found'; message: string }
+  | { status: 'no_script'; type: LifecycleScriptType }
+  | { status: 'started'; type: LifecycleScriptType }
+  | { status: 'already_running'; type: LifecycleScriptType };
+
+/**
+ * Starts one of a task's configured lifecycle scripts (`setup`, `run`, or
+ * `teardown`) and returns as soon as it has started, rather than waiting for it
+ * to finish. A caller that wants to know when a script has completed watches the
+ * Scripts panel / status events, and stops a still-running one with
+ * stopTaskScript. This drives the same PTY session and status events as the
+ * Scripts panel in the UI, so the run is visible there regardless of who
+ * started it.
+ */
+export async function runTaskScript(input: RunTaskScriptInput): Promise<RunTaskScriptResult> {
+  const { projectId, taskId, type } = input;
+
+  // Running a script resolves a live workspace, so the project must be mounted.
+  const resolvedWorkspace = await resolveTaskWorkspace(projectId, taskId, { openProject: true });
+  if (!resolvedWorkspace.ok) {
+    return { status: 'not_found', message: resolvedWorkspace.message };
+  }
+  const { workspaceId } = resolvedWorkspace;
+
+  const resolved = await resolveLifecycleScript({ projectId, workspaceId, type });
+  if (!resolved.success) {
+    const detail =
+      resolved.error.type === 'not_found'
+        ? `workspace ${resolved.error.workspaceId} is not mounted`
+        : resolved.error.message;
+    return { status: 'not_found', message: `Could not resolve ${type} script: ${detail}` };
+  }
+
+  const { workspace, script, shellSetup } = resolved.data;
+  if (!script) {
+    return { status: 'no_script', type };
+  }
+
+  // Already running (e.g. auto-run on provision, or an earlier call): the
+  // fire-and-forget below discards the coordinator's synchronous
+  // 'already-running' result, so without this check we'd report 'started' when
+  // nothing new started. Mirrors the UI's isRunning guard.
+  if (isLifecycleScriptSessionActive({ projectId, workspaceId, type })) {
+    return { status: 'already_running', type };
+  }
+
+  // Start and return without awaiting completion: setup/teardown may finish
+  // quickly, run (a dev server) is expected to stay up, and a caller should not
+  // block on either. The coordinator emits 'running' synchronously before the
+  // first await, so the Scripts panel reflects it once this returns.
+  void runLifecycleScriptWithPolicy({
+    workspace,
+    projectId,
+    taskId,
+    workspaceId,
+    type,
+    script,
+    shellSetup,
+    origin: 'manual',
+    policy: {
+      // Keep the shell alive after the command so a dev server stays up and a
+      // finished setup/teardown can respawn from the Scripts panel.
+      respawnAfterExit: true,
+      logFailure: true,
+      surfaceFailure: true,
+      // The caller has already returned; fail via logs/status, never throw
+      // into an unhandled rejection.
+      continueOnFailure: true,
+    },
+    logPrefix: 'McpHttpServer',
+  }).catch((error) => {
+    log.error(`McpHttpServer: ${type} script failed`, { error: String(error) });
+  });
+  return { status: 'started', type };
+}
+
+/**
+ * Stops a running lifecycle script session, mirroring the UI's Stop button.
+ * Any type (`setup`, `run`, or `teardown`) can be stopped, since runTaskScript
+ * starts them without waiting and a slow one may still be running. Emits the
+ * same `stopped` status event as the UI, so the Scripts panel updates live.
+ */
+export async function stopTaskScript(input: StopTaskScriptInput): Promise<StopTaskScriptResult> {
+  const { projectId, taskId, type } = input;
+
+  // Stopping works off the PTY registry by session id, so it doesn't need the
+  // project mounted; avoid opening one as a side effect of a stop.
+  const resolvedWorkspace = await resolveTaskWorkspace(projectId, taskId, { openProject: false });
+  if (!resolvedWorkspace.ok) {
+    return { status: 'not_found', message: resolvedWorkspace.message };
+  }
+  const { workspaceId } = resolvedWorkspace;
+
+  const stopped = stopLifecycleScriptSession({
+    projectId,
+    taskId,
+    workspaceId,
+    type,
+    origin: 'manual',
+  });
+  // stopLifecycleScriptSession returns false when there is no active,
+  // not-already-stopped session for this type; from the caller's view that all
+  // reduces to "there was nothing running to stop".
+  return stopped ? { status: 'stopped', type } : { status: 'not_running', type };
+}

--- a/apps/emdash-desktop/src/main/core/mcp/server/self-registration.test.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/server/self-registration.test.ts
@@ -1,0 +1,142 @@
+import type { McpServer } from '@emdash/core/mcp';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EMDASH_SELF_SERVER_NAME } from '@shared/core/mcp/types';
+
+const mocks = vi.hoisted(() => ({
+  loadAll: vi.fn(),
+  saveServer: vi.fn(),
+  getConnectionInfo: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock('../services/McpService', () => ({
+  mcpService: { loadAll: mocks.loadAll, saveServer: mocks.saveServer },
+}));
+
+vi.mock('./mcp-http-server', () => ({
+  mcpHttpServer: { getConnectionInfo: mocks.getConnectionInfo },
+}));
+
+vi.mock('@main/lib/logger', () => ({
+  log: { info: vi.fn(), warn: mocks.warn, error: vi.fn() },
+}));
+
+const { refreshSelfServerRegistration, resolveSelfServer } = await import('./self-registration');
+
+const RUNNING = { url: 'http://127.0.0.1:8212/mcp', token: 'token-1' };
+
+function selfEntry(overrides: Partial<McpServer> = {}): McpServer {
+  return {
+    name: EMDASH_SELF_SERVER_NAME,
+    transport: 'http',
+    url: 'http://127.0.0.1:9999/mcp',
+    headers: { Authorization: 'Bearer stale-token' },
+    providers: ['claude', 'codex'],
+    ...overrides,
+  };
+}
+
+function installServers(servers: McpServer[]): void {
+  mocks.loadAll.mockResolvedValue({ installed: servers });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getConnectionInfo.mockReturnValue(RUNNING);
+  mocks.saveServer.mockResolvedValue(undefined);
+  installServers([]);
+});
+
+describe('resolveSelfServer', () => {
+  it('throws when the http server is not running', () => {
+    mocks.getConnectionInfo.mockReturnValue(null);
+    expect(() => resolveSelfServer(['claude'])).toThrow('The emdash MCP server is not running');
+  });
+
+  it('builds the entry from the live url, bearer token, and given providers', () => {
+    expect(resolveSelfServer(['claude'])).toEqual({
+      name: EMDASH_SELF_SERVER_NAME,
+      transport: 'http',
+      url: RUNNING.url,
+      headers: { Authorization: `Bearer ${RUNNING.token}` },
+      providers: ['claude'],
+    });
+  });
+});
+
+describe('refreshSelfServerRegistration', () => {
+  it('does nothing when the http server is not running', async () => {
+    mocks.getConnectionInfo.mockReturnValue(null);
+    installServers([selfEntry()]);
+    await refreshSelfServerRegistration();
+    expect(mocks.saveServer).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when emdash is not registered in any agent config', async () => {
+    await refreshSelfServerRegistration();
+    expect(mocks.saveServer).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the entry has no providers', async () => {
+    installServers([selfEntry({ providers: [] })]);
+    await refreshSelfServerRegistration();
+    expect(mocks.saveServer).not.toHaveBeenCalled();
+  });
+
+  it('rewrites a loopback entry with the current url and token, keeping its providers', async () => {
+    installServers([selfEntry()]);
+    await refreshSelfServerRegistration();
+    expect(mocks.saveServer).toHaveBeenCalledWith({
+      name: EMDASH_SELF_SERVER_NAME,
+      transport: 'http',
+      url: RUNNING.url,
+      headers: { Authorization: `Bearer ${RUNNING.token}` },
+      providers: ['claude', 'codex'],
+    });
+  });
+
+  it('preserves user-set fields (enabled, timeout) when rewriting', async () => {
+    installServers([selfEntry({ enabled: false, timeout: 30_000 })]);
+    await refreshSelfServerRegistration();
+    expect(mocks.saveServer).toHaveBeenCalledWith({
+      name: EMDASH_SELF_SERVER_NAME,
+      transport: 'http',
+      url: RUNNING.url,
+      headers: { Authorization: `Bearer ${RUNNING.token}` },
+      providers: ['claude', 'codex'],
+      enabled: false,
+      timeout: 30_000,
+    });
+  });
+
+  it.each(['localhost', '[::1]'])('treats a %s entry as its own', async (host) => {
+    installServers([selfEntry({ url: `http://${host}:8212/mcp` })]);
+    await refreshSelfServerRegistration();
+    expect(mocks.saveServer).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves an unrelated server named "emdash" on a non-local host untouched', async () => {
+    installServers([selfEntry({ url: 'https://mcp.example.com/mcp' })]);
+    await refreshSelfServerRegistration();
+    expect(mocks.saveServer).not.toHaveBeenCalled();
+    expect(mocks.warn).toHaveBeenCalled();
+  });
+
+  it('leaves a loopback server on a different path untouched', async () => {
+    installServers([selfEntry({ url: 'http://127.0.0.1:3000/api/mcp' })]);
+    await refreshSelfServerRegistration();
+    expect(mocks.saveServer).not.toHaveBeenCalled();
+  });
+
+  it('leaves an entry without a url untouched', async () => {
+    installServers([selfEntry({ url: undefined })]);
+    await refreshSelfServerRegistration();
+    expect(mocks.saveServer).not.toHaveBeenCalled();
+  });
+
+  it('leaves an entry with an unparseable url untouched', async () => {
+    installServers([selfEntry({ url: 'not a url' })]);
+    await refreshSelfServerRegistration();
+    expect(mocks.saveServer).not.toHaveBeenCalled();
+  });
+});

--- a/apps/emdash-desktop/src/main/core/mcp/server/self-registration.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/server/self-registration.ts
@@ -1,0 +1,68 @@
+import type { McpServer } from '@emdash/core/mcp';
+import { log } from '@main/lib/logger';
+import { EMDASH_SELF_SERVER_NAME } from '@shared/core/mcp/types';
+import { mcpService } from '../services/McpService';
+import { mcpHttpServer } from './mcp-http-server';
+
+/**
+ * Builds the emdash server entry for the given agents from the live server's
+ * connection info. The URL and bearer token always come from here — callers
+ * (the saveServer RPC intercept, boot reconciliation) only choose providers.
+ * `saveServer` removes the entry from any MCP-capable agent not in the list,
+ * so an empty providers list deregisters emdash everywhere.
+ */
+export function resolveSelfServer(providers: string[]): McpServer {
+  const info = mcpHttpServer.getConnectionInfo();
+  if (!info) throw new Error('The emdash MCP server is not running');
+  return {
+    name: EMDASH_SELF_SERVER_NAME,
+    transport: 'http',
+    url: info.url,
+    headers: { Authorization: `Bearer ${info.token}` },
+    providers,
+  };
+}
+
+async function findSelfServer(): Promise<McpServer | undefined> {
+  const { installed } = await mcpService.loadAll();
+  return installed.find((server) => server.name === EMDASH_SELF_SERVER_NAME);
+}
+
+/** True when an installed entry named "emdash" looks like our own loopback registration. */
+export function isSelfServerEntry(server: McpServer): boolean {
+  if (!server.url) return false;
+  try {
+    const parsed = new URL(server.url);
+    return (
+      ['127.0.0.1', 'localhost', '[::1]'].includes(parsed.hostname) && parsed.pathname === '/mcp'
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Boot-time reconciliation: if the user previously registered emdash in agent
+ * configs, rewrite the entry with the current URL and token so token rotation
+ * or a port change heals silently. Never creates a registration the user did
+ * not opt into.
+ */
+export async function refreshSelfServerRegistration(): Promise<void> {
+  const info = mcpHttpServer.getConnectionInfo();
+  if (!info) return;
+  const existing = await findSelfServer();
+  if (!existing || existing.providers.length === 0) return;
+  if (!isSelfServerEntry(existing)) {
+    log.warn(
+      'McpHttpServer: found an unrelated MCP server named "emdash" in agent configs; leaving it untouched'
+    );
+    return;
+  }
+
+  // Always rewrite: loadAll collapses per-agent entries into one representative,
+  // so comparing against it can mask a stale token in another agent's config
+  // (e.g. after a partially failed save). saveServer rewrites every agent.
+  // Spread the existing entry first so user-set fields (enabled, timeout, cwd)
+  // survive the heal; only the connection details are replaced.
+  await mcpService.saveServer({ ...existing, ...resolveSelfServer(existing.providers) });
+}

--- a/apps/emdash-desktop/src/main/core/mcp/utils/catalog.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/utils/catalog.ts
@@ -9,9 +9,15 @@ export function loadCatalog(): McpCatalogEntry[] {
     docsUrl: entry.docsUrl,
     defaultConfig: entry.config,
     credentialKeys: entry.credentialKeys,
+    managed: entry.managed,
   }));
 }
 
 export function getCatalogServerConfig(key: string): RawServerEntry | undefined {
   return catalogData[key]?.config;
+}
+
+/** True when the catalog defines this name as a managed (emdash-provided) server. */
+export function isManagedCatalogKey(key: string): boolean {
+  return catalogData[key]?.managed === true;
 }

--- a/apps/emdash-desktop/src/main/core/tasks/operations/getDeletePreflight.test.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/getDeletePreflight.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  select: vi.fn(),
+  getProject: vi.fn(),
+  acquire: vi.fn(),
+  getProvisionedWorkspaceBranch: vi.fn(),
+  getWorktree: vi.fn(),
+  openWorktree: vi.fn(),
+  getStatus: vi.fn(),
+  releaseRuntime: vi.fn(),
+  releaseWorktree: vi.fn(),
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn(),
+  eq: vi.fn(),
+  ne: vi.fn(),
+}));
+
+vi.mock('@main/core/projects/project-manager', () => ({
+  projectManager: { getProject: mocks.getProject },
+}));
+
+vi.mock('@main/core/runtime/runtime-manager', () => ({
+  runtimeManager: { acquire: mocks.acquire },
+}));
+
+vi.mock('@main/core/workspaces/workspace-branch', () => ({
+  getProvisionedWorkspaceBranch: mocks.getProvisionedWorkspaceBranch,
+}));
+
+vi.mock('@main/db/client', () => ({
+  db: { select: mocks.select },
+}));
+
+vi.mock('@main/db/schema', () => ({
+  tasks: {},
+  workspaces: {},
+}));
+
+vi.mock('@main/lib/logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const { getDeletePreflight } = await import('./getDeletePreflight');
+
+/** Queues rows per db.select() call: task lookup, workspace lookup, sibling lookup. */
+function queueSelectResults(...results: unknown[][]): void {
+  const queue = [...results];
+  mocks.select.mockImplementation(() => {
+    const rows = queue.shift() ?? [];
+    const chain = {
+      from: () => chain,
+      where: () => chain,
+      limit: () => chain,
+      then: (onFulfilled: (rows: unknown) => unknown, onRejected?: (error: unknown) => unknown) =>
+        Promise.resolve(rows).then(onFulfilled, onRejected),
+    };
+    return chain;
+  });
+}
+
+const TASK_ROW = { id: 't1', workspaceId: 'ws1' };
+const WORKSPACE_ROW = {
+  id: 'ws1',
+  config: { git: { kind: 'create-branch', fromBranch: { branch: 'main' } } },
+};
+
+function queueProvisionedTask(): void {
+  queueSelectResults([TASK_ROW], [WORKSPACE_ROW], []);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  queueProvisionedTask();
+  mocks.getProvisionedWorkspaceBranch.mockReturnValue('feat-x');
+  mocks.getProject.mockReturnValue({
+    defaultWorkspaceMachine: 'local',
+    worktreeService: { getWorktree: mocks.getWorktree },
+  });
+  mocks.getWorktree.mockResolvedValue('/worktrees/feat-x');
+  mocks.acquire.mockResolvedValue({
+    value: { git: { openWorktree: mocks.openWorktree } },
+    release: mocks.releaseRuntime,
+  });
+  mocks.openWorktree.mockResolvedValue({
+    value: { getStatus: mocks.getStatus },
+    release: mocks.releaseWorktree,
+  });
+  mocks.getStatus.mockResolvedValue({ kind: 'ok', staged: [], unstaged: [] });
+});
+
+describe('getDeletePreflight', () => {
+  it('reports no worktree for an unknown task', async () => {
+    queueSelectResults([]);
+    const result = await getDeletePreflight('p1', ['t1']);
+    expect(result.tasks).toEqual([
+      { taskId: 't1', hasWorktree: false, hasUncommittedChanges: false, hasDeletableBranch: false },
+    ]);
+  });
+
+  it('reports no worktree when the workspace is shared with another task', async () => {
+    queueSelectResults([TASK_ROW], [WORKSPACE_ROW], [{ id: 'other-task' }]);
+    const result = await getDeletePreflight('p1', ['t1']);
+    expect(result.tasks[0]).toMatchObject({ hasWorktree: false, hasDeletableBranch: false });
+    expect(mocks.getStatus).not.toHaveBeenCalled();
+  });
+
+  it('reports a clean provisioned worktree as deletable', async () => {
+    const result = await getDeletePreflight('p1', ['t1']);
+    expect(result.tasks).toEqual([
+      { taskId: 't1', hasWorktree: true, hasUncommittedChanges: false, hasDeletableBranch: true },
+    ]);
+  });
+
+  it('reports staged changes as uncommitted', async () => {
+    mocks.getStatus.mockResolvedValue({ kind: 'ok', staged: ['a.ts'], unstaged: [] });
+    const result = await getDeletePreflight('p1', ['t1']);
+    expect(result.tasks[0]?.hasUncommittedChanges).toBe(true);
+  });
+
+  it('reports unstaged changes as uncommitted', async () => {
+    mocks.getStatus.mockResolvedValue({ kind: 'ok', staged: [], unstaged: ['b.ts'] });
+    const result = await getDeletePreflight('p1', ['t1']);
+    expect(result.tasks[0]?.hasUncommittedChanges).toBe(true);
+  });
+
+  it('fails closed when git status reports an error', async () => {
+    mocks.getStatus.mockResolvedValue({ kind: 'error', message: 'index locked' });
+    const result = await getDeletePreflight('p1', ['t1']);
+    expect(result.tasks[0]?.hasUncommittedChanges).toBe(true);
+  });
+
+  it('fails closed when the worktree has too many files to scan', async () => {
+    mocks.getStatus.mockResolvedValue({ kind: 'too-many-files' });
+    const result = await getDeletePreflight('p1', ['t1']);
+    expect(result.tasks[0]?.hasUncommittedChanges).toBe(true);
+  });
+
+  it('fails closed when the status check throws', async () => {
+    mocks.getWorktree.mockRejectedValue(new Error('runtime gone'));
+    const result = await getDeletePreflight('p1', ['t1']);
+    expect(result.tasks[0]?.hasUncommittedChanges).toBe(true);
+  });
+
+  it('releases the worktree and runtime leases even when getStatus throws', async () => {
+    mocks.getStatus.mockRejectedValue(new Error('boom'));
+    const result = await getDeletePreflight('p1', ['t1']);
+    expect(result.tasks[0]?.hasUncommittedChanges).toBe(true);
+    expect(mocks.releaseWorktree).toHaveBeenCalledTimes(1);
+    expect(mocks.releaseRuntime).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the git check when the project is not open', async () => {
+    // Current behavior: without an open project the check cannot run and the
+    // task is reported clean; MCP delete_task compensates by opening the
+    // project first and failing closed when that is impossible.
+    mocks.getProject.mockReturnValue(undefined);
+    const result = await getDeletePreflight('p1', ['t1']);
+    expect(result.tasks[0]?.hasUncommittedChanges).toBe(false);
+    expect(mocks.acquire).not.toHaveBeenCalled();
+  });
+
+  it('reports the branch as not deletable when it matches the source branch', async () => {
+    mocks.getProvisionedWorkspaceBranch.mockReturnValue('main');
+    const result = await getDeletePreflight('p1', ['t1']);
+    expect(result.tasks[0]).toMatchObject({ hasWorktree: true, hasDeletableBranch: false });
+  });
+});

--- a/apps/emdash-desktop/src/main/core/tasks/operations/getDeletePreflight.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/getDeletePreflight.ts
@@ -63,8 +63,12 @@ async function getTaskPreflight(
               }
               if (status.kind === 'ok') {
                 hasUncommittedChanges = status.staged.length > 0 || status.unstaged.length > 0;
+              } else {
+                // 'error' and 'too-many-files': the worktree could not be
+                // verified clean — report dirty so callers err toward
+                // preserving it.
+                hasUncommittedChanges = true;
               }
-              hasUncommittedChanges = status.kind === 'too-many-files';
             } finally {
               await worktreeLease.release();
             }
@@ -74,6 +78,7 @@ async function getTaskPreflight(
         }
       } catch (e) {
         log.warn('getDeletePreflight: git status check failed', { taskId, error: String(e) });
+        hasUncommittedChanges = true;
       }
     }
   }

--- a/apps/emdash-desktop/src/main/core/terminals/lifecycle-script-coordinator.ts
+++ b/apps/emdash-desktop/src/main/core/terminals/lifecycle-script-coordinator.ts
@@ -57,6 +57,19 @@ function lifecycleScriptSessionId({
   return makePtySessionId(projectId, workspaceId, createLifecycleScriptTerminalId(type));
 }
 
+/** True when a lifecycle script session of this type is currently running. */
+export function isLifecycleScriptSessionActive({
+  projectId,
+  workspaceId,
+  type,
+}: {
+  projectId: string;
+  workspaceId: string;
+  type: LifecycleScriptType;
+}): boolean {
+  return activeSessions.has(lifecycleScriptSessionId({ projectId, workspaceId, type }));
+}
+
 export function stopLifecycleScriptSession({
   projectId,
   taskId,

--- a/apps/emdash-desktop/src/main/index.ts
+++ b/apps/emdash-desktop/src/main/index.ts
@@ -29,6 +29,8 @@ import { localDependencyManager } from './core/dependencies/dependency-managers'
 import { editorBufferService } from './core/editor/editor-buffer-service';
 import { githubAccountReconciliationService } from './core/github/accounts/github-account-reconciliation-instance';
 import { GitHubAuthServerAdapter } from './core/github/accounts/github-auth-server-adapter';
+import { mcpHttpServer } from './core/mcp/server/mcp-http-server';
+import { refreshSelfServerRegistration } from './core/mcp/server/self-registration';
 import { projectSettingsService } from './core/projects/settings/project-settings-service';
 import { promptLibraryService } from './core/prompt-library/service';
 import { providerAccountRegistry } from './core/provider-accounts/provider-account-registry-instance';
@@ -157,6 +159,18 @@ void app.whenReady().then(async () => {
   agentHookService.initialize().catch((e) => {
     log.error('Failed to start agent event service:', e);
   });
+  if (process.env.EMDASH_MCP_SERVER !== 'false') {
+    mcpHttpServer
+      .start()
+      .then(() =>
+        refreshSelfServerRegistration().catch((e) => {
+          log.error('Failed to refresh emdash MCP server registration:', e);
+        })
+      )
+      .catch((e) => {
+        log.error('Failed to start MCP HTTP server:', e);
+      });
+  }
   initializeAcpRuntimeProcess().catch((e) => {
     log.error('Failed to start ACP runtime process:', e);
   });

--- a/apps/emdash-desktop/src/renderer/features/mcp/components/McpCard.tsx
+++ b/apps/emdash-desktop/src/renderer/features/mcp/components/McpCard.tsx
@@ -26,7 +26,9 @@ function getTransport(server?: McpServer, entry?: McpCatalogEntry): 'stdio' | 'h
 }
 
 export const McpCard: React.FC<McpCardProps> = ({ server, catalogEntry, onEdit, onAdd }) => {
-  const name = server?.name ?? catalogEntry?.name ?? 'Unknown';
+  // Prefer the catalog display name (e.g. "Emdash", "Linear") over the raw
+  // config key an installed server is stored under, matching the description.
+  const name = catalogEntry?.name ?? server?.name ?? 'Unknown';
   const description = catalogEntry?.description ?? (server ? `${server.transport} server` : '');
   const isInstalled = !!server;
   const transport = getTransport(server, catalogEntry);

--- a/apps/emdash-desktop/src/renderer/features/mcp/components/McpModal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/mcp/components/McpModal.tsx
@@ -35,6 +35,63 @@ interface McpModalProps extends BaseModalProps {
   onRemove?: (serverName: string) => void;
 }
 
+/**
+ * Main flags managed entries itself (see {@link McpCatalogEntry.managed}): on
+ * catalog entries directly, on installed servers as a load-time annotation.
+ */
+function isManaged(mode: McpModalMode): boolean {
+  if (mode.type === 'add-catalog') return mode.entry.managed === true;
+  return mode.type === 'edit' && mode.server.managed === true;
+}
+
+type FieldAccess = 'editable' | 'readonly' | 'hidden';
+
+interface FieldPolicy {
+  name: FieldAccess;
+  transport: FieldAccess;
+  /** Covers the command and arguments fields. */
+  command: FieldAccess;
+  url: FieldAccess;
+  env: FieldAccess;
+  headers: FieldAccess;
+}
+
+/**
+ * What each form field allows in each mode — the single place that decides
+ * it; the JSX below renders uniformly from this. Managed servers keep their
+ * connection details in the main process, so only agent selection is open.
+ */
+function getFieldPolicy(mode: McpModalMode): FieldPolicy {
+  if (isManaged(mode)) {
+    return {
+      name: 'readonly',
+      transport: 'hidden',
+      command: 'hidden',
+      url: 'readonly',
+      env: 'hidden',
+      headers: 'hidden',
+    };
+  }
+  if (mode.type === 'add-catalog') {
+    return {
+      name: 'readonly',
+      transport: 'hidden',
+      command: 'readonly',
+      url: 'readonly',
+      env: 'editable',
+      headers: 'editable',
+    };
+  }
+  return {
+    name: mode.type === 'edit' ? 'readonly' : 'editable',
+    transport: 'editable',
+    command: 'editable',
+    url: 'editable',
+    env: 'editable',
+    headers: 'editable',
+  };
+}
+
 export const McpModal: React.FC<McpModalProps> = ({
   mode,
   providers,
@@ -44,6 +101,7 @@ export const McpModal: React.FC<McpModalProps> = ({
 }) => {
   const isEdit = mode.type === 'edit';
   const isCatalog = mode.type === 'add-catalog';
+  const policy = getFieldPolicy(mode);
   const credentialKeys = isCatalog
     ? new Map(mode.entry.credentialKeys.map((c) => [c.key, c.required]))
     : new Map<string, boolean>();
@@ -127,7 +185,7 @@ export const McpModal: React.FC<McpModalProps> = ({
                 <Input
                   value={field.state.value}
                   onChange={(e) => field.handleChange(e.target.value)}
-                  disabled={isCatalog || isEdit}
+                  disabled={policy.name === 'readonly'}
                   placeholder="my-server"
                 />
               </Field>
@@ -135,7 +193,7 @@ export const McpModal: React.FC<McpModalProps> = ({
           </form.Field>
 
           {/* Transport */}
-          {!isCatalog && (
+          {policy.transport !== 'hidden' && (
             <form.Field name="transport">
               {(field) => (
                 <Field>
@@ -172,7 +230,7 @@ export const McpModal: React.FC<McpModalProps> = ({
           <form.Subscribe selector={(state) => state.values.transport}>
             {(transport) => (
               <>
-                {transport === 'stdio' && (
+                {transport === 'stdio' && policy.command !== 'hidden' && (
                   <>
                     <form.Field name="command">
                       {(field) => (
@@ -181,7 +239,7 @@ export const McpModal: React.FC<McpModalProps> = ({
                           <Input
                             value={field.state.value}
                             onChange={(e) => field.handleChange(e.target.value)}
-                            disabled={isCatalog}
+                            disabled={policy.command === 'readonly'}
                             placeholder="npx"
                           />
                         </Field>
@@ -194,7 +252,7 @@ export const McpModal: React.FC<McpModalProps> = ({
                           <textarea
                             value={field.state.value}
                             onChange={(e) => field.handleChange(e.target.value)}
-                            disabled={isCatalog}
+                            disabled={policy.command === 'readonly'}
                             placeholder={'-y\nmy-mcp-server'}
                             rows={3}
                             className="border-input placeholder:text-muted-foreground focus-visible:ring-ring flex w-full rounded-md border bg-background px-3 py-2 text-sm ring-offset-background focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
@@ -205,7 +263,7 @@ export const McpModal: React.FC<McpModalProps> = ({
                   </>
                 )}
 
-                {transport === 'http' && (
+                {transport === 'http' && policy.url !== 'hidden' && (
                   <form.Field name="url">
                     {(field) => (
                       <Field>
@@ -213,7 +271,7 @@ export const McpModal: React.FC<McpModalProps> = ({
                         <Input
                           value={field.state.value}
                           onChange={(e) => field.handleChange(e.target.value)}
-                          disabled={isCatalog}
+                          disabled={policy.url === 'readonly'}
                           placeholder="https://mcp.example.com"
                         />
                       </Field>
@@ -225,24 +283,27 @@ export const McpModal: React.FC<McpModalProps> = ({
           </form.Subscribe>
 
           {/* Env vars — both transports */}
-          <form.Field name="envEntries">
-            {(field) => (
-              <KeyValueSection
-                label="Environment Variables"
-                entries={field.state.value}
-                onChange={(entries) => field.handleChange(entries)}
-                addLabel="+ Add env var"
-                makeId={makeId}
-                credentialKeys={credentialKeys}
-                splitEnvPaste
-              />
-            )}
-          </form.Field>
+          {policy.env !== 'hidden' && (
+            <form.Field name="envEntries">
+              {(field) => (
+                <KeyValueSection
+                  label="Environment Variables"
+                  entries={field.state.value}
+                  onChange={(entries) => field.handleChange(entries)}
+                  addLabel="+ Add env var"
+                  makeId={makeId}
+                  credentialKeys={credentialKeys}
+                  splitEnvPaste
+                />
+              )}
+            </form.Field>
+          )}
 
           {/* Headers — http only */}
           <form.Subscribe selector={(state) => state.values.transport}>
             {(transport) =>
-              transport === 'http' && (
+              transport === 'http' &&
+              policy.headers !== 'hidden' && (
                 <form.Field name="headerEntries">
                   {(field) => (
                     <KeyValueSection

--- a/apps/emdash-desktop/src/renderer/features/mcp/components/McpView.tsx
+++ b/apps/emdash-desktop/src/renderer/features/mcp/components/McpView.tsx
@@ -46,7 +46,7 @@ export const McpView: React.FC = () => {
     });
   };
 
-  // Filter
+  // Filter. Recommendations keep catalog order, which pins emdash first.
   const lowerSearch = search.toLowerCase();
   const installedNames = new Set(installed.map((s) => s.name));
   const filteredInstalled = installed.filter(

--- a/apps/emdash-desktop/src/renderer/features/mcp/components/useMcps.ts
+++ b/apps/emdash-desktop/src/renderer/features/mcp/components/useMcps.ts
@@ -5,7 +5,7 @@ import { rpc } from '@renderer/lib/ipc';
 import { captureTelemetry } from '@renderer/utils/telemetryClient';
 import type { McpCatalogEntry, McpProvidersResponse, McpServer } from '@shared/core/mcp/types';
 
-const MCP_QUERY_KEY = ['mcp', 'all'] as const;
+export const MCP_QUERY_KEY = ['mcp', 'all'] as const;
 const PROVIDERS_QUERY_KEY = ['mcp', 'providers'] as const;
 
 export function useMcps() {

--- a/apps/emdash-desktop/src/shared/core/mcp/catalog.ts
+++ b/apps/emdash-desktop/src/shared/core/mcp/catalog.ts
@@ -1,4 +1,4 @@
-import type { RawServerEntry } from './types';
+import { EMDASH_SELF_SERVER_NAME, type RawServerEntry } from './types';
 
 export interface CredentialKeyDef {
   key: string;
@@ -11,9 +11,22 @@ export interface CatalogEntryDef {
   description: string;
   docsUrl: string;
   credentialKeys: CredentialKeyDef[];
+  /** See {@link import('./types').McpCatalogEntry.managed}. */
+  managed?: boolean;
 }
 
+// Entry order is display order in the catalog UI.
 export const catalogData: Record<string, CatalogEntryDef> = {
+  [EMDASH_SELF_SERVER_NAME]: {
+    // Managed: the real URL and bearer token are injected by the main process
+    // on save; this config is never used directly.
+    config: { type: 'http' },
+    name: 'Emdash',
+    description: 'Create and manage Emdash tasks and projects',
+    docsUrl: '',
+    credentialKeys: [],
+    managed: true,
+  },
   playwright: {
     config: {
       command: 'npx',

--- a/apps/emdash-desktop/src/shared/core/mcp/types.ts
+++ b/apps/emdash-desktop/src/shared/core/mcp/types.ts
@@ -15,6 +15,11 @@ export interface McpServer {
   timeout?: number;
   oauth?: Record<string, unknown> | false;
   providers: string[];
+  /**
+   * Set by the main process when loading a server whose connection details it
+   * manages (see {@link McpCatalogEntry.managed}); ignored on save.
+   */
+  managed?: boolean;
 }
 
 /** Credential key with required/optional distinction */
@@ -34,6 +39,12 @@ export interface McpCatalogEntry {
   docsUrl: string;
   defaultConfig: RawServerEntry;
   credentialKeys: CredentialKey[];
+  /**
+   * Managed entries are servers emdash itself provides: their connection
+   * details are filled in by the main process on save and shown read-only in
+   * the add/edit modal.
+   */
+  managed?: boolean;
 }
 
 export interface McpLoadAllResponse {
@@ -47,3 +58,6 @@ export interface McpProvidersResponse {
   installed: boolean;
   supportsHttp: boolean;
 }
+
+/** Name of the MCP server entry emdash registers for itself in agent configs. */
+export const EMDASH_SELF_SERVER_NAME = 'emdash';

--- a/packages/core/src/mcp/schemas.ts
+++ b/packages/core/src/mcp/schemas.ts
@@ -13,6 +13,8 @@ export const mcpServerSchema = z.object({
   timeout: z.number().optional(),
   oauth: z.union([z.record(z.string(), z.unknown()), z.literal(false)]).optional(),
   providers: z.array(z.string()),
+  /** Set by the main process on load for servers whose connection details it manages. */
+  managed: z.boolean().optional(),
 });
 
 export type McpServer = z.infer<typeof mcpServerSchema>;
@@ -31,6 +33,8 @@ export interface McpCatalogEntry {
   docsUrl: string;
   defaultConfig: RawServerEntry;
   credentialKeys: CredentialKey[];
+  /** Managed entries are provided by emdash itself; connection details are injected on save. */
+  managed?: boolean;
 }
 
 export interface McpLoadAllResponse {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@llamaduck/forgejo-ts':
         specifier: ^14.0.3
         version: 14.0.5
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
       '@octokit/auth-oauth-device':
         specifier: ^8.0.3
         version: 8.0.3
@@ -2170,7 +2173,6 @@ packages:
     resolution: {integrity: sha512-yASOY5MpsuzHKSF4xRyoVCIWv65GDlVs9VxZ+aZIfw5R9XbPgiaHaHRGlLBAm0j7WFw7wBCOB3WOxBK+wjC3dQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@23.0.0':
     resolution: {integrity: sha512-HvDP11Ub00C7kAMC7NvX+sbV8wM5j+OjLQalys0wlyqZ+7SL9OulQv/cyMCEHZSKW8YPt4326G0+omulZDwIGg==}
@@ -2317,14 +2319,12 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
     resolution: {integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
     resolution: {integrity: sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==}
@@ -2338,7 +2338,6 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
     resolution: {integrity: sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==}
@@ -2352,7 +2351,6 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.127.0':
     resolution: {integrity: sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==}
@@ -2453,7 +2451,6 @@ packages:
     resolution: {integrity: sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
     resolution: {integrity: sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==}
@@ -2471,7 +2468,6 @@ packages:
     resolution: {integrity: sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.20.0':
     resolution: {integrity: sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==}
@@ -2809,7 +2805,6 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
@@ -2823,14 +2818,12 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
@@ -3105,7 +3098,6 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.0':
     resolution: {integrity: sha512-QRDOVZd0bhQ5jLsUsCC3dUxDWdTSVY9WMznowZgCGOrZfLLgctWpelhUASEiBwsXfat/JwYnVd1EaxMhqyT+UQ==}
@@ -3207,19 +3199,16 @@ packages:
     resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.61.1':
     resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.61.1':
     resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.61.1':
     resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
@@ -3231,25 +3220,21 @@ packages:
     resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.61.1':
     resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.61.1':
     resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.61.1':
     resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.61.1':
     resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
@@ -3279,7 +3264,6 @@ packages:
     resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.61.1':
     resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}
@@ -3520,7 +3504,6 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
@@ -3534,7 +3517,6 @@ packages:
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -4190,7 +4172,6 @@ packages:
     resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
     resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
@@ -6718,14 +6699,12 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}


### PR DESCRIPTION
### Description

POC for MCP support in emdash: a local, token-protected MCP server that lets the agents emdash runs create and manage tasks themselves. Emdash registers the server with the agents it manages, and it shows up in the MCP library as a managed entry.

| Tool | Params | Description |
| --- | --- | --- |
| `list_projects` | none | List open projects |
| `list_tasks` | `projectId` | List tasks in a project with status |
| `create_task` | `projectId`, `prompt?`, `name?`, `provider?`, `model?`, `branchName?`, `baseBranch?`, `chatUi?` | Create a task in an isolated worktree; with a prompt, start an agent on it, otherwise leave it idle |
| `rename_task` | `projectId`, `taskId`, `name` | Rename a task |
| `archive_task` | `projectId`, `taskId` | Archive a task |
| `delete_task` | `projectId`, `taskId`, `confirm?` | Delete a task; requires `confirm: true` when the worktree has uncommitted changes |
| `run_task_script` | `projectId`, `taskId`, `type` | Start a task's `setup`, `run`, or `teardown` worktree lifecycle script |
| `stop_task_script` | `projectId`, `taskId`, `type` | Stop a running lifecycle script started by `run_task_script` |

Also includes a fix for the delete preflight, which reported dirty worktrees as clean; the `delete_task` confirmation gate depends on it.

High risk areas: a new localhost HTTP listener in the main process, writes to agent MCP configs, task deletion tooling, and one new dependency (`@modelcontextprotocol/sdk`).

### Related issues

Resolves #2937

### Testing

- `pnpm run typecheck`, `pnpm run lint`, `pnpm run format` clean
- `pnpm run test`: desktop node suite (2113 tests), core (481), including new suites for the HTTP server, tools, self-registration, task creation, controller redaction, and the preflight fix
- Manual: registered against Claude Code, exercised the tools end to end, verified 401 without token, the dirty-worktree confirm flow, and that the catalog card disappears when a second instance owns the port

### Screenshot/Recording (if applicable)
<img width="1512" height="1012" alt="Screenshot 2026-07-21 at 4 44 24 PM" src="https://github.com/user-attachments/assets/49464f16-b820-49ca-9bb8-b386c00b8fd8" />

https://github.com/user-attachments/assets/e8e161a4-7769-4900-9575-52586b338f75


