### PR TITLE
fix(chat-ui): stop cancelled plans appearing active

### DIFF
--- a/packages/chat-ui/src/components/rows/plan/Plan.test.ts
+++ b/packages/chat-ui/src/components/rows/plan/Plan.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { planIsActive, visiblePlanEntryStatus } from './plan-status';
+
+const IN_PROGRESS_ENTRY = {
+  content: 'Implement the fix',
+  status: 'in_progress' as const,
+  priority: 'high' as const,
+};
+
+describe('planIsActive', () => {
+  it('honors an explicit activity override', () => {
+    expect(
+      planIsActive({ kind: 'plan', id: 'active', entries: [IN_PROGRESS_ENTRY], active: true })
+    ).toBe(true);
+    expect(
+      planIsActive({ kind: 'plan', id: 'inactive', entries: [IN_PROGRESS_ENTRY], active: false })
+    ).toBe(false);
+  });
+
+  it('falls back to streaming and entry statuses for legacy plans', () => {
+    expect(
+      planIsActive({
+        kind: 'plan',
+        id: 'legacy-streaming',
+        entries: [],
+        streaming: true,
+      })
+    ).toBe(true);
+    expect(
+      planIsActive({
+        kind: 'plan',
+        id: 'legacy-progress',
+        entries: [IN_PROGRESS_ENTRY],
+        streaming: false,
+      })
+    ).toBe(true);
+  });
+});
+
+describe('visiblePlanEntryStatus', () => {
+  it('shows an in-progress step as inactive after its plan becomes inactive', () => {
+    expect(visiblePlanEntryStatus('in_progress', false)).toBe('inactive');
+  });
+
+  it('preserves running and completed step statuses in an active plan', () => {
+    expect(visiblePlanEntryStatus('in_progress', true)).toBe('in_progress');
+    expect(visiblePlanEntryStatus('completed', true)).toBe('completed');
+  });
+});

--- a/packages/chat-ui/src/components/rows/plan/Plan.tsx
+++ b/packages/chat-ui/src/components/rows/plan/Plan.tsx
@@ -5,13 +5,14 @@ import {
   PlanPendingIcon,
 } from '@components/primitives/icons';
 import { Match, Switch, For } from 'solid-js';
-import type { PlanEntryPriority, PlanEntryStatus } from '@/model';
+import type { PlanEntryPriority } from '@/model';
+import { type VisiblePlanEntryStatus, visiblePlanEntryStatus } from './plan-status';
 import type { PlanEntryLaid } from './plan.def';
 import { planVars } from './plan.css';
 
 // ── Status glyph helpers ──────────────────────────────────────────────────────
 
