### PR TITLE
fix(modal): prevent stuck close transitions

### DIFF
--- a/apps/emdash-desktop/src/renderer/lib/modal/modal-renderer.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/modal/modal-renderer.tsx
@@ -24,6 +24,8 @@ const POSITION_CLASSES: Record<ModalPosition, string> = {
   top: 'top-[15%] translate-y-0',
 };
 
+const CLOSE_ANIMATION_FALLBACK_MS = 200;
+
 export const ModalRenderer = observer(function ModalRenderer() {
   const entry = (
     modalStore.activeModalId
@@ -33,8 +35,8 @@ export const ModalRenderer = observer(function ModalRenderer() {
   // oxlint-disable-next-line typescript/no-explicit-any
   const Component = entry?.component as React.ComponentType<any> | undefined;
 
-  // Preserve the last rendered content and entry config until Base UI unmounts the closed popup,
-  // rather than briefly collapsing it while the close lifecycle completes.
+  // Preserve the last rendered content and entry config so the close animation plays with the
+  // correct dimensions and full content rather than collapsing while the popup fades out.
   // oxlint-disable-next-line typescript/no-explicit-any
   const lastComponentRef = useRef<React.ComponentType<any> | null>(null);
   const lastArgsRef = useRef<Record<string, unknown> | null>(null);
@@ -52,8 +54,23 @@ export const ModalRenderer = observer(function ModalRenderer() {
   const activeModalId = modalStore.activeModalId;
   const activeEntryRef = useRef<ModalRegistryEntry | null>(null);
   const ignoreNextOutsidePressRef = useRef(false);
+  const popupRef = useRef<HTMLDivElement>(null);
+  const dialogActionsRef = useRef<DialogPrimitive.Root.Actions>(null);
+  const isOpen = modalStore.isOpen;
 
   activeEntryRef.current = entry;
+
+  useEffect(() => {
+    if (isOpen) return;
+
+    const timeout = window.setTimeout(() => {
+      if (!modalStore.isOpen && popupRef.current?.hasAttribute('data-closed')) {
+        dialogActionsRef.current?.unmount();
+      }
+    }, CLOSE_ANIMATION_FALLBACK_MS);
+
+    return () => window.clearTimeout(timeout);
+  }, [isOpen]);
 
   useEffect(() => {
     ignoreNextOutsidePressRef.current = false;
@@ -92,8 +109,6 @@ export const ModalRenderer = observer(function ModalRenderer() {
     }
   };
 
-  const popupRef = useRef<HTMLDivElement>(null);
-
   // Restore focus to the element captured by modalStore.setModal when the modal closes.
   useEffect(
     () =>
@@ -122,9 +137,9 @@ export const ModalRenderer = observer(function ModalRenderer() {
   }, []);
 
   return (
-    <Dialog open={modalStore.isOpen} onOpenChange={handleOpenChange}>
+    <Dialog actionsRef={dialogActionsRef} open={modalStore.isOpen} onOpenChange={handleOpenChange}>
       <DialogPortal>
-        <DialogOverlay className="data-closed:animate-none" />
+        <DialogOverlay />
         <DialogPrimitive.Popup
           ref={popupRef}
           finalFocus={false}
@@ -141,7 +156,7 @@ export const ModalRenderer = observer(function ModalRenderer() {
             }
           }}
           className={cn(
-            'fixed left-1/2 z-50 flex max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] -translate-x-1/2 flex-col overflow-hidden rounded-xl bg-background-quaternary text-sm ring-1 ring-foreground/10 duration-100 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95',
+            'fixed left-1/2 z-50 flex max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] -translate-x-1/2 flex-col overflow-hidden rounded-xl bg-background-quaternary text-sm ring-1 ring-foreground/10 duration-100 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
             POSITION_CLASSES[displayEntry?.position ?? 'center'],
             SIZE_CLASSES[displayEntry?.size ?? 'md']
           )}

--- a/apps/emdash-desktop/src/renderer/lib/modal/modal-renderer.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/modal/modal-renderer.tsx
@@ -33,8 +33,8 @@ export const ModalRenderer = observer(function ModalRenderer() {
   // oxlint-disable-next-line typescript/no-explicit-any
   const Component = entry?.component as React.ComponentType<any> | undefined;
 
-  // Preserve the last rendered content and entry config so the close animation plays with the
-  // correct dimensions and full content rather than collapsing while the popup fades out.
+  // Preserve the last rendered content and entry config until Base UI unmounts the closed popup,
+  // rather than briefly collapsing it while the close lifecycle completes.
   // oxlint-disable-next-line typescript/no-explicit-any
   const lastComponentRef = useRef<React.ComponentType<any> | null>(null);
   const lastArgsRef = useRef<Record<string, unknown> | null>(null);
@@ -124,7 +124,7 @@ export const ModalRenderer = observer(function ModalRenderer() {
   return (
     <Dialog open={modalStore.isOpen} onOpenChange={handleOpenChange}>
       <DialogPortal>
-        <DialogOverlay />
+        <DialogOverlay className="data-closed:animate-none" />
         <DialogPrimitive.Popup
           ref={popupRef}
           finalFocus={false}
@@ -141,7 +141,7 @@ export const ModalRenderer = observer(function ModalRenderer() {
             }
           }}
           className={cn(
-            'fixed left-1/2 z-50 flex max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] -translate-x-1/2 flex-col overflow-hidden rounded-xl bg-background-quaternary text-sm ring-1 ring-foreground/10 duration-100 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+            'fixed left-1/2 z-50 flex max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] -translate-x-1/2 flex-col overflow-hidden rounded-xl bg-background-quaternary text-sm ring-1 ring-foreground/10 duration-100 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95',
             POSITION_CLASSES[displayEntry?.position ?? 'center'],
             SIZE_CLASSES[displayEntry?.size ?? 'md']
           )}

--- a/apps/emdash-desktop/src/renderer/tests/browser/modal-renderer.test.tsx
+++ b/apps/emdash-desktop/src/renderer/tests/browser/modal-renderer.test.tsx
@@ -37,7 +37,7 @@ describe('ModalRenderer', () => {
     host.remove();
   });
 
-  it('does not wait for a close animation when removing a modal', async () => {
+  it('force-unmounts a closed modal when its exit animation stalls', async () => {
     await act(async () => {
       root.render(<ModalRenderer />);
       modalStore.setModal('testModal', { label: 'Create task' });
@@ -45,22 +45,14 @@ describe('ModalRenderer', () => {
 
     const popup = document.querySelector<HTMLElement>('[data-slot="dialog-content"]');
     expect(popup).not.toBeNull();
-    expect(popup?.classList).not.toContain('data-closed:animate-out');
-    expect(
-      document.querySelector<HTMLElement>('[data-slot="dialog-overlay"]')?.classList
-    ).toContain('data-closed:animate-none');
 
-    const getAnimations = vi.fn(() =>
-      popup?.classList.contains('data-closed:animate-out')
-        ? [
-            {
-              finished: new Promise<Animation>(() => {}),
-              pending: false,
-              playState: 'running',
-            } as Animation,
-          ]
-        : []
-    );
+    const getAnimations = vi.fn(() => [
+      {
+        finished: new Promise<Animation>(() => {}),
+        pending: false,
+        playState: 'running',
+      } as Animation,
+    ]);
     Object.defineProperty(popup, 'getAnimations', { configurable: true, value: getAnimations });
 
     await act(async () => {
@@ -70,7 +62,44 @@ describe('ModalRenderer', () => {
 
     expect(modalStore.isOpen).toBe(false);
     expect(getAnimations).toHaveBeenCalled();
+    expect(document.querySelector('[data-slot="dialog-content"]')).not.toBeNull();
+
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 200));
+    });
+
     expect(document.querySelector('[data-slot="dialog-content"]')).toBeNull();
     expect(document.querySelector('[data-slot="dialog-overlay"]')).toBeNull();
+  });
+
+  it('does not let a stale close fallback unmount a reopened modal', async () => {
+    await act(async () => {
+      root.render(<ModalRenderer />);
+      modalStore.setModal('testModal', { label: 'First task' });
+    });
+
+    const popup = document.querySelector<HTMLElement>('[data-slot="dialog-content"]')!;
+    Object.defineProperty(popup, 'getAnimations', {
+      configurable: true,
+      value: () => [
+        {
+          finished: new Promise<Animation>(() => {}),
+          pending: false,
+          playState: 'running',
+        } as Animation,
+      ],
+    });
+
+    await act(async () => {
+      modalStore.closeModal('completed');
+      await new Promise((resolve) => window.setTimeout(resolve, 100));
+      modalStore.setModal('testModal', { label: 'Second task' });
+      await new Promise((resolve) => window.setTimeout(resolve, 150));
+    });
+
+    expect(modalStore.isOpen).toBe(true);
+    expect(document.querySelector('[data-slot="dialog-content"]')?.textContent).toContain(
+      'Second task'
+    );
   });
 });

--- a/apps/emdash-desktop/src/renderer/tests/browser/modal-renderer.test.tsx
+++ b/apps/emdash-desktop/src/renderer/tests/browser/modal-renderer.test.tsx
@@ -1,0 +1,76 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ModalRenderer } from '@renderer/lib/modal/modal-renderer';
+import { modalStore } from '@renderer/lib/modal/modal-store';
+
+vi.mock('@renderer/app/modal-registry', () => ({
+  modalRegistry: {
+    testModal: {
+      component: ({ label }: { label: string }) => <div>{label}</div>,
+      size: 'sm',
+    },
+  },
+}));
+
+beforeAll(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+describe('ModalRenderer', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      modalStore.closeModal();
+      root.unmount();
+    });
+    host.remove();
+  });
+
+  it('does not wait for a close animation when removing a modal', async () => {
+    await act(async () => {
+      root.render(<ModalRenderer />);
+      modalStore.setModal('testModal', { label: 'Create task' });
+    });
+
+    const popup = document.querySelector<HTMLElement>('[data-slot="dialog-content"]');
+    expect(popup).not.toBeNull();
+    expect(popup?.classList).not.toContain('data-closed:animate-out');
+    expect(
+      document.querySelector<HTMLElement>('[data-slot="dialog-overlay"]')?.classList
+    ).toContain('data-closed:animate-none');
+
+    const getAnimations = vi.fn(() =>
+      popup?.classList.contains('data-closed:animate-out')
+        ? [
+            {
+              finished: new Promise<Animation>(() => {}),
+              pending: false,
+              playState: 'running',
+            } as Animation,
+          ]
+        : []
+    );
+    Object.defineProperty(popup, 'getAnimations', { configurable: true, value: getAnimations });
+
+    await act(async () => {
+      modalStore.closeModal('completed');
+      await new Promise((resolve) => window.setTimeout(resolve, 50));
+    });
+
+    expect(modalStore.isOpen).toBe(false);
+    expect(getAnimations).toHaveBeenCalled();
+    expect(document.querySelector('[data-slot="dialog-content"]')).toBeNull();
+    expect(document.querySelector('[data-slot="dialog-overlay"]')).toBeNull();
+  });
+});


### PR DESCRIPTION
### Description
Fixes an intermittent issue where the Create Task modal could remain visibly stuck after task creation even though the modal state was already closed.

Base UI waits for the dialog's close animation before unmounting it. If Chromium leaves the animation completion pending under renderer lag, the closed popup can remain in the DOM indefinitely.

This change preserves the existing 100ms close animation and adds a guarded 200ms fallback using Base UI's `actionsRef.unmount()`. The fallback only runs when the modal store is still closed and the popup is still mounted with `data-closed`, so normal closes and reopened modals keep their existing behavior.

### Related issues
Fixes [ENG-1928](https://linear.app/general-action/issue/ENG-1928/create-modal-gets-stuck)

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
