### PR TITLE
fix(conversations): persist model and permission preferences

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/conversations/create-conversation-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/conversations/create-conversation-modal.tsx
@@ -45,23 +45,22 @@ export const CreateConversationModal = observer(function CreateConversationModal
   const taskSettings = useTaskSettings();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const {
-    autoApprove,
-    setAutoApprove,
-    model: selectedModel,
-    setModel: setSelectedModel,
-  } = useConversationPreferences(providerId, taskSettings.autoApproveByDefault);
-  const [useChatUiPreference, setUseChatUiPreference] = useLocalStorage(
-    'initial-conversation:chat-ui-enabled',
-    false
-  );
-  useCloseGuard(isSubmitting);
-
   const { data: agents } = useAgents();
   const selectedAgent = agents?.find((a) => a.id === providerId);
   const modelsCapability = selectedAgent?.capabilities.models;
   const modelOptions =
     modelsCapability?.kind === 'selectable' ? modelsCapability.modelOptions : null;
+  const {
+    autoApprove,
+    setAutoApprove,
+    model: selectedModel,
+    setModel: setSelectedModel,
+  } = useConversationPreferences(providerId, taskSettings.autoApproveByDefault, modelOptions);
+  const [useChatUiPreference, setUseChatUiPreference] = useLocalStorage(
+    'initial-conversation:chat-ui-enabled',
+    false
+  );
+  useCloseGuard(isSubmitting);
 
   const showAutoApproveToggle = agentSupportsAutoApprove(selectedAgent?.capabilities);
   const showAcpToggle = agentSupportsAcp(selectedAgent?.capabilities);

--- a/apps/emdash-desktop/src/renderer/features/conversations/create-conversation-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/conversations/create-conversation-modal.tsx
@@ -28,6 +28,7 @@ import { Switch } from '@renderer/lib/ui/switch';
 import { agentSupportsAcp, agentSupportsAutoApprove } from '@shared/core/agents/agent-payload';
 import type { ConversationType } from '@shared/core/conversations/conversations';
 import { nextDefaultConversationTitle } from './conversation-title-utils';
+import { useConversationPreferences } from './use-conversation-preferences';
 import { useEffectiveProvider } from './use-effective-provider';
 
 export const CreateConversationModal = observer(function CreateConversationModal({
@@ -44,8 +45,12 @@ export const CreateConversationModal = observer(function CreateConversationModal
   const taskSettings = useTaskSettings();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [autoApproveOverride, setAutoApproveOverride] = useState<boolean | null>(null);
-  const [selectedModel, setSelectedModel] = useState<string | null>(null);
+  const {
+    autoApprove,
+    setAutoApprove,
+    model: selectedModel,
+    setModel: setSelectedModel,
+  } = useConversationPreferences(providerId, taskSettings.autoApproveByDefault);
   const [useChatUiPreference, setUseChatUiPreference] = useLocalStorage(
     'initial-conversation:chat-ui-enabled',
     false
@@ -61,8 +66,7 @@ export const CreateConversationModal = observer(function CreateConversationModal
   const showAutoApproveToggle = agentSupportsAutoApprove(selectedAgent?.capabilities);
   const showAcpToggle = agentSupportsAcp(selectedAgent?.capabilities);
   const useAcp = showAcpToggle && useChatUiPreference;
-  const skipPermissions =
-    showAutoApproveToggle && (autoApproveOverride ?? taskSettings.autoApproveByDefault);
+  const skipPermissions = showAutoApproveToggle && autoApprove;
   const title = providerId
     ? nextDefaultConversationTitle(
         providerId,
@@ -72,15 +76,6 @@ export const CreateConversationModal = observer(function CreateConversationModal
         )
       )
     : 'Conversation';
-
-  // Reset model when the provider changes (ids are provider-specific).
-  const handleProviderChange = useCallback(
-    (next: typeof providerId) => {
-      setProviderOverride(next);
-      setSelectedModel(null);
-    },
-    [setProviderOverride]
-  );
 
   const handleCreateConversation = useCallback(async () => {
     if (createDisabled || isSubmitting || !conversationMgr || !providerId) return;
@@ -131,7 +126,7 @@ export const CreateConversationModal = observer(function CreateConversationModal
             <AgentSelector
               autoFocus
               value={providerId}
-              onChange={handleProviderChange}
+              onChange={setProviderOverride}
               connectionId={connectionId}
             />
           </Field>
@@ -166,7 +161,7 @@ export const CreateConversationModal = observer(function CreateConversationModal
                 <Switch
                   checked={skipPermissions}
                   disabled={!providerId || taskSettings.loading || taskSettings.saving}
-                  onCheckedChange={setAutoApproveOverride}
+                  onCheckedChange={setAutoApprove}
                 />
                 <FieldLabel>Auto-approve permissions</FieldLabel>
               </div>

--- a/apps/emdash-desktop/src/renderer/features/conversations/use-conversation-preferences.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/use-conversation-preferences.test.ts
@@ -1,0 +1,138 @@
+import type { AgentProviderId } from '@emdash/plugins/agents';
+import { JSDOM } from 'jsdom';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useConversationPreferences } from './use-conversation-preferences';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+type Preferences = ReturnType<typeof useConversationPreferences>;
+let latestPreferences: Preferences | undefined;
+let secondaryPreferences: Preferences | undefined;
+
+function Probe({
+  secondary = false,
+  providerId,
+  autoApproveByDefault,
+  modelOptions = {},
+}: {
+  secondary?: boolean;
+  providerId: AgentProviderId;
+  autoApproveByDefault: boolean;
+  modelOptions?: Record<string, unknown>;
+}) {
+  const preferences = useConversationPreferences(providerId, autoApproveByDefault, modelOptions);
+  if (secondary) secondaryPreferences = preferences;
+  else latestPreferences = preferences;
+  return null;
+}
+
+describe('useConversationPreferences', () => {
+  let dom: JSDOM;
+  let root: Root;
+  let secondaryRoot: Root;
+  let rootContainer: HTMLDivElement;
+  let secondaryContainer: HTMLDivElement;
+
+  beforeEach(() => {
+    dom = new JSDOM('<div id="root"></div><div id="secondary"></div>', {
+      url: 'http://localhost',
+    });
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('localStorage', dom.window.localStorage);
+    rootContainer = dom.window.document.getElementById('root') as HTMLDivElement;
+    secondaryContainer = dom.window.document.getElementById('secondary') as HTMLDivElement;
+    root = createRoot(rootContainer);
+    secondaryRoot = createRoot(secondaryContainer);
+    latestPreferences = undefined;
+    secondaryPreferences = undefined;
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+      secondaryRoot.unmount();
+    });
+    vi.unstubAllGlobals();
+    dom.window.close();
+  });
+
+  async function render(autoApproveByDefault: boolean, modelOptions: Record<string, unknown> = {}) {
+    await act(async () => {
+      root.render(
+        React.createElement(Probe, {
+          providerId: 'claude',
+          autoApproveByDefault,
+          modelOptions,
+        })
+      );
+    });
+  }
+
+  it('uses a task default that arrives after loading', async () => {
+    await render(false);
+    await render(true);
+
+    expect(latestPreferences?.autoApprove).toBe(true);
+  });
+
+  it('ignores a persisted model that is no longer available', async () => {
+    await render(false, { legacy: {} });
+    await act(async () => latestPreferences?.setModel('legacy'));
+    await render(false, { opus: {} });
+
+    expect(latestPreferences?.model).toBeNull();
+  });
+
+  it('keeps model writes from independently mounted windows', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(Probe, {
+          providerId: 'claude',
+          autoApproveByDefault: false,
+          modelOptions: { opus: {} },
+        })
+      );
+      secondaryRoot.render(
+        React.createElement(Probe, {
+          secondary: true,
+          providerId: 'codex',
+          autoApproveByDefault: false,
+          modelOptions: { gpt: {} },
+        })
+      );
+    });
+    await act(async () => latestPreferences?.setModel('opus'));
+    await act(async () => secondaryPreferences?.setModel('gpt'));
+    await act(async () => {
+      root.unmount();
+      secondaryRoot.unmount();
+    });
+    root = createRoot(rootContainer);
+    secondaryRoot = createRoot(secondaryContainer);
+    await act(async () => {
+      root.render(
+        React.createElement(Probe, {
+          providerId: 'claude',
+          autoApproveByDefault: false,
+          modelOptions: { opus: {} },
+        })
+      );
+      secondaryRoot.render(
+        React.createElement(Probe, {
+          secondary: true,
+          providerId: 'codex',
+          autoApproveByDefault: false,
+          modelOptions: { gpt: {} },
+        })
+      );
+    });
+
+    expect(latestPreferences?.model).toBe('opus');
+    expect(secondaryPreferences?.model).toBe('gpt');
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/conversations/use-conversation-preferences.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/use-conversation-preferences.ts
@@ -1,38 +1,81 @@
 import type { AgentProviderId } from '@emdash/plugins/agents';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useLocalStorage } from '@renderer/lib/hooks/useLocalStorage';
 
 const AUTO_APPROVE_STORAGE_KEY = 'initial-conversation:auto-approve-enabled';
-const MODEL_STORAGE_KEY = 'initial-conversation:model-by-provider';
+const MODEL_STORAGE_KEY_PREFIX = 'initial-conversation:model:';
 
-export function useConversationPreferences(
-  providerId: AgentProviderId | null,
-  autoApproveByDefault: boolean
-) {
-  const [autoApprove, setAutoApprove] = useLocalStorage(
-    AUTO_APPROVE_STORAGE_KEY,
-    autoApproveByDefault
-  );
-  const [modelsByProvider, setModelsByProvider] = useLocalStorage<
-    Partial<Record<AgentProviderId, string>>
-  >(MODEL_STORAGE_KEY, {});
+function modelStorageKey(providerId: AgentProviderId): string {
+  return `${MODEL_STORAGE_KEY_PREFIX}${providerId}`;
+}
 
-  const model = providerId ? (modelsByProvider[providerId] ?? null) : null;
+function readStoredModel(providerId: AgentProviderId | null): string | null {
+  if (!providerId) return null;
+  try {
+    const stored = JSON.parse(localStorage.getItem(modelStorageKey(providerId)) ?? 'null');
+    return typeof stored === 'string' ? stored : null;
+  } catch {
+    return null;
+  }
+}
+
+function useStoredModel(providerId: AgentProviderId | null) {
+  const [state, setState] = useState(() => ({
+    providerId,
+    model: readStoredModel(providerId),
+  }));
+  const model = state.providerId === providerId ? state.model : readStoredModel(providerId);
+
+  useEffect(() => {
+    setState({ providerId, model: readStoredModel(providerId) });
+    if (!providerId) return;
+    const key = modelStorageKey(providerId);
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === key) {
+        setState({ providerId, model: readStoredModel(providerId) });
+      }
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, [providerId]);
+
   const setModel = useCallback(
     (nextModel: string | null) => {
       if (!providerId) return;
-      setModelsByProvider((current) => {
-        const next = { ...current };
+      try {
+        const key = modelStorageKey(providerId);
         if (nextModel) {
-          next[providerId] = nextModel;
+          localStorage.setItem(key, JSON.stringify(nextModel));
         } else {
-          delete next[providerId];
+          localStorage.removeItem(key);
         }
-        return next;
-      });
+      } catch {
+        // Keep the in-memory preference when storage is unavailable.
+      }
+      setState({ providerId, model: nextModel });
     },
-    [providerId, setModelsByProvider]
+    [providerId]
   );
 
-  return { autoApprove, setAutoApprove, model, setModel };
+  return { model, setModel };
+}
+
+export function useConversationPreferences(
+  providerId: AgentProviderId | null,
+  autoApproveByDefault: boolean,
+  modelOptions: Readonly<Record<string, unknown>> | null
+) {
+  const [autoApprovePreference, setAutoApprove] = useLocalStorage<boolean | null>(
+    AUTO_APPROVE_STORAGE_KEY,
+    null
+  );
+  const { model: storedModel, setModel } = useStoredModel(providerId);
+  const model = storedModel && modelOptions && storedModel in modelOptions ? storedModel : null;
+
+  return {
+    autoApprove: autoApprovePreference ?? autoApproveByDefault,
+    setAutoApprove,
+    model,
+    setModel,
+  };
 }

--- a/apps/emdash-desktop/src/renderer/features/conversations/use-conversation-preferences.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/use-conversation-preferences.ts
@@ -1,0 +1,38 @@
+import type { AgentProviderId } from '@emdash/plugins/agents';
+import { useCallback } from 'react';
+import { useLocalStorage } from '@renderer/lib/hooks/useLocalStorage';
+
+const AUTO_APPROVE_STORAGE_KEY = 'initial-conversation:auto-approve-enabled';
+const MODEL_STORAGE_KEY = 'initial-conversation:model-by-provider';
+
+export function useConversationPreferences(
+  providerId: AgentProviderId | null,
+  autoApproveByDefault: boolean
+) {
+  const [autoApprove, setAutoApprove] = useLocalStorage(
+    AUTO_APPROVE_STORAGE_KEY,
+    autoApproveByDefault
+  );
+  const [modelsByProvider, setModelsByProvider] = useLocalStorage<
+    Partial<Record<AgentProviderId, string>>
+  >(MODEL_STORAGE_KEY, {});
+
+  const model = providerId ? (modelsByProvider[providerId] ?? null) : null;
+  const setModel = useCallback(
+    (nextModel: string | null) => {
+      if (!providerId) return;
+      setModelsByProvider((current) => {
+        const next = { ...current };
+        if (nextModel) {
+          next[providerId] = nextModel;
+        } else {
+          delete next[providerId];
+        }
+        return next;
+      });
+    },
+    [providerId, setModelsByProvider]
+  );
+
+  return { autoApprove, setAutoApprove, model, setModel };
+}

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.test.ts
@@ -94,7 +94,7 @@ vi.mock('@renderer/lib/stores/use-agents', () => ({
         capabilities: {
           acp: { kind: 'supported' },
           autoApprove: { kind: 'supported' },
-          models: { kind: 'none' },
+          models: { kind: 'selectable', modelOptions: { opus: { name: 'Opus' } } },
         },
       },
     ],

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.test.ts
@@ -243,6 +243,20 @@ describe('useInitialConversationState', () => {
     expect(latestState?.autoApprove).toBe(true);
   });
 
+  it('persists the model preference', async () => {
+    await renderProbe('project-1');
+
+    await act(async () => {
+      latestState?.setModel('opus');
+    });
+
+    await act(async () => root.unmount());
+    root = createRoot(container);
+    await renderProbe('project-2');
+
+    expect(latestState?.model).toBe('opus');
+  });
+
   it('defaults chat UI off when the provider supports ACP', async () => {
     await renderProbe('project-1');
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.tsx
@@ -78,12 +78,16 @@ export function useInitialConversationState(
   const { data: agents } = useAgents();
   const [prompt, setPrompt] = useState('');
   const [issueContext, setIssueContext] = useState<string | null>(null);
+  const capabilities = agents?.find((agent) => agent.id === providerId)?.capabilities;
+  const modelOptions = capabilities?.models;
+  const selectableModelOptions =
+    modelOptions?.kind === 'selectable' ? modelOptions.modelOptions : null;
   const {
     autoApprove: autoApprovePreference,
     setAutoApprove: setAutoApprovePreference,
     model,
     setModel,
-  } = useConversationPreferences(providerId, autoApproveByDefault);
+  } = useConversationPreferences(providerId, autoApproveByDefault, selectableModelOptions);
   const [issueContextEditorOpen, setIssueContextEditorOpen] = useState(false);
   const [issueMentionContexts, setIssueMentionContexts] = useState<Record<string, string>>({});
   const [useChatUiPreference, setUseChatUiPreference] = useLocalStorage(
@@ -105,7 +109,6 @@ export function useInitialConversationState(
     setIssueMentionContexts({});
   }
 
-  const capabilities = agents?.find((agent) => agent.id === providerId)?.capabilities;
   const autoApproveSupported = agentSupportsAutoApprove(capabilities);
   const autoApprove = autoApproveSupported && autoApprovePreference;
   const acpSupported = agentSupportsAcp(capabilities);

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.tsx
@@ -11,6 +11,7 @@ import {
   type Dispatch,
   type SetStateAction,
 } from 'react';
+import { useConversationPreferences } from '@renderer/features/conversations/use-conversation-preferences';
 import { useEffectiveProvider } from '@renderer/features/conversations/use-effective-provider';
 import { IntegrationIcon } from '@renderer/features/integrations/integration-icon';
 import { usePromptLibrary } from '@renderer/features/library/prompts/use-prompt-library';
@@ -77,12 +78,13 @@ export function useInitialConversationState(
   const { data: agents } = useAgents();
   const [prompt, setPrompt] = useState('');
   const [issueContext, setIssueContext] = useState<string | null>(null);
-  const [autoApprovePreference, setAutoApprovePreference] = useLocalStorage(
-    'initial-conversation:auto-approve-enabled',
-    autoApproveByDefault
-  );
+  const {
+    autoApprove: autoApprovePreference,
+    setAutoApprove: setAutoApprovePreference,
+    model,
+    setModel,
+  } = useConversationPreferences(providerId, autoApproveByDefault);
   const [issueContextEditorOpen, setIssueContextEditorOpen] = useState(false);
-  const [model, setModel] = useState<string | null>(null);
   const [issueMentionContexts, setIssueMentionContexts] = useState<Record<string, string>>({});
   const [useChatUiPreference, setUseChatUiPreference] = useLocalStorage(
     'initial-conversation:chat-ui-enabled',
@@ -90,9 +92,7 @@ export function useInitialConversationState(
   );
 
   const [prevProjectId, setPrevProjectId] = useState(projectId);
-  const [prevProviderId, setPrevProviderId] = useState(providerId);
   const projectChanged = projectId !== prevProjectId;
-  const providerChanged = providerId !== prevProviderId;
 
   if (projectChanged) {
     setPrevProjectId(projectId);
@@ -102,11 +102,7 @@ export function useInitialConversationState(
     }
     setIssueContext(null);
     setIssueContextEditorOpen(false);
-    setModel(null);
     setIssueMentionContexts({});
-  } else if (providerChanged) {
-    setPrevProviderId(providerId);
-    setModel(null);
   }
 
   const capabilities = agents?.find((agent) => agent.id === providerId)?.capabilities;


### PR DESCRIPTION
### Description

Persist the selected model and permission mode instead of resetting them whenever the create-conversation or create-task UI remounts.

- share conversation preferences between both creation flows
- remember model selections per provider so provider-specific model IDs do not leak across agents
- keep the existing task-level auto-approve default as the fallback until the user chooses a preference

### Related issues

[ENG-1905](https://linear.app/general-action/issue/ENG-1905/keep-model-and-permission-mode-pocket-state)

### Screenshot/Recording

https://cap.link/st1e4rkardss2bg

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed, or no docs were needed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit and PR title

</details>
