### PR TITLE
fix(ssh): report agent status for remote PTY conversations

### DIFF
--- a/apps/emdash-desktop/src/main/core/agent-hooks/hook-config-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/agent-hooks/hook-config-service.test.ts
@@ -1,0 +1,119 @@
+import path from 'node:path';
+import type { IFileSystem } from '@emdash/core/files';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IExecutionContext } from '@main/core/execution-context/types';
+import type { IFilesRuntime } from '@main/core/runtime/types';
+import { ensureHooksInstalled } from './hook-config-service';
+
+const PLUGIN_PATH = '.omp/extensions/emdash-hook.ts';
+const PLUGIN_CONTENT = 'export default function () {}';
+const TASK_PATH = '/remote/workspace/task';
+
+const installPlugin = vi.fn(async (fs: { write(p: string, c: string): Promise<void> }) => {
+  await fs.write(PLUGIN_PATH, PLUGIN_CONTENT);
+  return [PLUGIN_PATH];
+});
+
+vi.mock('@main/core/agents/plugin-registry', () => ({
+  getPlugin: vi.fn(() => ({
+    capabilities: { hooks: { kind: 'plugin', scope: 'workspace', supportedEvents: ['stop'] } },
+    behavior: { plugins: { installPlugin } },
+  })),
+}));
+
+vi.mock('@main/core/settings/settings-service', () => ({
+  appSettingsService: { get: vi.fn(async () => ({ writeAgentConfigToGitIgnore: true })) },
+}));
+
+/**
+ * Minimal remote host: an in-memory file map plus the handful of shell commands
+ * createRemotePluginFs shells out for (mkdir/mv/rm) and the `$HOME` probe.
+ */
+function makeRemoteHost(): {
+  files: Map<string, string>;
+  host: { kind: 'ssh'; ctx: IExecutionContext; files: IFilesRuntime };
+} {
+  const files = new Map<string, string>();
+
+  const ctx = {
+    supportsLocalSpawn: false,
+    async exec(command: string, args: string[] = []) {
+      if (command === 'sh') return { stdout: '/home/remote', stderr: '' };
+      if (command === 'mv') {
+        const [from, to] = args;
+        const content = files.get(from);
+        if (content === undefined) throw new Error(`no such file: ${from}`);
+        files.delete(from);
+        files.set(to, content);
+      }
+      if (command === 'rm') for (const arg of args) files.delete(arg);
+      return { stdout: '', stderr: '' };
+    },
+    async execStreaming() {},
+    dispose() {},
+  } satisfies Partial<IExecutionContext> as unknown as IExecutionContext;
+
+  const fileSystem = {
+    async readText(target: string) {
+      const content = files.get(target);
+      return content === undefined
+        ? {
+            success: false as const,
+            error: { type: 'fs-error', path: target, message: 'ENOENT', code: 'ENOENT' },
+          }
+        : { success: true as const, data: { content } };
+    },
+    async writeText(target: string, content: string) {
+      files.set(target, content);
+      return { success: true as const, data: {} };
+    },
+    async exists(target: string) {
+      return { success: true as const, data: files.has(target) };
+    },
+  } as unknown as IFileSystem;
+
+  const filesRuntime = {
+    fileSystem: () => ({ success: true as const, data: fileSystem }),
+  } as unknown as IFilesRuntime;
+
+  return { files, host: { kind: 'ssh', ctx, files: filesRuntime } };
+}
+
+beforeEach(() => {
+  installPlugin.mockClear();
+});
+
+describe('ensureHooksInstalled', () => {
+  it('installs a workspace plugin on the remote host for ssh conversations', async () => {
+    const { files, host } = makeRemoteHost();
+
+    const available = await ensureHooksInstalled({
+      providerId: 'oh-my-pi',
+      taskPath: TASK_PATH,
+      host,
+    });
+
+    expect(available).toBe(true);
+    expect(files.get(path.posix.join(TASK_PATH, PLUGIN_PATH))).toBe(PLUGIN_CONTENT);
+    expect(files.get(path.posix.join(TASK_PATH, '.gitignore'))).toBe(`${PLUGIN_PATH}\n`);
+  });
+
+  it('reports hooks unavailable when the remote filesystem cannot be opened', async () => {
+    const { host } = makeRemoteHost();
+    const files = {
+      fileSystem: () => ({
+        success: false as const,
+        error: { kind: 'unavailable', message: 'connection closed' },
+      }),
+    } as unknown as IFilesRuntime;
+
+    const available = await ensureHooksInstalled({
+      providerId: 'oh-my-pi',
+      taskPath: TASK_PATH,
+      host: { ...host, files },
+    });
+
+    expect(available).toBe(false);
+    expect(installPlugin).not.toHaveBeenCalled();
+  });
+});

