### PR TITLE
fix(chat-ui): tighten execute command spacing

### DIFF
--- a/packages/chat-ui/src/components/rows/tools/execute/Execute.tsx
+++ b/packages/chat-ui/src/components/rows/tools/execute/Execute.tsx
@@ -86,6 +86,7 @@ export function ExecuteBody(props: ExecuteBodyProps) {
       class={executeBody}
       style={{
         height: `${props.bodyH}px`,
+        'padding-bottom': `${props.scrollbarH}px`,
         '--execute-scrollbar-size': `${props.scrollbarH}px`,
         'overflow-x': 'auto',
         'overflow-y': props.expanded && overflows() ? 'auto' : 'hidden',

--- a/packages/chat-ui/src/components/rows/tools/execute/Execute.tsx
+++ b/packages/chat-ui/src/components/rows/tools/execute/Execute.tsx
@@ -88,9 +88,6 @@ export function ExecuteBody(props: ExecuteBodyProps) {
       style={{
         height: `${props.bodyH + props.scrollbarH}px`,
         '--execute-scrollbar-size': `${props.scrollbarSize}px`,
-        display: !props.expanded ? 'flex' : undefined,
-        'flex-direction': !props.expanded ? 'column' : undefined,
-        'justify-content': !props.expanded ? 'center' : undefined,
         'overflow-x': 'auto',
         'overflow-y': props.expanded && overflows() ? 'auto' : 'hidden',
       }}

--- a/packages/chat-ui/src/components/rows/tools/execute/Execute.tsx
+++ b/packages/chat-ui/src/components/rows/tools/execute/Execute.tsx
@@ -37,7 +37,6 @@ export type ExecuteBodyProps = {
   codeLineH: number;
   linePadX: number;
   scrollbarH: number;
-  scrollbarGap: number;
   expanded: boolean;
 };
 
@@ -87,7 +86,6 @@ export function ExecuteBody(props: ExecuteBodyProps) {
       class={executeBody}
       style={{
         height: `${props.bodyH}px`,
-        'padding-bottom': `${props.scrollbarH + props.scrollbarGap}px`,
         '--execute-scrollbar-size': `${props.scrollbarH}px`,
         'overflow-x': 'auto',
         'overflow-y': props.expanded && overflows() ? 'auto' : 'hidden',

--- a/packages/chat-ui/src/components/rows/tools/execute/Execute.tsx
+++ b/packages/chat-ui/src/components/rows/tools/execute/Execute.tsx
@@ -36,6 +36,7 @@ export type ExecuteBodyProps = {
   contentH: number;
   codeLineH: number;
   linePadX: number;
+  scrollbarSize: number;
   scrollbarH: number;
   expanded: boolean;
 };
@@ -85,9 +86,11 @@ export function ExecuteBody(props: ExecuteBodyProps) {
     <div
       class={executeBody}
       style={{
-        height: `${props.bodyH}px`,
-        'padding-bottom': `${props.scrollbarH}px`,
-        '--execute-scrollbar-size': `${props.scrollbarH}px`,
+        height: `${props.bodyH + props.scrollbarH}px`,
+        '--execute-scrollbar-size': `${props.scrollbarSize}px`,
+        display: !props.expanded ? 'flex' : undefined,
+        'flex-direction': !props.expanded ? 'column' : undefined,
+        'justify-content': !props.expanded ? 'center' : undefined,
         'overflow-x': 'auto',
         'overflow-y': props.expanded && overflows() ? 'auto' : 'hidden',
       }}

--- a/packages/chat-ui/src/components/rows/tools/execute/execute.def.tsx
+++ b/packages/chat-ui/src/components/rows/tools/execute/execute.def.tsx
@@ -35,6 +35,27 @@ const EXECUTE_VARS: ExecuteVars = {
   expandedMaxLines: 16,
 };
 
+let measuredScrollbarH: number | undefined;
+
+function scrollbarClearance(maxSize: number): number {
+  if (typeof document === 'undefined' || !document.body) return maxSize;
+  if (measuredScrollbarH === undefined) {
+    const probe = document.createElement('div');
+    Object.assign(probe.style, {
+      position: 'absolute',
+      visibility: 'hidden',
+      width: '100px',
+      height: '100px',
+      overflow: 'scroll',
+      scrollbarWidth: 'thin',
+    });
+    document.body.appendChild(probe);
+    measuredScrollbarH = probe.offsetHeight - probe.clientHeight;
+    probe.remove();
+  }
+  return Math.min(measuredScrollbarH, maxSize);
+}
+
 /** 3 borders: top card edge + header-separator + bottom card edge. */
 function chromeY(vars: ExecuteVars): number {
   return 3 * vars.border;
@@ -135,7 +156,9 @@ function scrollbarSpace(
   hasVerticalOverflow: boolean
 ): number {
   const verticalScrollbarW = hasVerticalOverflow ? vars.scrollbarSize : 0;
-  return hasHorizontalOverflow(lines, ctx, vars, verticalScrollbarW) ? vars.scrollbarSize : 0;
+  return hasHorizontalOverflow(lines, ctx, vars, verticalScrollbarW)
+    ? scrollbarClearance(vars.scrollbarSize)
+    : 0;
 }
 
 function executeUnitH(item: ChatExecute, ctx: MeasureCtx, vars: ExecuteVars): number {
@@ -207,7 +230,8 @@ function ExecuteUnitRender(props: { data: ChatExecute; ctx: RenderCtx; vars: Exe
           contentH={bodyGeometry().contentH}
           codeLineH={codeLineH()}
           linePadX={props.vars.linePadX}
-          scrollbarH={showScrollbar() ? props.vars.scrollbarSize : 0}
+          scrollbarSize={showScrollbar() ? props.vars.scrollbarSize : 0}
+          scrollbarH={showScrollbar() ? scrollbarClearance(props.vars.scrollbarSize) : 0}
           expanded={isExpanded()}
         />
       </Show>

--- a/packages/chat-ui/src/components/rows/tools/execute/execute.def.tsx
+++ b/packages/chat-ui/src/components/rows/tools/execute/execute.def.tsx
@@ -40,6 +40,7 @@ let measuredScrollbarH: number | undefined;
 function scrollbarClearance(maxSize: number): number {
   if (typeof document === 'undefined' || !document.body) return maxSize;
   if (measuredScrollbarH === undefined) {
+    // Overlay scrollbars consume no layout height; classic scrollbars do.
     const probe = document.createElement('div');
     Object.assign(probe.style, {
       position: 'absolute',
@@ -109,36 +110,6 @@ function executeLineWidth(text: string, ctx: MeasureCtx): number {
   return measureProseNaturalWidth(block, codeFonts);
 }
 
-function wrapExpandedCommand(
-  lines: ExecuteDisplayLine[],
-  ctx: MeasureCtx,
-  vars: ExecuteVars
-): ExecuteDisplayLine[] {
-  const availableWidth = ctx.width - 2 * vars.border - 2 * vars.linePadX;
-  const charWidth = executeLineWidth('M', ctx);
-  const maxChars = Math.max(1, Math.floor(availableWidth / charWidth));
-
-  return lines.flatMap((line) => {
-    if (line.kind !== 'command' || executeLineWidth(line.text, ctx) <= availableWidth) return line;
-
-    let characters = Array.from(line.text);
-    const wrapped: ExecuteDisplayLine[] = [];
-    while (characters.length > maxChars) {
-      let breakAt = maxChars;
-      for (let index = maxChars - 1; index > 0; index--) {
-        if (/\s/.test(characters[index])) {
-          breakAt = index + 1;
-          break;
-        }
-      }
-      wrapped.push({ kind: 'command', text: characters.slice(0, breakAt).join('') });
-      characters = characters.slice(breakAt);
-    }
-    wrapped.push({ kind: 'command', text: characters.join('') });
-    return wrapped;
-  });
-}
-
 function hasHorizontalOverflow(
   lines: ExecuteDisplayLine[],
   ctx: MeasureCtx,
@@ -163,8 +134,7 @@ function scrollbarSpace(
 
 function executeUnitH(item: ChatExecute, ctx: MeasureCtx, vars: ExecuteVars): number {
   const isExpanded = ctx.expanded(item.id);
-  const sourceLines = executeLines(item, isExpanded);
-  const lines = isExpanded ? wrapExpandedCommand(sourceLines, ctx, vars) : sourceLines;
+  const lines = executeLines(item, isExpanded);
   const { bodyH, contentH } = executeBodyH(
     lines,
     ctx.theme.fonts.code.lineHeight,
@@ -180,11 +150,7 @@ function ExecuteUnitRender(props: { data: ChatExecute; ctx: RenderCtx; vars: Exe
   // Inverted semantics: stored "collapsed" bool = "expanded".
   const isExpanded = () => props.ctx.viewState.isCollapsed(props.data.id);
 
-  const lines = createMemo(() => {
-    const sourceLines = executeLines(props.data, isExpanded());
-    const ctx = mCtx();
-    return isExpanded() && ctx ? wrapExpandedCommand(sourceLines, ctx, props.vars) : sourceLines;
-  });
+  const lines = createMemo(() => executeLines(props.data, isExpanded()));
   const codeLineH = createMemo(() => {
     const ctx = mCtx();
     return ctx?.theme.fonts.code.lineHeight ?? 0;

--- a/packages/chat-ui/src/components/rows/tools/execute/execute.def.tsx
+++ b/packages/chat-ui/src/components/rows/tools/execute/execute.def.tsx
@@ -128,12 +128,28 @@ function hasHorizontalOverflow(
   return lines.some((line) => executeLineWidth(line.text, ctx) > availableWidth);
 }
 
+function scrollbarSpace(
+  lines: ExecuteDisplayLine[],
+  ctx: MeasureCtx,
+  vars: ExecuteVars,
+  hasVerticalOverflow: boolean
+): number {
+  const verticalScrollbarW = hasVerticalOverflow ? vars.scrollbarSize : 0;
+  return hasHorizontalOverflow(lines, ctx, vars, verticalScrollbarW) ? vars.scrollbarSize : 0;
+}
+
 function executeUnitH(item: ChatExecute, ctx: MeasureCtx, vars: ExecuteVars): number {
   const isExpanded = ctx.expanded(item.id);
   const sourceLines = executeLines(item, isExpanded);
   const lines = isExpanded ? wrapExpandedCommand(sourceLines, ctx, vars) : sourceLines;
-  const { bodyH } = executeBodyH(lines, ctx.theme.fonts.code.lineHeight, isExpanded, vars);
-  return vars.rowH + bodyH + chromeY(vars);
+  const { bodyH, contentH } = executeBodyH(
+    lines,
+    ctx.theme.fonts.code.lineHeight,
+    isExpanded,
+    vars
+  );
+  const hasVerticalOverflow = isExpanded && contentH > bodyH;
+  return vars.rowH + bodyH + scrollbarSpace(lines, ctx, vars, hasVerticalOverflow) + chromeY(vars);
 }
 
 function ExecuteUnitRender(props: { data: ChatExecute; ctx: RenderCtx; vars: ExecuteVars }) {
@@ -208,7 +224,7 @@ export const executeUnitDef = defineUnit<ChatExecute, ExecuteVars>({
     // Use the collapsed line cap and current width for stable initial geometry.
     const lines = executeLines(item, false);
     const { bodyH } = executeBodyH(lines, ctx.theme.fonts.code.lineHeight, false, vars);
-    return vars.rowH + bodyH + chromeY(vars);
+    return vars.rowH + bodyH + scrollbarSpace(lines, ctx, vars, false) + chromeY(vars);
   },
 
   measure(item, ctx, vars): number {

--- a/packages/chat-ui/src/components/rows/tools/execute/execute.def.tsx
+++ b/packages/chat-ui/src/components/rows/tools/execute/execute.def.tsx
@@ -20,8 +20,6 @@ export type ExecuteVars = {
   linePadX: number;
   /** Width and height of the thin native scrollbar. */
   scrollbarSize: number;
-  /** Visual separation between command text and the horizontal scrollbar. */
-  scrollbarGap: number;
   /** Max lines shown in the collapsed (preview) state. */
   collapsedMaxLines: number;
   /** Max lines shown / scrollable in the expanded state. */
@@ -32,8 +30,7 @@ const EXECUTE_VARS: ExecuteVars = {
   rowH: ROW_H,
   border: 1,
   linePadX: 12,
-  scrollbarSize: 8,
-  scrollbarGap: 3,
+  scrollbarSize: 6,
   collapsedMaxLines: 2,
   expandedMaxLines: 16,
 };
@@ -52,13 +49,15 @@ function outputLines(outputText: string | undefined): string[] {
   return outputText.replace(/\r\n/g, '\n').split('\n');
 }
 
-function executeLines(item: ChatExecute): ExecuteDisplayLine[] {
+function executeLines(item: ChatExecute, isExpanded: boolean): ExecuteDisplayLine[] {
   const command = commandLines(item.command).map(
     (line, index): ExecuteDisplayLine => ({
       kind: 'command',
       text: `${index === 0 ? '$' : ' '} ${line}`,
     })
   );
+  if (!isExpanded) return command;
+
   const output = outputLines(item.outputText).map(
     (line): ExecuteDisplayLine => ({ kind: 'output', text: line })
   );
@@ -78,6 +77,47 @@ function executeBodyH(
   return { bodyH, contentH };
 }
 
+function executeLineWidth(text: string, ctx: MeasureCtx): number {
+  const block: ProseBlock = {
+    kind: 'prose',
+    id: 'execute-width',
+    variant: 'body',
+    runs: [{ kind: 'text', text }],
+  };
+  const codeFonts = { ...ctx.theme.fonts, body: ctx.theme.fonts.code };
+  return measureProseNaturalWidth(block, codeFonts);
+}
+
+function wrapExpandedCommand(
+  lines: ExecuteDisplayLine[],
+  ctx: MeasureCtx,
+  vars: ExecuteVars
+): ExecuteDisplayLine[] {
+  const availableWidth = ctx.width - 2 * vars.border - 2 * vars.linePadX;
+  const charWidth = executeLineWidth('M', ctx);
+  const maxChars = Math.max(1, Math.floor(availableWidth / charWidth));
+
+  return lines.flatMap((line) => {
+    if (line.kind !== 'command' || executeLineWidth(line.text, ctx) <= availableWidth) return line;
+
+    let characters = Array.from(line.text);
+    const wrapped: ExecuteDisplayLine[] = [];
+    while (characters.length > maxChars) {
+      let breakAt = maxChars;
+      for (let index = maxChars - 1; index > 0; index--) {
+        if (/\s/.test(characters[index])) {
+          breakAt = index + 1;
+          break;
+        }
+      }
+      wrapped.push({ kind: 'command', text: characters.slice(0, breakAt).join('') });
+      characters = characters.slice(breakAt);
+    }
+    wrapped.push({ kind: 'command', text: characters.join('') });
+    return wrapped;
+  });
+}
+
 function hasHorizontalOverflow(
   lines: ExecuteDisplayLine[],
   ctx: MeasureCtx,
@@ -85,42 +125,15 @@ function hasHorizontalOverflow(
   verticalScrollbarW: number
 ): boolean {
   const availableWidth = ctx.width - 2 * vars.border - 2 * vars.linePadX - verticalScrollbarW;
-  const codeFonts = { ...ctx.theme.fonts, body: ctx.theme.fonts.code };
-
-  return lines.some((line) => {
-    const block: ProseBlock = {
-      kind: 'prose',
-      id: 'execute-width',
-      variant: 'body',
-      runs: [{ kind: 'text', text: line.text }],
-    };
-    return measureProseNaturalWidth(block, codeFonts) > availableWidth;
-  });
-}
-
-function scrollbarSpace(
-  lines: ExecuteDisplayLine[],
-  ctx: MeasureCtx,
-  vars: ExecuteVars,
-  hasVerticalOverflow: boolean
-): number {
-  const verticalScrollbarW = hasVerticalOverflow ? vars.scrollbarSize : 0;
-  return hasHorizontalOverflow(lines, ctx, vars, verticalScrollbarW)
-    ? vars.scrollbarGap + vars.scrollbarSize
-    : 0;
+  return lines.some((line) => executeLineWidth(line.text, ctx) > availableWidth);
 }
 
 function executeUnitH(item: ChatExecute, ctx: MeasureCtx, vars: ExecuteVars): number {
   const isExpanded = ctx.expanded(item.id);
-  const lines = executeLines(item);
-  const { bodyH, contentH } = executeBodyH(
-    lines,
-    ctx.theme.fonts.code.lineHeight,
-    isExpanded,
-    vars
-  );
-  const hasVerticalOverflow = isExpanded && contentH > bodyH;
-  return vars.rowH + bodyH + scrollbarSpace(lines, ctx, vars, hasVerticalOverflow) + chromeY(vars);
+  const sourceLines = executeLines(item, isExpanded);
+  const lines = isExpanded ? wrapExpandedCommand(sourceLines, ctx, vars) : sourceLines;
+  const { bodyH } = executeBodyH(lines, ctx.theme.fonts.code.lineHeight, isExpanded, vars);
+  return vars.rowH + bodyH + chromeY(vars);
 }
 
 function ExecuteUnitRender(props: { data: ChatExecute; ctx: RenderCtx; vars: ExecuteVars }) {
@@ -128,8 +141,15 @@ function ExecuteUnitRender(props: { data: ChatExecute; ctx: RenderCtx; vars: Exe
   // Inverted semantics: stored "collapsed" bool = "expanded".
   const isExpanded = () => props.ctx.viewState.isCollapsed(props.data.id);
 
-  const lines = createMemo(() => executeLines(props.data));
-  const codeLineH = createMemo(() => mCtx()?.theme.fonts.code.lineHeight ?? 0);
+  const lines = createMemo(() => {
+    const sourceLines = executeLines(props.data, isExpanded());
+    const ctx = mCtx();
+    return isExpanded() && ctx ? wrapExpandedCommand(sourceLines, ctx, props.vars) : sourceLines;
+  });
+  const codeLineH = createMemo(() => {
+    const ctx = mCtx();
+    return ctx?.theme.fonts.code.lineHeight ?? 0;
+  });
   const bodyGeometry = createMemo(() => {
     const lineH = codeLineH();
     if (!lineH) return { bodyH: 0, contentH: 0 };
@@ -172,7 +192,6 @@ function ExecuteUnitRender(props: { data: ChatExecute; ctx: RenderCtx; vars: Exe
           codeLineH={codeLineH()}
           linePadX={props.vars.linePadX}
           scrollbarH={showScrollbar() ? props.vars.scrollbarSize : 0}
-          scrollbarGap={showScrollbar() ? props.vars.scrollbarGap : 0}
           expanded={isExpanded()}
         />
       </Show>
@@ -187,11 +206,9 @@ export const executeUnitDef = defineUnit<ChatExecute, ExecuteVars>({
 
   estimate(item, ctx, vars): number {
     // Use the collapsed line cap and current width for stable initial geometry.
-    const lines = executeLines(item);
-    // Approximate code line height — use a fixed fallback of 20px for estimate.
-    const approxLineH = 20;
-    const { bodyH } = executeBodyH(lines, approxLineH, false, vars);
-    return vars.rowH + bodyH + scrollbarSpace(lines, ctx, vars, false) + chromeY(vars);
+    const lines = executeLines(item, false);
+    const { bodyH } = executeBodyH(lines, ctx.theme.fonts.code.lineHeight, false, vars);
+    return vars.rowH + bodyH + chromeY(vars);
   },
 
   measure(item, ctx, vars): number {

--- a/packages/chat-ui/src/stories/rows/tools/execute.stories.tsx
+++ b/packages/chat-ui/src/stories/rows/tools/execute.stories.tsx
@@ -153,6 +153,45 @@ export const LongCommand: Story = {
   ),
 };
 
+/** Completed commands stay compact regardless of command length or captured output. */
+export const CommandLengths: Story = {
+  render: () => (
+    <ChatHost
+      items={[
+        {
+          kind: 'execute',
+          id: 'ex-length-short',
+          command: 'git status',
+          outputText: 'On branch main\nnothing to commit, working tree clean',
+          status: 'done',
+          startedAt: Date.now() - 900,
+          durationMs: 900,
+        },
+        {
+          kind: 'execute',
+          id: 'ex-length-medium',
+          command: 'git diff .gitignore',
+          outputText: 'diff --git a/.gitignore b/.gitignore',
+          status: 'done',
+          startedAt: Date.now() - 1200,
+          durationMs: 1200,
+        },
+        {
+          kind: 'execute',
+          id: 'ex-length-long',
+          command:
+            'find . -type f -name "*.ts" | xargs grep -l "import.*from.*solid-js" --color=never',
+          outputText: 'packages/chat-ui/src/index.tsx',
+          status: 'done',
+          startedAt: Date.now() - 1800,
+          durationMs: 1800,
+        },
+      ]}
+      height={280}
+    />
+  ),
+};
+
 /**
  * Multi-line command — exercises:
  *  - Collapsed cap (3 lines with fade overlay).


### PR DESCRIPTION
### Description
Reduces unnecessary bottom spacing in collapsed Execute cards while keeping long commands fully accessible.

- Measures only visible command lines while collapsed instead of hidden output and spacer lines
- Keeps short, medium, and long commands at a consistent compact height
- Preserves horizontal scrolling for long commands
- Reserves scrollbar clearance only when the browser’s native scrollbar actually consumes layout space
- Keeps captured output available in the expanded state

### Screenshot/Recording (if applicable)
before:
<img width="706" height="217" alt="image" src="https://github.com/user-attachments/assets/261ed8a2-94c9-4b48-8629-57e40d8567fa" />

after:
<img width="680" height="235" alt="image" src="https://github.com/user-attachments/assets/c39b87e6-1450-46fd-88b8-c0bc7e797f45" />

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
