### PR TITLE
fix(ui): center switch thumb vertically

### DIFF
--- a/apps/emdash-desktop/src/renderer/lib/ui/switch.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/ui/switch.tsx
@@ -13,7 +13,7 @@ function Switch({
       data-slot="switch"
       data-size={size}
       className={cn(
-        'peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-border-1 transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:ring-destructive/40 data-checked:bg-background-neutral data-unchecked:bg-background data-disabled:cursor-not-allowed data-disabled:opacity-50',
+        'peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-border-1 transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:ring-destructive/40 data-checked:bg-background-neutral data-unchecked:bg-background data-disabled:cursor-not-allowed data-disabled:opacity-50',
         className
       )}
       onKeyDown={(e) => {


### PR DESCRIPTION
### Description
Fixes the vertical alignment of the default switch thumb by changing the track height from 18.4px to 18px.

The previous fractional height caused asymmetric subpixel rounding between the 16px thumb and the switch border, making the off-state appear vertically misaligned.

### Screenshot/Recording (if applicable)
before:
<img width="102" height="122" alt="image" src="https://github.com/user-attachments/assets/25e53e34-b0e3-4311-8f40-91855eff120d" />

after:
<img width="70" height="97" alt="image" src="https://github.com/user-attachments/assets/eff17eb5-3f22-4e42-a643-8bc2c4cb38ac" />

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