--- a/apps/emdash-desktop/src/main/core/agent-hooks/hook-config-service.ts
+++ b/apps/emdash-desktop/src/main/core/agent-hooks/hook-config-service.ts
@@ -1,13 +1,55 @@
 import { homedir } from 'node:os';
+import type { PluginFs } from '@emdash/core/agents/plugins';
 import { createPluginFs } from '@main/core/agents/plugin-fs';
 import { getPlugin } from '@main/core/agents/plugin-registry';
+import { createRemotePluginFs } from '@main/core/agents/remote-plugin-fs';
+import type { IExecutionContext } from '@main/core/execution-context/types';
+import type { IFilesRuntime } from '@main/core/runtime/types';
 import { appSettingsService } from '@main/core/settings/settings-service';
+import { resolveRemoteHome } from '@main/core/ssh/lifecycle/remote-shell-profile';
 import { log } from '@main/lib/logger';
 
 const GITIGNORE_PATH = '.gitignore';
 
-async function ensureGitIgnoreEntries(taskPath: string, entries: string[]): Promise<void> {
-  const wsFs = createPluginFs(taskPath);
+/**
+ * Where the agent that will consume these hooks actually runs. Remote agents
+ * need the config written on the remote box, not on the machine running the
+ * desktop app.
+ */
+export type HookInstallHost =
+  | { kind: 'local' }
+  | { kind: 'ssh'; ctx: IExecutionContext; files: IFilesRuntime };
+
+/** Lazily resolved plugin filesystems for the workspace and the agent's home. */
+type HookInstallTarget = {
+  workspace: PluginFs;
+  global: () => Promise<PluginFs>;
+};
+
+async function resolveHookInstallTarget(
+  host: HookInstallHost,
+  taskPath: string
+): Promise<HookInstallTarget> {
+  if (host.kind === 'local') {
+    return {
+      workspace: createPluginFs(taskPath),
+      global: async () => createPluginFs(homedir()),
+    };
+  }
+
+  const opened = host.files.fileSystem();
+  if (!opened.success) {
+    throw new Error(`failed to open remote filesystem: ${opened.error.message}`);
+  }
+
+  const remoteFs = opened.data;
+  return {
+    workspace: createRemotePluginFs(host.ctx, remoteFs, taskPath),
+    global: async () => createRemotePluginFs(host.ctx, remoteFs, await resolveRemoteHome(host.ctx)),
+  };
+}
+
+async function ensureGitIgnoreEntries(wsFs: PluginFs, entries: string[]): Promise<void> {
   const existing = (await wsFs.read(GITIGNORE_PATH)) ?? '';
   const existingLines = existing
     .split(/\r?\n/)
@@ -45,9 +87,11 @@ async function ensureGitIgnoreEntries(taskPath: string, entries: string[]): Prom
 export async function ensureHooksInstalled({
   providerId,
   taskPath,
+  host = { kind: 'local' },
 }: {
   providerId: string;
   taskPath: string;
+  host?: HookInstallHost;
 }): Promise<boolean> {
   try {
     const localProjectSettings = await appSettingsService.get('localProject');
@@ -59,19 +103,18 @@ export async function ensureHooksInstalled({
     let hooksAvailable = false;
 
     let writtenPaths: string[] = [];
+    const target = await resolveHookInstallTarget(host, taskPath);
 
     if (hooksKind === 'config' && plugin.behavior.hooks) {
       const scope = hooksDescriptor.scope;
-      const root = scope === 'global' ? homedir() : taskPath;
-      const fs = createPluginFs(root);
+      const fs = scope === 'global' ? await target.global() : target.workspace;
       const paths = await plugin.behavior.hooks.writeHooks(fs, []);
       // For global-scope hooks the paths are relative to homedir; don't add
       // them to the workspace .gitignore (they live in the user's home).
       writtenPaths = scope === 'global' ? [] : paths;
       hooksAvailable = true;
     } else if (hooksKind === 'plugin' && plugin.behavior.plugins) {
-      const fs = createPluginFs(taskPath);
-      writtenPaths = await plugin.behavior.plugins.installPlugin(fs, {
+      writtenPaths = await plugin.behavior.plugins.installPlugin(target.workspace, {
         kind: 'workspace',
         path: taskPath,
       });
@@ -79,7 +122,7 @@ export async function ensureHooksInstalled({
     }
 
     if (writeGitIgnoreEntries && writtenPaths.length > 0) {
-      await ensureGitIgnoreEntries(taskPath, writtenPaths);
+      await ensureGitIgnoreEntries(target.workspace, writtenPaths);
     }
 
     return hooksAvailable;

--- a/apps/emdash-desktop/src/main/core/agent-hooks/remote-hook-tunnel.test.ts
+++ b/apps/emdash-desktop/src/main/core/agent-hooks/remote-hook-tunnel.test.ts
@@ -1,0 +1,166 @@
+import { EventEmitter } from 'node:events';
+import net from 'node:net';
+import type { Client, ClientChannel } from 'ssh2';
+import { afterEach, describe, expect, it } from 'vitest';
+import { RemoteHookTunnelManager, type HookTunnelProxy } from './remote-hook-tunnel';
+
+const BOUND_REMOTE_PORT = 45123;
+
+class FakeClient extends EventEmitter {
+  forwardInCalls: Array<{ remoteAddr: string; remotePort: number }> = [];
+
+  constructor(private readonly bind: { error?: Error; port?: number } = {}) {
+    super();
+  }
+
+  forwardIn(
+    remoteAddr: string,
+    remotePort: number,
+    callback: (error: Error | undefined, port: number) => void
+  ): this {
+    this.forwardInCalls.push({ remoteAddr, remotePort });
+    callback(this.bind.error, this.bind.port ?? BOUND_REMOTE_PORT);
+    return this;
+  }
+
+  emitTcpConnection(destPort: number, accept: () => ClientChannel): void {
+    this.emit(
+      'tcp connection',
+      { srcIP: '127.0.0.1', srcPort: 1234, destIP: '127.0.0.1', destPort },
+      accept,
+      () => {}
+    );
+  }
+}
+
+function makeProxy(client: FakeClient, connectionId = 'conn-1'): HookTunnelProxy {
+  return {
+    connectionId,
+    get isConnected() {
+      return true;
+    },
+    get client() {
+      return client as unknown as Client;
+    },
+  };
+}
+
+function listen(server: net.Server): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      resolve(typeof address === 'object' && address !== null ? address.port : 0);
+    });
+  });
+}
+
+const servers: net.Server[] = [];
+const sockets: net.Socket[] = [];
+
+function track<T extends net.Server | net.Socket>(value: T): T {
+  if (value instanceof net.Server) servers.push(value);
+  else sockets.push(value);
+  return value;
+}
+
+afterEach(() => {
+  for (const socket of sockets.splice(0)) socket.destroy();
+  for (const server of servers.splice(0)) server.close();
+});
+
+describe('RemoteHookTunnelManager', () => {
+  it('binds a remote loopback port and pipes accepted channels to the hook server', async () => {
+    const requests: string[] = [];
+    const hookServer = track(
+      net.createServer((socket) => {
+        socket.on('data', (chunk: Buffer) => {
+          requests.push(chunk.toString('utf8'));
+          socket.write('hook-ok');
+        });
+      })
+    );
+    const hookPort = await listen(hookServer);
+
+    // Stands in for the ssh2 channel: the socket the manager pipes is the one
+    // accepted here, the socket dialing in is the one the remote agent holds.
+    const channelServer = track(net.createServer());
+    const channelPort = await listen(channelServer);
+    const accepted = new Promise<net.Socket>((resolve) => {
+      channelServer.once('connection', (socket) => resolve(track(socket)));
+    });
+    const agentSocket = track(net.connect(channelPort, '127.0.0.1'));
+    const channel = await accepted;
+
+    const client = new FakeClient();
+    const manager = new RemoteHookTunnelManager();
+    const remotePort = await manager.ensure(makeProxy(client), hookPort);
+
+    expect(remotePort).toBe(BOUND_REMOTE_PORT);
+    expect(client.forwardInCalls).toEqual([{ remoteAddr: '127.0.0.1', remotePort: 0 }]);
+
+    const response = new Promise<string>((resolve) => {
+      agentSocket.once('data', (chunk: Buffer) => resolve(chunk.toString('utf8')));
+    });
+    client.emitTcpConnection(BOUND_REMOTE_PORT, () => channel as unknown as ClientChannel);
+    agentSocket.write('POST /hook');
+
+    expect(await response).toBe('hook-ok');
+    expect(requests).toEqual(['POST /hook']);
+  });
+
+  it('ignores forwarded connections that target another bound port', async () => {
+    const client = new FakeClient();
+    const manager = new RemoteHookTunnelManager();
+    await manager.ensure(makeProxy(client), 4000);
+
+    let accepted = false;
+    client.emitTcpConnection(BOUND_REMOTE_PORT + 1, () => {
+      accepted = true;
+      return new EventEmitter() as unknown as ClientChannel;
+    });
+
+    expect(accepted).toBe(false);
+  });
+
+  it('reuses one tunnel per connection', async () => {
+    const client = new FakeClient();
+    const manager = new RemoteHookTunnelManager();
+    const proxy = makeProxy(client);
+
+    const [first, second] = await Promise.all([
+      manager.ensure(proxy, 4000),
+      manager.ensure(proxy, 4000),
+    ]);
+
+    expect(first).toBe(BOUND_REMOTE_PORT);
+    expect(second).toBe(BOUND_REMOTE_PORT);
+    expect(client.forwardInCalls).toHaveLength(1);
+  });
+
+  it('rebinds after a reconnect replaces the ssh client', async () => {
+    const manager = new RemoteHookTunnelManager();
+    const first = new FakeClient();
+    await manager.ensure(makeProxy(first), 4000);
+
+    const second = new FakeClient({ port: BOUND_REMOTE_PORT + 7 });
+    const rebound = await manager.ensure(makeProxy(second), 4000);
+
+    expect(rebound).toBe(BOUND_REMOTE_PORT + 7);
+    expect(second.forwardInCalls).toHaveLength(1);
+  });
+
+  it('returns null when the remote refuses port forwarding', async () => {
+    const client = new FakeClient({ error: new Error('administratively prohibited') });
+    const manager = new RemoteHookTunnelManager();
+
+    expect(await manager.ensure(makeProxy(client), 4000)).toBeNull();
+  });
+
+  it('returns null when the hook server is not listening', async () => {
+    const client = new FakeClient();
+    const manager = new RemoteHookTunnelManager();
+
+    expect(await manager.ensure(makeProxy(client), 0)).toBeNull();
+    expect(client.forwardInCalls).toHaveLength(0);
+  });
+});

--- a/apps/emdash-desktop/src/main/core/agent-hooks/remote-hook-tunnel.ts
+++ b/apps/emdash-desktop/src/main/core/agent-hooks/remote-hook-tunnel.ts
@@ -1,0 +1,94 @@
+import net from 'node:net';
+import type { Client, ClientChannel } from 'ssh2';
+import type { SshClientProxy } from '@main/core/ssh/lifecycle/ssh-client-proxy';
+import { log } from '@main/lib/logger';
+
+const REMOTE_BIND_HOST = '127.0.0.1';
+const LOCAL_HOOK_HOST = '127.0.0.1';
+
+export type HookTunnelProxy = Pick<SshClientProxy, 'client' | 'isConnected' | 'connectionId'>;
+
+type TunnelEntry = {
+  client: Client;
+  remotePort: Promise<number | null>;
+};
+
+function pipeToHookServer(channel: ClientChannel, hookPort: number): void {
+  const socket = net.connect(hookPort, LOCAL_HOOK_HOST);
+  socket.on('error', () => channel.destroy());
+  channel.on('error', () => socket.destroy());
+  socket.pipe(channel).pipe(socket);
+}
+
+/**
+ * Reverse SSH tunnels that let a remote agent CLI reach the local hook server.
+ *
+ * The hook payloads agents run target `http://127.0.0.1:$EMDASH_HOOK_PORT/hook`
+ * (see `packages/core/src/agents/plugins/helpers/hooks.ts`) and the hook server
+ * only listens on the desktop machine's loopback. Binding a remote loopback port
+ * and piping it back over the existing ssh2 connection is what makes that URL
+ * resolve from the remote box, without changing the hook layer itself.
+ *
+ * One tunnel per SSH connection is enough, since EMDASH_PTY_ID disambiguates
+ * conversations. Tunnels die with their connection, so the cache is keyed by
+ * connection id and revalidated against the live client on every lookup.
+ */
+export class RemoteHookTunnelManager {
+  private readonly entries = new Map<string, TunnelEntry>();
+
+  /**
+   * Returns the remote port that reaches `hookPort` on this machine, or null
+   * when the remote refuses port forwarding. A null result is cached for the
+   * lifetime of the connection: `AllowTcpForwarding no` will not change under us.
+   */
+  async ensure(proxy: HookTunnelProxy, hookPort: number): Promise<number | null> {
+    if (hookPort <= 0 || !proxy.isConnected) return null;
+
+    let client: Client;
+    try {
+      client = proxy.client;
+    } catch {
+      return null;
+    }
+
+    const existing = this.entries.get(proxy.connectionId);
+    if (existing && existing.client === client) return existing.remotePort;
+
+    const entry: TunnelEntry = { client, remotePort: this.bind(client, hookPort) };
+    this.entries.set(proxy.connectionId, entry);
+    client.once('close', () => {
+      if (this.entries.get(proxy.connectionId) === entry) {
+        this.entries.delete(proxy.connectionId);
+      }
+    });
+
+    return entry.remotePort;
+  }
+
+  private bind(client: Client, hookPort: number): Promise<number | null> {
+    return new Promise((resolve) => {
+      client.forwardIn(REMOTE_BIND_HOST, 0, (error, remotePort) => {
+        if (error) {
+          log.warn(
+            'RemoteHookTunnel: remote refused port forwarding, agent status will not update',
+            {
+              error: String(error),
+            }
+          );
+          resolve(null);
+          return;
+        }
+
+        client.on('tcp connection', (details, accept) => {
+          if (details.destPort !== remotePort) return;
+          pipeToHookServer(accept(), hookPort);
+        });
+
+        log.info('RemoteHookTunnel: bound remote hook port', { remotePort, hookPort });
+        resolve(remotePort);
+      });
+    });
+  }
+}
+
+export const remoteHookTunnels = new RemoteHookTunnelManager();

--- a/apps/emdash-desktop/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/ssh-conversation.ts
@@ -1,3 +1,6 @@
+import { agentHookService } from '@main/core/agent-hooks/agent-hook-service';
+import { ensureHooksInstalled } from '@main/core/agent-hooks/hook-config-service';
+import { remoteHookTunnels } from '@main/core/agent-hooks/remote-hook-tunnel';
 import { getPlugin } from '@main/core/agents/plugin-registry';
 import { workspaceTrustService } from '@main/core/agents/workspace-trust';
 import { ConversationSessionSupervisor } from '@main/core/conversations/conversation-session-supervisor';
@@ -6,7 +9,9 @@ import type { ConversationProvider } from '@main/core/conversations/types';
 import { hostDependencyStore } from '@main/core/dependencies/host-dependency-store';
 import type { IExecutionContext } from '@main/core/execution-context/types';
 import type { Pty } from '@main/core/pty/pty';
+import { buildHookEnv } from '@main/core/pty/pty-env';
 import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
+import { makePtyId } from '@main/core/pty/ptyId';
 import { resolveSshCommand } from '@main/core/pty/spawn-utils';
 import { openSsh2Pty } from '@main/core/pty/ssh2-pty';
 import { getTerminalColorEnv } from '@main/core/pty/terminal-color-scheme';
@@ -123,6 +128,11 @@ export class SshConversationProvider implements ConversationProvider {
         host: { kind: 'ssh', ctx: this.ctx, files: this.filesRuntime },
         force: conversation.autoApprove === true,
       });
+      const hooksAvailable = await ensureHooksInstalled({
+        providerId: conversation.providerId,
+        taskPath: this.taskPath,
+        host: { kind: 'ssh', ctx: this.ctx, files: this.filesRuntime },
+      });
 
       const providerConfig = await providerOverrideSettings.getItem(conversation.providerId);
       const agentSession = resolveAgentSessionCommandArgs(conversation, isResuming, {
@@ -171,14 +181,15 @@ export class SshConversationProvider implements ConversationProvider {
         resume: agentSession.isResuming,
       };
 
-      const [profile, colorEnv] = await Promise.all([
+      const [profile, colorEnv, hookEnv] = await Promise.all([
         this.proxy.getRemoteShellProfile(),
         getTerminalColorEnv(),
+        hooksAvailable ? this.resolveHookEnv(conversation) : {},
       ]);
       const sshCommand = resolveSshCommand(
         'agent',
         cfg,
-        { ...providerEnv, ...colorEnv, ...this.taskEnvVars },
+        { ...providerEnv, ...colorEnv, ...hookEnv, ...this.taskEnvVars },
         profile
       );
 
@@ -298,6 +309,23 @@ export class SshConversationProvider implements ConversationProvider {
       this.supervisor.failSpawn(sessionId, spawnToken);
       throw error;
     }
+  }
+
+  /**
+   * Hook callbacks run on the remote host, so `127.0.0.1:$EMDASH_HOOK_PORT` has
+   * to resolve there: reverse-forward a remote loopback port to the local hook
+   * server and hand the agent that port. Without a tunnel the agent would post
+   * into the remote box's own loopback, so leave the vars unset instead.
+   */
+  private async resolveHookEnv(conversation: Conversation): Promise<Record<string, string>> {
+    const remotePort = await remoteHookTunnels.ensure(this.proxy, agentHookService.getPort());
+    if (remotePort === null) return {};
+
+    return buildHookEnv({
+      port: remotePort,
+      ptyId: makePtyId(conversation.providerId, conversation.id),
+      token: agentHookService.getToken(),
+    });
   }
 
   private detachPty(sessionId: string): void {

--- a/apps/emdash-desktop/src/main/core/pty/pty-env.ts
+++ b/apps/emdash-desktop/src/main/core/pty/pty-env.ts
@@ -57,6 +57,32 @@ function getWindowsEssentialEnv(resolvedPath: string): Record<string, string> {
   };
 }
 
+export interface AgentHookEnv {
+  /**
+   * Loopback port that reaches the emdash hook server from wherever the agent
+   * runs: the hook server's own port for local spawns, the remote end of a
+   * reverse SSH tunnel for remote ones.
+   */
+  port: number;
+  ptyId: string;
+  token: string;
+}
+
+/**
+ * Env vars an agent CLI needs to POST lifecycle events back to the hook server.
+ * Shared by the local PTY env and the SSH remote command env so both spawn
+ * paths agree on the variable names.
+ */
+export function buildHookEnv(hook: AgentHookEnv | undefined): Record<string, string> {
+  if (!hook || hook.port <= 0) return {};
+  return {
+    EMDASH_HOOK_PORT: String(hook.port),
+    EMDASH_PTY_ID: hook.ptyId,
+    EMDASH_HOOK_NONCE: hook.token,
+    EMDASH_HOOK_TOKEN: hook.token,
+  };
+}
+
 export interface AgentEnvOptions {
   /**
    * Pass through AGENT_ENV_VARS from process.env.
@@ -82,11 +108,7 @@ export interface AgentEnvOptions {
    * EMDASH_HOOK_PORT, EMDASH_PTY_ID, and EMDASH_HOOK_NONCE so agent CLIs
    * can call back on lifecycle events.
    */
-  hook?: {
-    port: number;
-    ptyId: string;
-    token: string;
-  };
+  hook?: AgentHookEnv;
 
   /**
    * Per-provider variables configured in custom execution settings.
@@ -204,12 +226,7 @@ export function buildAgentEnv(options: AgentEnvOptions = {}): Record<string, str
     Object.assign(env, providerVars);
   }
 
-  if (hook && hook.port > 0) {
-    env.EMDASH_HOOK_PORT = String(hook.port);
-    env.EMDASH_PTY_ID = hook.ptyId;
-    env.EMDASH_HOOK_NONCE = hook.token;
-    env.EMDASH_HOOK_TOKEN = hook.token;
-  }
+  Object.assign(env, buildHookEnv(hook));
 
   return env;
 }


### PR DESCRIPTION
### Description

On SSH projects the agent status indicator never leaves idle, because the whole hook path is local-only. I traced this in #2770 and this is the fix for it.

Three things were missing on the remote path:

1. `ensureHooksInstalled()` always wrote through the local plugin fs (`createLocalPluginFs`), and it was only called from `LocalConversationProvider`. A remote agent would have needed its hook config on the machine running the desktop app. It now takes a `host`, and for ssh it writes the workspace config through `createRemotePluginFs`, with global-scope hooks (Claude, Codex) resolved against the remote `$HOME` via `resolveRemoteHome`.
2. The hook payload posts to `http://127.0.0.1:$EMDASH_HOOK_PORT/hook` (`packages/core/src/agents/plugins/helpers/hooks.ts`), which on a remote box is that box's own loopback. `RemoteHookTunnelManager` binds a remote loopback port with `forwardIn` and pipes accepted channels back to the hook server over the existing ssh2 client, so that URL resolves from the remote host without touching the hook layer. One tunnel per SSH connection is enough since `EMDASH_PTY_ID` disambiguates conversations, and the cache is revalidated against the live client so a reconnect rebinds.
3. `SshConversationProvider` now injects `EMDASH_HOOK_PORT` / `EMDASH_PTY_ID` / `EMDASH_HOOK_NONCE` / `EMDASH_HOOK_TOKEN` into the remote command env, pointing at the forwarded port.

If the remote refuses port forwarding (`AllowTcpForwarding no`) the vars stay unset, the manager logs a warning and caches the refusal for that connection, so behavior degrades to exactly what it is today instead of failing the spawn.

I pulled the hook var names into `buildHookEnv()` so the local PTY env and the SSH command env cannot drift apart.

Side effect worth calling out: providers whose hooks are a workspace plugin file (oh-my-pi, pi, amp, opencode, kilocode, mimocode) pass the plugin path on every spawn via `defaultArgs`, but over SSH that file was never written. Every remote oh-my-pi session started with `Failed to load extension ... Cannot find module '<workspace>/.omp/extensions/emdash-hook.ts'`. That file is now written on the remote host before the spawn.

Known limitation, not addressed here: with tmux-backed sessions a session that outlives its SSH connection keeps the old forwarded port, so status stops updating until the agent is respawned.

### Related issues

Fixes #2770

### Testing

- `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck`, all green repo-wide.
- `pnpm exec vitest run --project node` for the app: 2026 passed. The 2 failures on my box are environmental and also fail on a clean checkout of `main` here (`local-pty.integration.test.ts` needs the node-pty prebuild, `browser-webcontents-registry.test.ts`).
- New unit tests: `remote-hook-tunnel.test.ts` (binds and pipes a channel through to a real local server, ignores connections for other bound ports, one tunnel per connection, rebinds after a reconnect, null on refusal) and `hook-config-service.test.ts` (ssh host installs through the remote fs and updates the remote `.gitignore`, reports unavailable when the remote fs cannot be opened).
- End to end against a real sshd: I ran `RemoteHookTunnelManager` against an ssh2 connection to a remote Debian host, then ran the exact hook curl remotely (`curl -X POST -H "X-Emdash-Token: ..." -H "X-Emdash-Pty-Id: claude:conv-1" -H "X-Emdash-Event-Type: stop" --data-binary '{"message":"Task completed"}' http://127.0.0.1:<forwarded-port>/hook`). curl exited 0 and the local server received the request on `/hook` with the headers and body intact. That check was a throwaway, it is not in the diff since it needs a real host.

I could not exercise the full desktop flow (my remote box is headless), so a second pair of eyes on the reconnect path would be welcome.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [ ] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>