### PR TITLE
fix(chat-ui): hide plan fade when content fits

### DIFF
--- a/packages/chat-ui/src/chat-view.contract.test.tsx
+++ b/packages/chat-ui/src/chat-view.contract.test.tsx
@@ -11,6 +11,7 @@ import { describe, expect, it } from 'vitest';
 import { createChatContext } from '@/chat-context';
 import { createChatView } from '@/chat-view';
 import { generateMockTranscript } from '@/mock-transcript';
+import type { ChatPlanEntry, TranscriptTurn } from '@/model';
 import { createChatState } from '@/state/chat-state';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -26,6 +27,37 @@ async function waitFor<T>(fn: () => T | null, frames = 10): Promise<T | null> {
     await nextPaint();
   }
   return null;
+}
+
+async function mountPlan(entries: ChatPlanEntry[]) {
+  const ctx = createChatContext({ theme: DEFAULT_THEME });
+  const state = createChatState(ctx);
+  const plan = { kind: 'plan' as const, id: 'plan-fade-contract', entries };
+  state.transcript.history.seed([
+    {
+      id: 'plan-turn',
+      seq: 0,
+      initiator: 'agent',
+      // ChatPlan is a renderer-owned compatibility item accepted by the transcript flattener.
+      items: [plan] as unknown as TranscriptTurn['items'],
+    },
+  ]);
+
+  const host = document.createElement('div');
+  host.style.cssText = 'position:fixed;top:0;left:0;width:800px;height:300px;';
+  document.body.appendChild(host);
+  const view = createChatView({ context: ctx, state, parent: host });
+  await nextPaint();
+
+  return {
+    host,
+    dispose: () => {
+      view.dispose();
+      ctx.dispose();
+      state.dispose();
+      document.body.removeChild(host);
+    },
+  };
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -112,6 +144,42 @@ describe('createChatView', () => {
     ctx.dispose();
     state.dispose();
     document.body.removeChild(host);
+  });
+});
+
+describe('plan preview fade', () => {
+  it('only shows the bottom fade when rendered entries overflow the preview', async () => {
+    const fitting = await mountPlan([
+      { content: 'Review the repository', status: 'completed', priority: 'high' },
+      { content: 'Summarize the architecture', status: 'in_progress', priority: 'medium' },
+      { content: 'Document requirements', status: 'pending', priority: 'medium' },
+    ]);
+
+    try {
+      const scroll = fitting.host.querySelector('[data-preview-scroll]');
+      expect(scroll).not.toBeNull();
+      expect(scroll!.scrollHeight).toBeLessThanOrEqual(scroll!.clientHeight);
+      expect(fitting.host.querySelector('[data-preview-overlay="fade-bottom"]')).toBeNull();
+    } finally {
+      fitting.dispose();
+    }
+
+    const overflowing = await mountPlan(
+      Array.from({ length: 5 }, () => ({
+        content: '',
+        status: 'pending' as const,
+        priority: 'medium' as const,
+      }))
+    );
+
+    try {
+      const scroll = overflowing.host.querySelector('[data-preview-scroll]');
+      expect(scroll).not.toBeNull();
+      expect(scroll!.scrollHeight).toBeGreaterThan(scroll!.clientHeight);
+      expect(overflowing.host.querySelector('[data-preview-overlay="fade-bottom"]')).not.toBeNull();
+    } finally {
+      overflowing.dispose();
+    }
   });
 });
 

