### PR TITLE
fix(chat): preserve scroll position when switching tabs

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-panel.tsx
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-panel.tsx
@@ -237,7 +237,7 @@ const ComposerForStore = observer(function ComposerForStore({
 
   // Autofocus when the slot becomes available.
   useEffect(() => {
-    editorApiRef.current?.focus();
+    editorApiRef.current?.focus({ scrollIntoView: false });
   }, []);
 
   useEffect(() => {

--- a/apps/emdash-desktop/src/renderer/features/tabs/content-focus.ts
+++ b/apps/emdash-desktop/src/renderer/features/tabs/content-focus.ts
@@ -1,0 +1,8 @@
+const CONTENT_FOCUS_SELECTOR = 'textarea, webview, [contenteditable="true"]';
+
+export function focusActiveContentElement(container: HTMLElement): void {
+  for (const element of container.querySelectorAll<HTMLElement>(CONTENT_FOCUS_SELECTOR)) {
+    element.focus({ preventScroll: true });
+    if (document.activeElement === element) return;
+  }
+}

--- a/apps/emdash-desktop/src/renderer/features/tabs/pane-content.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tabs/pane-content.tsx
@@ -3,16 +3,8 @@ import { observer } from 'mobx-react-lite';
 import { useCallback, useEffect, useRef, type ReactNode } from 'react';
 import { PaneDimensionProvider } from '@renderer/features/tabs/pane-dimension-provider';
 import { usePaneContext } from '../tabs/pane-context';
+import { focusActiveContentElement } from './content-focus';
 import { TabBar } from './tab-bar';
-
-const CONTENT_FOCUS_SELECTOR = 'textarea, webview, [contenteditable="true"]';
-
-function focusActiveContentElement(container: HTMLElement): void {
-  for (const el of container.querySelectorAll<HTMLElement>(CONTENT_FOCUS_SELECTOR)) {
-    el.focus();
-    if (document.activeElement === el) return;
-  }
-}
 
 /** The content for a single pane: tab bar + content area. */
 export const PaneContent = observer(function PaneContent({

--- a/apps/emdash-desktop/src/renderer/tests/browser/pane-content-focus.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/browser/pane-content-focus.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { focusActiveContentElement } from '@renderer/features/tabs/content-focus';
+
+describe('pane content focus', () => {
+  it('does not move a scroll container when restoring focus after a tab switch', () => {
+    const container = document.createElement('div');
+    container.style.cssText = 'position:fixed;top:0;left:0;width:400px;height:200px;overflow:auto;';
+
+    const content = document.createElement('div');
+    content.style.cssText = 'position:relative;height:2000px;';
+
+    const editor = document.createElement('div');
+    editor.contentEditable = 'true';
+    editor.style.cssText = 'position:absolute;top:0;left:0;width:200px;height:40px;';
+    content.appendChild(editor);
+    container.appendChild(content);
+    document.body.appendChild(container);
+
+    container.scrollTop = 1500;
+    expect(container.scrollTop).toBe(1500);
+
+    focusActiveContentElement(container);
+
+    expect(document.activeElement).toBe(editor);
+    expect(container.scrollTop).toBe(1500);
+
+    container.remove();
+  });
+});

--- a/packages/ui/src/react/components/prompt-editor/prompt-editor.tsx
+++ b/packages/ui/src/react/components/prompt-editor/prompt-editor.tsx
@@ -311,8 +311,8 @@ export const PromptEditor = forwardRef<PromptEditorRef, PromptEditorProps>(funct
   editorRef.current = editor;
 
   useImperativeHandle(ref, () => ({
-    focus() {
-      editor?.commands.focus();
+    focus(options) {
+      editor?.commands.focus(undefined, options);
     },
     clear() {
       editor?.commands.clearContent(true);

--- a/packages/ui/src/react/components/prompt-editor/types.ts
+++ b/packages/ui/src/react/components/prompt-editor/types.ts
@@ -84,7 +84,7 @@ export interface CommandItem {
 
 export interface PromptEditorRef {
   /** Focus the editor. */
-  focus(): void;
+  focus(options?: { scrollIntoView?: boolean }): void;
   /** Clear all content. */
   clear(): void;
   /** Read the current serialized plain text. */


### PR DESCRIPTION
### Description

Prevent long chats from jumping to a different scroll position when switching tabs while preserving the existing focus-restoration behavior.

Native pane focus now uses `preventScroll`, and ACP composer autofocus disables Tiptap's default `scrollIntoView` behavior. A browser regression test covers the underlying Chromium behavior and verifies that focus is restored without changing the surrounding scroll container.

This is complementary to #2940, which restores ACP chat focus across task switches; this PR ensures focus restoration itself does not move chat scroll position.

### Related issues

- [ENG-1927](https://linear.app/general-action/issue/ENG-1927/chat-sometimes-scrolls-up-when-switching-tabs)

### Screenshot/Recording (if applicable)

https://cap.link/z8fcscwpqv09hsf

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] Docs do not need updating for this behavior fix
- [x] I added a browser regression test for the changed behavior
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit and PR title

</details>
