### PR TITLE
fix(codex): preserve existing hook configuration

### DIFF
--- a/packages/plugins/src/agents/impl/codex/hooks.test.ts
+++ b/packages/plugins/src/agents/impl/codex/hooks.test.ts
@@ -28,7 +28,7 @@ function createMemoryFs(initial: Record<string, string> = {}): PluginFs & {
 }
 
 describe('buildCodexHookConfig', () => {
-  it('writes Codex hooks to config.toml and removes legacy hooks.json', async () => {
+  it('writes Codex hooks to an existing hooks.json without changing config.toml', async () => {
     const fs = createMemoryFs({
       [CODEX_CONFIG_PATH]: 'model = "gpt-5"\n',
       [CODEX_LEGACY_HOOKS_PATH]: JSON.stringify(
@@ -60,18 +60,18 @@ describe('buildCodexHookConfig', () => {
     });
     const hooks = buildCodexHookConfig();
 
-    await expect(hooks.writeHooks(fs, [])).resolves.toEqual([CODEX_CONFIG_PATH]);
+    await expect(hooks.writeHooks(fs, [])).resolves.toEqual([CODEX_LEGACY_HOOKS_PATH]);
 
-    await expect(fs.exists(CODEX_LEGACY_HOOKS_PATH)).resolves.toBe(false);
     const config = await fs.read(CODEX_CONFIG_PATH);
-    expect(config).toContain('model = "gpt-5"');
-    expect(config).toContain('echo user-stop');
-    expect(config).toContain('echo user-prompt');
-    expect(config).toContain('notification_type');
-    expect(config).toContain('session-start');
+    expect(config).toBe('model = "gpt-5"\n');
+    const legacy = await fs.read(CODEX_LEGACY_HOOKS_PATH);
+    expect(legacy).toContain('echo user-stop');
+    expect(legacy).toContain('echo user-prompt');
+    expect(legacy).toContain('notification_type');
+    expect(legacy).toContain('session-start');
   });
 
-  it('keeps legacy hooks.json when writing config.toml fails', async () => {
+  it('keeps legacy hooks.json when updating it fails', async () => {
     const legacyHooks = JSON.stringify({
       hooks: {
         Stop: [
@@ -87,7 +87,7 @@ describe('buildCodexHookConfig', () => {
     });
     const write = fs.write.bind(fs);
     fs.write = async (path, content) => {
-      if (path === CODEX_CONFIG_PATH) {
+      if (path === CODEX_LEGACY_HOOKS_PATH) {
         throw new Error('permission denied');
       }
       await write(path, content);

--- a/packages/plugins/src/agents/impl/codex/hooks.ts
+++ b/packages/plugins/src/agents/impl/codex/hooks.ts
@@ -76,27 +76,6 @@ async function readLegacyHooks(fs: PluginFs): Promise<Record<string, unknown[]>>
   return getHooks(config);
 }
 
-async function migrateLegacyHooks(
-  fs: PluginFs,
-  hooks: Record<string, unknown[]>
-): Promise<() => Promise<void>> {
-  const legacyHooks = await readLegacyHooks(fs);
-
-  for (const [key, entries] of Object.entries(legacyHooks)) {
-    if (!Array.isArray(entries)) continue;
-
-    const userEntries = filterUserHooks(entries as Record<string, unknown>[]);
-    if (!userEntries.length) continue;
-
-    const existing = Array.isArray(hooks[key]) ? hooks[key] : [];
-    hooks[key] = [...filterUserHooks(existing as Record<string, unknown>[]), ...userEntries];
-  }
-
-  return async () => {
-    await fs.delete(CODEX_LEGACY_HOOKS_PATH).catch(() => {});
-  };
-}
-
 function makeCodexSessionStartCommand(): string {
   const post = makeHookPostCommand('session-start', 'stdin', {});
   if (process.platform === 'win32') return post;
@@ -149,9 +128,30 @@ export function buildCodexHookConfig() {
         : [];
     },
     async writeHooks(fs: PluginFs, _hooks: HookRegistration[]): Promise<string[]> {
+      const legacyConfig = await readJsonConfig(fs, CODEX_LEGACY_HOOKS_PATH);
+      if (await fs.exists(CODEX_LEGACY_HOOKS_PATH)) {
+        const legacyHooks = getHooks(legacyConfig);
+        for (const [key, cmd] of [
+          ['Stop', stopCmd],
+          ['PermissionRequest', permCmd],
+          ['SessionStart', sessionCmd],
+        ] as [string, string][]) {
+          const existing = Array.isArray(legacyHooks[key]) ? legacyHooks[key] : [];
+          legacyHooks[key] = [
+            ...filterUserHooks(existing as Record<string, unknown>[]),
+            buildNestedEntry(cmd),
+          ];
+        }
+        await writeJsonConfig(fs, CODEX_LEGACY_HOOKS_PATH, {
+          ...legacyConfig,
+          hooks: legacyHooks,
+        });
+        await removeLegacyCodexNotify(fs).catch(() => {});
+        return [CODEX_LEGACY_HOOKS_PATH];
+      }
+
       const config = await readTomlConfig(fs, CODEX_CONFIG_PATH);
       const hooks = getHooks(config);
-      const cleanupLegacy = await migrateLegacyHooks(fs, hooks);
 
       for (const [key, cmd] of [
         ['Stop', stopCmd],
@@ -165,7 +165,6 @@ export function buildCodexHookConfig() {
         ];
       }
       await writeTomlConfig(fs, CODEX_CONFIG_PATH, { ...config, hooks });
-      await cleanupLegacy();
       await removeLegacyCodexNotify(fs).catch(() => {});
       return [CODEX_CONFIG_PATH];
     },

--- a/packages/plugins/src/agents/impl/codex/index.ts
+++ b/packages/plugins/src/agents/impl/codex/index.ts
@@ -151,8 +151,7 @@ export const provider = registerPluginBehavior(plugin, {
   prompt: {
     buildCommand: (ctx) =>
       buildStandardCommand(ctx, {
-        autoApproveFlag:
-          '-c approval_policy="never" -c sandbox_mode="danger-full-access" --dangerously-bypass-hook-trust',
+        autoApproveFlag: '-c approval_policy="never" -c sandbox_mode="danger-full-access"',
         initialPromptFlag: '',
         resumeFlag: 'resume',
         sessionIdFlag: ' ',

--- a/packages/plugins/src/agents/impl/index.test.ts
+++ b/packages/plugins/src/agents/impl/index.test.ts
@@ -54,6 +54,22 @@ describe('pluginRegistry', () => {
     expect(cliLoginArgs(opencode, 'opencode-login')).toEqual(['auth', 'login']);
   });
 
+  it('keeps Codex hook trust enabled in auto-approve mode', () => {
+    const codex = pluginRegistry.get('codex')!;
+    const command = codex.behavior.prompt!.buildCommand({
+      cli: 'codex',
+      autoApprove: true,
+      initialPrompt: 'Fix the bug',
+      sessionId: 'conv-1',
+      isResuming: false,
+      model: '',
+    });
+
+    expect(command.args).toContain('approval_policy="never"');
+    expect(command.args).toContain('sandbox_mode="danger-full-access"');
+    expect(command.args).not.toContain('--dangerously-bypass-hook-trust');
+  });
+
   it('each entry has hostDependency.updates with valid kind', () => {
     for (const d of pluginRegistry.getAll()) {
       expect(d.capabilities.hostDependency.updates).toBeDefined();


### PR DESCRIPTION
## What changed

- Keep an existing Codex hooks.json as the active hook representation and add Emdash hooks there in place.
- Use config.toml only when hooks.json does not exist.
- Stop passing --dangerously-bypass-hook-trust in Codex auto-approve mode while retaining approval_policy=never and sandbox_mode=danger-full-access.

## Root cause

Emdash migrated user hooks from hooks.json into config.toml and deleted the JSON file. Configuration managers can legitimately recreate a managed hooks.json, causing Codex to load hooks from both representations. Auto-approve also disabled hook trust independently of approval and sandbox policy.

## Validation

- 24 focused Codex/provider tests passed.
- Plugin format check, lint, and typecheck passed.
- Full workspace build passed.
- Full plugin suite: 352 passed; two unrelated ACP fixture snapshot mismatches remain on upstream main behavior.