### PR TITLE
feat(logging): record renderer and helper process crashes

### DIFF
--- a/apps/emdash-desktop/src/main/app/process-crash-logging.test.ts
+++ b/apps/emdash-desktop/src/main/app/process-crash-logging.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  registerProcessCrashLogging,
+  reportChildProcessGone,
+  reportRenderProcessGone,
+  type ChildProcessGoneDetails,
+  type ProcessCrashEventSource,
+  type ProcessGoneDetails,
+} from './process-crash-logging';
+
+const APP_URL = 'app://emdash/index.html';
+
+describe('reportRenderProcessGone', () => {
+  it('reports an out-of-memory kill with the window it took down', () => {
+    const report = reportRenderProcessGone({ reason: 'oom', exitCode: 0 }, APP_URL);
+    expect(report).toEqual({
+      message: 'Renderer process gone',
+      fields: { reason: 'oom', exitCode: 0, url: APP_URL },
+    });
+  });
+
+  it('reports a crash with its exit code', () => {
+    expect(reportRenderProcessGone({ reason: 'crashed', exitCode: 133 }, APP_URL)?.fields).toEqual({
+      reason: 'crashed',
+      exitCode: 133,
+      url: APP_URL,
+    });
+  });
+
+  it('ignores the clean exit every window reports at shutdown', () => {
+    expect(reportRenderProcessGone({ reason: 'clean-exit', exitCode: 0 }, APP_URL)).toBeNull();
+  });
+
+  it('still reports when the URL could not be read', () => {
+    expect(reportRenderProcessGone({ reason: 'killed', exitCode: 9 }, undefined)?.fields).toEqual({
+      reason: 'killed',
+      exitCode: 9,
+      url: undefined,
+    });
+  });
+});
+
+describe('reportChildProcessGone', () => {
+  it('names the helper that died', () => {
+    const details: ChildProcessGoneDetails = {
+      type: 'Utility',
+      reason: 'crashed',
+      exitCode: 11,
+      name: 'Audio Service',
+      serviceName: 'audio.mojom.AudioService',
+    };
+    expect(reportChildProcessGone(details)).toEqual({
+      message: 'Child process gone',
+      fields: {
+        type: 'Utility',
+        reason: 'crashed',
+        exitCode: 11,
+        name: 'Audio Service',
+        serviceName: 'audio.mojom.AudioService',
+      },
+    });
+  });
+
+  it('ignores the clean exit every helper reports at shutdown', () => {
+    expect(reportChildProcessGone({ type: 'GPU', reason: 'clean-exit', exitCode: 0 })).toBeNull();
+  });
+});
+
+describe('registerProcessCrashLogging', () => {
+  function stubSource() {
+    const listeners = new Map<string, (...args: never[]) => void>();
+    const source: ProcessCrashEventSource = {
+      on(event: string, listener: (...args: never[]) => void) {
+        listeners.set(event, listener);
+        return this;
+      },
+    } as ProcessCrashEventSource;
+
+    return {
+      source,
+      renderProcessGone(details: ProcessGoneDetails, contents: { getURL(): string }) {
+        (listeners.get('render-process-gone') as unknown as RenderListener)({}, contents, details);
+      },
+      childProcessGone(details: ChildProcessGoneDetails) {
+        (listeners.get('child-process-gone') as unknown as ChildListener)({}, details);
+      },
+    };
+  }
+
+  type RenderListener = (
+    event: unknown,
+    contents: { getURL(): string },
+    details: ProcessGoneDetails
+  ) => void;
+  type ChildListener = (event: unknown, details: ChildProcessGoneDetails) => void;
+
+  it('logs a renderer crash as an error', () => {
+    const logger = { error: vi.fn() };
+    const stub = stubSource();
+    registerProcessCrashLogging(stub.source, logger);
+
+    stub.renderProcessGone({ reason: 'oom', exitCode: 0 }, { getURL: () => APP_URL });
+
+    expect(logger.error).toHaveBeenCalledExactlyOnceWith('Renderer process gone', {
+      reason: 'oom',
+      exitCode: 0,
+      url: APP_URL,
+    });
+  });
+
+  it('logs a helper crash as an error', () => {
+    const logger = { error: vi.fn() };
+    const stub = stubSource();
+    registerProcessCrashLogging(stub.source, logger);
+
+    stub.childProcessGone({ type: 'GPU', reason: 'launch-failed', exitCode: 1 });
+
+    expect(logger.error).toHaveBeenCalledExactlyOnceWith('Child process gone', {
+      type: 'GPU',
+      reason: 'launch-failed',
+      exitCode: 1,
+      name: undefined,
+      serviceName: undefined,
+    });
+  });
+
+  it('stays quiet through a normal shutdown', () => {
+    const logger = { error: vi.fn() };
+    const stub = stubSource();
+    registerProcessCrashLogging(stub.source, logger);
+
+    stub.renderProcessGone({ reason: 'clean-exit', exitCode: 0 }, { getURL: () => APP_URL });
+    stub.childProcessGone({ type: 'GPU', reason: 'clean-exit', exitCode: 0 });
+
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('logs the crash even when the dying WebContents cannot report its URL', () => {
+    const logger = { error: vi.fn() };
+    const stub = stubSource();
+    registerProcessCrashLogging(stub.source, logger);
+
+    stub.renderProcessGone(
+      { reason: 'crashed', exitCode: 5 },
+      {
+        getURL: () => {
+          throw new Error('Object has been destroyed');
+        },
+      }
+    );
+
+    expect(logger.error).toHaveBeenCalledExactlyOnceWith('Renderer process gone', {
+      reason: 'crashed',
+      exitCode: 5,
+      url: undefined,
+    });
+  });
+});

--- a/apps/emdash-desktop/src/main/app/process-crash-logging.ts
+++ b/apps/emdash-desktop/src/main/app/process-crash-logging.ts
@@ -1,0 +1,106 @@
+/**
+ * Logging for the process deaths that never reach an exception handler.
+ *
+ * A renderer, GPU, or utility process that dies takes no main-process code
+ * path with it: the window white-screens, or a feature quietly stops working,
+ * and `uncaughtException` never fires. The session log just ends. That leaves
+ * an OS-killed renderer — the shape a memory incident takes — reconstructible
+ * only from a platform crash report, if one was kept at all.
+ *
+ * These handlers put the cause in emdash's own log, where the rest of the
+ * session already is. Electron reports `clean-exit` for every normally
+ * terminated helper at shutdown, so that reason is dropped rather than
+ * recorded as a crash.
+ */
+
+/** Common shape of both `*-process-gone` detail payloads. */
+export interface ProcessGoneDetails {
+  reason: string;
+  exitCode: number;
+}
+
+export interface ChildProcessGoneDetails extends ProcessGoneDetails {
+  type: string;
+  name?: string;
+  serviceName?: string;
+}
+
+/** A structured log line: message plus the fields worth keeping. */
+export interface ProcessGoneReport {
+  message: string;
+  fields: Record<string, unknown>;
+}
+
+/** Ordinary teardown, reported by every helper process at shutdown. */
+const CLEAN_EXIT = 'clean-exit';
+
+/**
+ * The renderer report, or null when the exit was ordinary teardown. The URL
+ * distinguishes the app window from a browser-pane webview, whose crash says
+ * nothing about emdash itself.
+ */
+export function reportRenderProcessGone(
+  details: ProcessGoneDetails,
+  url: string | undefined
+): ProcessGoneReport | null {
+  if (details.reason === CLEAN_EXIT) return null;
+  return {
+    message: 'Renderer process gone',
+    fields: { reason: details.reason, exitCode: details.exitCode, url },
+  };
+}
+
+/** The child-process report, or null when the exit was ordinary teardown. */
+export function reportChildProcessGone(details: ChildProcessGoneDetails): ProcessGoneReport | null {
+  if (details.reason === CLEAN_EXIT) return null;
+  return {
+    message: 'Child process gone',
+    fields: {
+      type: details.type,
+      reason: details.reason,
+      exitCode: details.exitCode,
+      name: details.name,
+      serviceName: details.serviceName,
+    },
+  };
+}
+
+/** Reading the URL of a WebContents that is already tearing down throws. */
+function urlOf(contents: { getURL(): string }): string | undefined {
+  try {
+    return contents.getURL();
+  } catch {
+    return undefined;
+  }
+}
+
+/** The `Electron.App` surface these handlers need, narrowed so tests can stub it. */
+export interface ProcessCrashEventSource {
+  on(
+    event: 'render-process-gone',
+    listener: (event: unknown, contents: { getURL(): string }, details: ProcessGoneDetails) => void
+  ): unknown;
+  on(
+    event: 'child-process-gone',
+    listener: (event: unknown, details: ChildProcessGoneDetails) => void
+  ): unknown;
+}
+
+export interface CrashLogger {
+  error(message: string, data?: unknown): void;
+}
+
+export function registerProcessCrashLogging(
+  source: ProcessCrashEventSource,
+  logger: CrashLogger
+): void {
+  source.on('render-process-gone', (_event, contents, details) => {
+    const report = reportRenderProcessGone(details, urlOf(contents));
+    if (report) logger.error(report.message, report.fields);
+  });
+
+  source.on('child-process-gone', (_event, details) => {
+    const report = reportChildProcessGone(details);
+    if (report) logger.error(report.message, report.fields);
+  });
+}

--- a/apps/emdash-desktop/src/main/index.ts
+++ b/apps/emdash-desktop/src/main/index.ts
@@ -10,6 +10,7 @@ import { githubAccountsChangedChannel } from '@shared/events/githubEvents';
 import { registerRPCRouter } from '@shared/lib/ipc/rpc';
 import { LIBSECRET_PASSWORD_STORE, shouldForceLibsecretBackend } from './app/linux-secret-storage';
 import { setupApplicationMenu } from './app/menu';
+import { registerProcessCrashLogging } from './app/process-crash-logging';
 import { registerAppScheme, setupAppProtocol } from './app/protocol';
 import { registerQuitHandler } from './app/shutdown';
 import { applyNativeTheme, createMainWindow } from './app/window';
@@ -72,6 +73,7 @@ registerAppScheme();
 
 initializeFileLogger();
 registerProcessErrorLogging(log);
+registerProcessCrashLogging(app, log);
 registerRendererLogHandler(ipcMain);
 
 app.on('second-instance', () => {


### PR DESCRIPTION
### Description

Another suggestion — independent of #2971, either can stand alone.

`render-process-gone` and `child-process-gone` have no handlers anywhere in the
repo. When a renderer, GPU, or utility process dies, no main-process code path
runs: the window white-screens or a feature quietly stops working, and
`uncaughtException` never fires, so `registerProcessErrorLogging` doesn't see it
either. `emdash.log` just ends mid-session.

That's the worst case for the failure mode #80's memory watchdog exists for. An
OS-killed renderer is exactly what leaves no trace — the evidence is a platform
crash report (a macOS `JetsamEvent`, say), outside the app, kept only if the OS
felt like it. This puts the cause in emdash's own log next to the rest of the
session, so `reason` and `exitCode` are one grep away.

`clean-exit` is dropped rather than recorded. Electron reports it for every
helper that terminates normally at shutdown, so logging it would mean a burst of
errors on every ordinary quit. For a renderer death the report also carries the
`WebContents` URL, which separates the app window from a browser-pane webview —
a page in the in-app browser crashing says nothing about emdash.

**Shape.** `reportRenderProcessGone` / `reportChildProcessGone` are pure
functions returning a message plus fields, or `null` for a clean exit — no
Electron import, so the filtering and field selection are directly testable.
`registerProcessCrashLogging(app, log)` is the wiring, typed against a narrowed
`ProcessCrashEventSource` interface rather than `Electron.App` so a test can
hand it a stub emitter. Same split as `dev-worktree-profile.ts` and
`reap-dev-profiles.ts`. `index.ts` gains one import and one call, next to the
existing `registerProcessErrorLogging`.

One thing worth flagging: reading `contents.getURL()` on a `WebContents` that is
already tearing down can throw, so it's wrapped and the URL is simply omitted
when unavailable — the crash still gets logged.

### Related issues

None filed. It came up while reading #80 — the watchdog catches the run-up to a
memory kill, but if the kill lands anyway there's nothing in the log to confirm
what happened.

### Testing

- `oxfmt --check`, `oxlint`, `tsgo --noEmit` on `apps/emdash-desktop` — all clean.
- `vitest run --project node` — 283 files / 2032 tests pass, including 10 new
  ones: `oom` / `crashed` / `killed` renderer reasons, `clean-exit` suppressed
  on both events, a missing URL falling back to `undefined`, child-process type
  and `serviceName` passthrough, and the registration seam driven by a stub
  emitter (both handlers registered, both firing, clean exits producing no log
  call).
- Not run: the full workspace `pnpm run test` across every project. No manual
  crash reproduction — I didn't want to guess at forcing an OOM kill on a real
  session, so the Electron event payloads are taken from the documented shapes
  and exercised through the stub rather than from a live crash. If you'd rather
  see a real one in a log before taking this, that's fair.

### Screenshot/Recording (if applicable)

n/a — log output only.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [ ] I updated docs when behavior or setup changed — no docs describe log contents
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for commit messages and the PR title

</details>