--- a/packages/chat-ui/src/components/primitives/PreviewWindow.tsx
+++ b/packages/chat-ui/src/components/primitives/PreviewWindow.tsx
@@ -39,6 +39,7 @@ export function PreviewWindow(props: PreviewWindowProps): JSX.Element {
 
   return (
     <div
+      data-preview-window
       style={{
         height: `${props.height}px`,
         'max-height': `${props.maxH}px`,
@@ -48,12 +49,14 @@ export function PreviewWindow(props: PreviewWindowProps): JSX.Element {
     >
       <Show when={props.overlay}>
         <div
+          data-preview-overlay={props.overlay}
           class={`${props.overlay === 'fade-top' ? fadeOverlayTop : fadeOverlayBottom} ${overlay({ position: props.overlay === 'fade-top' ? 'top' : 'bottom' })}`}
           style={{ height: '28px' }}
           aria-hidden="true"
         />
       </Show>
       <div
+        data-preview-scroll
         ref={(el) => {
           scrollEl = el;
         }}

--- a/packages/chat-ui/src/components/rows/plan/Plan.tsx
+++ b/packages/chat-ui/src/components/rows/plan/Plan.tsx
@@ -50,7 +50,7 @@ export function PlanList(props: PlanListProps) {
             <div
               style={{
                 width: planVars.iconBox,
-                height: '20px',
+                height: planVars.entryMinH,
                 'flex-shrink': '0',
                 display: 'flex',
                 'align-items': 'center',

--- a/packages/chat-ui/src/components/rows/plan/plan.css.ts
+++ b/packages/chat-ui/src/components/rows/plan/plan.css.ts
@@ -8,6 +8,7 @@ export type PlanStyleVars = {
   padX: number;
   padY: number;
   iconBox: number;
+  entryMinH: number;
   iconGap: number;
   entryGap: number;
 };
@@ -16,6 +17,7 @@ export const planVars = createVariableThemeContract<PlanStyleVars>({
   padX: null,
   padY: null,
   iconBox: null,
+  entryMinH: null,
   iconGap: null,
   entryGap: null,
 });

--- a/packages/chat-ui/src/components/rows/plan/plan.def.tsx
+++ b/packages/chat-ui/src/components/rows/plan/plan.def.tsx
@@ -25,6 +25,8 @@ export type PlanVars = {
   padY: number;
   /** Width (px) of the status-icon box to the left of each entry body. */
   iconBox: number;
+  /** Minimum height (px) of an entry, matching the status-icon box. */
+  entryMinH: number;
   /** Horizontal gap (px) between the status icon and the entry text. */
   iconGap: number;
   /** Vertical gap (px) between consecutive plan entries. */
@@ -79,7 +81,10 @@ function measureEntries(item: ChatPlan, ctx: MeasureCtx, vars: PlanVars): PlanEn
 }
 
 function listHeight(entries: PlanEntryLaid[], vars: PlanVars): number {
-  const totalEntryH = entries.reduce((sum, e) => sum + e.measured.height, 0);
+  const totalEntryH = entries.reduce(
+    (sum, entry) => sum + Math.max(entry.measured.height, vars.entryMinH),
+    0
+  );
   const gaps = entries.length > 1 ? (entries.length - 1) * vars.entryGap : 0;
   return totalEntryH + gaps + 2 * vars.padY;
 }
@@ -123,6 +128,7 @@ function PlanUnitRender(props: { data: ChatPlan; ctx: RenderCtx; vars: PlanVars 
     padX: props.vars.padX,
     padY: props.vars.padY,
     iconBox: props.vars.iconBox,
+    entryMinH: props.vars.entryMinH,
     iconGap: props.vars.iconGap,
     entryGap: props.vars.entryGap,
   });
@@ -148,7 +154,7 @@ function PlanUnitRender(props: { data: ChatPlan; ctx: RenderCtx; vars: PlanVars 
             <PreviewWindow
               height={bodyH()}
               maxH={props.vars.windowH}
-              overlay="fade-bottom"
+              overlay={listH() > bodyH() ? 'fade-bottom' : undefined}
               autoScrollBottom={autoScroll()}
               contentHeight={() => listH()}
             >
@@ -170,6 +176,7 @@ export const planUnitDef = defineUnit<ChatPlan, PlanVars>({
     padX: 8,
     padY: 6,
     iconBox: 14,
+    entryMinH: 20,
     iconGap: 8,
     entryGap: 4,
     windowH: 96,
@@ -179,7 +186,7 @@ export const planUnitDef = defineUnit<ChatPlan, PlanVars>({
     const headerH = vars.rowH;
     const isExpanded = ctx.expanded(item.id);
     const lineH = ctx.theme.fonts.body.lineHeight;
-    const entryH = 2 * lineH;
+    const entryH = Math.max(2 * lineH, vars.entryMinH);
     const gaps = item.entries.length > 1 ? (item.entries.length - 1) * vars.entryGap : 0;
     const listH = item.entries.length * entryH + gaps + 2 * vars.padY;
     const bodyH = isExpanded ? listH : Math.min(listH, vars.windowH);

--- a/packages/chat-ui/src/stories/rows/messages/agent/plan.stories.tsx
+++ b/packages/chat-ui/src/stories/rows/messages/agent/plan.stories.tsx
@@ -150,6 +150,54 @@ export const SinglePending: Story = {
   ),
 };
 
+const ENTRIES_FIT: ChatPlanEntry[] = [
+  {
+    content: 'Repository structure and central documentation reviewed',
+    status: 'completed',
+    priority: 'high',
+  },
+  {
+    content: 'Architecture, apps, and packages summarized',
+    status: 'in_progress',
+    priority: 'medium',
+  },
+  {
+    content: 'Development and operational requirements documented',
+    status: 'pending',
+    priority: 'medium',
+  },
+];
+
+const ENTRIES_OVERFLOW: ChatPlanEntry[] = [
+  ...ENTRIES_FIT,
+  { content: 'Update automated tests', status: 'pending', priority: 'medium' },
+  { content: 'Prepare the implementation handoff', status: 'pending', priority: 'medium' },
+];
+
+/** Compare a fully visible three-item plan with a five-item plan that continues below. */
+export const FadeComparison: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: '24px' }}>
+      <div>
+        <p style={{ margin: '0 0 8px', 'font-weight': 600 }}>3 To-dos — no fade</p>
+        <ChatHost
+          width={600}
+          height={180}
+          items={[{ kind: 'plan', id: 'plan-fits-without-fade', entries: ENTRIES_FIT }]}
+        />
+      </div>
+      <div>
+        <p style={{ margin: '0 0 8px', 'font-weight': 600 }}>5 To-dos — overflow fade</p>
+        <ChatHost
+          width={600}
+          height={180}
+          items={[{ kind: 'plan', id: 'plan-overflows-with-fade', entries: ENTRIES_OVERFLOW }]}
+        />
+      </div>
+    </div>
+  ),
+};
+
 export const Streaming: Story = {
   render: () => (
     <ScriptedChat


### PR DESCRIPTION
### Description
Fixes the plan preview fade so it only appears when the measured plan content actually exceeds the visible preview area.

Previously, the bottom fade was always rendered for collapsed plans, even when all items fit. This made complete plans look as though more content was hidden below.

This change:
- hides the bottom fade when all plan entries fit in the preview
- preserves the fade when additional entries continue below the visible area
- accounts for the 20px minimum rendered height of each status-icon row so measured and rendered heights stay consistent
- adds stable preview selectors and browser regression coverage for fitting and overflowing plans
- adds a Storybook comparison showing the 3-item and 5-item states

### Related issues

ENG-1934 — Remove fade-out at end of plan when no more items follow

### Screenshot/Recording (if applicable)
before:
<img width="1320" height="258" alt="image" src="https://github.com/user-attachments/assets/78cc4a7c-5e5a-4238-92ac-87086fa58273" />

just 3 todos:
<img width="544" height="142" alt="image" src="https://github.com/user-attachments/assets/da95f9e2-38ea-44b3-9f0a-84f639672b1d" />

more todos:
<img width="541" height="142" alt="image" src="https://github.com/user-attachments/assets/ea75ca84-39c5-442b-bd29-89397e677f2c" />

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
