### PR TITLE
fix(markdown): increase checked checkbox contrast

### DIFF
--- a/apps/emdash-desktop/src/renderer/lib/ui/markdown-renderer.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/ui/markdown-renderer.tsx
@@ -277,12 +277,18 @@ function useFullComponents(
       strong: ({ children }: WithChildren) => (
         <strong className="font-semibold text-foreground">{children}</strong>
       ),
-      input: ({ checked, ...props }: React.ComponentPropsWithoutRef<'input'>) => (
+      input: ({
+        checked,
+        disabled: _disabled,
+        ...props
+      }: React.ComponentPropsWithoutRef<'input'>) => (
         <input
           type="checkbox"
           checked={checked}
-          disabled
-          className="mr-2 align-middle"
+          readOnly
+          aria-disabled="true"
+          tabIndex={-1}
+          className="pointer-events-none mr-2 align-middle checked:accent-foreground-info"
           {...props}
         />
       ),

--- a/apps/emdash-desktop/src/renderer/tests/markdown-renderer.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/markdown-renderer.test.ts
@@ -105,6 +105,19 @@ describe('MarkdownRenderer', () => {
     expect(html).toContain('Primary');
   });
 
+  it('uses the info accent for checked task list items', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(MarkdownRenderer, {
+        content: '- [ ] Pending\n- [x] Complete',
+      })
+    );
+
+    expect(html).toContain('checked:accent-foreground-info');
+    expect(html).toContain('checked=""');
+    expect(html).toContain('aria-disabled="true"');
+    expect(html).not.toContain('disabled=""');
+  });
+
   it('prevents browser navigation when a link handler claims a relative href', () => {
     const onOpenLink = vi.fn(() => true);
 


### PR DESCRIPTION
### Description
Improves the contrast between checked and unchecked task-list items rendered from Markdown.

Previously, Chromium rendered both states with the same neutral grey checkbox background because the inputs were natively disabled. Checked items were distinguishable only by the small checkmark.

This change:
- renders checked Markdown checkboxes using the existing blue info/link accent
- keeps unchecked checkboxes neutral
- preserves the non-interactive behavior using `readOnly`, `aria-disabled`, `tabIndex={-1}`, and disabled pointer events
- adds regression coverage for the checked-state styling and accessibility attributes

### Related issues
Discord

### Screenshot/Recording (if applicable)
before:
<img width="440" height="146" alt="image" src="https://github.com/user-attachments/assets/a8a52230-1fab-497f-bb62-ebeec75a76af" />

after:
<img width="440" height="146" alt="image" src="https://github.com/user-attachments/assets/50c2a43a-2dcb-4cd8-a34d-f68269212109" />

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
