### PR TITLE
feat(claude): enable live permission mode switching

### DIFF
--- a/apps/emdash-desktop/src/main/core/conversations/claude-permission-mode-capability.test.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/claude-permission-mode-capability.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from 'vitest';
+import { canExposeClaudeBypassPermissions } from './claude-permission-mode-capability';
+
+const supportedVersion = '2.1.220 (Claude Code)\n';
+
+function execWith(
+  implementation: (command: string, args?: string[]) => Promise<{ stdout: string; stderr: string }>
+) {
+  return { exec: vi.fn(implementation) };
+}
+
+describe('canExposeClaudeBypassPermissions', () => {
+  it('enables the switch for a non-root local host with a supporting CLI', async () => {
+    const ctx = execWith(async () => ({ stdout: supportedVersion, stderr: '' }));
+
+    await expect(
+      canExposeClaudeBypassPermissions({
+        cli: '/usr/local/bin/claude',
+        ctx,
+        host: { kind: 'local', platform: 'linux', uid: 1000 },
+      })
+    ).resolves.toBe(true);
+    expect(ctx.exec).toHaveBeenCalledWith(
+      '/usr/local/bin/claude',
+      ['--version'],
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+  });
+
+  it('does not probe or enable the switch for a local root process', async () => {
+    const ctx = execWith(async () => ({ stdout: supportedVersion, stderr: '' }));
+
+    await expect(
+      canExposeClaudeBypassPermissions({
+        cli: 'claude',
+        ctx,
+        host: { kind: 'local', platform: 'linux', uid: 0 },
+      })
+    ).resolves.toBe(false);
+    expect(ctx.exec).not.toHaveBeenCalled();
+  });
+
+  it('allows Windows hosts to use the CLI capability probe without a POSIX uid', async () => {
+    const ctx = execWith(async () => ({ stdout: '', stderr: supportedVersion }));
+
+    await expect(
+      canExposeClaudeBypassPermissions({
+        cli: 'claude.exe',
+        ctx,
+        host: { kind: 'local', platform: 'win32', uid: undefined },
+      })
+    ).resolves.toBe(true);
+  });
+
+  it('fails closed when the local uid or CLI version cannot be confirmed', async () => {
+    const missingUidCtx = execWith(async () => ({ stdout: supportedVersion, stderr: '' }));
+    const oldCliCtx = execWith(async () => ({
+      stdout: '2.0.25 (Claude Code)',
+      stderr: '',
+    }));
+
+    await expect(
+      canExposeClaudeBypassPermissions({
+        cli: 'claude',
+        ctx: missingUidCtx,
+        host: { kind: 'local', platform: 'darwin', uid: undefined },
+      })
+    ).resolves.toBe(false);
+    await expect(
+      canExposeClaudeBypassPermissions({
+        cli: 'claude',
+        ctx: oldCliCtx,
+        host: { kind: 'local', platform: 'darwin', uid: 501 },
+      })
+    ).resolves.toBe(false);
+  });
+
+  it.each([
+    { version: '2.0.25 (Claude Code)', expected: false },
+    { version: '2.0.26 (Claude Code)', expected: true },
+    { version: '3.0.0 (Claude Code)', expected: true },
+    { version: '2.0.26-beta.1 (Claude Code)', expected: false },
+    { version: 'unknown', expected: false },
+  ])('maps Claude $version support to $expected', async ({ version, expected }) => {
+    const ctx = execWith(async () => ({ stdout: version, stderr: '' }));
+
+    await expect(
+      canExposeClaudeBypassPermissions({
+        cli: 'claude',
+        ctx,
+        host: { kind: 'local', platform: 'linux', uid: 1000 },
+      })
+    ).resolves.toBe(expected);
+  });
+
+  it('fails closed when warnings make the version output ambiguous', async () => {
+    const ctx = execWith(async () => ({
+      stdout: '2.1.220 (Claude Code)',
+      stderr: 'Node.js 99.0.0 warning',
+    }));
+
+    await expect(
+      canExposeClaudeBypassPermissions({
+        cli: 'claude',
+        ctx,
+        host: { kind: 'local', platform: 'linux', uid: 1000 },
+      })
+    ).resolves.toBe(false);
+  });
+
+  it('enables the switch for a confirmed non-root SSH host with a supporting CLI', async () => {
+    const ctx = execWith(async (command) =>
+      command === 'id' ? { stdout: '1000\n', stderr: '' } : { stdout: supportedVersion, stderr: '' }
+    );
+
+    await expect(
+      canExposeClaudeBypassPermissions({
+        cli: '/home/user/.local/bin/claude',
+        ctx,
+        host: { kind: 'ssh' },
+      })
+    ).resolves.toBe(true);
+    expect(ctx.exec).toHaveBeenCalledWith(
+      'id',
+      ['-u'],
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+    expect(ctx.exec).toHaveBeenCalledWith(
+      '/home/user/.local/bin/claude',
+      ['--version'],
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+  });
+
+  it.each([
+    { name: 'root', uid: '0\n' },
+    { name: 'malformed uid', uid: 'unknown\n' },
+    { name: 'unsafe integer uid', uid: '999999999999999999999\n' },
+  ])('fails closed for an SSH $name response', async ({ uid }) => {
+    const ctx = execWith(async () => ({ stdout: uid, stderr: '' }));
+
+    await expect(
+      canExposeClaudeBypassPermissions({
+        cli: 'claude',
+        ctx,
+        host: { kind: 'ssh' },
+      })
+    ).resolves.toBe(false);
+    expect(ctx.exec).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails closed when an SSH uid or CLI version probe errors', async () => {
+    const uidErrorCtx = execWith(async () => {
+      throw new Error('connection lost');
+    });
+    const versionErrorCtx = execWith(async (command) => {
+      if (command === 'id') return { stdout: '1000\n', stderr: '' };
+      throw new Error('version probe failed');
+    });
+
+    await expect(
+      canExposeClaudeBypassPermissions({
+        cli: 'claude',
+        ctx: uidErrorCtx,
+        host: { kind: 'ssh' },
+      })
+    ).resolves.toBe(false);
+    await expect(
+      canExposeClaudeBypassPermissions({
+        cli: 'claude',
+        ctx: versionErrorCtx,
+        host: { kind: 'ssh' },
+      })
+    ).resolves.toBe(false);
+  });
+});

--- a/apps/emdash-desktop/src/main/core/conversations/claude-permission-mode-capability.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/claude-permission-mode-capability.ts
@@ -1,0 +1,97 @@
+import type { IExecutionContext } from '@main/core/execution-context/types';
+
+const PROBE_TIMEOUT_MS = 5_000;
+const PROBE_MAX_BUFFER = 256 * 1024;
+const MINIMUM_SUPPORTED_VERSION = [2, 0, 26] as const;
+
+type LocalHost = {
+  kind: 'local';
+  platform: NodeJS.Platform;
+  uid: number | undefined;
+};
+
+type SshHost = {
+  kind: 'ssh';
+};
+
+type ClaudePermissionModeCapabilityParams = {
+  cli: string;
+  ctx: Pick<IExecutionContext, 'exec'>;
+  host: LocalHost | SshHost;
+};
+
+function supportsBypassToggle(versionOutput: string): boolean {
+  const match = /^(\d+)\.(\d+)\.(\d+) \(Claude Code\)$/.exec(versionOutput.trim());
+  if (!match) return false;
+
+  const current = match.slice(1, 4).map(Number);
+  for (let index = 0; index < MINIMUM_SUPPORTED_VERSION.length; index += 1) {
+    if (current[index]! > MINIMUM_SUPPORTED_VERSION[index]) return true;
+    if (current[index]! < MINIMUM_SUPPORTED_VERSION[index]) return false;
+  }
+  return true;
+}
+
+async function hasSafeHostUser(
+  ctx: Pick<IExecutionContext, 'exec'>,
+  host: LocalHost | SshHost
+): Promise<boolean> {
+  if (host.kind === 'local') {
+    if (host.platform === 'win32') return true;
+    return host.uid !== undefined && host.uid > 0;
+  }
+
+  try {
+    const { stdout } = await ctx.exec('id', ['-u'], {
+      timeout: PROBE_TIMEOUT_MS,
+      maxBuffer: PROBE_MAX_BUFFER,
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    const uid = stdout.trim();
+    const parsedUid = Number(uid);
+    return /^\d+$/.test(uid) && Number.isSafeInteger(parsedUid) && parsedUid > 0;
+  } catch {
+    return false;
+  }
+}
+
+async function hasSupportedCli(
+  ctx: Pick<IExecutionContext, 'exec'>,
+  cli: string
+): Promise<boolean> {
+  try {
+    const { stdout, stderr } = await ctx.exec(cli, ['--version'], {
+      timeout: PROBE_TIMEOUT_MS,
+      maxBuffer: PROBE_MAX_BUFFER,
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    return supportsBypassToggle(`${stdout}\n${stderr}`);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Fail-closed host capability probe for Claude's opt-in bypass mode switch.
+ *
+ * Outside recognized sandboxes, Claude refuses both bypass flags under
+ * root/sudo. We fail closed for uid 0 because Claude's sandbox recognition is
+ * not exposed here. The opt-in `--allow-...` flag was added in 2.0.26, so older
+ * or unparseable CLIs stay restricted.
+ */
+export async function canExposeClaudeBypassPermissions({
+  cli,
+  ctx,
+  host,
+}: ClaudePermissionModeCapabilityParams): Promise<boolean> {
+  if (host.kind === 'local') {
+    if (!(await hasSafeHostUser(ctx, host))) return false;
+    return hasSupportedCli(ctx, cli);
+  }
+
+  const [safeHostUser, supportedCli] = await Promise.all([
+    hasSafeHostUser(ctx, host),
+    hasSupportedCli(ctx, cli),
+  ]);
+  return safeHostUser && supportedCli;
+}

--- a/apps/emdash-desktop/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
@@ -12,6 +12,7 @@ import { SshConversationProvider } from './ssh-conversation';
 
 const spawnLocalPty = vi.hoisted(() => vi.fn());
 const openSsh2Pty = vi.hoisted(() => vi.fn());
+const canExposeClaudeBypassPermissions = vi.hoisted(() => vi.fn());
 const buildCommandMock = vi.hoisted(() =>
   vi.fn((_ctx: Record<string, unknown>) => ({
     command: 'agent',
@@ -40,6 +41,10 @@ vi.mock('@main/core/agents/workspace-trust', () => ({
   workspaceTrustService: {
     maybeAutoTrust: vi.fn(),
   },
+}));
+
+vi.mock('@main/core/conversations/claude-permission-mode-capability', () => ({
+  canExposeClaudeBypassPermissions,
 }));
 
 vi.mock('@main/core/agents/plugin-registry', () => ({
@@ -250,6 +255,8 @@ describe('conversation provider respawn state', () => {
     vi.useRealTimers();
     spawnLocalPty.mockReset();
     openSsh2Pty.mockReset();
+    canExposeClaudeBypassPermissions.mockReset();
+    canExposeClaudeBypassPermissions.mockResolvedValue(true);
     buildCommandMock.mockReset();
     buildCommandMock.mockReturnValue({ command: 'agent', args: [], env: {} });
     installPluginMock.mockReset();
@@ -289,6 +296,64 @@ describe('conversation provider respawn state', () => {
         process.env.SHELL = previousShell;
       }
     }
+  });
+
+  it('rechecks and passes the safe Claude bypass capability for local sessions', async () => {
+    spawnLocalPty.mockImplementation(() => fakePty([]));
+    const provider = localProvider();
+    const first = conversation({ providerId: 'claude' });
+    const second = conversation({ id: 'conversation-2', providerId: 'claude' });
+
+    await provider.startSession(first);
+    await provider.startSession(second);
+
+    expect(canExposeClaudeBypassPermissions).toHaveBeenCalledTimes(2);
+    expect(canExposeClaudeBypassPermissions).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        cli: 'claude',
+        host: expect.objectContaining({ kind: 'local' }),
+      })
+    );
+    expect(buildCommandMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ canToggleBypassPermissions: true })
+    );
+    expect(buildCommandMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ canToggleBypassPermissions: true })
+    );
+
+    await provider.destroyAll();
+  });
+
+  it('rechecks and passes the safe Claude bypass capability for SSH sessions', async () => {
+    openSsh2Pty.mockImplementation(() => Promise.resolve({ success: true, data: fakePty([]) }));
+    const provider = sshProvider();
+    const first = conversation({ providerId: 'claude' });
+    const second = conversation({ id: 'conversation-2', providerId: 'claude' });
+
+    await provider.startSession(first);
+    await provider.startSession(second);
+
+    expect(canExposeClaudeBypassPermissions).toHaveBeenCalledTimes(2);
+    expect(canExposeClaudeBypassPermissions).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        cli: 'claude',
+        host: { kind: 'ssh' },
+      })
+    );
+    expect(buildCommandMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ canToggleBypassPermissions: true })
+    );
+    expect(buildCommandMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ canToggleBypassPermissions: true })
+    );
+
+    await provider.destroyAll();
   });
 
   it('uses the injected shell profile for local agent sessions', async () => {

--- a/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
@@ -3,6 +3,7 @@ import { agentHookService } from '@main/core/agent-hooks/agent-hook-service';
 import { ensureHooksInstalled } from '@main/core/agent-hooks/hook-config-service';
 import { getPlugin } from '@main/core/agents/plugin-registry';
 import { workspaceTrustService } from '@main/core/agents/workspace-trust';
+import { canExposeClaudeBypassPermissions } from '@main/core/conversations/claude-permission-mode-capability';
 import { ConversationSessionSupervisor } from '@main/core/conversations/conversation-session-supervisor';
 import { resolveAgentSessionCommandArgs } from '@main/core/conversations/resolve-agent-session-command';
 import {
@@ -142,6 +143,18 @@ export class LocalConversationProvider implements ConversationProvider {
         hostDependencyStore,
         cachedStatePath,
       });
+      const canToggleBypassPermissions =
+        conversation.providerId === 'claude' && !conversation.autoApprove
+          ? await canExposeClaudeBypassPermissions({
+              cli: executableCli,
+              ctx: this.ctx,
+              host: {
+                kind: 'local',
+                platform: process.platform,
+                uid: process.getuid?.(),
+              },
+            })
+          : false;
 
       // Very large prompts (e.g. a full Linear issue + activity context) can blow
       // past OS argument limits and crash the underlying CLI. Spill them to a temp
@@ -160,6 +173,7 @@ export class LocalConversationProvider implements ConversationProvider {
         providerSessionId: conversation.sessionId ?? undefined,
         isResuming: agentSession.isResuming,
         model: conversation.model ?? '',
+        canToggleBypassPermissions,
       });
 
       const customEnv = providerConfig?.env ?? {};

--- a/apps/emdash-desktop/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/ssh-conversation.ts
@@ -1,5 +1,6 @@
 import { getPlugin } from '@main/core/agents/plugin-registry';
 import { workspaceTrustService } from '@main/core/agents/workspace-trust';
+import { canExposeClaudeBypassPermissions } from '@main/core/conversations/claude-permission-mode-capability';
 import { ConversationSessionSupervisor } from '@main/core/conversations/conversation-session-supervisor';
 import { resolveAgentSessionCommandArgs } from '@main/core/conversations/resolve-agent-session-command';
 import type { ConversationProvider } from '@main/core/conversations/types';
@@ -141,6 +142,14 @@ export class SshConversationProvider implements ConversationProvider {
         hostDependencyStore,
         connectionId: this.proxy.connectionId,
       });
+      const canToggleBypassPermissions =
+        conversation.providerId === 'claude' && !conversation.autoApprove
+          ? await canExposeClaudeBypassPermissions({
+              cli: executableCli,
+              ctx: this.ctx,
+              host: { kind: 'ssh' },
+            })
+          : false;
 
       const agentCommand = plugin.behavior.prompt!.buildCommand({
         cli: executableCli,
@@ -151,6 +160,7 @@ export class SshConversationProvider implements ConversationProvider {
         providerSessionId: conversation.sessionId ?? undefined,
         isResuming: agentSession.isResuming,
         model: conversation.model ?? '',
+        canToggleBypassPermissions,
       });
 
       const customEnv = providerConfig?.env ?? {};

--- a/packages/core/src/agents/plugins/capabilities/prompt.ts
+++ b/packages/core/src/agents/plugins/capabilities/prompt.ts
@@ -14,6 +14,11 @@ export type CommandContext = {
    * codex, droid). Undefined means the provider has not yet emitted a session ID. */
   providerSessionId?: string;
   isResuming?: boolean;
+  /**
+   * The host confirmed that Claude may safely expose bypassPermissions in its
+   * in-session mode cycle. False/undefined keeps the CLI's restricted default.
+   */
+  canToggleBypassPermissions?: boolean;
   model: string;
 };
 

--- a/packages/plugins/src/agents/impl/claude/index.test.ts
+++ b/packages/plugins/src/agents/impl/claude/index.test.ts
@@ -1,0 +1,84 @@
+import type { CommandContext } from '@emdash/core/agents/plugins';
+import { describe, expect, it } from 'vitest';
+import { provider } from './index';
+
+const sessionId = '550e8400-e29b-41d4-a716-446655440000';
+const allowFlag = '--allow-dangerously-skip-permissions';
+const bypassFlag = '--dangerously-skip-permissions';
+
+function build(context: Partial<CommandContext> = {}) {
+  return provider.behavior.prompt!.buildCommand({
+    cli: 'claude',
+    autoApprove: false,
+    initialPrompt: 'Start here',
+    sessionId,
+    isResuming: false,
+    model: '',
+    canToggleBypassPermissions: true,
+    ...context,
+  });
+}
+
+describe('Claude prompt command', () => {
+  it('starts a restricted fresh session with the bypass mode switch available', () => {
+    const command = build();
+
+    expect(command).toEqual({
+      command: 'claude',
+      args: [allowFlag, '--session-id', sessionId, 'Start here'],
+      env: {},
+    });
+    expect(command.args).not.toContain(bypassFlag);
+  });
+
+  it('starts an auto-approved fresh session directly in bypass mode', () => {
+    const command = build({ autoApprove: true });
+
+    expect(command.args).toEqual(['--session-id', sessionId, bypassFlag, 'Start here']);
+    expect(command.args).not.toContain(allowFlag);
+  });
+
+  it('resumes a restricted session with the bypass mode switch available', () => {
+    const command = build({ isResuming: true });
+
+    expect(command.args).toEqual([allowFlag, '--resume', sessionId]);
+    expect(command.args).not.toContain(bypassFlag);
+    expect(command.args).not.toContain('Start here');
+  });
+
+  it('resumes an auto-approved session directly in bypass mode', () => {
+    const command = build({ autoApprove: true, isResuming: true });
+
+    expect(command.args).toEqual(['--resume', sessionId, bypassFlag]);
+    expect(command.args).not.toContain(allowFlag);
+    expect(command.args).not.toContain('Start here');
+  });
+
+  it.each([false, undefined])(
+    'keeps restricted mode unchanged when the host capability is %s',
+    (canToggleBypassPermissions) => {
+      const command = build({ canToggleBypassPermissions });
+
+      expect(command.args).toEqual(['--session-id', sessionId, 'Start here']);
+      expect(command.args).not.toContain(allowFlag);
+      expect(command.args).not.toContain(bypassFlag);
+    }
+  );
+
+  it('deduplicates a user-configured allow flag against the generated capability flag', () => {
+    const command = build({ extraArgs: [allowFlag] });
+
+    expect(command.args.filter((arg) => arg === allowFlag)).toHaveLength(1);
+  });
+
+  it('does not add PTY permission flags to the ACP spawn', () => {
+    const spawn = provider.behavior.acp!.buildSpawn({
+      cli: '/usr/local/bin/claude',
+      cwd: '/tmp/worktree',
+      env: {},
+    });
+
+    expect(spawn.args).not.toContain(allowFlag);
+    expect(spawn.args).not.toContain(bypassFlag);
+  });
+});

--- a/packages/plugins/src/agents/impl/claude/index.ts
+++ b/packages/plugins/src/agents/impl/claude/index.ts
@@ -169,11 +169,16 @@ export const provider = registerPluginBehavior(plugin, {
   prompt: {
     buildCommand: (ctx) =>
       buildStandardCommand(ctx, {
+        defaultArgs:
+          !ctx.autoApprove && ctx.canToggleBypassPermissions
+            ? ['--allow-dangerously-skip-permissions']
+            : undefined,
         autoApproveFlag: '--dangerously-skip-permissions',
         initialPromptFlag: '',
         resumeFlag: '--resume',
         sessionIdFlag: '--session-id',
         modelFlag: '--model',
+        deduplicateFlags: ['--allow-dangerously-skip-permissions'],
       }),
   },
   hooks: buildClaudeHookConfig(),


### PR DESCRIPTION
### Description

- start supported, non-root Claude Code TUI sessions with `--allow-dangerously-skip-permissions`, so users can enter bypass mode through Claude's native Shift+Tab permission-mode cycle without restarting or losing session context
- probe the exact local or SSH CLI on every spawn and fail closed for root, Claude versions older than 2.0.26, ambiguous version output, timeouts, and probe errors
- preserve the existing `--dangerously-skip-permissions` behavior for auto-approved tasks and leave ACP sessions unchanged
- deduplicate the new generated allow flag when users already supplied it through provider arguments

### Related issues

Fixes #1671

### Testing

Passed:

- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run build`
- desktop focused Vitest: 2 files, 46 tests
- Claude plugin focused Vitest: 1 file, 8 tests
- `git diff --check`

`pnpm run test` was also attempted both in the sandbox and outside it after `pnpm run db:setup`. The full workspace suite remains red only in unrelated existing paths: stale ACP/UI snapshots, a Vitest worker termination, native PTY spawning, and parallel DB/UI timeouts. All 54 changed and adjacent tests pass.

### Screenshot/Recording (if applicable)

N/A — this changes Claude's PTY startup capability and native in-session permission-mode cycle; there is no new Emdash UI.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>