### PR TITLE
fix(tasks): persist create-task prompt drafts

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/build-create-task-params.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/build-create-task-params.test.ts
@@ -15,6 +15,7 @@ function makeInitialConversationState(
     setProvider: () => {},
     prompt: 'Check this',
     setPrompt: () => {},
+    clearPrompt: () => {},
     issueContext: null,
     setIssueContext: () => {},
     autoApprove,

--- a/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
@@ -102,7 +102,8 @@ export const CreateTaskModal = observer(function CreateTaskModal({
   const initialConversation = useInitialConversationState(
     selectedProjectId,
     undefined,
-    autoApproveByDefault
+    autoApproveByDefault,
+    { persistPromptPerProject: true }
   );
   const isWorkspaceProviderEnabled = useFeatureFlag('workspace-provider');
   const { navigate } = useNavigate();

--- a/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/use-create-task-callback.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/use-create-task-callback.test.ts
@@ -1,0 +1,123 @@
+import { JSDOM } from 'jsdom';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { InitialConversationState } from '@renderer/features/tasks/task-config/initial-conversation-section';
+import type { NavigateFnTyped } from '@renderer/lib/layout/navigation-provider';
+import { useCreateTaskCallback } from './use-create-task-callback';
+import type { CreateTaskState } from './use-create-task-state';
+
+const mocks = vi.hoisted(() => ({
+  createTask: vi.fn(),
+  logError: vi.fn(),
+  tasks: new Map<string, { phase: string }>(),
+}));
+
+vi.mock('@renderer/features/tasks/stores/task-selectors', () => ({
+  getTaskManagerStore: () => ({ createTask: mocks.createTask, tasks: mocks.tasks }),
+}));
+
+vi.mock('@renderer/utils/logger', () => ({
+  log: { error: mocks.logError },
+}));
+
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('useCreateTaskCallback', () => {
+  let dom: JSDOM;
+  let root: Root;
+  let handleCreateTask: (() => void) | undefined;
+  const clearPrompt = vi.fn();
+
+  beforeEach(() => {
+    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>');
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    root = createRoot(dom.window.document.getElementById('root') as HTMLDivElement);
+    handleCreateTask = undefined;
+    clearPrompt.mockReset();
+    mocks.createTask.mockReset();
+    mocks.logError.mockReset();
+    mocks.tasks.clear();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    vi.unstubAllGlobals();
+    dom.window.close();
+  });
+
+  async function renderCallback() {
+    const state = {
+      isValid: true,
+      taskName: { effectiveTaskName: 'Test task' },
+      linkedType: null,
+      linkedIssue: null,
+      linkedPR: null,
+      workspaceConfig: { resolvedConfig: {} },
+    } as unknown as CreateTaskState;
+    const initialConversation = {
+      provider: null,
+      clearPrompt,
+    } as unknown as InitialConversationState;
+
+    function Probe() {
+      ({ handleCreateTask } = useCreateTaskCallback({
+        selectedProjectId: 'project-1',
+        state,
+        initialConversation,
+        navigate: (() => {}) as NavigateFnTyped,
+        onClose: vi.fn(),
+      }));
+      return null;
+    }
+
+    await act(async () => root.render(React.createElement(Probe)));
+  }
+
+  it('clears the prompt only after task creation succeeds', async () => {
+    const creation = deferred();
+    mocks.createTask.mockReturnValue(creation.promise);
+    await renderCallback();
+
+    handleCreateTask?.();
+    expect(clearPrompt).not.toHaveBeenCalled();
+
+    await act(async () => creation.resolve());
+
+    expect(clearPrompt).toHaveBeenCalledOnce();
+  });
+
+  it('preserves the prompt when task creation fails', async () => {
+    const creation = deferred();
+    mocks.createTask.mockReturnValue(creation.promise);
+    await renderCallback();
+
+    handleCreateTask?.();
+    await act(async () => creation.reject(new Error('creation failed')));
+
+    expect(clearPrompt).not.toHaveBeenCalled();
+    expect(mocks.logError).toHaveBeenCalledOnce();
+  });
+
+  it('preserves the prompt when workspace provisioning fails', async () => {
+    mocks.createTask.mockImplementation(async ({ id }: { id: string }) => {
+      mocks.tasks.set(id, { phase: 'provision-error' });
+    });
+    await renderCallback();
+
+    handleCreateTask?.();
+    await act(async () => {});
+
+    expect(clearPrompt).not.toHaveBeenCalled();
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/use-create-task-callback.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/use-create-task-callback.ts
@@ -29,6 +29,8 @@ export function useCreateTaskCallback({
     if (!taskManager) return;
 
     const id = crypto.randomUUID();
+    const initialConversationConfig = buildInitialConversation(initialConversation);
+    initialConversation.setPrompt('');
     void taskManager
       .createTask({
         id,
@@ -38,7 +40,7 @@ export function useCreateTaskCallback({
           name: state.taskName.effectiveTaskName,
           linkedIssue: state.linkedType === 'issue' ? (state.linkedIssue ?? undefined) : undefined,
           initialStatus: deriveInitialStatus(state.linkedType, state.linkedPR),
-          initialConversation: buildInitialConversation(initialConversation),
+          initialConversation: initialConversationConfig,
         },
         workspaceConfig: state.workspaceConfig.resolvedConfig,
       })

--- a/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/use-create-task-callback.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/use-create-task-callback.ts
@@ -30,7 +30,6 @@ export function useCreateTaskCallback({
 
     const id = crypto.randomUUID();
     const initialConversationConfig = buildInitialConversation(initialConversation);
-    initialConversation.setPrompt('');
     void taskManager
       .createTask({
         id,
@@ -43,6 +42,11 @@ export function useCreateTaskCallback({
           initialConversation: initialConversationConfig,
         },
         workspaceConfig: state.workspaceConfig.resolvedConfig,
+      })
+      .then(() => {
+        if (taskManager.tasks.get(id)?.phase !== 'provision-error') {
+          initialConversation.clearPrompt();
+        }
       })
       .catch((e) => log.error('create task failed', e));
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.test.ts
@@ -229,6 +229,38 @@ describe('useInitialConversationState', () => {
     expect(latestState?.prompt).toBe('Keep this automation prompt');
   });
 
+  it('restores a persisted prompt for the same project after remounting', async () => {
+    await renderProbe('project-1', { persistPromptPerProject: true });
+    await setPrompt('A long task description');
+
+    await act(async () => root.unmount());
+    root = createRoot(container);
+    await renderProbe('project-1', { persistPromptPerProject: true });
+
+    expect(latestState?.prompt).toBe('A long task description');
+  });
+
+  it('keeps persisted prompts isolated by project', async () => {
+    await renderProbe('project-1', { persistPromptPerProject: true });
+    await setPrompt('Project one draft');
+
+    await renderProbe('project-2', { persistPromptPerProject: true });
+    expect(latestState?.prompt).toBe('');
+
+    await setPrompt('Project two draft');
+    await renderProbe('project-1', { persistPromptPerProject: true });
+
+    expect(latestState?.prompt).toBe('Project one draft');
+  });
+
+  it('removes a persisted prompt when it is cleared', async () => {
+    await renderProbe('project-1', { persistPromptPerProject: true });
+    await setPrompt('Draft to clear');
+    await setPrompt('');
+
+    expect(dom.window.localStorage.getItem('initial-conversation:draft:project-1')).toBeNull();
+  });
+
   it('persists the auto-approve preference', async () => {
     await renderProbe('project-1');
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.test.ts
@@ -240,6 +240,20 @@ describe('useInitialConversationState', () => {
     expect(latestState?.prompt).toBe('A long task description');
   });
 
+  it.each([null, 42, { text: 'not a string' }])(
+    'ignores a persisted non-string prompt: %j',
+    async (persistedValue) => {
+      dom.window.localStorage.setItem(
+        'initial-conversation:draft:project-1',
+        JSON.stringify(persistedValue)
+      );
+
+      await renderProbe('project-1', { persistPromptPerProject: true });
+
+      expect(latestState?.prompt).toBe('');
+    }
+  );
+
   it('keeps persisted prompts isolated by project', async () => {
     await renderProbe('project-1', { persistPromptPerProject: true });
     await setPrompt('Project one draft');

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.tsx
@@ -63,6 +63,21 @@ export type InitialConversationState = {
 
 interface InitialConversationStateOptions {
   resetPromptOnProjectChange?: boolean;
+  persistPromptPerProject?: boolean;
+}
+
+function initialConversationDraftKey(projectId: string): string {
+  return `initial-conversation:draft:${projectId}`;
+}
+
+function readPromptDraft(projectId: string | undefined, persist: boolean): string {
+  if (!projectId || !persist) return '';
+  try {
+    const draft = localStorage.getItem(initialConversationDraftKey(projectId));
+    return draft === null ? '' : (JSON.parse(draft) as string);
+  } catch {
+    return '';
+  }
 }
 
 export function useInitialConversationState(
@@ -71,11 +86,34 @@ export function useInitialConversationState(
   autoApproveByDefault = false,
   options: InitialConversationStateOptions = {}
 ): InitialConversationState {
-  const { resetPromptOnProjectChange = true } = options;
+  const { resetPromptOnProjectChange = true, persistPromptPerProject = false } = options;
   const connectionId = projectId ? getProjectSshConnectionId(projectId) : undefined;
   const { providerId, setProviderOverride } = useEffectiveProvider(connectionId, initialProvider);
   const { data: agents } = useAgents();
-  const [prompt, setPrompt] = useState('');
+  const [prompt, setPromptState] = useState(() =>
+    readPromptDraft(projectId, persistPromptPerProject)
+  );
+  const setPrompt = useCallback<Dispatch<SetStateAction<string>>>(
+    (value) => {
+      setPromptState((current) => {
+        const next = typeof value === 'function' ? value(current) : value;
+        if (projectId && persistPromptPerProject) {
+          try {
+            const key = initialConversationDraftKey(projectId);
+            if (next) {
+              localStorage.setItem(key, JSON.stringify(next));
+            } else {
+              localStorage.removeItem(key);
+            }
+          } catch {
+            // Ignore storage failures; the in-memory draft still works.
+          }
+        }
+        return next;
+      });
+    },
+    [persistPromptPerProject, projectId]
+  );
   const [issueContext, setIssueContext] = useState<string | null>(null);
   const [autoApprovePreference, setAutoApprovePreference] = useLocalStorage(
     'initial-conversation:auto-approve-enabled',
@@ -98,7 +136,7 @@ export function useInitialConversationState(
     setPrevProjectId(projectId);
     setProviderOverride(null);
     if (resetPromptOnProjectChange) {
-      setPrompt('');
+      setPromptState(readPromptDraft(projectId, persistPromptPerProject));
     }
     setIssueContext(null);
     setIssueContextEditorOpen(false);

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.tsx
@@ -44,6 +44,7 @@ export type InitialConversationState = {
   projectId?: string;
   prompt: string;
   setPrompt: Dispatch<SetStateAction<string>>;
+  clearPrompt: () => void;
   issueContext: string | null;
   setIssueContext: (ctx: string | null) => void;
   autoApprove: boolean;
@@ -74,7 +75,9 @@ function readPromptDraft(projectId: string | undefined, persist: boolean): strin
   if (!projectId || !persist) return '';
   try {
     const draft = localStorage.getItem(initialConversationDraftKey(projectId));
-    return draft === null ? '' : (JSON.parse(draft) as string);
+    if (draft === null) return '';
+    const parsed: unknown = JSON.parse(draft);
+    return typeof parsed === 'string' ? parsed : '';
   } catch {
     return '';
   }
@@ -114,6 +117,16 @@ export function useInitialConversationState(
     },
     [persistPromptPerProject, projectId]
   );
+  const clearPrompt = useCallback(() => {
+    if (projectId && persistPromptPerProject) {
+      try {
+        localStorage.removeItem(initialConversationDraftKey(projectId));
+      } catch {
+        // Ignore storage failures; the in-memory draft can still be cleared.
+      }
+    }
+    setPromptState('');
+  }, [persistPromptPerProject, projectId]);
   const [issueContext, setIssueContext] = useState<string | null>(null);
   const [autoApprovePreference, setAutoApprovePreference] = useLocalStorage(
     'initial-conversation:auto-approve-enabled',
@@ -159,6 +172,7 @@ export function useInitialConversationState(
     projectId,
     prompt,
     setPrompt,
+    clearPrompt,
     issueContext,
     setIssueContext,
     autoApprove,


### PR DESCRIPTION
### Description
- persist Create Task initial-conversation drafts per project
- restore drafts when the modal is closed and reopened
- keep drafts isolated between projects
- clear the persisted draft after creating the task
- leave other initial-conversation consumers, such as automations, unchanged

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
