### PR TITLE
fix(resource-monitor): close panel without disabling setting

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/command-palette/command-palette-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/command-palette/command-palette-modal.tsx
@@ -297,7 +297,7 @@ export function CommandPaletteModal({
   if (view === 'resource-monitor') {
     return (
       <div className="flex flex-col overflow-hidden">
-        <ResourceMonitorView onBack={handleResourceMonitorBack} />
+        <ResourceMonitorView onBack={handleResourceMonitorBack} onClose={handleClose} />
         <div className="flex items-center gap-4 border-t border-foreground/10 px-3 py-2">
           <span className="flex items-center gap-1 text-xs text-foreground/40">
             <Shortcut hotkey="Escape" variant="keycaps" />

--- a/apps/emdash-desktop/src/renderer/features/command-palette/resource-monitor-view.tsx
+++ b/apps/emdash-desktop/src/renderer/features/command-palette/resource-monitor-view.tsx
@@ -25,8 +25,10 @@ import {
 
 export const ResourceMonitorView = observer(function ResourceMonitorView({
   onBack,
+  onClose,
 }: {
   onBack: () => void;
+  onClose: () => void;
 }) {
   const store = appState.resourceMonitor;
   const snapshot = store.snapshot;
@@ -56,6 +58,19 @@ export const ResourceMonitorView = observer(function ResourceMonitorView({
           <Stat label="CPU" value={cpuLabel} />
           <Stat label="Mem" value={memLabel} />
           <CopyReportButton snapshot={snapshot} groups={groups} />
+          <Tooltip>
+            <TooltipTrigger>
+              <button
+                type="button"
+                onClick={onClose}
+                className="flex size-6 shrink-0 items-center justify-center rounded-md text-foreground/50 transition-colors hover:bg-background-2 hover:text-foreground"
+                aria-label="Close resource monitor"
+              >
+                <X size={13} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Close</TooltipContent>
+          </Tooltip>
         </div>
       </div>
 


### PR DESCRIPTION
### Description

Add a dedicated `x` button to the Resource Monitor panel. It closes the command-palette modal through the existing `onClose` callback, while leaving the `resourceMonitor.enabled` setting unchanged.

The session-level `x` buttons remain unchanged and still stop individual sessions.

### Related issues

Not provided.

### Testing

- `git diff --check` ✅
- `pnpm exec oxfmt --check ...` not run: workspace binaries are not installed in this checkout.
- `pnpm --filter @emdash/emdash-desktop exec tsgo --noEmit` not run: `tsgo` is not installed in this checkout.
- Manual UI verification not run.

### Screenshot/Recording (if applicable)

Not included; this is a small UI wiring change.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [ ] I updated docs when behavior or setup changed — not applicable
- [ ] I added or updated tests when behavior changed — no component test harness exists for this view
- [x] I only added comments where the logic is not obvious
- [x] I used a Conventional Commit for the commit message and PR title

</details>