### PR TITLE
Support non-Latin (e.g. Japanese) task titles in branch/worktree names

### DIFF
--- a/apps/emdash-desktop/src/main/core/tasks/name-generation/generateTaskName.test.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/name-generation/generateTaskName.test.ts
@@ -34,6 +34,22 @@ describe('generateTaskName', () => {
     });
   });
 
+  describe('non-Latin titles', () => {
+    it('preserves Japanese characters instead of collapsing to a generic slug', () => {
+      const result = generateTaskName({ title: '日本語でタスク名をつける' });
+      expect(result).toBeTruthy();
+      expect(result).not.toContain('/');
+      expect(result).toBe('日本語でタスク名をつける');
+    });
+
+    it('sanitizes unsafe characters in Japanese titles', () => {
+      const result = generateTaskName({ title: 'ログイン / バグ修正 (#123)' });
+      expect(result).toBeTruthy();
+      expect(result).not.toContain('/');
+      expect(result).not.toMatch(/^-|-$/);
+    });
+  });
+
   describe('random generation (no title)', () => {
     it('generates a random friendly name when no input provided', () => {
       const result = generateTaskName({});

--- a/apps/emdash-desktop/src/main/core/tasks/name-generation/generateTaskName.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/name-generation/generateTaskName.ts
@@ -6,7 +6,7 @@ const MAX_TASK_NAME_LENGTH = 64;
 function sanitize(raw: string): string {
   return raw
     .toLowerCase()
-    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/[^\p{L}\p{N}-]/gu, '-')
     .replace(/-+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, MAX_TASK_NAME_LENGTH);
@@ -16,7 +16,15 @@ export function generateRandom(): string {
   return sanitize(humanId({ separator: '-', capitalize: false }));
 }
 
+// nbranch transliterates to ASCII and drops non-Latin scripts entirely
+// (e.g. Japanese input collapses to a generic "feat-unknown"), so
+// non-Latin titles are slugified directly instead of going through it.
+const NON_LATIN_PATTERN = /[^\x00-\x7f]/;
+
 function generateFromInput(title: string, description?: string): string {
+  if (NON_LATIN_PATTERN.test(title)) {
+    return sanitize(title) || generateRandom();
+  }
   const input = description ? `${title}\n\n${description}` : title;
   const raw = generateBranchName(input, {
     addRandomSuffix: false,

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-env.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-env.ts
@@ -23,7 +23,7 @@ export function getTaskEnvVars(ctx: TaskEnvContext): Record<string, string> {
 function slugify(value: string): string {
   return value
     .toLowerCase()
-    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/[^\p{L}\p{N}-]/gu, '-')
     .replace(/-+/g, '-')
     .replace(/^-|-$/g, '');
 }


### PR DESCRIPTION
## Summary
- Task/branch names are generated via `nbranch`, which transliterates input to ASCII and drops non-Latin scripts entirely — a Japanese task title collapses to a generic `feat-unknown` slug instead of preserving any of the original title.
- Non-Latin titles now bypass `nbranch` and are slugified directly with a Unicode-aware sanitizer (`\p{L}\p{N}-` instead of `a-z0-9-}`), so the original characters (Japanese, etc.) are preserved in the generated branch name and worktree folder name.
- Applied the same fix to the `EMDASH_TASK_NAME` env var slugify helper in `workspace-env.ts` for consistency.

## Test plan
- [x] Added unit tests in `generateTaskName.test.ts` covering a Japanese title and a Japanese title containing unsafe characters (`/`, parentheses, spaces).
- [x] Verified existing ASCII-title test cases are unaffected (regex/logic unchanged for ASCII input path).
- [ ] CI / full test suite (not run locally — pnpm not available in this environment).