### PR TITLE
fix(windows): support npm shims in agent authentication

### DIFF
--- a/packages/core/src/agents/plugins/capabilities/auth.ts
+++ b/packages/core/src/agents/plugins/capabilities/auth.ts
@@ -63,7 +63,12 @@ export type AgentAuthContext = {
   exec: (
     command: string,
     args?: string[],
-    opts?: { timeout?: number; maxBuffer?: number; signal?: AbortSignal }
+    opts?: {
+      timeout?: number;
+      maxBuffer?: number;
+      signal?: AbortSignal;
+      windowsScript?: 'trusted';
+    }
   ) => Promise<{ stdout: string; stderr: string }>;
   fs: PluginFs;
   env: Record<string, string>;

--- a/packages/core/src/exec/execution-context.ts
+++ b/packages/core/src/exec/execution-context.ts
@@ -11,6 +11,7 @@ export type ExecContextOptions = {
   timeout?: number;
   maxBuffer?: number;
   signal?: AbortSignal;
+  windowsScript?: 'trusted';
 };
 
 /**

--- a/packages/core/src/exec/node-execution-context.test.ts
+++ b/packages/core/src/exec/node-execution-context.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { NodeExecutionContext } from './node-execution-context';
+import { resolveWindowsScriptCommand } from './windows-script-command';
+
+const { execFileAsyncMock } = vi.hoisted(() => ({
+  execFileAsyncMock: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+vi.mock('node:util', () => ({
+  promisify: () => execFileAsyncMock,
+}));
+
+const originalPlatform = process.platform;
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', { value: originalPlatform });
+  vi.clearAllMocks();
+});
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform });
+}
+
+describe('NodeExecutionContext', () => {
+  it('runs a Windows Codex status command through cmd.exe', async () => {
+    setPlatform('win32');
+    execFileAsyncMock.mockResolvedValue({ stdout: 'Logged in', stderr: '' });
+    const env = { ComSpec: 'C:\\Windows\\System32\\cmd.exe' };
+    const context = new NodeExecutionContext({ env });
+
+    await context.exec('C:\\Users\\me\\AppData\\Roaming\\npm\\codex.cmd', ['login', 'status'], {
+      windowsScript: 'trusted',
+    });
+
+    expect(execFileAsyncMock).toHaveBeenCalledWith(
+      'C:\\Windows\\System32\\cmd.exe',
+      ['/d', '/s', '/c', '"C:\\Users\\me\\AppData\\Roaming\\npm\\codex.cmd ^"login^" ^"status^""'],
+      expect.objectContaining({
+        env,
+        windowsVerbatimArguments: true,
+      })
+    );
+  });
+
+  it('leaves non-Windows commands unchanged', async () => {
+    setPlatform('linux');
+    execFileAsyncMock.mockResolvedValue({ stdout: 'agent 1.0.0', stderr: '' });
+    const context = new NodeExecutionContext();
+
+    await context.exec('/usr/bin/agent', ['--version']);
+
+    expect(execFileAsyncMock).toHaveBeenCalledWith(
+      '/usr/bin/agent',
+      ['--version'],
+      expect.objectContaining({ windowsVerbatimArguments: undefined })
+    );
+  });
+
+  it('does not shell-wrap Windows scripts without an explicit trust marker', async () => {
+    setPlatform('win32');
+    execFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' });
+    const context = new NodeExecutionContext();
+
+    await context.exec('C:\\npm\\agent.cmd', ['user-controlled']);
+
+    expect(execFileAsyncMock).toHaveBeenCalledWith(
+      'C:\\npm\\agent.cmd',
+      ['user-controlled'],
+      expect.objectContaining({ windowsVerbatimArguments: undefined })
+    );
+  });
+});
+
+describe('resolveWindowsScriptCommand', () => {
+  it('escapes cmd.exe metacharacters, quotes, empty arguments, and trailing backslashes', () => {
+    const resolved = resolveWindowsScriptCommand(
+      'C:\\Program Files (x86)\\npm\\codex.cmd',
+      ['A&B', '%PATH%', '!', '^', 'say "hi"', '', 'ends\\'],
+      { ComSpec: 'cmd.exe' },
+      'win32',
+      true
+    );
+
+    expect(resolved).toEqual({
+      command: 'cmd.exe',
+      args: [
+        '/d',
+        '/s',
+        '/c',
+        expect.stringContaining(
+          'C:\\Program^ Files^ ^(x86^)\\npm\\codex.cmd ^"A^&B^" ^"^%PATH^%^"'
+        ),
+      ],
+      ptyCommandLine: expect.stringContaining('/d /s /c'),
+      windowsVerbatimArguments: true,
+    });
+    expect(resolved.args[3]).toContain('^"^!^"');
+    expect(resolved.args[3]).toContain('^"^^^"');
+    expect(resolved.args[3]).toContain('^"^"');
+    expect(resolved.args[3]).toContain('ends\\\\');
+  });
+});

--- a/packages/core/src/exec/node-execution-context.ts
+++ b/packages/core/src/exec/node-execution-context.ts
@@ -2,6 +2,7 @@ import { execFile, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 import type { ExecContextOptions, IExecutionContext } from './execution-context';
 import type { ExecResult } from './types';
+import { resolveWindowsScriptCommand } from './windows-script-command';
 
 const execFileAsync = promisify(execFile);
 
@@ -19,12 +20,20 @@ export class NodeExecutionContext implements IExecutionContext {
   private readonly env: NodeJS.ProcessEnv | undefined;
 
   exec(command: string, args: string[] = [], opts: ExecContextOptions = {}): Promise<ExecResult> {
-    return execFileAsync(command, args, {
+    const resolved = resolveWindowsScriptCommand(
+      command,
+      args,
+      this.env ?? process.env,
+      process.platform,
+      opts.windowsScript === 'trusted'
+    );
+    return execFileAsync(resolved.command, resolved.args, {
       cwd: this.root || undefined,
       env: this.env,
       timeout: opts.timeout,
       maxBuffer: opts.maxBuffer,
       signal: this.signal(opts.signal),
+      windowsVerbatimArguments: resolved.windowsVerbatimArguments,
     }) as Promise<ExecResult>;
   }
 

--- a/packages/core/src/exec/windows-script-command.ts
+++ b/packages/core/src/exec/windows-script-command.ts
@@ -1,0 +1,50 @@
+import path from 'node:path';
+
+type ResolvedCommand = {
+  command: string;
+  args: string[];
+  ptyCommandLine?: string;
+  windowsVerbatimArguments?: boolean;
+};
+
+const CMD_META_CHARS = /([()\][%!^"`<>&|;, *?])/g;
+
+function escapeCmdCommand(command: string): string {
+  return command.replace(CMD_META_CHARS, '^$1');
+}
+
+function escapeCmdArgument(argument: string, doubleEscapeMetaChars: boolean): string {
+  let escaped = argument.replace(/(?=(\\+?)?)\1"/g, '$1$1\\"');
+  escaped = escaped.replace(/(?=(\\+?)?)\1$/, '$1$1');
+  escaped = `"${escaped}"`.replace(CMD_META_CHARS, '^$1');
+  if (doubleEscapeMetaChars) escaped = escaped.replace(CMD_META_CHARS, '^$1');
+  return escaped;
+}
+
+export function resolveWindowsScriptCommand(
+  command: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+  trustedScript: boolean
+): ResolvedCommand {
+  if (platform !== 'win32' || !trustedScript) return { command, args };
+
+  const extension = path.win32.extname(command).toLowerCase();
+  if (extension === '.cmd' || extension === '.bat') {
+    const doubleEscapeMetaChars = /node_modules[\\/]\.bin[\\/][^\\/]+\.cmd$/i.test(command);
+    const commandLine = [
+      escapeCmdCommand(path.win32.normalize(command)),
+      ...args.map((argument) => escapeCmdArgument(argument, doubleEscapeMetaChars)),
+    ].join(' ');
+    const shellCommand = `"${commandLine}"`;
+    return {
+      command: env.ComSpec ?? env.COMSPEC ?? 'cmd.exe',
+      args: ['/d', '/s', '/c', shellCommand],
+      ptyCommandLine: `/d /s /c ${shellCommand}`,
+      windowsVerbatimArguments: true,
+    };
+  }
+
+  return { command, args };
+}

--- a/packages/core/src/host-dependencies/runtime/host-dependency-manager.test.ts
+++ b/packages/core/src/host-dependencies/runtime/host-dependency-manager.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { IExecutionContext } from '../../exec/execution-context';
 import { HostDependencyManager } from './host-dependency-manager';
 import type { InstallMethodDetector } from './method-detection';
+import { resolveAllCommandPaths, resolveCommandPath } from './probe';
 import type { DependencyDescriptor, Provenance } from './types';
 
 const TEST_DEPENDENCIES: DependencyDescriptor[] = [
@@ -114,6 +115,22 @@ const availableCtx = makeCtx(async (command, args = []) => {
     return { stdout: 'codex-cli 1.2.3\n', stderr: '' };
   }
   throw new Error('missing');
+});
+
+describe('Windows command probing', () => {
+  it('prefers an executable npm shim over its extensionless POSIX sibling', async () => {
+    const ctx = makeCtx(async () => ({
+      stdout: ['C:\\stale\\codex', 'C:\\Users\\me\\AppData\\Roaming\\npm\\codex.cmd'].join('\n'),
+      stderr: '',
+    }));
+
+    await expect(resolveCommandPath('codex', ctx, 'windows')).resolves.toBe(
+      'C:\\Users\\me\\AppData\\Roaming\\npm\\codex.cmd'
+    );
+    await expect(resolveAllCommandPaths('codex', ctx, 'windows')).resolves.toEqual([
+      'C:\\Users\\me\\AppData\\Roaming\\npm\\codex.cmd',
+    ]);
+  });
 });
 
 describe('HostDependencyManager install', () => {

--- a/packages/core/src/host-dependencies/runtime/probe.ts
+++ b/packages/core/src/host-dependencies/runtime/probe.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import type { IExecutionContext } from '../../exec/execution-context';
 import type { Platform } from '../capability';
 import { toPlatform } from './install-options';
@@ -6,6 +7,22 @@ import type { ProbeResult } from './types';
 const WHICH_TIMEOUT_MS = 5_000;
 const VERSION_PROBE_TIMEOUT_MS = 10_000;
 const REALPATH_TIMEOUT_MS = 5_000;
+
+function outputLines(stdout: string): string[] {
+  return stdout
+    .trim()
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function windowsCommandPaths(stdout: string): string[] {
+  const paths = outputLines(stdout);
+  const executablePaths = paths.filter((candidate) =>
+    ['.com', '.exe', '.cmd', '.bat'].includes(path.win32.extname(candidate).toLowerCase())
+  );
+  return executablePaths.length > 0 ? executablePaths : paths;
+}
 
 function targetPlatform(platform?: Platform): Platform {
   return platform ?? toPlatform(process.platform);
@@ -27,18 +44,10 @@ export async function resolveAllCommandPaths(
   try {
     if (plat === 'windows') {
       const { stdout } = await ctx.exec('where', [command], { timeout: WHICH_TIMEOUT_MS });
-      return stdout
-        .trim()
-        .split('\n')
-        .map((s) => s.trim())
-        .filter(Boolean);
+      return windowsCommandPaths(stdout);
     }
     const { stdout } = await ctx.exec('which', ['-a', command], { timeout: WHICH_TIMEOUT_MS });
-    return stdout
-      .trim()
-      .split('\n')
-      .map((s) => s.trim())
-      .filter(Boolean);
+    return outputLines(stdout);
   } catch {
     return [];
   }
@@ -54,10 +63,11 @@ export async function resolveCommandPath(
   ctx: IExecutionContext,
   platform?: Platform
 ): Promise<string | null> {
-  const resolveCmd = targetPlatform(platform) === 'windows' ? 'where' : 'which';
+  const plat = targetPlatform(platform);
+  const resolveCmd = plat === 'windows' ? 'where' : 'which';
   try {
     const { stdout } = await ctx.exec(resolveCmd, [command], { timeout: WHICH_TIMEOUT_MS });
-    const firstLine = stdout.trim().split('\n')[0]?.trim();
+    const firstLine = (plat === 'windows' ? windowsCommandPaths(stdout) : outputLines(stdout))[0];
     return firstLine ?? null;
   } catch {
     return null;

--- a/packages/core/src/pty/node/node-pty-spawner.test.ts
+++ b/packages/core/src/pty/node/node-pty-spawner.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { NodePtySpawner } from './node-pty-spawner';
 
 const { spawnMock } = vi.hoisted(() => ({
@@ -9,17 +9,35 @@ vi.mock('node-pty', () => ({
   spawn: spawnMock,
 }));
 
+const originalPlatform = process.platform;
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', { value: originalPlatform });
+  vi.clearAllMocks();
+});
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform });
+}
+
+function mockPtyProcess() {
+  const proc = {
+    pid: 123,
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    on: vi.fn(),
+  };
+  spawnMock.mockReturnValue(proc);
+  return proc;
+}
+
 describe('NodePtySpawner', () => {
   it('lazy-loads node-pty and adapts the spawned process', async () => {
-    const proc = {
-      pid: 123,
-      write: vi.fn(),
-      resize: vi.fn(),
-      kill: vi.fn(),
-      onData: vi.fn(),
-      onExit: vi.fn(),
-    };
-    spawnMock.mockReturnValue(proc);
+    setPlatform('linux');
+    const proc = mockPtyProcess();
 
     const spawned = await new NodePtySpawner().spawn({
       command: 'agent',
@@ -41,5 +59,54 @@ describe('NodePtySpawner', () => {
     spawned.resize(100, 30);
     expect(proc.write).toHaveBeenCalledWith('input');
     expect(proc.resize).toHaveBeenCalledWith(100, 30);
+  });
+
+  it('launches Windows npm command shims through cmd.exe', async () => {
+    setPlatform('win32');
+    mockPtyProcess();
+
+    await new NodePtySpawner().spawn({
+      command: 'C:\\Users\\Me User\\AppData\\Roaming\\npm\\codex.cmd',
+      args: ['login'],
+      cwd: 'C:\\Users\\Me User',
+      env: { ComSpec: 'C:\\Windows\\System32\\cmd.exe' },
+      cols: 80,
+      rows: 24,
+      windowsScript: 'trusted',
+    });
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'C:\\Windows\\System32\\cmd.exe',
+      '/d /s /c "C:\\Users\\Me^ User\\AppData\\Roaming\\npm\\codex.cmd ^"login^""',
+      {
+        name: 'xterm-256color',
+        cols: 80,
+        rows: 24,
+        cwd: 'C:\\Users\\Me User',
+        env: { ComSpec: 'C:\\Windows\\System32\\cmd.exe' },
+      }
+    );
+  });
+
+  it('does not shell-wrap Windows scripts without an explicit trust marker', async () => {
+    setPlatform('win32');
+    mockPtyProcess();
+
+    await new NodePtySpawner().spawn({
+      command: 'C:\\npm\\agent.cmd',
+      args: ['user-controlled'],
+      cwd: 'C:\\workspace',
+      env: {},
+      cols: 80,
+      rows: 24,
+    });
+
+    expect(spawnMock).toHaveBeenCalledWith('C:\\npm\\agent.cmd', ['user-controlled'], {
+      name: 'xterm-256color',
+      cols: 80,
+      rows: 24,
+      cwd: 'C:\\workspace',
+      env: {},
+    });
   });
 });

--- a/packages/core/src/pty/node/node-pty-spawner.ts
+++ b/packages/core/src/pty/node/node-pty-spawner.ts
@@ -1,3 +1,4 @@
+import { resolveWindowsScriptCommand } from '../../exec/windows-script-command';
 import {
   normalizeSignal,
   PosixPtyTerminator,
@@ -13,7 +14,7 @@ const MIN_ROWS = 1;
 type NodePtyModule = {
   spawn(
     command: string,
-    args: string[],
+    args: string[] | string,
     options: {
       name: string;
       cols: number;
@@ -42,7 +43,14 @@ export class NodePtySpawner implements PtySpawner {
   async spawn(spec: PtySpawnSpec): Promise<PtyProcess> {
     try {
       const nodePty = await loadNodePty();
-      const proc = nodePty.spawn(spec.command, spec.args, {
+      const resolved = resolveWindowsScriptCommand(
+        spec.command,
+        spec.args,
+        spec.env,
+        process.platform,
+        spec.windowsScript === 'trusted'
+      );
+      const proc = nodePty.spawn(resolved.command, resolved.ptyCommandLine ?? resolved.args, {
         name: 'xterm-256color',
         cols: spec.cols,
         rows: spec.rows,

--- a/packages/core/src/pty/types.ts
+++ b/packages/core/src/pty/types.ts
@@ -24,6 +24,7 @@ export interface PtySpawnSpec extends PtyDimensions {
   args: string[];
   cwd: string;
   env: Record<string, string>;
+  windowsScript?: 'trusted';
 }
 
 export interface PtySpawner {

--- a/packages/plugins/src/agents/helpers/auth.test.ts
+++ b/packages/plugins/src/agents/helpers/auth.test.ts
@@ -39,6 +39,10 @@ describe('agent auth helpers', () => {
         authenticatedPattern: /authenticated/i,
       })
     ).resolves.toEqual({ kind: 'authenticated' });
+    expect(exec).toHaveBeenCalledWith('agent', ['login', 'status'], {
+      timeout: 5000,
+      windowsScript: 'trusted',
+    });
   });
 
   it('maps command errors to unauthenticated status when output matches', async () => {

--- a/packages/plugins/src/agents/helpers/auth.ts
+++ b/packages/plugins/src/agents/helpers/auth.ts
@@ -21,6 +21,7 @@ export async function commandAuthStatus(
   try {
     const { stdout, stderr } = await ctx.exec(ctx.cli, args, {
       timeout: options.timeout ?? 5000,
+      windowsScript: 'trusted',
     });
     const output = `${stdout}\n${stderr}`;
     if (options.unauthenticatedPattern?.test(output)) {

--- a/packages/plugins/src/agents/impl/claude/auth.test.ts
+++ b/packages/plugins/src/agents/impl/claude/auth.test.ts
@@ -42,7 +42,10 @@ describe('claudeAuthStatus', () => {
       kind: 'authenticated',
       account: 'user@example.com',
     });
-    expect(exec).toHaveBeenCalledWith('claude', ['auth', 'status'], { timeout: 5000 });
+    expect(exec).toHaveBeenCalledWith('claude', ['auth', 'status'], {
+      timeout: 5000,
+      windowsScript: 'trusted',
+    });
   });
 
   it('reports unauthenticated when claude auth status exits 1 with status JSON', async () => {

--- a/packages/plugins/src/agents/impl/claude/auth.ts
+++ b/packages/plugins/src/agents/impl/claude/auth.ts
@@ -18,6 +18,7 @@ export async function claudeAuthStatus(ctx: AgentAuthContext): Promise<AgentAuth
   try {
     const { stdout } = await ctx.exec(ctx.cli, ['auth', 'status'], {
       timeout: AUTH_STATUS_TIMEOUT_MS,
+      windowsScript: 'trusted',
     });
     return { kind: 'authenticated', account: accountFromAuthStatus(stdout) };
   } catch (error) {

--- a/packages/plugins/src/agents/impl/opencode/auth.test.ts
+++ b/packages/plugins/src/agents/impl/opencode/auth.test.ts
@@ -35,7 +35,10 @@ describe('opencodeAuthStatus', () => {
     });
 
     await expect(opencodeAuthStatus(ctx({ exec }))).resolves.toEqual({ kind: 'authenticated' });
-    expect(exec).toHaveBeenCalledWith('opencode', ['auth', 'list'], { timeout: 5000 });
+    expect(exec).toHaveBeenCalledWith('opencode', ['auth', 'list'], {
+      timeout: 5000,
+      windowsScript: 'trusted',
+    });
   });
 
   it('reports unauthenticated when opencode auth list reports zero credentials', async () => {

--- a/packages/plugins/src/agents/impl/opencode/auth.ts
+++ b/packages/plugins/src/agents/impl/opencode/auth.ts
@@ -11,6 +11,7 @@ export async function opencodeAuthStatus(ctx: AgentAuthContext): Promise<AgentAu
   try {
     const { stdout, stderr } = await ctx.exec(ctx.cli, ['auth', 'list'], {
       timeout: AUTH_STATUS_TIMEOUT_MS,
+      windowsScript: 'trusted',
     });
     return statusFromAuthListOutput(`${stdout}\n${stderr}`);
   } catch (error) {

--- a/packages/runtime/src/agent-config/runtime/auth.ts
+++ b/packages/runtime/src/agent-config/runtime/auth.ts
@@ -205,6 +205,7 @@ export class AgentAuthManager {
         env,
         cols: DEFAULT_COLS,
         rows: DEFAULT_ROWS,
+        windowsScript: 'trusted',
       },
       {
         replaceExisting: false,

--- a/packages/runtime/src/agent-config/runtime/runtime.test.ts
+++ b/packages/runtime/src/agent-config/runtime/runtime.test.ts
@@ -200,6 +200,7 @@ describe('AgentConfigRuntime', () => {
       cwd: '/home/ada',
       cols: 120,
       rows: 30,
+      windowsScript: 'trusted',
     });
 
     ptySpawner.processes[0]?.emitData('Open https://example.com/login\n');

--- a/packages/runtime/src/tui-agents/runtime/runtime.test.ts
+++ b/packages/runtime/src/tui-agents/runtime/runtime.test.ts
@@ -117,6 +117,7 @@ describe('TuiAgentsRuntime', () => {
           PROVIDER_VAR: '1',
         }),
       });
+      expect(harness.spawner.processes[0]?.spec.windowsScript).toBeUndefined();
       detach();
     } finally {
       wire.dispose();


### PR DESCRIPTION
### Description
Fix Codex authentication on Windows when an npm installation exposes an extensionless POSIX shim before `codex.cmd`.

Previously, Emdash could pass the extensionless shim directly to node-pty/ConPTY, causing: Failed to spawn PTY: Cannot create process, error code: 193

This change:
- filters extensionless Windows command matches when a runnable `.cmd`, `.bat`, `.com`, or `.exe` candidate exists
- launches trusted static authentication commands through the appropriate Windows command wrapper
- supports both the interactive `codex login` PTY and the `codex login status` check
- keeps the Windows script adapter behind an explicit `windowsScript: 'trusted'` boundary
- prevents generic TUI prompts and user-controlled arguments from entering the `cmd.exe` serializer
- adds regression coverage for command resolution, Windows argument escaping, trusted auth execution, and untrusted TUI pass-through

The trust boundary is intentionally limited to plugin-owned static authentication commands. Generic Windows npm-shim TUI execution remains outside the scope of this PR.

### Related issues
https://discord.com/channels/1422831935553667175/1530791430929256508

### Testing
tested this on my windows 10 computer

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
