### PR TITLE
fix(opencode): render todo updates as plans

### DIFF
--- a/packages/plugins/src/agents/impl/opencode/acp-transform.test.ts
+++ b/packages/plugins/src/agents/impl/opencode/acp-transform.test.ts
@@ -56,6 +56,7 @@ describe('enrichOpenCodeUpdate', () => {
       sessionUpdate: 'tool_call_update',
       title: '0 todos',
       status: 'completed',
+      rawInput: { todos: pendingTodos },
       rawOutput: {
         metadata: {
           todos: [
@@ -75,12 +76,20 @@ describe('enrichOpenCodeUpdate', () => {
     });
   });
 
-  it('preserves unrelated tool calls and suppresses todo phases without entries', () => {
+  it('preserves unrelated tools even when their payload contains todos', () => {
     const update: NormalizedEvent = {
       ...makeToolCall(),
       title: 'Run command',
     };
-    expect(enrichOpenCodeUpdate(update, makeRaw({ title: 'Run command' }))).toBe(update);
+    expect(
+      enrichOpenCodeUpdate(
+        update,
+        makeRaw({ title: 'Run command', rawInput: { todos: pendingTodos } })
+      )
+    ).toBe(update);
+  });
+
+  it('suppresses todo phases without usable entries', () => {
     expect(enrichOpenCodeUpdate(makeToolCall(), makeRaw())).toEqual({ kind: 'ignored' });
     expect(
       enrichOpenCodeUpdate(
@@ -88,6 +97,24 @@ describe('enrichOpenCodeUpdate', () => {
         makeRaw({ rawInput: { todos: [{ content: 'invalid' }] } })
       )
     ).toEqual({ kind: 'ignored' });
+  });
+
+  it('keeps valid todos when another entry is malformed', () => {
+    expect(
+      enrichOpenCodeUpdate(
+        makeToolCall(),
+        makeRaw({
+          rawInput: {
+            todos: [
+              ...pendingTodos,
+              { content: 'Missing priority', status: 'pending' },
+              { content: 'Unknown status', status: 'blocked', priority: 'low' },
+              { content: 42, status: 'pending', priority: 'low' },
+            ],
+          },
+        })
+      )
+    ).toEqual({ kind: 'plan', entries: pendingTodos });
   });
 
   it('folds repeated todowrite calls into one plan row instead of generic tool rows', () => {

--- a/packages/plugins/src/agents/impl/opencode/acp-transform.test.ts
+++ b/packages/plugins/src/agents/impl/opencode/acp-transform.test.ts
@@ -1,0 +1,130 @@
+import type { SessionUpdate } from '@agentclientprotocol/sdk';
+import { AcpTranscriptParser, type NormalizedEvent } from '@emdash/core/acp';
+import { describe, expect, it } from 'vitest';
+import { enrichOpenCodeUpdate } from './acp-transform';
+
+const pendingTodos = [
+  { content: 'Investigate todo rendering', status: 'in_progress', priority: 'high' },
+];
+const completedTodos = [
+  { content: 'Investigate todo rendering', status: 'completed', priority: 'high' },
+];
+
+function makeToolCall(): Extract<NormalizedEvent, { kind: 'tool_call' }> {
+  return {
+    kind: 'tool_call',
+    toolCallId: 'todo-1',
+    title: 'todowrite',
+    toolKind: 'other',
+    status: 'in_progress',
+    parentToolCallId: null,
+    diffs: [],
+  };
+}
+
+function makeRaw(overrides: Record<string, unknown> = {}): SessionUpdate {
+  return {
+    sessionUpdate: 'tool_call',
+    sessionId: 'session-1',
+    toolCallId: 'todo-1',
+    title: 'todowrite',
+    kind: 'other',
+    status: 'in_progress',
+    ...overrides,
+  } as unknown as SessionUpdate;
+}
+
+describe('enrichOpenCodeUpdate', () => {
+  it('converts todowrite raw input into a canonical plan update', () => {
+    expect(
+      enrichOpenCodeUpdate(makeToolCall(), makeRaw({ rawInput: { todos: pendingTodos } }))
+    ).toEqual({
+      kind: 'plan',
+      entries: pendingTodos,
+    });
+  });
+
+  it('uses completed tool metadata and maps cancelled todos to completed', () => {
+    const update: NormalizedEvent = {
+      ...makeToolCall(),
+      kind: 'tool_update',
+      title: '0 todos',
+      toolKind: null,
+      status: 'completed',
+    };
+    const raw = makeRaw({
+      sessionUpdate: 'tool_call_update',
+      title: '0 todos',
+      status: 'completed',
+      rawOutput: {
+        metadata: {
+          todos: [
+            ...completedTodos,
+            { content: 'Discarded task', status: 'cancelled', priority: 'low' },
+          ],
+        },
+      },
+    });
+
+    expect(enrichOpenCodeUpdate(update, raw)).toEqual({
+      kind: 'plan',
+      entries: [
+        ...completedTodos,
+        { content: 'Discarded task', status: 'completed', priority: 'low' },
+      ],
+    });
+  });
+
+  it('preserves unrelated tool calls and suppresses todo phases without entries', () => {
+    const update: NormalizedEvent = {
+      ...makeToolCall(),
+      title: 'Run command',
+    };
+    expect(enrichOpenCodeUpdate(update, makeRaw({ title: 'Run command' }))).toBe(update);
+    expect(enrichOpenCodeUpdate(makeToolCall(), makeRaw())).toEqual({ kind: 'ignored' });
+    expect(
+      enrichOpenCodeUpdate(
+        { ...makeToolCall(), kind: 'tool_update', title: '1 todos' },
+        makeRaw({ rawInput: { todos: [{ content: 'invalid' }] } })
+      )
+    ).toEqual({ kind: 'ignored' });
+  });
+
+  it('folds repeated todowrite calls into one plan row instead of generic tool rows', () => {
+    const parser = new AcpTranscriptParser({
+      conversationId: 'conversation-1',
+      enrich: enrichOpenCodeUpdate,
+    });
+    parser.push(
+      makeRaw({
+        rawInput: { todos: pendingTodos },
+      })
+    );
+    parser.push(
+      makeRaw({
+        toolCallId: 'todo-2',
+        rawInput: { todos: completedTodos },
+      })
+    );
+    parser.push(
+      makeRaw({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'todo-2',
+        title: '0 todos',
+        status: 'completed',
+        rawOutput: { metadata: { todos: completedTodos } },
+      })
+    );
+
+    expect(parser.activeTurn?.items).toEqual([
+      expect.objectContaining({ kind: 'create-plan-tool-call', status: 'done' }),
+    ]);
+    expect(parser.plan?.entries).toEqual([
+      expect.objectContaining({
+        content: 'Investigate todo rendering',
+        status: 'completed',
+        priority: 'high',
+      }),
+    ]);
+  });
+});

--- a/packages/plugins/src/agents/impl/opencode/acp-transform.ts
+++ b/packages/plugins/src/agents/impl/opencode/acp-transform.ts
@@ -1,0 +1,80 @@
+import type { SessionUpdate } from '@agentclientprotocol/sdk';
+import type {
+  NormalizedEvent,
+  PlanEntryInput,
+  PlanEntryPriority,
+  PlanEntryStatus,
+} from '@emdash/core/acp';
+
+type OpenCodeTodo = {
+  content: unknown;
+  status: unknown;
+  priority: unknown;
+};
+
+/** Convert OpenCode's generic `todowrite` tool calls into canonical ACP plan updates. */
+export function enrichOpenCodeUpdate(update: NormalizedEvent, raw: SessionUpdate): NormalizedEvent {
+  if (update.kind !== 'tool_call' && update.kind !== 'tool_update') return update;
+
+  const entries = extractTodoEntries(raw);
+  if (entries !== null) return { kind: 'plan', entries };
+
+  return isTodoWriteTitle(update.title) ? { kind: 'ignored' } : update;
+}
+
+function isTodoWriteTitle(title: string | null): boolean {
+  return title !== null && /^(?:todowrite|\d+ todos?)$/i.test(title.trim());
+}
+
+function extractTodoEntries(raw: SessionUpdate): PlanEntryInput[] | null {
+  const value = raw as unknown as { rawInput?: unknown; rawOutput?: unknown };
+  const todos = readTodos(value.rawInput) ?? readTodos(readMetadata(value.rawOutput));
+  if (todos === null) return null;
+
+  const entries: PlanEntryInput[] = [];
+  for (const todo of todos) {
+    if (!todo || typeof todo !== 'object') return null;
+    const value = todo as OpenCodeTodo;
+    const status = readStatus(value.status);
+    const priority = readPriority(value.priority);
+    if (typeof value.content !== 'string' || status === null || priority === null) return null;
+    entries.push({ content: value.content, status, priority });
+  }
+  return entries;
+}
+
+function readTodos(value: unknown): unknown[] | null {
+  if (!value || typeof value !== 'object') return null;
+  const todos = (value as { todos?: unknown }).todos;
+  return Array.isArray(todos) ? todos : null;
+}
+
+function readMetadata(value: unknown): unknown {
+  return value && typeof value === 'object'
+    ? (value as { metadata?: unknown }).metadata
+    : undefined;
+}
+
+function readStatus(value: unknown): PlanEntryStatus | null {
+  switch (value) {
+    case 'pending':
+    case 'in_progress':
+    case 'completed':
+      return value;
+    case 'cancelled':
+      return 'completed';
+    default:
+      return null;
+  }
+}
+
+function readPriority(value: unknown): PlanEntryPriority | null {
+  switch (value) {
+    case 'high':
+    case 'medium':
+    case 'low':
+      return value;
+    default:
+      return null;
+  }
+}

--- a/packages/plugins/src/agents/impl/opencode/acp-transform.ts
+++ b/packages/plugins/src/agents/impl/opencode/acp-transform.ts
@@ -15,11 +15,10 @@ type OpenCodeTodo = {
 /** Convert OpenCode's generic `todowrite` tool calls into canonical ACP plan updates. */
 export function enrichOpenCodeUpdate(update: NormalizedEvent, raw: SessionUpdate): NormalizedEvent {
   if (update.kind !== 'tool_call' && update.kind !== 'tool_update') return update;
+  if (!isTodoWriteTitle(update.title)) return update;
 
   const entries = extractTodoEntries(raw);
-  if (entries !== null) return { kind: 'plan', entries };
-
-  return isTodoWriteTitle(update.title) ? { kind: 'ignored' } : update;
+  return entries !== null ? { kind: 'plan', entries } : { kind: 'ignored' };
 }
 
 function isTodoWriteTitle(title: string | null): boolean {
@@ -28,19 +27,19 @@ function isTodoWriteTitle(title: string | null): boolean {
 
 function extractTodoEntries(raw: SessionUpdate): PlanEntryInput[] | null {
   const value = raw as unknown as { rawInput?: unknown; rawOutput?: unknown };
-  const todos = readTodos(value.rawInput) ?? readTodos(readMetadata(value.rawOutput));
+  const todos = readTodos(readMetadata(value.rawOutput)) ?? readTodos(value.rawInput);
   if (todos === null) return null;
 
   const entries: PlanEntryInput[] = [];
   for (const todo of todos) {
-    if (!todo || typeof todo !== 'object') return null;
+    if (!todo || typeof todo !== 'object') continue;
     const value = todo as OpenCodeTodo;
     const status = readStatus(value.status);
     const priority = readPriority(value.priority);
-    if (typeof value.content !== 'string' || status === null || priority === null) return null;
+    if (typeof value.content !== 'string' || status === null || priority === null) continue;
     entries.push({ content: value.content, status, priority });
   }
-  return entries;
+  return todos.length > 0 && entries.length === 0 ? null : entries;
 }
 
 function readTodos(value: unknown): unknown[] | null {

--- a/packages/plugins/src/agents/impl/opencode/index.ts
+++ b/packages/plugins/src/agents/impl/opencode/index.ts
@@ -6,6 +6,7 @@ import {
   opencodeMcpAdapter,
 } from '@emdash/core/agents/plugins/helpers';
 import { connectStdioAcp } from '../../helpers/acp-stdio';
+import { enrichOpenCodeUpdate } from './acp-transform';
 import { opencodeAuthStatus } from './auth';
 import { OPENCODE_PLUGIN_CONTENT } from './plugin-file';
 
@@ -88,6 +89,7 @@ export const provider = registerPluginBehavior(plugin, {
     connect: (io, toClient) => {
       return connectStdioAcp(io, toClient);
     },
+    enrich: enrichOpenCodeUpdate,
   },
   prompt: {
     buildCommand: (ctx) =>


### PR DESCRIPTION
Fixes ENG-1919.

Converts OpenCode `todowrite` ACP updates into plan updates and suppresses the generic todo tool rows.

### Screenshot
<img width="759" height="806" alt="Screenshot 2026-07-22 at 16 21 35" src="https://github.com/user-attachments/assets/3f2630ac-7464-4840-aa37-297a367a68dd" />