### PR TITLE
fix(automations): reliably deliver prompts to unattended agents

### DIFF
--- a/apps/emdash-desktop/src/main/core/automations/actions/taskCreate.test.ts
+++ b/apps/emdash-desktop/src/main/core/automations/actions/taskCreate.test.ts
@@ -369,6 +369,36 @@ describe('executeTaskCreate', () => {
     });
   });
 
+  it('uses ACP for unattended providers whose PTY prompt requires keystroke injection', async () => {
+    await executeTaskCreate(
+      {
+        ...automation,
+        conversationConfig: {
+          prompt: 'Complete the full assignment',
+          provider: 'kimi',
+          autoApprove: true,
+          type: 'pty',
+        },
+      },
+      run,
+      noopStep
+    );
+
+    expect(createConversation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'kimi',
+        initialQueue: [{ text: 'Complete the full assignment' }],
+        type: 'acp',
+      })
+    );
+    expect(mockAcpStartSession).toHaveBeenCalledWith({
+      input: expect.objectContaining({
+        providerId: 'kimi',
+        initialQueue: [{ text: 'Complete the full assignment' }],
+      }),
+    });
+  });
+
   it('opens the project when it is not loaded', async () => {
     vi.mocked(projectManager.getProject)
       .mockReturnValueOnce(undefined)

--- a/apps/emdash-desktop/src/main/core/automations/actions/taskCreate.ts
+++ b/apps/emdash-desktop/src/main/core/automations/actions/taskCreate.ts
@@ -63,6 +63,22 @@ function resolveAutomationAgentAutoApprove(
   return getPlugin(provider).capabilities.autoApprove.kind === 'supported' ? true : configured;
 }
 
+function resolveAutomationConversationType(
+  provider: AgentProviderId,
+  configured: 'pty' | 'acp' | undefined
+): 'pty' | 'acp' {
+  if (configured === 'acp' || !isValidProviderId(provider)) return configured ?? 'pty';
+
+  const capabilities = getPlugin(provider).capabilities;
+  // Background runs cannot recover when a TUI misses synthetic paste/Enter delivery. ACP gives
+  // the prompt to the provider as a structured first turn and acknowledges session startup.
+  if (capabilities.prompt.kind === 'keystroke' && capabilities.acp.kind === 'supported') {
+    return 'acp';
+  }
+
+  return 'pty';
+}
+
 async function buildAutomationInitialQueue(
   automation: Automation,
   projectId: string,
@@ -141,7 +157,10 @@ export async function executeTaskCreate(
     const provider = (automation.conversationConfig?.provider ||
       (await appSettingsService.get('defaultAgent')) ||
       DEFAULT_AGENT_ID) as AgentProviderId;
-    const conversationType = automation.conversationConfig?.type ?? 'pty';
+    const conversationType = resolveAutomationConversationType(
+      provider,
+      automation.conversationConfig?.type
+    );
     const initialQueue =
       conversationType === 'acp'
         ? await buildAutomationInitialQueue(automation, projectId, prompt)


### PR DESCRIPTION
## Summary

- route unattended PTY automations through ACP when the provider can only receive the initial prompt via synthetic keystrokes
- preserve explicit ACP and normal argv-based PTY providers
- verify Kimi receives the complete assignment as the structured first `initialQueue` turn and that `startSession` is called

## Root cause

Automation persisted the full prompt, provisioned the task, and marked the run launched. Kimi PTY, however, starts without a prompt argument and depends on delayed synthetic paste/Enter into its TUI. A background card cannot recover if that injection is missed, leaving a running `kimi-code` process with no work. ACP sends the prompt as a protocol turn and acknowledges session startup.

## Checks

- `pnpm run build`
- `pnpm --filter @emdash/emdash-desktop run typecheck`
- `pnpm --filter @emdash/emdash-desktop run lint`
- `pnpm --filter @emdash/emdash-desktop exec vitest run src/main/core/automations/actions/taskCreate.test.ts --project node` (16 passed)
- `git diff --check`

## Risk

This changes transport selection for background automations configured as PTY only when the provider advertises both keystroke-only prompt delivery and ACP support. Interactive/manual task behavior is unchanged.
