### PR TITLE
fix(linux): keep window controls visible across views

### DIFF
--- a/apps/emdash-desktop/src/renderer/lib/components/titlebar/Titlebar.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/titlebar/Titlebar.tsx
@@ -13,6 +13,10 @@ const platform = detectPlatform();
 const isMac = platform === 'mac';
 const isLinux = platform === 'linux';
 
+export function LinuxTitlebar() {
+  return isLinux ? <Titlebar /> : null;
+}
+
 export function Titlebar({ leftSlot, rightSlot }: { leftSlot?: ReactNode; rightSlot?: ReactNode }) {
   const { setCollapsed, isLeftOpen } = useWorkspaceLayoutContext();
   return (

--- a/apps/emdash-desktop/src/renderer/lib/components/titlebar/window-controls.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/titlebar/window-controls.tsx
@@ -9,9 +9,10 @@ const isLinux = detectPlatform() === 'linux';
 
 /**
  * Linux-only top overlay providing a draggable strip and window controls for
- * full-screen views that do not render the {@link Titlebar} (onboarding and the
- * welcome splash). Sits above the welcome screen's `z-50` overlay. No-op on
- * macOS/Windows, which keep their native frame or traffic lights.
+ * full-screen views that do not render the {@link Titlebar}, including workspace
+ * views, onboarding, and the welcome splash. Sits above the welcome screen's
+ * `z-50` overlay. No-op on macOS/Windows, which keep their native frame or traffic
+ * lights.
  */
 export function FramelessTitlebarOverlay() {
   if (!isLinux) return null;

--- a/apps/emdash-desktop/src/renderer/lib/layout/navigation-provider.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/layout/navigation-provider.tsx
@@ -6,7 +6,7 @@ import {
   type ViewId,
   type WrapParams,
 } from '@renderer/app/view-registry';
-import { FramelessTitlebarOverlay } from '@renderer/lib/components/titlebar/window-controls';
+import { LinuxTitlebar } from '@renderer/lib/components/titlebar/Titlebar';
 import { appState } from '@renderer/lib/stores/app-state';
 
 export type NonSettingsViewId = Exclude<ViewId, 'settings'>;
@@ -64,7 +64,7 @@ export function useWorkspaceSlots(): SlotsContextValue {
       WrapView: (def.WrapView ?? Fragment) as ComponentType<
         { children: ReactNode } & Record<string, unknown>
       >,
-      TitlebarSlot: def.TitlebarSlot ?? FramelessTitlebarOverlay,
+      TitlebarSlot: def.TitlebarSlot ?? LinuxTitlebar,
       MainPanel: def.MainPanel,
       currentView: resolvedViewId,
       lastNonSettingsView: appState.navigation.lastNonSettingsView,

--- a/apps/emdash-desktop/src/renderer/lib/layout/navigation-provider.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/layout/navigation-provider.tsx
@@ -6,6 +6,7 @@ import {
   type ViewId,
   type WrapParams,
 } from '@renderer/app/view-registry';
+import { FramelessTitlebarOverlay } from '@renderer/lib/components/titlebar/window-controls';
 import { appState } from '@renderer/lib/stores/app-state';
 
 export type NonSettingsViewId = Exclude<ViewId, 'settings'>;
@@ -63,7 +64,7 @@ export function useWorkspaceSlots(): SlotsContextValue {
       WrapView: (def.WrapView ?? Fragment) as ComponentType<
         { children: ReactNode } & Record<string, unknown>
       >,
-      TitlebarSlot: def.TitlebarSlot ?? (() => null),
+      TitlebarSlot: def.TitlebarSlot ?? FramelessTitlebarOverlay,
       MainPanel: def.MainPanel,
       currentView: resolvedViewId,
       lastNonSettingsView: appState.navigation.lastNonSettingsView,


### PR DESCRIPTION
### Description

Keep the standard window controls visible when navigating to Settings and other views without a custom titlebar on Linux.

Views without a `TitlebarSlot` now fall back to the existing Linux-only `FramelessTitlebarOverlay` instead of rendering no titlebar content. The overlay remains a no-op on macOS and Windows, so their native window chrome is unchanged.

### Related issues

Fixes #2934
Linear: ENG-1922

### Screenshot/Recording (if applicable)
before:
<img width="1400" height="900" alt="image" src="https://github.com/user-attachments/assets/06ec1080-c039-4b9f-9ebd-ff982030d731" />

after:
<img width="1400" height="900" alt="image" src="https://github.com/user-attachments/assets/d310109f-b9d2-46d0-93f8-80b7b5f08b9a" />


<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] Docs were not required for this behavior fix
- [x] Automated coverage was not added; the Linux-specific behavior was verified against the running Electron app in a Railway Linux sandbox
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit and PR title

</details>
