### PR TITLE
feat(window): remember window size and position between launches

### DIFF
--- a/apps/emdash-desktop/src/main/app/window-state.test.ts
+++ b/apps/emdash-desktop/src/main/app/window-state.test.ts
@@ -1,0 +1,215 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createDebouncedSaver,
+  fitsOnDisplay,
+  parseWindowState,
+  readWindowStateFile,
+  resolveWindowState,
+  writeWindowStateFile,
+  type Rect,
+  type WindowState,
+} from './window-state';
+
+const DEFAULT_SIZE = { width: 1400, height: 900 };
+const MIN_SIZE = { width: 700, height: 500 };
+const PRIMARY: Rect = { x: 0, y: 0, width: 1920, height: 1080 };
+
+const SAVED: WindowState = {
+  x: 100,
+  y: 80,
+  width: 1200,
+  height: 800,
+  maximized: false,
+  fullScreen: false,
+};
+
+function resolve(raw: string | null, workAreas: Rect[] = [PRIMARY]) {
+  return resolveWindowState({ raw, workAreas, defaultSize: DEFAULT_SIZE, minSize: MIN_SIZE });
+}
+
+describe('parseWindowState', () => {
+  it('reads bounds and both mode flags', () => {
+    expect(parseWindowState(JSON.stringify({ ...SAVED, maximized: true }))).toEqual({
+      ...SAVED,
+      maximized: true,
+    });
+  });
+
+  it('defaults absent mode flags to windowed', () => {
+    expect(parseWindowState(JSON.stringify({ x: 1, y: 2, width: 3, height: 4 }))).toEqual({
+      x: 1,
+      y: 2,
+      width: 3,
+      height: 4,
+      maximized: false,
+      fullScreen: false,
+    });
+  });
+
+  it('rejects a truncated write', () => {
+    expect(parseWindowState('{"x":100,"y":80,"wid')).toBeNull();
+  });
+
+  it('rejects a missing coordinate', () => {
+    expect(parseWindowState(JSON.stringify({ x: 1, y: 2, width: 3 }))).toBeNull();
+  });
+
+  it('rejects non-finite numbers', () => {
+    expect(parseWindowState('{"x":0,"y":0,"width":null,"height":800}')).toBeNull();
+    expect(parseWindowState(JSON.stringify({ ...SAVED, width: '1200' }))).toBeNull();
+  });
+
+  it('rejects a payload that is not an object', () => {
+    expect(parseWindowState('42')).toBeNull();
+    expect(parseWindowState('null')).toBeNull();
+  });
+});
+
+describe('fitsOnDisplay', () => {
+  it('accepts bounds inside a work area', () => {
+    expect(fitsOnDisplay({ x: 10, y: 10, width: 800, height: 600 }, [PRIMARY])).toBe(true);
+  });
+
+  it('rejects bounds that overhang the right edge', () => {
+    expect(fitsOnDisplay({ x: 1800, y: 10, width: 800, height: 600 }, [PRIMARY])).toBe(false);
+  });
+
+  it('rejects bounds above the work area, where a menu bar would hide the title bar', () => {
+    expect(fitsOnDisplay({ x: 10, y: -40, width: 800, height: 600 }, [PRIMARY])).toBe(false);
+  });
+
+  it('accepts bounds on a secondary display', () => {
+    const secondary: Rect = { x: 1920, y: 0, width: 1280, height: 800 };
+    const bounds: Rect = { x: 2000, y: 40, width: 900, height: 600 };
+    expect(fitsOnDisplay(bounds, [PRIMARY, secondary])).toBe(true);
+    expect(fitsOnDisplay(bounds, [PRIMARY])).toBe(false);
+  });
+});
+
+describe('resolveWindowState', () => {
+  it('centers a default-sized window on first launch', () => {
+    expect(resolve(null)).toEqual({
+      creationBounds: DEFAULT_SIZE,
+      maximized: false,
+      fullScreen: false,
+    });
+  });
+
+  it('restores a saved rectangle that still fits', () => {
+    expect(resolve(JSON.stringify(SAVED)).creationBounds).toEqual({
+      x: 100,
+      y: 80,
+      width: 1200,
+      height: 800,
+    });
+  });
+
+  it('falls back to the default size when the file is corrupt', () => {
+    expect(resolve('not json').creationBounds).toEqual(DEFAULT_SIZE);
+  });
+
+  it('keeps the mode when the display the window was on is gone', () => {
+    const raw = JSON.stringify({ ...SAVED, x: 2400, maximized: true });
+    expect(resolve(raw)).toEqual({
+      creationBounds: DEFAULT_SIZE,
+      maximized: true,
+      fullScreen: false,
+    });
+  });
+
+  it('keeps the mode when the saved rectangle is below the minimum size', () => {
+    const raw = JSON.stringify({ ...SAVED, width: 320, height: 240, fullScreen: true });
+    expect(resolve(raw)).toEqual({
+      creationBounds: DEFAULT_SIZE,
+      maximized: false,
+      fullScreen: true,
+    });
+  });
+
+  it('restores maximized alongside the rectangle it returns to', () => {
+    const raw = JSON.stringify({ ...SAVED, maximized: true });
+    expect(resolve(raw)).toEqual({
+      creationBounds: { x: 100, y: 80, width: 1200, height: 800 },
+      maximized: true,
+      fullScreen: false,
+    });
+  });
+});
+
+describe('window state file', () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function scratchDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'emdash-window-state-'));
+    dirs.push(dir);
+    return dir;
+  }
+
+  it('round-trips through the file', () => {
+    const path = join(scratchDir(), 'window-state.json');
+    writeWindowStateFile(path, { ...SAVED, fullScreen: true });
+    expect(parseWindowState(readWindowStateFile(path)!)).toEqual({ ...SAVED, fullScreen: true });
+  });
+
+  it('reads a missing file as no saved state', () => {
+    expect(readWindowStateFile(join(scratchDir(), 'window-state.json'))).toBeNull();
+  });
+
+  it('survives a write to an unwritable path', () => {
+    const path = join(scratchDir(), 'no-such-dir', 'window-state.json');
+    expect(() => writeWindowStateFile(path, SAVED)).not.toThrow();
+  });
+
+  it('overwrites a stale file rather than appending to it', () => {
+    const path = join(scratchDir(), 'window-state.json');
+    writeFileSync(path, JSON.stringify({ ...SAVED, width: 1900, height: 1000 }));
+    writeWindowStateFile(path, SAVED);
+    expect(parseWindowState(readWindowStateFile(path)!)).toEqual(SAVED);
+  });
+});
+
+describe('createDebouncedSaver', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('collapses a resize storm into one write of the final value', () => {
+    vi.useFakeTimers();
+    const write = vi.fn();
+    const saver = createDebouncedSaver(write, 500);
+
+    for (const width of [800, 900, 1000]) saver.update(width);
+    vi.advanceTimersByTime(499);
+    expect(write).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(write).toHaveBeenCalledExactlyOnceWith(1000);
+  });
+
+  it('writes pending state immediately on flush', () => {
+    vi.useFakeTimers();
+    const write = vi.fn();
+    const saver = createDebouncedSaver(write, 500);
+
+    saver.update(1000);
+    saver.flush();
+    expect(write).toHaveBeenCalledExactlyOnceWith(1000);
+
+    // The timer the update armed must not fire a second write after the flush.
+    vi.advanceTimersByTime(500);
+    expect(write).toHaveBeenCalledOnce();
+  });
+
+  it('does nothing when flushed with nothing pending', () => {
+    const write = vi.fn();
+    createDebouncedSaver(write, 500).flush();
+    expect(write).not.toHaveBeenCalled();
+  });
+});

