### PR TITLE
feat(chat-composer): show queue send button while working

### DIFF
--- a/packages/ui/src/react/components/chat-composer/index.tsx
+++ b/packages/ui/src/react/components/chat-composer/index.tsx
@@ -570,6 +570,7 @@ export function ChatComposer({
 }: ChatComposerProps) {
   const editorRef = useRef<PromptEditorRef | null>(null);
   const [dragActive, setDragActive] = useState(false);
+  const [editorText, setEditorText] = useState('');
 
   // Retain the last notice so its content stays rendered while the band
   // collapses out, letting the exit transition play before unmount.
@@ -672,6 +673,10 @@ export function ChatComposer({
   };
 
   const imageAttachments = attachments.filter((a) => a.kind === 'image');
+  const canQueuePrompt =
+    isWorking &&
+    !!onSubmitWhileWorking &&
+    (editorText.trim().length > 0 || imageAttachments.length > 0);
 
   // ── Model items ─────────────────────────────────────────────────────────────
 
@@ -819,7 +824,10 @@ export function ChatComposer({
             }}
             placeholder={resolvedPlaceholder}
             disabled={disabled}
-            onChange={onInputChange}
+            onChange={(text) => {
+              setEditorText(text);
+              onInputChange?.(text);
+            }}
             onSubmit={shouldHandleSubmitAttempt ? handleSubmit : undefined}
             onMentionInsert={onMentionInsert}
             mentionProvider={mentionProvider}
@@ -1007,7 +1015,7 @@ export function ChatComposer({
             )}
 
             {showSubmitButton ? (
-              isWorking ? (
+              isWorking && !canQueuePrompt ? (
                 <Button
                   variant="primary"
                   tone="destructive"
@@ -1026,8 +1034,8 @@ export function ChatComposer({
                   icon
                   className={styles.sendButtonRound}
                   onClick={() => handleSubmit(editorRef.current?.getText() ?? '')}
-                  disabled={disabled || !canSubmit}
-                  aria-label="Send message"
+                  disabled={disabled || (!isWorking && !canSubmit)}
+                  aria-label={isWorking ? 'Queue message' : 'Send message'}
                 >
                   <ArrowUp />
                 </Button>


### PR DESCRIPTION
### Description

Replace the composer stop control with the send arrow when the agent is working and the user has entered a follow-up message or attached an image. Clicking the arrow uses the existing `onSubmitWhileWorking` path, so the follow-up is queued while the active turn continues.

The stop control remains available while the composer is empty.

### Screenshot/Recording (if applicable)

[Demo recording](https://cap.link/amx0xdvbqqqe3ky)

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] Docs do not need updating for this UI-only behavior change
- [x] Existing queue behavior is reused; manual coverage is included and the unrelated test failure is documented
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit message and PR title

</details>