### PR TITLE
fix(conversations): restore ACP chat focus across task switches

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-panel.tsx
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-panel.tsx
@@ -23,6 +23,7 @@ import {
   getProjectViewStore,
 } from '@renderer/features/projects/stores/project-selectors';
 import { usePaneContext } from '@renderer/features/tabs/pane-context';
+import { useIsActiveTask } from '@renderer/features/tasks/hooks/use-is-active-task';
 // TODO(conversations-extraction): Inject task editor/file-opening behavior into ACP chat.
 import {
   openFileInAdjacentPane,
@@ -34,6 +35,10 @@ import {
   getRegisteredTaskData,
   getTaskStore,
 } from '@renderer/features/tasks/stores/task-selectors';
+import {
+  useTaskViewContext,
+  useWorkspaceViewModel,
+} from '@renderer/features/tasks/task-view-context';
 import {
   issueMentionToken,
   parseIssueMentionToken,
@@ -645,7 +650,10 @@ const ComposerForStore = observer(function ComposerForStore({
 // editor state reset on each switch (equivalent to the old remount behavior).
 
 export const AcpChatPanel = observer(function AcpChatPanel() {
+  const { taskId } = useTaskViewContext();
+  const taskView = useWorkspaceViewModel();
   const { pane } = usePaneContext();
+  const isActive = useIsActiveTask(taskId);
 
   const activeTab = pane.resolvedTabs.find((t) => t.isActive && t.kind === 'acp-chat');
   const store = activeTab ? (activeTab.resource as AcpChatTabResource).store : null;
@@ -808,7 +816,13 @@ export const AcpChatPanel = observer(function AcpChatPanel() {
   const showHero = showComposer && store.isEmpty;
 
   return (
-    <div ref={rootRef} className="relative h-full overflow-hidden bg-background-secondary-1">
+    <div
+      ref={rootRef}
+      className="relative h-full overflow-hidden bg-background-secondary-1"
+      onFocus={() => {
+        if (isActive) taskView.setFocusedRegion('main');
+      }}
+    >
       <ChatTranscript
         context={store.chatContext}
         state={store.chatState}


### PR DESCRIPTION
### Description

Record focus inside the active ACP chat panel as the task's main focused region. This prevents an open terminal drawer from stealing focus when returning to a task after the user last focused the chat composer.

The implementation mirrors the existing legacy conversation panel behavior and only updates focus state for the active task.

### Related issues

Fixes #2930.

### Screenshot/Recording (if applicable)

https://cap.link/4wqnp7njna8djm8

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] Docs do not need updating for this behavior fix
- [x] I explained the focused manual coverage in lieu of a new component test
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit and PR title

</details>
