### PR TITLE
fix(search): make workspace file index queries O(workspace) via external-content FTS5

### DIFF
--- a/apps/emdash-desktop/src/main/core/search/workspace-file-index-service.db.test.ts
+++ b/apps/emdash-desktop/src/main/core/search/workspace-file-index-service.db.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type BetterSqlite3 from 'better-sqlite3';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createFileIndexSchema } from '@main/db/file-index-schema';
 import type {
   WorkspaceFileEnumerator,
   WorkspaceFileIndexServiceOptions,
@@ -188,34 +189,13 @@ async function loadService(options: WorkspaceFileIndexServiceOptions = {}) {
     import('./workspace-file-index-service'),
     import('@main/db/client'),
   ]);
-  createFileIndexTables(sqlite);
+  createFileIndexSchema(sqlite);
 
   return {
     service: new WorkspaceFileIndexService(options),
     sqlite,
     tempDir,
   };
-}
-
-function createFileIndexTables(sqlite: BetterSqlite3.Database): void {
-  sqlite.exec(`
-    CREATE VIRTUAL TABLE workspace_file_index USING fts5(
-      workspace_id UNINDEXED,
-      path,
-      filename,
-      tokenize = 'trigram case_sensitive 0'
-    );
-    CREATE TABLE workspace_file_index_meta (
-      workspace_id     TEXT PRIMARY KEY,
-      indexed_at       INTEGER NOT NULL,
-      root_path        TEXT NOT NULL,
-      status           TEXT NOT NULL
-        CHECK (status IN ('complete', 'stale', 'truncated')),
-      file_count       INTEGER NOT NULL,
-      truncate_reason  TEXT
-        CHECK (truncate_reason IS NULL OR truncate_reason IN ('maxEntries', 'timeBudget'))
-    );
-  `);
 }
 
 function enumerator(readPaths: () => readonly string[]): WorkspaceFileEnumerator {
@@ -231,7 +211,7 @@ function enumerator(readPaths: () => readonly string[]): WorkspaceFileEnumerator
 
 function indexedPaths(sqlite: BetterSqlite3.Database): string[] {
   return (
-    sqlite.prepare(`SELECT path FROM workspace_file_index ORDER BY path`).all() as Array<{
+    sqlite.prepare(`SELECT path FROM workspace_files ORDER BY path`).all() as Array<{
       path: string;
     }>
   ).map((row) => row.path);

--- a/apps/emdash-desktop/src/main/core/search/workspace-file-index-store.db.test.ts
+++ b/apps/emdash-desktop/src/main/core/search/workspace-file-index-store.db.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type BetterSqlite3 from 'better-sqlite3';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createFileIndexSchema } from '@main/db/file-index-schema';
 
 type LoadedStore = Awaited<ReturnType<typeof loadStore>>;
 
@@ -47,6 +48,7 @@ describe('WorkspaceFileIndexStore', () => {
 
     expect(indexedPaths(sqlite, 'ws-1')).toEqual(['/repo/b.ts', '/repo/c.ts']);
     expect(store.countIndexedFiles('ws-1')).toBe(2);
+    expectFtsConsistent(sqlite);
   });
 
   it('returns whether insertPath added a new row', async () => {
@@ -84,6 +86,43 @@ describe('WorkspaceFileIndexStore', () => {
     store.deleteSubtree('ws-1', '/repo/foo_%');
 
     expect(indexedPaths(sqlite, 'ws-1')).toEqual(['/repo/foo-x/a.ts']);
+    expectFtsConsistent(sqlite);
+  });
+
+  it('drops trigger-synced deletes from FTS search results', async () => {
+    loadedStore = await loadStore();
+    const { store, sqlite } = loadedStore;
+    store.syncRows('ws-1', paths(['/repo/src/index.ts', '/repo/src/router.ts']));
+
+    store.deletePath('ws-1', '/repo/src/index.ts');
+
+    expect(store.search('ws-1', 'index')).toEqual([]);
+    expect(store.search('ws-1', 'router')).toEqual([
+      { path: '/repo/src/router.ts', filename: 'router.ts' },
+    ]);
+    expectFtsConsistent(sqlite);
+  });
+
+  it('never full-scans the FTS index for bookkeeping queries', async () => {
+    loadedStore = await loadStore();
+    const { sqlite } = loadedStore;
+
+    const bookkeepingQueries = [
+      `SELECT path FROM workspace_files WHERE workspace_id = 'ws'`,
+      `SELECT COUNT(*) FROM workspace_files WHERE workspace_id = 'ws'`,
+      `SELECT path, filename FROM workspace_files WHERE workspace_id = 'ws' ORDER BY path LIMIT 5`,
+      `DELETE FROM workspace_files WHERE workspace_id = 'ws' AND path = '/repo/a.ts'`,
+      `DELETE FROM workspace_files WHERE workspace_id = 'ws'`,
+    ];
+
+    for (const query of bookkeepingQueries) {
+      const plan = sqlite.prepare(`EXPLAIN QUERY PLAN ${query}`).all() as Array<{
+        detail: string;
+      }>;
+      const details = plan.map((row) => row.detail).join('; ');
+      expect(details, query).not.toMatch(/SCAN workspace_file/);
+      expect(details, query).toMatch(/SEARCH workspace_files USING/);
+    }
   });
 
   it('deletes an entire workspace index', async () => {
@@ -137,6 +176,7 @@ describe('WorkspaceFileIndexStore', () => {
 
     expect(allIndexedWorkspaces(sqlite)).toEqual(['fresh']);
     expect(indexedPaths(sqlite, 'fresh')).toEqual(['/repo/fresh.ts']);
+    expectFtsConsistent(sqlite);
   });
 });
 
@@ -159,23 +199,8 @@ async function loadStore() {
 }
 
 function createTables(sqlite: BetterSqlite3.Database): void {
+  createFileIndexSchema(sqlite);
   sqlite.exec(`
-    CREATE VIRTUAL TABLE workspace_file_index USING fts5(
-      workspace_id UNINDEXED,
-      path,
-      filename,
-      tokenize = 'trigram case_sensitive 0'
-    );
-    CREATE TABLE workspace_file_index_meta (
-      workspace_id     TEXT PRIMARY KEY,
-      indexed_at       INTEGER NOT NULL,
-      root_path        TEXT NOT NULL,
-      status           TEXT NOT NULL
-        CHECK (status IN ('complete', 'stale', 'truncated')),
-      file_count       INTEGER NOT NULL,
-      truncate_reason  TEXT
-        CHECK (truncate_reason IS NULL OR truncate_reason IN ('maxEntries', 'timeBudget'))
-    );
     CREATE TABLE workspaces (
       id TEXT PRIMARY KEY
     );
@@ -189,7 +214,7 @@ function paths(values: string[]): string[] {
 function indexedPaths(sqlite: BetterSqlite3.Database, workspaceId: string): string[] {
   return (
     sqlite
-      .prepare(`SELECT path FROM workspace_file_index WHERE workspace_id = ? ORDER BY path`)
+      .prepare(`SELECT path FROM workspace_files WHERE workspace_id = ? ORDER BY path`)
       .all(workspaceId) as Array<{ path: string }>
   ).map((row) => row.path);
 }
@@ -197,7 +222,17 @@ function indexedPaths(sqlite: BetterSqlite3.Database, workspaceId: string): stri
 function allIndexedWorkspaces(sqlite: BetterSqlite3.Database): string[] {
   return (
     sqlite
-      .prepare(`SELECT DISTINCT workspace_id FROM workspace_file_index ORDER BY workspace_id`)
+      .prepare(`SELECT DISTINCT workspace_id FROM workspace_files ORDER BY workspace_id`)
       .all() as Array<{ workspace_id: string }>
   ).map((row) => row.workspace_id);
+}
+
+function expectFtsConsistent(sqlite: BetterSqlite3.Database): void {
+  expect(() =>
+    sqlite
+      .prepare(
+        `INSERT INTO workspace_file_index(workspace_file_index, rank) VALUES ('integrity-check', 1)`
+      )
+      .run()
+  ).not.toThrow();
 }

--- a/apps/emdash-desktop/src/main/core/search/workspace-file-index-store.ts
+++ b/apps/emdash-desktop/src/main/core/search/workspace-file-index-store.ts
@@ -95,10 +95,10 @@ export class WorkspaceFileIndexStore implements IWorkspaceFileIndexStore {
     const existingPaths = this.indexedPathSet(workspaceId);
     const desiredPaths = new Set<string>(paths);
     const deletePath = sqlite.prepare(
-      `DELETE FROM workspace_file_index WHERE workspace_id = ? AND path = ?`
+      `DELETE FROM workspace_files WHERE workspace_id = ? AND path = ?`
     );
     const insertPath = sqlite.prepare(
-      `INSERT INTO workspace_file_index(workspace_id, path, filename) VALUES (?, ?, ?)`
+      `INSERT INTO workspace_files(workspace_id, path, filename) VALUES (?, ?, ?)`
     );
 
     for (const path of existingPaths) {
@@ -111,16 +111,18 @@ export class WorkspaceFileIndexStore implements IWorkspaceFileIndexStore {
   }
 
   insertPath(workspaceId: string, path: string): boolean {
-    if (this.hasIndexedPath(workspaceId, path)) return false;
-    sqlite
-      .prepare(`INSERT INTO workspace_file_index(workspace_id, path, filename) VALUES (?, ?, ?)`)
+    const result = sqlite
+      .prepare(
+        `INSERT INTO workspace_files(workspace_id, path, filename) VALUES (?, ?, ?)
+         ON CONFLICT(workspace_id, path) DO NOTHING`
+      )
       .run(workspaceId, path, basename(path));
-    return true;
+    return result.changes > 0;
   }
 
   deletePath(workspaceId: string, path: string): boolean {
     const result = sqlite
-      .prepare(`DELETE FROM workspace_file_index WHERE workspace_id = ? AND path = ?`)
+      .prepare(`DELETE FROM workspace_files WHERE workspace_id = ? AND path = ?`)
       .run(workspaceId, path);
     return result.changes > 0;
   }
@@ -128,7 +130,7 @@ export class WorkspaceFileIndexStore implements IWorkspaceFileIndexStore {
   deleteSubtree(workspaceId: string, path: string): void {
     sqlite
       .prepare(
-        `DELETE FROM workspace_file_index
+        `DELETE FROM workspace_files
          WHERE workspace_id = ?
            AND (path = ? OR path LIKE ? ESCAPE '\\')`
       )
@@ -137,7 +139,7 @@ export class WorkspaceFileIndexStore implements IWorkspaceFileIndexStore {
 
   countIndexedFiles(workspaceId: string): number {
     const row = sqlite
-      .prepare(`SELECT COUNT(*) AS count FROM workspace_file_index WHERE workspace_id = ?`)
+      .prepare(`SELECT COUNT(*) AS count FROM workspace_files WHERE workspace_id = ?`)
       .get(workspaceId) as { count: number };
     return row.count;
   }
@@ -157,7 +159,7 @@ export class WorkspaceFileIndexStore implements IWorkspaceFileIndexStore {
       try {
         return sqlite
           .prepare(
-            `SELECT path, filename FROM workspace_file_index
+            `SELECT path, filename FROM workspace_files
              WHERE workspace_id = ?
              ORDER BY path
              LIMIT ?`
@@ -180,7 +182,7 @@ export class WorkspaceFileIndexStore implements IWorkspaceFileIndexStore {
       try {
         return sqlite
           .prepare(
-            `SELECT path, filename FROM workspace_file_index
+            `SELECT path, filename FROM workspace_files
              WHERE workspace_id = ?
                AND (filename LIKE ? ESCAPE '\\' OR path LIKE ? ESCAPE '\\')
              LIMIT ?`
@@ -239,7 +241,7 @@ export class WorkspaceFileIndexStore implements IWorkspaceFileIndexStore {
   deleteIndex(workspaceId: string): void {
     try {
       sqlite.transaction(() => {
-        sqlite.prepare(`DELETE FROM workspace_file_index WHERE workspace_id = ?`).run(workspaceId);
+        sqlite.prepare(`DELETE FROM workspace_files WHERE workspace_id = ?`).run(workspaceId);
         sqlite
           .prepare(`DELETE FROM workspace_file_index_meta WHERE workspace_id = ?`)
           .run(workspaceId);
@@ -257,17 +259,9 @@ export class WorkspaceFileIndexStore implements IWorkspaceFileIndexStore {
 
   private indexedPathSet(workspaceId: string): Set<string> {
     const rows = sqlite
-      .prepare(`SELECT path FROM workspace_file_index WHERE workspace_id = ?`)
+      .prepare(`SELECT path FROM workspace_files WHERE workspace_id = ?`)
       .all(workspaceId) as Array<{ path: string }>;
     return new Set(rows.map((row) => row.path));
-  }
-
-  private hasIndexedPath(workspaceId: string, path: string): boolean {
-    return Boolean(
-      sqlite
-        .prepare(`SELECT 1 FROM workspace_file_index WHERE workspace_id = ? AND path = ? LIMIT 1`)
-        .get(workspaceId, path)
-    );
   }
 
   private evictStale(staleDays: number): void {
@@ -280,7 +274,7 @@ export class WorkspaceFileIndexStore implements IWorkspaceFileIndexStore {
       if (stale.length === 0) return;
 
       sqlite.transaction(() => {
-        const delIndex = sqlite.prepare(`DELETE FROM workspace_file_index WHERE workspace_id = ?`);
+        const delIndex = sqlite.prepare(`DELETE FROM workspace_files WHERE workspace_id = ?`);
         const delMeta = sqlite.prepare(
           `DELETE FROM workspace_file_index_meta WHERE workspace_id = ?`
         );
@@ -309,7 +303,7 @@ export class WorkspaceFileIndexStore implements IWorkspaceFileIndexStore {
       if (orphans.length === 0) return;
 
       sqlite.transaction(() => {
-        const delIndex = sqlite.prepare(`DELETE FROM workspace_file_index WHERE workspace_id = ?`);
+        const delIndex = sqlite.prepare(`DELETE FROM workspace_files WHERE workspace_id = ?`);
         const delMeta = sqlite.prepare(
           `DELETE FROM workspace_file_index_meta WHERE workspace_id = ?`
         );

--- a/apps/emdash-desktop/src/main/db/file-index-schema.ts
+++ b/apps/emdash-desktop/src/main/db/file-index-schema.ts
@@ -1,0 +1,81 @@
+import type BetterSqlite3 from 'better-sqlite3';
+
+/**
+ * Workspace file index schema, shared by initialize.ts, legacy-port/reset.ts,
+ * and the db tests so the DDL lives in exactly one place.
+ *
+ * `workspace_files` is the source of truth: a plain table whose
+ * UNIQUE(workspace_id, path) index makes every bookkeeping query (sync, count,
+ * delete-by-workspace) an indexed lookup. `workspace_file_index` is an
+ * external-content FTS5 table over it, kept in sync by triggers, so FTS
+ * deletes resolve by rowid instead of scanning the whole trigram index
+ * (issue #2882 — the previous content-owning FTS table full-scanned on every
+ * `WHERE workspace_id = ?`).
+ *
+ * The FTS column order (workspace_id, path, filename) is load-bearing: the
+ * bm25() weights in workspace-file-index-store.ts are positional.
+ */
+export const FILE_INDEX_TABLES = [
+  // Drop order matters: the FTS virtual table must go before its content table
+  // so we never operate on the FTS index while the content is gone. Dropping
+  // workspace_files also drops its triggers.
+  'workspace_file_index',
+  'workspace_files',
+  'workspace_file_index_meta',
+] as const;
+
+export function dropFileIndexSchema(connection: BetterSqlite3.Database): void {
+  for (const table of FILE_INDEX_TABLES) {
+    connection.exec(`DROP TABLE IF EXISTS ${table}`);
+  }
+}
+
+export function createFileIndexSchema(connection: BetterSqlite3.Database): void {
+  dropFileIndexSchema(connection);
+  connection.exec(`
+    CREATE TABLE workspace_files (
+      id INTEGER PRIMARY KEY,
+      workspace_id TEXT NOT NULL,
+      path TEXT NOT NULL,
+      filename TEXT NOT NULL,
+      UNIQUE(workspace_id, path)
+    );
+
+    CREATE VIRTUAL TABLE workspace_file_index USING fts5(
+      workspace_id UNINDEXED,
+      path,
+      filename,
+      content='workspace_files',
+      content_rowid='id',
+      tokenize = 'trigram case_sensitive 0'
+    );
+
+    CREATE TRIGGER workspace_files_ai AFTER INSERT ON workspace_files BEGIN
+      INSERT INTO workspace_file_index(rowid, workspace_id, path, filename)
+      VALUES (new.id, new.workspace_id, new.path, new.filename);
+    END;
+
+    CREATE TRIGGER workspace_files_ad AFTER DELETE ON workspace_files BEGIN
+      INSERT INTO workspace_file_index(workspace_file_index, rowid, workspace_id, path, filename)
+      VALUES ('delete', old.id, old.workspace_id, old.path, old.filename);
+    END;
+
+    CREATE TRIGGER workspace_files_au AFTER UPDATE ON workspace_files BEGIN
+      INSERT INTO workspace_file_index(workspace_file_index, rowid, workspace_id, path, filename)
+      VALUES ('delete', old.id, old.workspace_id, old.path, old.filename);
+      INSERT INTO workspace_file_index(rowid, workspace_id, path, filename)
+      VALUES (new.id, new.workspace_id, new.path, new.filename);
+    END;
+
+    CREATE TABLE workspace_file_index_meta (
+      workspace_id     TEXT PRIMARY KEY,
+      indexed_at       INTEGER NOT NULL,
+      root_path        TEXT NOT NULL,
+      status           TEXT NOT NULL
+        CHECK (status IN ('complete', 'stale', 'truncated')),
+      file_count       INTEGER NOT NULL,
+      truncate_reason  TEXT
+        CHECK (truncate_reason IS NULL OR truncate_reason IN ('maxEntries', 'timeBudget'))
+    );
+  `);
+}

--- a/apps/emdash-desktop/src/main/db/initialize.db.test.ts
+++ b/apps/emdash-desktop/src/main/db/initialize.db.test.ts
@@ -1,0 +1,102 @@
+import Database from 'better-sqlite3';
+import { afterEach, describe, expect, it } from 'vitest';
+import { dropFileIndexSchema } from './file-index-schema';
+import { initializeDatabase } from './initialize';
+
+let sqlite: Database.Database | undefined;
+
+describe('ensureFileIndex', () => {
+  afterEach(() => {
+    sqlite?.close();
+    sqlite = undefined;
+  });
+
+  it('creates the v5 file index schema on a fresh database', async () => {
+    sqlite = await initializeDatabase(new Database(':memory:'));
+
+    expect(schemaNames(sqlite, 'table')).toEqual(
+      expect.arrayContaining([
+        'workspace_files',
+        'workspace_file_index',
+        'workspace_file_index_meta',
+      ])
+    );
+    expect(schemaNames(sqlite, 'trigger')).toEqual(
+      expect.arrayContaining(['workspace_files_ai', 'workspace_files_ad', 'workspace_files_au'])
+    );
+    expect(fileIndexVersion(sqlite)).toBe('5');
+  });
+
+  it('upgrades a populated v4 file index to v5', async () => {
+    sqlite = await initializeDatabase(new Database(':memory:'));
+
+    // Recreate the historical v4 shape: content-owning FTS5, no content table.
+    dropFileIndexSchema(sqlite);
+    sqlite.exec(`
+      CREATE VIRTUAL TABLE workspace_file_index USING fts5(
+        workspace_id UNINDEXED,
+        path,
+        filename,
+        tokenize = 'trigram case_sensitive 0'
+      );
+      CREATE TABLE workspace_file_index_meta (
+        workspace_id     TEXT PRIMARY KEY,
+        indexed_at       INTEGER NOT NULL,
+        root_path        TEXT NOT NULL,
+        status           TEXT NOT NULL,
+        file_count       INTEGER NOT NULL,
+        truncate_reason  TEXT
+      );
+    `);
+    sqlite
+      .prepare(`INSERT INTO workspace_file_index(workspace_id, path, filename) VALUES (?, ?, ?)`)
+      .run('ws-1', '/repo/a.ts', 'a.ts');
+    sqlite
+      .prepare(
+        `INSERT INTO workspace_file_index_meta
+         (workspace_id, indexed_at, root_path, status, file_count, truncate_reason)
+         VALUES ('ws-1', unixepoch(), '/repo', 'complete', 1, NULL)`
+      )
+      .run();
+    sqlite.prepare(`UPDATE kv SET value = '4' WHERE key = 'file_index_version'`).run();
+
+    await initializeDatabase(sqlite);
+
+    expect(fileIndexVersion(sqlite)).toBe('5');
+    expect(schemaNames(sqlite, 'table')).toEqual(expect.arrayContaining(['workspace_files']));
+    expect(sqlite.prepare(`SELECT COUNT(*) AS count FROM workspace_files`).get()).toEqual({
+      count: 0,
+    });
+    expect(sqlite.prepare(`SELECT COUNT(*) AS count FROM workspace_file_index_meta`).get()).toEqual(
+      { count: 0 }
+    );
+  });
+
+  it('preserves indexed rows when the version already matches', async () => {
+    sqlite = await initializeDatabase(new Database(':memory:'));
+    sqlite
+      .prepare(`INSERT INTO workspace_files(workspace_id, path, filename) VALUES (?, ?, ?)`)
+      .run('ws-1', '/repo/a.ts', 'a.ts');
+
+    await initializeDatabase(sqlite);
+
+    expect(sqlite.prepare(`SELECT COUNT(*) AS count FROM workspace_files`).get()).toEqual({
+      count: 1,
+    });
+  });
+});
+
+function schemaNames(sqlite: Database.Database, type: 'table' | 'trigger'): string[] {
+  return (
+    sqlite.prepare(`SELECT name FROM sqlite_master WHERE type = ?`).all(type) as Array<{
+      name: string;
+    }>
+  ).map((row) => row.name);
+}
+
+function fileIndexVersion(sqlite: Database.Database): string | undefined {
+  const row = sqlite.prepare(`SELECT value FROM kv WHERE key = 'file_index_version'`).get() as
+    | { value: string }
+    | undefined;
+  return row?.value;
+}

--- a/apps/emdash-desktop/src/main/db/initialize.ts
+++ b/apps/emdash-desktop/src/main/db/initialize.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import type BetterSqlite3 from 'better-sqlite3';
 import journal from '@root/drizzle/meta/_journal.json';
+import { createFileIndexSchema } from './file-index-schema';
 
 // Vite bundles all migration SQL files at build time — no runtime path resolution needed.
 // Each value is the raw SQL string content of the file.
@@ -85,13 +86,15 @@ function ensureSearchIndex(connection: BetterSqlite3.Database): void {
 }
 
 /**
- * Creates the FTS5 virtual table and companion meta table used for workspace
- * file indexing. Managed outside Drizzle (same reason as ensureSearchIndex).
- * Version-gated via `kv` so the tables can be dropped and recreated on schema
- * changes without a full Drizzle migration.
+ * Creates the workspace file index tables (see file-index-schema.ts). Managed
+ * outside Drizzle (same reason as ensureSearchIndex). Version-gated via `kv`
+ * so the tables can be dropped and recreated on schema changes without a full
+ * Drizzle migration. Dropping returns pages to the freelist but does not
+ * shrink the file (no VACUUM here — it would rewrite multi-GB files
+ * synchronously before the window exists).
  */
 function ensureFileIndex(connection: BetterSqlite3.Database): void {
-  const FILE_INDEX_VERSION = '4';
+  const FILE_INDEX_VERSION = '5';
 
   const row = connection.prepare(`SELECT value FROM kv WHERE key = 'file_index_version'`).get() as
     | { value: string }
@@ -99,28 +102,7 @@ function ensureFileIndex(connection: BetterSqlite3.Database): void {
 
   if (row?.value === FILE_INDEX_VERSION) return;
 
-  connection.exec(`DROP TABLE IF EXISTS workspace_file_index`);
-  connection.exec(`DROP TABLE IF EXISTS workspace_file_index_meta`);
-  connection.exec(`
-    CREATE VIRTUAL TABLE workspace_file_index USING fts5(
-      workspace_id UNINDEXED,
-      path,
-      filename,
-      tokenize = 'trigram case_sensitive 0'
-    )
-  `);
-  connection.exec(`
-    CREATE TABLE workspace_file_index_meta (
-      workspace_id     TEXT PRIMARY KEY,
-      indexed_at       INTEGER NOT NULL,
-      root_path        TEXT NOT NULL,
-      status           TEXT NOT NULL
-        CHECK (status IN ('complete', 'stale', 'truncated')),
-      file_count       INTEGER NOT NULL,
-      truncate_reason  TEXT
-        CHECK (truncate_reason IS NULL OR truncate_reason IN ('maxEntries', 'timeBudget'))
-    )
-  `);
+  createFileIndexSchema(connection);
   connection
     .prepare(
       `INSERT OR REPLACE INTO kv (key, value, updated_at) VALUES ('file_index_version', ?, unixepoch())`

--- a/apps/emdash-desktop/src/main/db/legacy-port/reset.test.ts
+++ b/apps/emdash-desktop/src/main/db/legacy-port/reset.test.ts
@@ -1,6 +1,7 @@
 import Database from 'better-sqlite3';
 import { describe, expect, it } from 'vitest';
-import { listUserTables } from './reset';
+import { createFileIndexSchema } from '../file-index-schema';
+import { clearDestinationDataPreservingSignIn, listUserTables, PRESERVED_KV_KEYS } from './reset';
 
 describe('listUserTables', () => {
   it('excludes SQLite shadow tables for virtual tables', () => {
@@ -13,6 +14,61 @@ describe('listUserTables', () => {
       `);
 
       expect(listUserTables(db).sort()).toEqual(['app_data', 'legacy_index', 'search_index']);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+describe('clearDestinationDataPreservingSignIn', () => {
+  it('resets a populated file index without corrupting the FTS table', () => {
+    const db = new Database(':memory:');
+    try {
+      db.exec(`
+        CREATE TABLE kv (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at INTEGER NOT NULL);
+        CREATE TABLE app_data (id TEXT PRIMARY KEY);
+      `);
+      createFileIndexSchema(db);
+      db.prepare(`INSERT INTO app_data (id) VALUES ('row')`).run();
+      db.prepare(`INSERT INTO kv (key, value, updated_at) VALUES (?, 'kept', 0)`).run(
+        PRESERVED_KV_KEYS[0]
+      );
+      db.prepare(
+        `INSERT INTO kv (key, value, updated_at) VALUES ('file_index_version', '5', 0)`
+      ).run();
+      db.prepare(
+        `INSERT INTO workspace_files (workspace_id, path, filename) VALUES ('ws', '/repo/a.ts', 'a.ts')`
+      ).run();
+      db.prepare(
+        `INSERT INTO workspace_file_index_meta
+         (workspace_id, indexed_at, root_path, status, file_count, truncate_reason)
+         VALUES ('ws', 0, '/repo', 'complete', 1, NULL)`
+      ).run();
+
+      clearDestinationDataPreservingSignIn(db);
+
+      expect(db.prepare(`SELECT COUNT(*) AS count FROM app_data`).get()).toEqual({ count: 0 });
+      expect(db.prepare(`SELECT COUNT(*) AS count FROM workspace_files`).get()).toEqual({
+        count: 0,
+      });
+      expect(db.prepare(`SELECT COUNT(*) AS count FROM workspace_file_index_meta`).get()).toEqual({
+        count: 0,
+      });
+      expect(
+        db
+          .prepare(`SELECT path FROM workspace_file_index WHERE workspace_file_index MATCH ?`)
+          .all('"a.ts"')
+      ).toEqual([]);
+      expect(() =>
+        db
+          .prepare(
+            `INSERT INTO workspace_file_index(workspace_file_index, rank) VALUES ('integrity-check', 1)`
+          )
+          .run()
+      ).not.toThrow();
+      expect(db.prepare(`SELECT value FROM kv WHERE key = ?`).get(PRESERVED_KV_KEYS[0])).toEqual({
+        value: 'kept',
+      });
     } finally {
       db.close();
     }

--- a/apps/emdash-desktop/src/main/db/legacy-port/reset.ts
+++ b/apps/emdash-desktop/src/main/db/legacy-port/reset.ts
@@ -1,4 +1,5 @@
 import type Database from 'better-sqlite3';
+import { createFileIndexSchema, FILE_INDEX_TABLES } from '../file-index-schema';
 import { quoteIdentifier, tableExists, withForeignKeysDisabled } from './sqlite-utils';
 
 export const PRESERVED_SECRET_KEYS = ['emdash-account-token', 'emdash-github-token'] as const;
@@ -34,8 +35,15 @@ export function listUserTables(sqlite: Database.Database): string[] {
 export function clearDestinationDataPreservingSignIn(sqlite: Database.Database): void {
   withForeignKeysDisabled(sqlite, () => {
     const tables = listUserTables(sqlite);
+    const fileIndexTables = new Set<string>(FILE_INDEX_TABLES);
+    const hasFileIndex = tables.some((table) => fileIndexTables.has(table));
     const clear = sqlite.transaction(() => {
       for (const table of tables) {
+        // The file index is an external-content FTS5 table synced by triggers:
+        // a plain DELETE on the virtual table followed by trigger-fired FTS
+        // 'delete' commands corrupts the index. Drop and recreate it instead.
+        if (fileIndexTables.has(table)) continue;
+
         if (table === 'app_secrets' && tableExists(sqlite, 'app_secrets')) {
           sqlite
             .prepare(
@@ -56,6 +64,8 @@ export function clearDestinationDataPreservingSignIn(sqlite: Database.Database):
 
         sqlite.prepare(`DELETE FROM ${quoteIdentifier(table)}`).run();
       }
+
+      if (hasFileIndex) createFileIndexSchema(sqlite);
     });
 
     clear();

--- a/apps/emdash-desktop/vitest.config.ts
+++ b/apps/emdash-desktop/vitest.config.ts
@@ -137,7 +137,7 @@ export default defineConfig({
             'src/renderer/tests/browser/**',
             'src/main/db/tests/migrations/**',
             'src/main/db/legacy-port/**/*.test.ts',
-            'src/main/core/**/*.db.test.ts',
+            'src/main/**/*.db.test.ts',
           ],
         },
       },
@@ -149,7 +149,7 @@ export default defineConfig({
         test: {
           name: 'main-db',
           environment: 'node',
-          include: ['src/main/core/**/*.db.test.ts', 'src/main/db/legacy-port/**/*.test.ts'],
+          include: ['src/main/**/*.db.test.ts', 'src/main/db/legacy-port/**/*.test.ts'],
         },
       },
       {


### PR DESCRIPTION
### Description

Every bookkeeping query on `workspace_file_index` filters by the `UNINDEXED` `workspace_id` column, which FTS5 can only resolve by scanning the entire trigram index (`EXPLAIN QUERY PLAN` → `SCAN workspace_file_index VIRTUAL TABLE INDEX 0`). At reporter scale (~1M rows, 1–2.5 GB DBs) each scan is seconds of disk-bound work executed synchronously via better-sqlite3 on the main process, freezing UI, IPC, and PTYs on every reindex. Still reproducible after the #2883 hotfix — the diffing sync full-scans per statement (`indexedPathSet` once per reindex, `deletePath` once per removed file, plus `countIndexedFiles`, `deleteSubtree`, evict loops, and the empty/LIKE search branches).

**Fix (as suggested in the issue):** back the FTS table with a plain `workspace_files` table with a `UNIQUE(workspace_id, path)` index, synced to an external-content FTS5 table via the standard AI/AD/AU triggers. Bookkeeping queries become indexed B-tree lookups; FTS deletes resolve by rowid instead of scanning. The FTS table name, column order, and MATCH query are unchanged, so search behavior and positional `bm25()` ranking are identical.

Implementation notes:

- `FILE_INDEX_VERSION` bumped `4` → `5`: existing (possibly multi-GB bloated) indexes are dropped and rebuilt on next launch — the issue's manual workaround, built in. No VACUUM: freed pages are reused so the file stops growing, but shrinking would block startup for minutes on the worst DBs.
- The DDL, previously duplicated verbatim in `initialize.ts` and both db tests, is consolidated into `src/main/db/file-index-schema.ts`.
- **`legacy-port/reset.ts` behavior change (load-bearing):** `clearDestinationDataPreservingSignIn` now skips the file-index tables in its delete loop and drop/recreates them instead. A plain `DELETE` on the external-content virtual table followed by trigger-fired FTS `'delete'` commands corrupts the index (`database disk image is malformed` — reproduced, regression test added).
- `insertPath` simplified to a single `INSERT … ON CONFLICT DO NOTHING` (the old existence pre-check was itself a full scan).
- vitest `.db.test.ts` globs widened from `src/main/core/**` to `src/main/**` so the new `initialize.db.test.ts` runs under the main-db project.

Measured at 1M rows (sqlite3 CLI, fully cached): single-path delete **106ms → 4ms**, per-workspace path-set select **83ms → 5ms**; whole-workspace delete unchanged. The reporters' disk-bound case was seconds per statement.

**High-risk areas touched:** `src/main/db/` (schema + version-gated rebuild), `legacy-port/reset.ts`. Known limitation (follow-up, matches the maintainers' plan in #2883): cold-reindex trigram *insert* cost still runs on the main process — this PR removes the scans, which are what escalated to multi-second freezes.

### Related issues

Fixes #2882.

### Testing

- `pnpm run format` / `pnpm run lint` / `pnpm run typecheck` — clean
- `pnpm vitest run --project main-db` — 167 passed, including new tests: an `EXPLAIN QUERY PLAN` regression test asserting no bookkeeping query scans the FTS table, FTS `integrity-check` after mutating operations, trigger-synced-delete search test, v4→v5 upgrade on a populated v4 DB, idempotence, and the reset-corruption test (fails with `SQLITE_CORRUPT` against the unfixed reset)
- `pnpm vitest run --project node` — 2021 passed; `--project migrations --project scripts` — 34 passed
- Manual smoke on macOS: ran the dev app against a `.backup` copy of a real production DB (64k FTS rows, 151 workspaces, v4) — index upgraded to v5 on boot, workspaces reindexed into `workspace_files` on activation (18.5k files, `complete`), command-palette trigram file search returns correct hits, UI responsive throughout

### Screenshot/Recording (if applicable)

From the manual smoke run on macOS, against a `.backup` copy of a real production DB (v4, 64k FTS rows) that the version gate upgraded to v5 on boot.

Command palette returning trigram FTS hits from the rebuilt v5 index (the hit happens to be this PR's new file):

<img width="1120" height="898" alt="obraz" src="https://github.com/user-attachments/assets/2175c5a6-6379-4063-91be-724679778a96" />


App booted on the upgraded DB, task view restored, workspace reindexed into `workspace_files` on activation:

<img width="1119" height="899" alt="obraz" src="https://github.com/user-attachments/assets/bdbb7c89-1865-4d35-b3e4-7f63278efe01" />


<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed (no doc changes needed — schema is internal; behavior documented in code comments)
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
