### PR TITLE
feat(terminal): render inline images in the terminal view

### DIFF
--- a/apps/emdash-desktop/package.json
+++ b/apps/emdash-desktop/package.json
@@ -110,6 +110,7 @@
     "@vitest/browser": "^4.1.0",
     "@vitest/browser-playwright": "^4.1.0",
     "@vitest/browser-preview": "^4.1.0",
+    "@xterm/addon-image": "^0.9.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
     "allotment": "^1.20.5",

--- a/apps/emdash-desktop/src/main/core/pty/tmux-session-name.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/tmux-session-name.test.ts
@@ -7,7 +7,7 @@ import {
 } from './tmux-session-name';
 
 describe('buildTmuxShellLine', () => {
-  it('enables tmux mouse scrolling and deep history before attach', () => {
+  it('enables tmux mouse scrolling, deep history and passthrough before attach', () => {
     const result = buildTmuxShellLine('agent-session', 'exec /bin/zsh -il');
 
     expect(result).toMatch(/^\/bin\/sh -c /);
@@ -17,9 +17,11 @@ describe('buildTmuxShellLine', () => {
     );
     expect(result).toContain('tmux set-option -t \\"agent-session\\" mouse on');
     expect(result).toContain('tmux set-option -t \\"agent-session\\" history-limit 100000');
+    expect(result).toContain('tmux set-option -t \\"agent-session\\" allow-passthrough on');
     expect(result).toContain('tmux -u attach-session -t \\"agent-session\\"');
     expect(result.indexOf('mouse on')).toBeLessThan(result.indexOf('attach-session'));
     expect(result.indexOf('history-limit')).toBeLessThan(result.indexOf('attach-session'));
+    expect(result.indexOf('allow-passthrough')).toBeLessThan(result.indexOf('attach-session'));
   });
 });
 

--- a/apps/emdash-desktop/src/main/core/pty/tmux-session-name.ts
+++ b/apps/emdash-desktop/src/main/core/pty/tmux-session-name.ts
@@ -14,7 +14,11 @@ export function buildTmuxShellLine(sessionName: string, commandLine: string): st
   const newSession = `tmux -u new-session -d -s ${quotedName} ${quotedCmd}`;
   const enableMouse = `tmux set-option -t ${quotedName} mouse on 2>/dev/null || true`;
   const setHistoryLimit = `tmux set-option -t ${quotedName} history-limit ${TMUX_HISTORY_LIMIT} 2>/dev/null || true`;
-  const configure = `(${enableMouse}) && (${setHistoryLimit})`;
+  // Inline images (SIXEL, iTerm2 OSC 1337) reach the terminal wrapped in a tmux
+  // passthrough DCS. tmux drops those unless passthrough is allowed, which is why
+  // image output shows up as a blank gap inside a session but works without tmux.
+  const allowPassthrough = `tmux set-option -t ${quotedName} allow-passthrough on 2>/dev/null || true`;
+  const configure = `(${enableMouse}) && (${setHistoryLimit}) && (${allowPassthrough})`;
   const attach = `tmux -u attach-session -t ${quotedName}`;
   const script = `(${checkExists} || ${newSession}) && ${configure} && ${attach}`;
   return `/bin/sh -c ${JSON.stringify(script)}`;

--- a/apps/emdash-desktop/src/renderer/lib/pty/pty.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/pty.ts
@@ -1,3 +1,4 @@
+import { ImageAddon } from '@xterm/addon-image';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { Terminal, type ITerminalOptions } from '@xterm/xterm';
 import { events, rpc } from '@renderer/lib/ipc';
@@ -11,6 +12,10 @@ import { buildTerminalFontFamily } from './terminal-font';
 import { ensureXtermHost } from './xterm-host';
 
 const SCROLLBACK_LINES = 100_000;
+// Decoded-image budget per terminal, in MB. Every session keeps its Terminal alive
+// off-screen, so the addon default of 128 would let a handful of image-heavy sessions
+// pin more than a gigabyte. Oldest images are evicted first once the budget is hit.
+const IMAGE_STORAGE_LIMIT_MB = 32;
 
 export const TERMINAL_PADDING_PX = 8;
 export const TERMINAL_LINE_HEIGHT = 1.2;
@@ -120,6 +125,13 @@ export class FrontendPty {
     });
 
     this.terminal.loadAddon(webLinksAddon);
+
+    // Inline images (SIXEL and iTerm2 OSC 1337). Agents and CLIs that draw
+    // screenshots, plots or previews otherwise leave a blank gap here: xterm.js
+    // on its own drops the escape sequence and reserves no space for it.
+    // Disposed with the terminal by xterm's addon manager.
+    this.terminal.loadAddon(new ImageAddon({ storageLimit: IMAGE_STORAGE_LIMIT_MB }));
+
     if (onOpenFile && onOpenExternal) {
       this.terminal.registerLinkProvider(
         new FileLinkProvider(this.terminal, onOpenFile, onOpenExternal)

--- a/apps/emdash-desktop/src/renderer/tests/browser/terminal-images.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/browser/terminal-images.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+async function getPtyModule() {
+  return import('@renderer/lib/pty/pty');
+}
+
+// Solid red 12x6 block: raster attributes 1;1;12;6, one colour register, one sixel band.
+const RED_BLOCK_SIXEL = '\x1bP0;1;0q"1;1;12;6#0;2;100;0;0#0~~~~~~~~~~~~\x1b\\';
+
+function imageLayer(): HTMLCanvasElement | null {
+  return document.querySelector<HTMLCanvasElement>('canvas.xterm-image-layer');
+}
+
+describe('FrontendPty inline images', () => {
+  beforeEach(() => {
+    vi.stubGlobal('electronAPI', {
+      eventOn: vi.fn(() => () => {}),
+      eventSend: vi.fn(),
+      invoke: vi.fn(() => Promise.resolve({ success: true, data: null })),
+    });
+
+    document.documentElement.style.setProperty('--xterm-bg', '#101010');
+    document.documentElement.style.setProperty('--xterm-fg', '#f0f0f0');
+    document.documentElement.style.setProperty('--xterm-cursor', '#f0f0f0');
+    document.documentElement.style.setProperty('--xterm-cursor-accent', '#101010');
+    document.documentElement.style.setProperty('--xterm-selection-bg', '#335577');
+    document.documentElement.style.setProperty('--xterm-selection-fg', '#ffffff');
+  });
+
+  afterEach(async () => {
+    const { disposeAllPtys } = await getPtyModule();
+    disposeAllPtys();
+    document.querySelector('[data-terminal-host="true"]')?.remove();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('paints a SIXEL image onto the terminal instead of dropping it', async () => {
+    const { FrontendPty } = await getPtyModule();
+    const frontendPty = new FrontendPty('image-session');
+
+    expect(imageLayer()).toBeNull();
+
+    frontendPty.terminal.write(RED_BLOCK_SIXEL);
+
+    await expect.poll(() => imageLayer()).not.toBeNull();
+    const layer = imageLayer();
+    if (!layer) throw new Error('image layer missing');
+    const ctx = layer.getContext('2d');
+    if (!ctx) throw new Error('image layer has no 2d context');
+
+    await expect.poll(() => ctx.getImageData(2, 2, 1, 1).data[3]).toBeGreaterThan(0);
+    const [r, g, b] = ctx.getImageData(2, 2, 1, 1).data;
+    expect(r).toBeGreaterThan(200);
+    expect(g).toBeLessThan(60);
+    expect(b).toBeLessThan(60);
+  });
+
+  it('advertises SIXEL support in the primary device attributes reply', async () => {
+    const { FrontendPty } = await getPtyModule();
+    const frontendPty = new FrontendPty('da1-session');
+
+    const replies: string[] = [];
+    frontendPty.terminal.onData((data) => replies.push(data));
+    frontendPty.terminal.write('\x1b[c');
+
+    // Parameter 4 is what tmux and CLI tools look for to decide that an image
+    // protocol is usable.
+    await expect.poll(() => replies.join('')).toContain('\x1b[?62;4;');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       '@vitest/browser-preview':
         specifier: ^4.1.0
         version: 4.1.8(vite@6.4.3(@types/node@20.19.42)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
+      '@xterm/addon-image':
+        specifier: ^0.9.0
+        version: 0.9.0
       '@xterm/addon-web-links':
         specifier: ^0.12.0
         version: 0.12.0
@@ -4429,6 +4432,9 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+
+  '@xterm/addon-image@0.9.0':
+    resolution: {integrity: sha512-oYWA8/QAr5/Emwl1xL7WCoOqeG3IZfpzEz/OVq1j4Oi9934TQmHiyubClikRf0D/jL3JNiNuz/Lsqx0kXQ02BA==}
 
   '@xterm/addon-web-links@0.12.0':
     resolution: {integrity: sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==}
@@ -12560,6 +12566,8 @@ snapshots:
   '@webcontainer/env@1.1.1': {}
 
   '@xmldom/xmldom@0.8.13': {}
+
+  '@xterm/addon-image@0.9.0': {}
 
   '@xterm/addon-web-links@0.12.0': {}
 


### PR DESCRIPTION
### Description

Anything a CLI draws inline in the terminal, a screenshot, a plot, an image preview, currently disappears. xterm.js ships no image protocol of its own, so the escape sequence is parsed and dropped, and since the emitting program has already reserved rows for the picture you end up staring at a blank gap in the middle of the transcript. I hit this with an agent that takes screenshots, but it affects `imgcat`, `chafa`, `viu`, `timg` and anything else that draws pixels.

Two things were missing, so the PR does two things:

1. Load `@xterm/addon-image` in `FrontendPty`. It adds SIXEL and iTerm2 (OSC 1337) support, and it makes the terminal answer the primary device attributes query with parameter 4, which is how tmux and CLI tools decide an image protocol is usable. `allowProposedApi` was already on, which the addon requires. Storage is capped at 32 MB per terminal instead of the addon default of 128, because every session keeps its `Terminal` alive off-screen and a handful of image-heavy sessions would otherwise pin more than a gigabyte.

2. Set `allow-passthrough on` when an agent tmux session is created, next to `mouse` and `history-limit`. Inside tmux those image sequences arrive wrapped in a passthrough DCS, and tmux throws them away unless that option is on. Without this the addon only helps the non-tmux path.

One known limitation I want to be upfront about: tmux can also translate SIXEL natively, but only when the client tty reports a non-zero pixel size. node-pty's `resize(cols, rows)` leaves `ws_xpixel`/`ws_ypixel` at 0, so on tmux 3.5 and older that path stays on the `SIXEL IMAGE (WxH)` text placeholder. tmux master queries the terminal with `CSI 14 t` instead, which the addon does answer, so that case fixes itself on newer tmux. The passthrough route in this PR works today regardless.

### Related issues

I could not find an existing issue for this, so there is nothing to link. Closest match is #552, but that is the opposite direction (sending images to the agent).

### Testing

- `pnpm run format`, `pnpm run lint`, `pnpm run typecheck`: clean.
- `pnpm run test`: `@emdash/emdash-desktop` passes (482 tests, including the new ones). Five failures elsewhere (`@emdash/core` session-manager, `@emdash/ui` prompt-editor serialize, two acp fixture tests) also fail on a clean `main` checkout here, so they are not from this change.
- New browser test `src/renderer/tests/browser/terminal-images.test.ts`: writes a SIXEL to a real `FrontendPty` and asserts the addon's canvas layer ends up with red pixels, plus asserts the DA1 reply advertises sixel. Both fail with the addon removed and pass with it.
- `src/main/core/pty/tmux-session-name.test.ts` extended for the new option.
- Manual check of the tmux half, running the exact shell line `buildTmuxShellLine` produces against a real tmux 3.5a with a pty client: with the new option a `\033Ptmux;`-wrapped OSC 1337 sequence reaches the client verbatim, without it tmux swallows it.

### Screenshot/Recording

No desktop capture, I work on a headless machine, but the browser test above is the visual assertion: it reads the pixels back off the canvas the addon paints.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [ ] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for commit messages and, when possible, the PR title

</details>