### PR TITLE
fix(desktop): restore theme command in command palette

### DIFF
--- a/apps/emdash-desktop/src/core/features/workbench/browser/command-palette/command-palette-modal.tsx
+++ b/apps/emdash-desktop/src/core/features/workbench/browser/command-palette/command-palette-modal.tsx
@@ -326,11 +326,7 @@ export function CommandPaletteModal({ projectId, taskId, workspaceId }: CommandP
                     key={item.id}
                     value={item.id}
                     item={displayItem}
-                    onSelect={() => {
-                      if (displayItem.bound.availability.kind !== 'enabled') return;
-                      handleClose();
-                      scopes.execute(displayItem.item.command, undefined, 'palette');
-                    }}
+                    onSelect={displayItem.execute}
                   />
                 );
               }

--- a/apps/emdash-desktop/src/core/primitives/view-scopes/browser/scopes.test.ts
+++ b/apps/emdash-desktop/src/core/primitives/view-scopes/browser/scopes.test.ts
@@ -409,6 +409,57 @@ describe('ViewScopes', () => {
     scopes.dispose();
   });
 
+  it('preserves the underlying scope when a capturing scope activates before focus', () => {
+    const dom = new JSDOM('<div id="modal" tabindex="-1"></div>');
+    const scopes = new ViewScopes(dom.window.document);
+    const execute = vi.fn();
+    const outer = scopes.instantiate(windowScope(), {
+      impl: { 'task.archive': () => ({ execute }) },
+    });
+    const modal = scopes.instantiate(capturingScope(), { impl: {} });
+    modal.attachRef(dom.window.document.querySelector<HTMLElement>('#modal'));
+    scopes.activate(outer);
+
+    // ModalRenderer explicitly activates a fresh modal before Base UI's focus pass.
+    scopes.activate(modal);
+    dom.window.document
+      .querySelector<HTMLElement>('#modal')
+      ?.dispatchEvent(new dom.window.FocusEvent('focusin', { bubbles: true }));
+
+    expect(
+      scopes.getActiveCommand(archiveCommand, { fromCaptureOrigin: true })?.availability.kind
+    ).toBe('enabled');
+    scopes
+      .getActiveCommand(archiveCommand, { fromCaptureOrigin: true })
+      ?.execute(undefined, 'palette');
+    expect(execute).toHaveBeenCalledOnce();
+    scopes.dispose();
+  });
+
+  it('retains a capturing scope origin when a stacked scope temporarily replaces it', () => {
+    const scopes = new ViewScopes(undefined);
+    const execute = vi.fn();
+    const outer = scopes.instantiate(windowScope(), {
+      impl: { 'task.archive': () => ({ execute }) },
+    });
+    const bottomModal = scopes.instantiate(capturingScope(), { impl: {} });
+    const topModal = scopes.instantiate(capturingScope(), { impl: {} });
+    scopes.activate(outer);
+    scopes.activate(bottomModal);
+    scopes.activate(topModal);
+
+    expect(scopes.getActiveCommand(archiveCommand, { fromCaptureOrigin: true })).toBeUndefined();
+
+    topModal.dispose();
+    scopes.activate(bottomModal);
+    scopes
+      .getActiveCommand(archiveCommand, { fromCaptureOrigin: true })
+      ?.execute(undefined, 'palette');
+
+    expect(execute).toHaveBeenCalledOnce();
+    scopes.dispose();
+  });
+
   it('does not resolve palette commands against a disposed capture origin', () => {
     const dom = new JSDOM(
       '<div id="terminal" tabindex="-1"></div><div id="modal" tabindex="-1"></div>'

--- a/apps/emdash-desktop/src/core/primitives/view-scopes/browser/scopes.ts
+++ b/apps/emdash-desktop/src/core/primitives/view-scopes/browser/scopes.ts
@@ -158,7 +158,12 @@ export class ViewScopes {
   private readonly instancesByKey = new Map<string, ViewScopeInstance[]>();
   private readonly logicalActive: IObservableValue<ViewScopeInstance | undefined>;
   private readonly focusActive: IObservableValue<ViewScopeInstance | undefined>;
-  private readonly captureOriginPath: IObservableValue<readonly ViewScopeInstance[]>;
+  // Each capturing scope owns the path it replaced so stacked modals cannot
+  // overwrite one another's command-palette discovery context.
+  private readonly captureOriginPaths = new WeakMap<
+    ViewScopeInstance,
+    readonly ViewScopeInstance[]
+  >();
   private readonly activePathValue: IComputedValue<readonly ViewScopeHandle[]>;
   private readonly document: Document | undefined;
 
@@ -166,7 +171,6 @@ export class ViewScopes {
     this.document = document;
     this.logicalActive = observable.box(undefined, { deep: false });
     this.focusActive = observable.box(undefined, { deep: false });
-    this.captureOriginPath = observable.box([], { deep: false });
     this.activePathValue = computed(() => this.computeActivePath());
     this.document?.addEventListener('focusin', this.handleFocusIn);
   }
@@ -218,6 +222,7 @@ export class ViewScopes {
     if (instance?.isDisposed) {
       throw new Error('Cannot activate a disposed view scope');
     }
+    if (instance) this.captureOrigin(instance);
     const focused = this.focusActive.get();
     if (instance && focused && !this.isDescendantOf(focused, instance)) {
       this.focusActive.set(undefined);
@@ -246,9 +251,12 @@ export class ViewScopes {
     command: TCommand,
     options: { readonly fromCaptureOrigin?: boolean } = {}
   ): BoundCommand<TCommand> | undefined {
+    const activeInstance = this.activeScopeInstance();
     const path =
-      options.fromCaptureOrigin && this.activePath[0]?.def.traits.has('capturing')
-        ? this.captureOriginPath.get().filter((instance) => !instance.isDisposed)
+      options.fromCaptureOrigin && activeInstance?.def.traits.has('capturing')
+        ? (this.captureOriginPaths.get(activeInstance) ?? []).filter(
+            (instance) => !instance.isDisposed
+          )
         : this.activePath;
     for (const handle of path) {
       const bound = handle.getCommand(command);
@@ -376,6 +384,12 @@ export class ViewScopes {
     return false;
   }
 
+  private captureOrigin(instance: ViewScopeInstance): void {
+    if (!instance.def.traits.has('capturing')) return;
+    if (this.captureOriginPaths.has(instance) || this.activePath[0] === instance) return;
+    this.captureOriginPaths.set(instance, this.computeActiveInstancePath());
+  }
+
   private activeScopeInstance(): ViewScopeInstance | undefined {
     let current = this.focusActive.get() ?? this.logicalActive.get();
     while (current?.isDisposed) current = current.parent;
@@ -392,9 +406,7 @@ export class ViewScopes {
     const id = element?.getAttribute('data-view-scope');
     const instance = id ? this.instancesById.get(id) : undefined;
     if (!instance) return;
-    if (instance.def.traits.has('capturing') && this.activePath[0] !== instance) {
-      this.captureOriginPath.set(this.computeActiveInstancePath());
-    }
+    this.captureOrigin(instance);
     this.focusActive.set(instance);
   };
 }

--- a/apps/emdash-desktop/src/renderer/tests/browser/modal-escape.test.tsx
+++ b/apps/emdash-desktop/src/renderer/tests/browser/modal-escape.test.tsx
@@ -2,10 +2,13 @@ import '@emdash/ui/style.css';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { toggleThemeCommand } from '@core/features/workbench/contributions/commands';
+import { windowScope } from '@core/manifests/browser/scope-catalog';
 import { COMMAND_CATALOG } from '@core/manifests/shared/command-catalog';
 import { KeybindingService } from '@core/primitives/keybindings/browser/keybinding-service';
 import { modalStore } from '@core/primitives/modals/react/modal-store';
 import { ThemeProvider } from '@core/primitives/theme/browser/theme-provider';
+import type { ViewScopeImpl } from '@core/primitives/view-scopes/api';
 import { scopes } from '@core/primitives/view-scopes/browser';
 import { KeybindingDispatcher } from '@renderer/lib/keybindings/keybinding-dispatcher';
 import { ModalRenderer } from '@renderer/lib/modal/modal-renderer';
@@ -88,6 +91,34 @@ describe('Modal Escape routing', () => {
     });
 
     expect(modalStore.isOpen).toBe(false);
+  });
+
+  it('preserves window commands when a fresh modal activates before focus', async () => {
+    const executeTheme = vi.fn();
+    const implementation = Object.fromEntries(
+      windowScope.commands.map((command) => [
+        command.id,
+        () => ({
+          execute: command === toggleThemeCommand ? executeTheme : vi.fn(),
+        }),
+      ])
+    ) as unknown as ViewScopeImpl<typeof windowScope>;
+    const windowInstance = scopes.instantiate(windowScope(), { impl: implementation });
+    scopes.activate(windowInstance);
+
+    try {
+      await act(async () => {
+        void openConfirmModal('Capture origin');
+      });
+      await flushOpen();
+
+      const bound = scopes.getActiveCommand(toggleThemeCommand, { fromCaptureOrigin: true });
+      expect(bound?.availability.kind).toBe('enabled');
+      bound?.execute(undefined, 'palette');
+      expect(executeTheme).toHaveBeenCalledOnce();
+    } finally {
+      windowInstance.dispose();
+    }
   });
 
   it('closes a modal on Escape after clicking inside it (control)', async () => {


### PR DESCRIPTION
- preserve per-modal capture origins during explicit activation and stacked modal flows
- execute the resolved palette binding directly so toggle theme remains available and runs from command k