--- a/apps/emdash-desktop/src/main/app/window-state.ts
+++ b/apps/emdash-desktop/src/main/app/window-state.ts
@@ -1,0 +1,182 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { log } from '@main/lib/logger';
+
+export interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface Size {
+  width: number;
+  height: number;
+}
+
+/**
+ * The persisted geometry: the unmaximized rectangle plus the display modes
+ * layered on top of it.
+ *
+ * The modes have to be stored explicitly. macOS reports a zoomed or fullscreen
+ * window's normal bounds as the rectangle it returns to — for a window zoomed
+ * right after first launch that is the centered default forever — so bounds
+ * alone would restore a maximized session as a plain default-sized window.
+ */
+export interface WindowState extends Rect {
+  maximized: boolean;
+  fullScreen: boolean;
+}
+
+export const WINDOW_STATE_FILE_NAME = 'window-state.json';
+
+/** Interactive resizes emit dozens of events a second; one write per settle is enough. */
+export const SAVE_DEBOUNCE_MS = 500;
+
+/**
+ * Parse persisted state, requiring four finite numbers. Anything else — a
+ * partial write, a hand-edited file — reads as no saved state rather than an
+ * error. The mode flags are optional so a bounds-only file restores windowed.
+ */
+export function parseWindowState(raw: string): WindowState | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const { x, y, width, height, maximized, fullScreen } = parsed as Record<string, unknown>;
+  if (![x, y, width, height].every((v) => typeof v === 'number' && Number.isFinite(v))) {
+    return null;
+  }
+  return {
+    x: x as number,
+    y: y as number,
+    width: width as number,
+    height: height as number,
+    maximized: maximized === true,
+    fullScreen: fullScreen === true,
+  };
+}
+
+/**
+ * A saved rectangle is restorable only when it sits fully inside one current
+ * display's work area. Bounds saved on a display that has since been unplugged
+ * or rearranged would come back partly off-screen, potentially with the title
+ * bar out of reach.
+ */
+export function fitsOnDisplay(bounds: Rect, workAreas: readonly Rect[]): boolean {
+  return workAreas.some(
+    (area) =>
+      bounds.x >= area.x &&
+      bounds.y >= area.y &&
+      bounds.x + bounds.width <= area.x + area.width &&
+      bounds.y + bounds.height <= area.y + area.height
+  );
+}
+
+export interface ResolveWindowStateOptions {
+  /** Contents of the window-state file, or null when it does not exist. */
+  raw: string | null;
+  /** Work areas of the displays currently attached. */
+  workAreas: readonly Rect[];
+  defaultSize: Size;
+  minSize: Size;
+}
+
+/** A positionless rectangle lets the OS center the window. */
+export interface WindowCreationBounds {
+  width: number;
+  height: number;
+  x?: number;
+  y?: number;
+}
+
+export interface ResolvedWindowState {
+  creationBounds: WindowCreationBounds;
+  maximized: boolean;
+  fullScreen: boolean;
+}
+
+/**
+ * What a new window should be created as. The saved rectangle is used when it
+ * is intact, at least the window's minimum size, and safe to restore on the
+ * current displays — the default size otherwise.
+ *
+ * The mode flags survive a rectangle fallback independently: maximize and
+ * fullscreen re-derive their geometry from whatever display the window lands
+ * on, so a stale rectangle is no reason to drop the mode the user was in.
+ */
+export function resolveWindowState(options: ResolveWindowStateOptions): ResolvedWindowState {
+  const { raw, workAreas, defaultSize, minSize } = options;
+  const fallback: WindowCreationBounds = { width: defaultSize.width, height: defaultSize.height };
+  const saved = raw === null ? null : parseWindowState(raw);
+  if (!saved) return { creationBounds: fallback, maximized: false, fullScreen: false };
+
+  const { maximized, fullScreen } = saved;
+  const bounds: Rect = { x: saved.x, y: saved.y, width: saved.width, height: saved.height };
+  if (bounds.width < minSize.width || bounds.height < minSize.height) {
+    return { creationBounds: fallback, maximized, fullScreen };
+  }
+  if (!fitsOnDisplay(bounds, workAreas)) {
+    return { creationBounds: fallback, maximized, fullScreen };
+  }
+  return { creationBounds: bounds, maximized, fullScreen };
+}
+
+/** Missing or unreadable both mean "no saved state" — the first launch case. */
+export function readWindowStateFile(filePath: string): string | null {
+  try {
+    return readFileSync(filePath, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+/** Losing a write costs the next launch its geometry, so failure is logged, not thrown. */
+export function writeWindowStateFile(filePath: string, state: WindowState): void {
+  try {
+    writeFileSync(filePath, JSON.stringify(state));
+  } catch (error) {
+    log.warn('Failed to persist window state', { error });
+  }
+}
+
+export interface DebouncedSaver<T> {
+  update(value: T): void;
+  flush(): void;
+}
+
+/**
+ * Coalesces updates into one write per settle: each update re-arms the timer
+ * and only the latest value survives. `flush` writes what is pending
+ * immediately — the window-close path, where waiting out the timer would lose
+ * the final state.
+ */
+export function createDebouncedSaver<T>(
+  write: (value: T) => void,
+  delayMs: number = SAVE_DEBOUNCE_MS
+): DebouncedSaver<T> {
+  let pending: T | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const fire = (): void => {
+    timer = null;
+    if (pending === null) return;
+    const value = pending;
+    pending = null;
+    write(value);
+  };
+
+  return {
+    update(value: T): void {
+      pending = value;
+      if (timer !== null) clearTimeout(timer);
+      timer = setTimeout(fire, delayMs);
+    },
+    flush(): void {
+      if (timer !== null) clearTimeout(timer);
+      fire();
+    },
+  };
+}

--- a/apps/emdash-desktop/src/main/app/window.ts
+++ b/apps/emdash-desktop/src/main/app/window.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { BrowserWindow, nativeTheme } from 'electron';
+import { app, BrowserWindow, nativeTheme, screen } from 'electron';
 import devIcon from '@/assets/images/emdash/emdash-dev.png?asset';
 import { browserWebContentsRegistry } from '@main/core/browser/browser-webcontents-registry';
 import {
@@ -15,6 +15,17 @@ import { PRODUCT_NAME } from '@shared/app-identity';
 import type { Theme } from '@shared/core/app-settings';
 import { windowMaximizeChangedChannel } from '@shared/events/appEvents';
 import { APP_ORIGIN } from './protocol';
+import {
+  createDebouncedSaver,
+  readWindowStateFile,
+  resolveWindowState,
+  WINDOW_STATE_FILE_NAME,
+  writeWindowStateFile,
+  type WindowState,
+} from './window-state';
+
+const DEFAULT_WINDOW_SIZE = { width: 1400, height: 900 };
+const MIN_WINDOW_SIZE = { width: 700, height: 500 };
 
 let mainWindow: BrowserWindow | null = null;
 
@@ -23,12 +34,24 @@ export function applyNativeTheme(theme: Theme): void {
   nativeTheme.themeSource = theme === 'emdark' ? 'dark' : theme === 'emlight' ? 'light' : 'system';
 }
 
+// Resolved per call rather than at module load: the userData path is only
+// final once app identity has been configured.
+function windowStateFilePath(): string {
+  return join(app.getPath('userData'), WINDOW_STATE_FILE_NAME);
+}
+
 export function createMainWindow(): BrowserWindow {
+  const restored = resolveWindowState({
+    raw: readWindowStateFile(windowStateFilePath()),
+    workAreas: screen.getAllDisplays().map((display) => display.workArea),
+    defaultSize: DEFAULT_WINDOW_SIZE,
+    minSize: MIN_WINDOW_SIZE,
+  });
+
   mainWindow = new BrowserWindow({
-    width: 1400,
-    height: 900,
-    minWidth: 700,
-    minHeight: 500,
+    ...restored.creationBounds,
+    minWidth: MIN_WINDOW_SIZE.width,
+    minHeight: MIN_WINDOW_SIZE.height,
     title: PRODUCT_NAME,
     // In production, electron-builder injects the icon from the app bundle.
     ...(import.meta.env.DEV && { icon: devIcon }),
@@ -57,6 +80,12 @@ export function createMainWindow(): BrowserWindow {
     ...(process.platform === 'linux' ? { frame: false } : {}),
     show: false,
   });
+
+  // Applied while the window is still hidden so it never shows at the
+  // windowed size first and then jumps.
+  if (restored.maximized) mainWindow.maximize();
+  if (restored.fullScreen) mainWindow.setFullScreen(true);
+  trackWindowState(mainWindow);
 
   if (process.platform !== 'darwin') {
     mainWindow.setMenuBarVisibility(false);
@@ -109,6 +138,44 @@ export function createMainWindow(): BrowserWindow {
 
 export function getMainWindow(): BrowserWindow | null {
   return mainWindow;
+}
+
+/**
+ * Persist geometry as the user changes it, so the next launch opens where the
+ * last one left off.
+ *
+ * `getNormalBounds` is the rectangle to save in every mode: for a maximized or
+ * fullscreen window it reports the one the window returns to, which is what a
+ * later un-maximize needs.
+ */
+function trackWindowState(win: BrowserWindow): void {
+  const filePath = windowStateFilePath();
+  const saver = createDebouncedSaver<WindowState>((state) => {
+    writeWindowStateFile(filePath, state);
+  });
+
+  const capture = (): void => {
+    if (win.isDestroyed()) return;
+    saver.update({
+      ...win.getNormalBounds(),
+      maximized: win.isMaximized(),
+      fullScreen: win.isFullScreen(),
+    });
+  };
+
+  win.on('resize', capture);
+  win.on('move', capture);
+  win.on('maximize', capture);
+  win.on('unmaximize', capture);
+  win.on('enter-full-screen', capture);
+  win.on('leave-full-screen', capture);
+
+  // The final state matters most and arrives last, so close takes the pending
+  // write rather than waiting out a debounce the window will not survive.
+  win.on('close', () => {
+    capture();
+    saver.flush();
+  });
 }
 
 function registerBrowserWebviewHandlers(win: BrowserWindow): void {


### PR DESCRIPTION
### Description

A suggestion, not a request — take it or leave it.

`createMainWindow` builds the window at a hardcoded `1400x900`, centered, on
every launch. There's no bounds persistence anywhere in the repo and no
`electron-window-state` dependency, so on a large display Emdash opens as a
small window in the middle of the screen and the resize gets re-done by hand
at the start of every session.

This persists geometry to `window-state.json` under `userData` and restores it
next launch.

**What's stored, and why it's more than a rectangle.** The file carries the
`maximized` and `fullScreen` flags alongside the bounds. macOS reports a zoomed
window's *normal* bounds — the rectangle it will return to — so saving bounds
alone would bring a maximized session back as a plain default-sized window. The
two are restored independently.

**When a saved rectangle is refused.** Only bounds that still sit fully inside
one current display's work area are restored. Bounds saved on a monitor that has
since been unplugged or rearranged would otherwise come back partly off-screen,
possibly with the title bar out of reach. A rectangle below `minWidth`/
`minHeight` is refused the same way. In both cases the *mode* flags still apply,
since maximize and fullscreen re-derive their geometry from whatever display the
window lands on — a stale rectangle is no reason to drop the mode the user was
in.

**Write behavior.** A drag-resize emits dozens of events a second, so writes are
debounced 500 ms and only the latest value survives. `close` flushes what's
pending rather than waiting out a timer the window won't survive;
`getNormalBounds()` is what gets saved in every mode.

**Shape.** All the decisions — parse, fit, resolve, debounce — are pure
functions in `window-state.ts` with no Electron import, matching how
`dev-worktree-profile.ts` and `reap-dev-profiles.ts` are organized. `window.ts`
keeps the ~25 lines of event wiring. Restoring happens before the window is
shown, so it never appears at the windowed size and then jumps.

`DEFAULT_WINDOW_SIZE` and `MIN_WINDOW_SIZE` are now named constants used both to
construct the window and to validate a saved rectangle, so the two can't drift.

### Related issues

None — noticed while using the app.

### Testing

- `oxfmt --check`, `oxlint`, `tsgo --noEmit` on `apps/emdash-desktop` — all clean.
- `vitest run --project node` — 283 files / 2045 tests pass, including 23 new
  ones covering: truncated and hand-edited state files, missing and non-finite
  coordinates, absent mode flags, bounds overhanging a work area, bounds above it
  (where a menu bar would hide the title bar), a second display present and then
  gone, sub-minimum rectangles, mode-survives-fallback, file round-trip, an
  unwritable path, and the debouncer's coalesce / flush / flush-when-empty paths.
- Not run: the full workspace `pnpm run test` across every project, and manual
  GUI verification of the restore across a real quit/relaunch. The pure resolver
  is covered by the unit tests above; the Electron wiring is event registration
  that unit tests don't reach.

### Screenshot/Recording (if applicable)

n/a — no visual change beyond the window opening where it was left.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [ ] I updated docs when behavior or setup changed — no docs describe window sizing
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for commit messages and the PR title

</details>