### PR TITLE
fix(ui): prevent prompt links from opening on click

### DIFF
--- a/packages/ui/src/react/components/prompt-editor/prompt-editor.tsx
+++ b/packages/ui/src/react/components/prompt-editor/prompt-editor.tsx
@@ -281,6 +281,9 @@ export const PromptEditor = forwardRef<PromptEditorRef, PromptEditorProps>(funct
         orderedList: false,
         listItem: false,
         horizontalRule: false,
+        // Links remain visible, but clicking inside an editable prompt must place the cursor
+        // instead of opening an external URL.
+        link: { openOnClick: false },
       }),
       mentionExtension,
       slashExtension,


### PR DESCRIPTION
### Description
Prevent automatically detected links from opening when clicked inside editable prompt fields.

TipTap's `StarterKit` automatically converts domain-like text such as `block.edu` into a link. Its Link extension also enables `openOnClick` by default.

As a result, clicking linked text while editing a task prompt opened Emdash's external-link confirmation dialog instead of positioning the cursor for editing.

This PR disables `openOnClick` for links inside `PromptEditor`.

Links remain automatically detected and visually linkified, but clicking them while editing now keeps focus in the editor and positions the cursor without opening the URL.

This change only affects editable prompt fields, including:

- Create New Task prompts
- Automation prompts
- The ACP chat composer

It does not affect links in read-only output surfaces:

- Terminal and TUI links remain clickable
- ACP agent output links remain clickable
- Links in already-sent messages remain clickable
- File and resource links continue to use their existing handlers

### Related issues
ENG-1958

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