-function statusColor(status: PlanEntryStatus): string {
+function statusColor(status: VisiblePlanEntryStatus): string {
   if (status === 'completed') return 'var(--chat-plan-done, #22c55e)';
   if (status === 'in_progress') return 'var(--chat-plan-active, #f59e0b)';
   return 'var(--chat-fg-passive, currentColor)';
@@ -26,6 +27,7 @@ function priorityOpacity(priority: PlanEntryPriority): string {
 
 export type PlanListProps = {
   entries: PlanEntryLaid[];
+  active: boolean;
 };
 
 export function PlanList(props: PlanListProps) {
@@ -37,46 +39,49 @@ export function PlanList(props: PlanListProps) {
       }}
     >
       <For each={props.entries}>
-        {(entry, i) => (
-          <div
-            style={{
-              display: 'flex',
-              'align-items': 'flex-start',
-              'column-gap': planVars.iconGap,
-              'margin-top': i() > 0 ? planVars.entryGap : '0',
-              opacity: priorityOpacity(entry.priority),
-            }}
-          >
+        {(entry, i) => {
+          const status = () => visiblePlanEntryStatus(entry.status, props.active);
+          return (
             <div
               style={{
-                width: planVars.iconBox,
-                height: '20px',
-                'flex-shrink': '0',
                 display: 'flex',
-                'align-items': 'center',
-                'justify-content': 'center',
-                color: statusColor(entry.status),
-                'user-select': 'none',
+                'align-items': 'flex-start',
+                'column-gap': planVars.iconGap,
+                'margin-top': i() > 0 ? planVars.entryGap : '0',
+                opacity: priorityOpacity(entry.priority),
               }}
-              aria-label={entry.status.replace('_', ' ')}
             >
-              <Switch>
-                <Match when={entry.status === 'completed'}>
-                  <PlanCompletedIcon />
-                </Match>
-                <Match when={entry.status === 'in_progress'}>
-                  <PlanInProgressIcon />
-                </Match>
-                <Match when={entry.status === 'pending'}>
-                  <PlanPendingIcon />
-                </Match>
-              </Switch>
+              <div
+                style={{
+                  width: planVars.iconBox,
+                  height: '20px',
+                  'flex-shrink': '0',
+                  display: 'flex',
+                  'align-items': 'center',
+                  'justify-content': 'center',
+                  color: statusColor(status()),
+                  'user-select': 'none',
+                }}
+                aria-label={status().replace('_', ' ')}
+              >
+                <Switch>
+                  <Match when={status() === 'completed'}>
+                    <PlanCompletedIcon />
+                  </Match>
+                  <Match when={status() === 'in_progress'}>
+                    <PlanInProgressIcon />
+                  </Match>
+                  <Match when={status() === 'pending' || status() === 'inactive'}>
+                    <PlanPendingIcon />
+                  </Match>
+                </Switch>
+              </div>
+              <div style={{ flex: '1' }}>
+                <BlockStackView node={entry.measured} />
+              </div>
             </div>
-            <div style={{ flex: '1' }}>
-              <BlockStackView node={entry.measured} />
-            </div>
-          </div>
-        )}
+          );
+        }}
       </For>
     </div>
   );

--- a/packages/chat-ui/src/components/rows/plan/plan-status.ts
+++ b/packages/chat-ui/src/components/rows/plan/plan-status.ts
@@ -1,0 +1,17 @@
+import type { ChatPlan, PlanEntryStatus } from '@/model';
+
+export type VisiblePlanEntryStatus = PlanEntryStatus | 'inactive';
+
+export function planIsActive(plan: ChatPlan): boolean {
+  return (
+    plan.active ??
+    (!!plan.streaming || plan.entries.some((entry) => entry.status === 'in_progress'))
+  );
+}
+
+export function visiblePlanEntryStatus(
+  status: PlanEntryStatus,
+  active: boolean
+): VisiblePlanEntryStatus {
+  return status === 'in_progress' && !active ? 'inactive' : status;
+}

--- a/packages/chat-ui/src/components/rows/plan/plan.def.tsx
+++ b/packages/chat-ui/src/components/rows/plan/plan.def.tsx
@@ -12,6 +12,7 @@ import { assignInlineVars } from '@vanilla-extract/dynamic';
 import { Show, createMemo } from 'solid-js';
 import type { ChatPlan, PlanEntryPriority, PlanEntryStatus, ToolNode } from '@/model';
 import { PlanList } from './Plan';
+import { planIsActive } from './plan-status';
 import { planVars, type PlanStyleVars } from './plan.css';
 
 export type PlanVars = {
@@ -42,6 +43,7 @@ export function planFromItem(
     kind: 'plan',
     id: item.id,
     entries: plan?.entries ?? [],
+    active: item.status === 'running',
     streaming: item.status === 'running',
   };
 }
@@ -114,8 +116,7 @@ function PlanUnitRender(props: { data: ChatPlan; ctx: RenderCtx; vars: PlanVars 
   });
 
   const autoScroll = () => !!props.data.streaming;
-  const active = () =>
-    !!props.data.streaming || props.data.entries.some((e) => e.status === 'in_progress');
+  const active = () => planIsActive(props.data);
   const done = () => props.data.entries.filter((e) => e.status === 'completed').length;
   const total = () => props.data.entries.length;
 
@@ -144,7 +145,7 @@ function PlanUnitRender(props: { data: ChatPlan; ctx: RenderCtx; vars: PlanVars 
         }
       >
         <div style={{ 'padding-left': planVars.padX, 'padding-right': planVars.padX }}>
-          <Show when={!isExpanded()} fallback={<PlanList entries={entries()} />}>
+          <Show when={!isExpanded()} fallback={<PlanList entries={entries()} active={active()} />}>
             <PreviewWindow
               height={bodyH()}
               maxH={props.vars.windowH}
@@ -152,7 +153,7 @@ function PlanUnitRender(props: { data: ChatPlan; ctx: RenderCtx; vars: PlanVars 
               autoScrollBottom={autoScroll()}
               contentHeight={() => listH()}
             >
-              <PlanList entries={entries()} />
+              <PlanList entries={entries()} active={active()} />
             </PreviewWindow>
           </Show>
         </div>

--- a/packages/chat-ui/src/model.ts
+++ b/packages/chat-ui/src/model.ts
@@ -271,6 +271,8 @@ export type ChatPlan = {
   kind: 'plan';
   id: string;
   entries: ChatPlanEntry[];
+  /** Authoritative activity override. Set to false when the owning turn has settled. */
+  active?: boolean;
   /** True while tasks are still being appended (drives preview auto-scroll + shimmer). */
   streaming?: boolean;
 };

--- a/packages/chat-ui/src/state/transcript.test.ts
+++ b/packages/chat-ui/src/state/transcript.test.ts
@@ -122,9 +122,16 @@ describe('activeTurn', () => {
   it('commit cancelled records cancelled outcome', () => {
     const tx = createTranscript();
     drive(tx, { type: 'message_chunk', id: 'a1', role: 'assistant', text: 'partial' });
+    drive(tx, {
+      type: 'plan_update',
+      id: 'plan-1',
+      entries: [{ content: 'Implement fix', status: 'in_progress', priority: 'high' }],
+      streaming: true,
+    });
     tx.activeTurn.commit('cancelled');
     expect(tx.state.turnStatus).toBe('cancelled');
     expect(tx.state.committedTurns[0].outcome?.kind).toBe('cancelled');
+    expect(tx.findItemById('plan-1')).toMatchObject({ active: false, streaming: false });
   });
 });
 

--- a/packages/chat-ui/src/state/transcript.ts
+++ b/packages/chat-ui/src/state/transcript.ts
@@ -85,7 +85,7 @@ function finalizeCompatItem(item: ChatItem): ChatItem {
     return { ...item, streaming: false } as ChatItem;
   }
   if ('status' in item && item.status === 'running') return { ...item, status: 'done' } as ChatItem;
-  if (item.kind === 'plan') return { ...item, streaming: false } as ChatItem;
+  if (item.kind === 'plan') return { ...item, active: false, streaming: false } as ChatItem;
   return item;
 }
 

--- a/packages/chat-ui/src/stories/_harness/turn-reducer.ts
+++ b/packages/chat-ui/src/stories/_harness/turn-reducer.ts
@@ -199,7 +199,7 @@ export function finalizeTurn(turn: TranscriptTurn): TranscriptTurn {
     items: items.map((item) => {
       if (item.kind === 'message' && 'streaming' in item) return { ...item, streaming: false };
       if ('status' in item && item.status === 'running') return { ...item, status: 'done' };
-      if (item.kind === 'plan') return { ...item, streaming: false };
+      if (item.kind === 'plan') return { ...item, active: false, streaming: false };
       return item;
     }) as TranscriptTurn['items'],
   };

--- a/packages/chat-ui/src/stories/rows/messages/agent/plan.stories.tsx
+++ b/packages/chat-ui/src/stories/rows/messages/agent/plan.stories.tsx
@@ -150,6 +150,33 @@ export const SinglePending: Story = {
   ),
 };
 
+/** Cancelled plan — the previously running task is shown as inactive. */
+export const Cancelled: Story = {
+  render: () => (
+    <ScriptedChat
+      height={220}
+      script={[
+        {
+          kind: 'call',
+          fn: (api) => {
+            api.activeTurn.set(
+              applyTurnEvent(null, {
+                type: 'plan_update',
+                id: 'plan-cancelled',
+                entries: ENTRIES_IN_PROGRESS.slice(2),
+                streaming: true,
+              }),
+              'generating'
+            );
+          },
+        },
+        { kind: 'wait', ms: 1_500 },
+        { kind: 'call', fn: (api) => api.activeTurn.commit('cancelled') },
+      ]}
+    />
+  ),
+};
+
 export const Streaming: Story = {
   render: () => (
     <ScriptedChat


### PR DESCRIPTION
### Description
Fixes a UI inconsistency where a cancelled turn could still show its plan as actively running.

This PR:
- adds an explicit plan activity state instead of treating streaming state as the source of truth
- marks plans as inactive when their owning turn is finalized or cancelled
- renders stale `in_progress` steps with a neutral inactive appearance after cancellation
- announces interrupted steps as `inactive` instead of incorrectly reporting them as `pending`
- preserves the existing behavior for active and legacy plans
- adds a Storybook cancellation scenario and regression tests

### Related issues
ENG-1932 — Canceled turn still shows plan as running

### Screenshot/Recording (if applicable)
<img width="695" height="174" alt="image" src="https://github.com/user-attachments/assets/1a14212b-0c12-4f1c-8f6f-39b0cea4158a" />


<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
