### PR TITLE
fix(terminal): remove line gaps from QR codes

### DIFF
--- a/apps/emdash-desktop/src/renderer/lib/pty/pty.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/pty.ts
@@ -13,7 +13,9 @@ import { ensureXtermHost } from './xterm-host';
 const SCROLLBACK_LINES = 100_000;
 
 export const TERMINAL_PADDING_PX = 8;
-export const TERMINAL_LINE_HEIGHT = 1.2;
+// The DOM renderer cannot draw custom contiguous block glyphs. Keep xterm's
+// default line height so ANSI block QR codes have no vertical seams.
+export const TERMINAL_LINE_HEIGHT = 1;
 export const TERMINAL_LETTER_SPACING = 0;
 
 // ── Theme helpers ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
### Description
Fixes distorted and unreadable QR codes in the terminal, including Claude Remote Control QR codes.

Emdash configured xterm.js with `lineHeight: 1.2`, which introduced vertical gaps between rows of ANSI block characters. Because Emdash intentionally uses xterm’s DOM renderer, custom contiguous block glyph rendering cannot compensate for this spacing.

This changes the shared terminal line height to xterm’s default value of `1`, ensuring block-based QR codes render without vertical seams. The invariant is documented next to the setting to prevent accidental regression.

### Related issues

Slack issue from Dominik

### Screenshot/Recording (if applicable)
e.g. now: 
<img width="399" height="276" alt="image" src="https://github.com/user-attachments/assets/887cc13d-80eb-4667-82ef-9e04ac6db4d1" />

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>


