### PR TITLE
fix(tui): restore codex notification delivery

### DIFF
--- a/packages/core/src/runtimes/tui-agents/node/runtime/runtime.test.ts
+++ b/packages/core/src/runtimes/tui-agents/node/runtime/runtime.test.ts
@@ -28,21 +28,23 @@ function createRuntime(
     exec?: Partial<IExecutionContext>;
     intents?: ReturnType<typeof createMemorySessionIntentStore>;
     conversationReports?: ConversationLifecycleReporter;
+    hooks?: ResolvedTuiProvider['hooks'];
     trustWorkspace?: ITrustBehavior['trustWorkspace'];
   } = {}
 ) {
   const spawner = new FakePtySpawner();
+  const hooks = options.hooks ?? { kind: 'none' as const };
   const provider: ResolvedTuiProvider = {
     name: 'Test Agent',
     prompt: { kind: 'argv' },
-    hooks: { kind: 'none' },
+    hooks,
     buildCommand: () => ({ command: 'agent', args: ['run'], env: {} }),
   };
   const agentHost = {
     homeDir: '/home/test-user',
     resolveTuiProvider: vi.fn(() => provider),
     get: vi.fn(() => ({
-      capabilities: { hooks: { kind: 'none' } },
+      capabilities: { hooks },
       behavior: options.trustWorkspace ? { trust: { trustWorkspace: options.trustWorkspace } } : {},
     })),
     buildPromptCommand: vi.fn(() =>
@@ -126,6 +128,45 @@ describe('TuiAgentsRuntime', () => {
     expect(trustWorkspace).toHaveBeenCalledWith(expect.any(Object), {
       workspacePath: '/workspace',
     });
+  });
+
+  it('delivers hook events when hook installation fails', async () => {
+    const { runtime, spawner } = createRuntime({
+      hooks: { kind: 'config', scope: 'global', supportedEvents: ['stop'] },
+    });
+    vi.spyOn(runtime['hookInstaller'], 'ensureHooksInstalled').mockResolvedValue(false);
+
+    await runtime.startSession(startInput());
+    try {
+      const env = spawner.specs[0]?.env;
+      expect(env).toMatchObject({
+        EMDASH_PTY_ID: 'conversation-1',
+        EMDASH_HOOK_PORT: expect.stringMatching(/^\d+$/),
+        EMDASH_HOOK_NONCE: expect.any(String),
+        EMDASH_HOOK_TOKEN: expect.any(String),
+      });
+      if (!env?.EMDASH_HOOK_PORT || !env.EMDASH_HOOK_NONCE) {
+        throw new Error('hook endpoint was not provided');
+      }
+
+      const response = await fetch(`http://127.0.0.1:${env.EMDASH_HOOK_PORT}/hook`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Emdash-Token': env.EMDASH_HOOK_NONCE,
+          'X-Emdash-Pty-Id': 'conversation-1',
+          'X-Emdash-Event-Type': 'stop',
+        },
+        body: '{}',
+      });
+
+      expect(response.status).toBe(200);
+      expect(peek(runtime.agentStatesLiveModel.get(undefined)!.states.list)).toMatchObject({
+        'conversation-1': { status: 'completed' },
+      });
+    } finally {
+      await runtime.dispose();
+    }
   });
 
   it('wraps command execution with shellSetup and tmux', async () => {

--- a/packages/core/src/runtimes/tui-agents/node/runtime/runtime.ts
+++ b/packages/core/src/runtimes/tui-agents/node/runtime/runtime.ts
@@ -465,7 +465,7 @@ export class TuiAgentsRuntime {
         workspacePath: config.input.cwd,
       });
     }
-    const hookEnv = await this.prepareHookEnv(config.input);
+    const hookEnv = await this.prepareHookEnv(config.input, provider);
     if (!this.isCurrentGeneration(config.input.conversationId, generation)) {
       return this.cancelledSpawn(config.input.conversationId);
     }
@@ -698,12 +698,25 @@ export class TuiAgentsRuntime {
       : err({ type: 'unknown-provider', providerId });
   }
 
-  private async prepareHookEnv(input: TuiAgentStartInput): Promise<Record<string, string>> {
+  private async prepareHookEnv(
+    input: TuiAgentStartInput,
+    provider: ResolvedTuiProvider
+  ): Promise<Record<string, string>> {
+    if (provider.hooks.kind === 'none') return {};
+
     const hooksAvailable = await this.hookInstaller.ensureHooksInstalled({
       providerId: input.providerId,
       workspacePath: input.cwd,
     });
-    if (!hooksAvailable) return {};
+    if (!hooksAvailable) {
+      this.deps.logger.warn(
+        'TuiAgentsRuntime: hook installation unavailable; continuing with hook endpoint',
+        {
+          conversationId: input.conversationId,
+          providerId: input.providerId,
+        }
+      );
+    }
 
     let hook;
     try {

--- a/packages/plugins/src/agents/impl/codex/hooks.test.ts
+++ b/packages/plugins/src/agents/impl/codex/hooks.test.ts
@@ -101,6 +101,58 @@ describe('buildCodexHookConfig', () => {
     await expect(fs.read(CODEX_LEGACY_HOOKS_PATH)).resolves.toBe(legacyHooks);
   });
 
+  it('preserves Codex hook trust state while installing and deleting Emdash hooks', async () => {
+    const trustKey = '/home/user/.codex/config.toml:stop:0:0';
+    const fs = createMemoryFs({
+      [CODEX_CONFIG_PATH]: `[hooks.state."${trustKey}"]
+enabled = true
+trusted_hash = "sha256:trusted"
+`,
+    });
+    const hooks = buildCodexHookConfig();
+
+    await expect(hooks.writeHooks(fs, [])).resolves.toEqual([CODEX_CONFIG_PATH]);
+    await expect(hooks.getHooksInstalled(fs)).resolves.toBe(true);
+
+    const installed = parseToml((await fs.read(CODEX_CONFIG_PATH)) ?? '') as {
+      hooks: {
+        state: Record<string, { enabled?: boolean; trusted_hash?: string }>;
+      };
+    };
+    expect(installed.hooks.state[trustKey]).toEqual({
+      enabled: true,
+      trusted_hash: 'sha256:trusted',
+    });
+
+    await hooks.deleteHooks(fs);
+
+    const deleted = parseToml((await fs.read(CODEX_CONFIG_PATH)) ?? '') as {
+      hooks: {
+        state: Record<string, { enabled?: boolean; trusted_hash?: string }>;
+      };
+    };
+    expect(deleted.hooks.state[trustKey]).toEqual({
+      enabled: true,
+      trusted_hash: 'sha256:trusted',
+    });
+    expect(await hooks.getHooksInstalled(fs)).toBe(false);
+  });
+
+  it('still validates Codex event hooks after separating trust state', async () => {
+    const fs = createMemoryFs({
+      [CODEX_CONFIG_PATH]: `[hooks.state."config.toml:stop:0:0"]
+enabled = true
+
+[hooks.Stop]
+invalid = true
+`,
+    });
+
+    await expect(buildCodexHookConfig().getHooksInstalled(fs)).rejects.toThrow(
+      'expected "hooks.Stop" to be an array of objects'
+    );
+  });
+
   it.skipIf(process.platform === 'win32')(
     'pipes the Codex session argument through to the hook request body',
     async () => {

--- a/packages/plugins/src/agents/impl/codex/hooks.ts
+++ b/packages/plugins/src/agents/impl/codex/hooks.ts
@@ -66,11 +66,38 @@ async function removeLegacyCodexNotify(fs: PluginFs): Promise<void> {
   await fs.write(CODEX_CONFIG_PATH, toml.stringify(config));
 }
 
+function isConfigObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 function getHooks(
   config: Record<string, unknown>,
   configPath: string
 ): Record<string, Record<string, unknown>[]> {
-  return hookMapFromConfig(config, configPath);
+  if (configPath !== CODEX_CONFIG_PATH) return hookMapFromConfig(config, configPath);
+
+  const hooks = config.hooks;
+  if (hooks === undefined) return {};
+  if (!isConfigObject(hooks)) {
+    throw new Error(`Invalid ${configPath}: expected "hooks" to be an object`);
+  }
+
+  // Codex owns this map and updates it as hook definitions are reviewed or disabled.
+  // It shares the `hooks` table with event arrays but is not itself an event.
+  const { state, ...eventHooks } = hooks;
+  if (state !== undefined && !isConfigObject(state)) {
+    throw new Error(`Invalid ${configPath}: expected "hooks.state" to be an object`);
+  }
+
+  return hookMapFromConfig({ hooks: eventHooks }, configPath);
+}
+
+function configWithEventHooks(
+  config: Record<string, unknown>,
+  eventHooks: Record<string, Record<string, unknown>[]>
+): Record<string, unknown> {
+  const existingHooks = isConfigObject(config.hooks) ? config.hooks : {};
+  return { ...config, hooks: { ...existingHooks, ...eventHooks } };
 }
 
 function hasCodexEmdashHooks(hooks: Record<string, unknown[]>, specs: [string, string][]): boolean {
@@ -174,7 +201,7 @@ export function buildCodexHookConfig() {
         const existing = Array.isArray(hooks[key]) ? hooks[key] : [];
         hooks[key] = [...filterUserHooks(existing), buildNestedEntry(cmd)];
       }
-      await writeTomlConfig(fs, CODEX_CONFIG_PATH, { ...config, hooks });
+      await writeTomlConfig(fs, CODEX_CONFIG_PATH, configWithEventHooks(config, hooks));
       await cleanupLegacy();
       await removeLegacyCodexNotify(fs).catch(() => {});
       return [CODEX_CONFIG_PATH];
@@ -185,7 +212,7 @@ export function buildCodexHookConfig() {
       for (const key of Object.keys(hooks)) {
         hooks[key] = filterUserHooks(hooks[key]);
       }
-      await writeTomlConfig(fs, CODEX_CONFIG_PATH, { ...config, hooks });
+      await writeTomlConfig(fs, CODEX_CONFIG_PATH, configWithEventHooks(config, hooks));
 
       const legacyConfig = await readJsonConfig(fs, CODEX_LEGACY_HOOKS_PATH);
       const legacyHooks = getHooks(legacyConfig, CODEX_LEGACY_HOOKS_PATH);


### PR DESCRIPTION
- preserve codex hook trust state while validating event hooks through hookMapFromConfig
- refresh stale emdash hook definitions without overwriting codex-owned metadata
- keep authenticated tui hook delivery available when hook installation or inspection fails
- skip hook infrastructure for providers that do not support hooks