### PR TITLE
fix(workspaces): recover from watcher startup failures

### DIFF
--- a/packages/core/src/runtimes/workspace-registry/node/scan/scheduler.test.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/scan/scheduler.test.ts
@@ -15,10 +15,25 @@ import {
 
 class FakeWatchService implements IWatchService {
   readonly roots = new Map<string, (events: WatchEvent[]) => void>();
+  readonly watchCalls = new Map<string, number>();
+  private readonly failures = new Set<string>();
+
+  fail(root: string): void {
+    this.failures.add(root);
+  }
+
+  recover(root: string): void {
+    this.failures.delete(root);
+  }
+
   watch(root: string, onEvents: (events: WatchEvent[]) => void, _options?: WatchOptions) {
+    this.watchCalls.set(root, (this.watchCalls.get(root) ?? 0) + 1);
     this.roots.set(root, onEvents);
     return {
-      ready: () => Promise.resolve(),
+      ready: () =>
+        this.failures.has(root)
+          ? Promise.reject(new Error(`Watcher failed for ${root}`))
+          : Promise.resolve(),
       release: () => {
         this.roots.delete(root);
         return Promise.resolve();
@@ -89,9 +104,12 @@ function createHarness(
     pollIntervalMs?: number;
     active?: Set<string>;
     block?: () => Promise<void>;
+    fail?: string[];
+    watchRetryDelayMs?: number;
   } = {}
 ): Harness {
   const watcher = new FakeWatchService();
+  for (const root of options.fail ?? []) watcher.fail(root);
   const requests: ScanRequest[] = [];
   const scheduler = new WorkspaceScanScheduler({
     watcher,
@@ -104,6 +122,7 @@ function createHarness(
     debounceMs: options.debounceMs ?? 20,
     activeDebounceMs: options.activeDebounceMs ?? 5,
     pollIntervalMs: options.pollIntervalMs ?? 60 * 60_000,
+    watchRetryDelayMs: options.watchRetryDelayMs,
   });
   scheduler.start();
   return { watcher, requests, scheduler };
@@ -251,6 +270,42 @@ describe('WorkspaceScanScheduler', () => {
         expect(requests).toContainEqual({ kind: 'repository', id: 'repo-1' });
         // Missing records poll too — that is how a returned path is noticed.
         expect(requests).toContainEqual({ kind: 'workspace', id: 'dir-1', mode: 'full' });
+      });
+    } finally {
+      await scheduler.dispose();
+    }
+  });
+
+  it('keeps polling when native watcher startup fails', async () => {
+    const repo = repoTarget('repo-1', '/repos/main');
+    const { requests, scheduler } = createHarness([repo], {
+      debounceMs: 1,
+      pollIntervalMs: 25,
+      fail: ['/repos/main', path.join('/repos/main', '.git')],
+    });
+    try {
+      await eventually(() => {
+        expect(requests).toContainEqual({ kind: 'repository', id: 'repo-1' });
+      });
+    } finally {
+      await scheduler.dispose();
+    }
+  });
+
+  it('reattaches a failed native watcher after the path recovers', async () => {
+    const repo = repoTarget('repo-1', '/repos/main');
+    const { watcher, requests, scheduler } = createHarness([repo], {
+      debounceMs: 1,
+      fail: ['/repos/main'],
+      watchRetryDelayMs: 5,
+    });
+    try {
+      watcher.recover('/repos/main');
+      await eventually(() => expect(watcher.watchCalls.get('/repos/main')).toBe(2));
+
+      watcher.emit('/repos/main', [{ kind: 'update', path: '/repos/main/recovered.txt' }]);
+      await eventually(() => {
+        expect(requests).toContainEqual({ kind: 'workspace', id: 'repo-1', mode: 'full' });
       });
     } finally {
       await scheduler.dispose();

--- a/packages/core/src/runtimes/workspace-registry/node/scan/scheduler.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/scan/scheduler.ts
@@ -34,6 +34,8 @@ export type WorkspaceScanSchedulerOptions = {
   activeDebounceMs?: number;
   /** The freshness floor: no record goes longer than this without a rescan. */
   pollIntervalMs?: number;
+  /** Initial retry delay for a failed native watch; subsequent attempts back off exponentially. */
+  watchRetryDelayMs?: number;
 };
 
 export const DEFAULT_SCAN_DEBOUNCE_MS = 2_000;
@@ -44,6 +46,8 @@ export const DEFAULT_SCAN_DEBOUNCE_MS = 2_000;
  */
 export const DEFAULT_ACTIVE_SCAN_DEBOUNCE_MS = 1_000;
 const DEFAULT_POLL_INTERVAL_MS = 5 * 60_000;
+const DEFAULT_WATCH_RETRY_DELAY_MS = 250;
+const MAX_WATCH_RETRY_DELAY_MS = 30_000;
 
 type PendingScan = {
   request: ScanRequest;
@@ -67,8 +71,11 @@ export class WorkspaceScanScheduler {
   private readonly debounceMs: number;
   private readonly activeDebounceMs: number;
   private readonly pollIntervalMs: number;
+  private readonly watchRetryDelayMs: number;
 
   private readonly watches = new Map<string, WatchHandle>();
+  private readonly watchRetryAttempts = new Map<string, number>();
+  private readonly watchRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly pending = new Map<string, PendingScan>();
   /** Refcounted self-suppression: ids the registry is actively writing into. */
   private readonly muted = new Map<string, number>();
@@ -87,6 +94,7 @@ export class WorkspaceScanScheduler {
     this.debounceMs = options.debounceMs ?? DEFAULT_SCAN_DEBOUNCE_MS;
     this.activeDebounceMs = options.activeDebounceMs ?? DEFAULT_ACTIVE_SCAN_DEBOUNCE_MS;
     this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.watchRetryDelayMs = options.watchRetryDelayMs ?? DEFAULT_WATCH_RETRY_DELAY_MS;
   }
 
   start(): void {
@@ -110,8 +118,15 @@ export class WorkspaceScanScheduler {
     for (const [key, handle] of this.watches) {
       if (!desired.has(key)) {
         this.watches.delete(key);
+        this.watchRetryAttempts.delete(key);
         void handle.release().catch(() => undefined);
       }
+    }
+    for (const [key, timer] of this.watchRetryTimers) {
+      if (desired.has(key)) continue;
+      clearTimeout(timer);
+      this.watchRetryTimers.delete(key);
+      this.watchRetryAttempts.delete(key);
     }
     for (const [key, { target, gitDir }] of desired) {
       if (this.watches.has(key)) continue;
@@ -130,7 +145,34 @@ export class WorkspaceScanScheduler {
             }
           );
       this.watches.set(key, handle);
+      void handle.ready().then(
+        () => this.watchRetryAttempts.delete(key),
+        (error) => {
+          if (this.disposed || this.watches.get(key) !== handle) return;
+          this.watches.delete(key);
+          void handle.release().catch(() => undefined);
+          this.logger.warn('workspace watch unavailable; using polling fallback', {
+            path: target.path,
+            gitDir,
+            error,
+          });
+          this.scheduleWatchRetry(key);
+        }
+      );
     }
+  }
+
+  private scheduleWatchRetry(key: string): void {
+    if (this.disposed || this.watchRetryTimers.has(key)) return;
+    const attempt = this.watchRetryAttempts.get(key) ?? 0;
+    const delay = Math.min(this.watchRetryDelayMs * 2 ** attempt, MAX_WATCH_RETRY_DELAY_MS);
+    this.watchRetryAttempts.set(key, attempt + 1);
+    const timer = setTimeout(() => {
+      this.watchRetryTimers.delete(key);
+      if (!this.disposed) this.syncWatches();
+    }, delay);
+    timer.unref?.();
+    this.watchRetryTimers.set(key, timer);
   }
 
   /**
@@ -155,6 +197,9 @@ export class WorkspaceScanScheduler {
   async dispose(): Promise<void> {
     this.disposed = true;
     if (this.pollTimer !== null) clearInterval(this.pollTimer);
+    for (const timer of this.watchRetryTimers.values()) clearTimeout(timer);
+    this.watchRetryTimers.clear();
+    this.watchRetryAttempts.clear();
     for (const pending of this.pending.values()) clearTimeout(pending.timer);
     this.pending.clear();
     const handles = [...this.watches.values()];

--- a/packages/core/src/runtimes/workspace-registry/node/worker-spec.test.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/worker-spec.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { workspaceRegistryWorkerSpec, type WorkspaceRegistryWorkerSpecInput } from './worker-spec';
 
 describe('workspaceRegistryWorkerSpec', () => {
-  it('keeps default restart for the durable index with a 3s shutdown grace', () => {
+  it('restarts the durable index indefinitely with bounded backoff', () => {
     const env = { PATH: '/usr/bin' };
     const [component, options] = workspaceRegistryWorkerSpec({
       executable: '/w/workspace-registry.mjs',
@@ -13,7 +13,11 @@ describe('workspaceRegistryWorkerSpec', () => {
     expect(component.id).toBe('workspace-registry');
     expect(options.name).toBe('workspace-registry');
     expect(options.env).toBe(env);
-    expect(options.supervision).toBeUndefined();
+    expect(options.supervision?.restart).toBe('on-failure');
+    if (options.supervision?.restart !== 'on-failure') throw new Error('Missing supervision');
+    expect(options.supervision.schedule.delayFor(0)).toBe(250);
+    expect(options.supervision.schedule.delayFor(4)).toBe(30_000);
+    expect(options.supervision.schedule.delayFor(100)).toBe(30_000);
     expect(options.shutdownGraceMs).toBe(3_000);
     expect(component.configSchema.parse(options.config)).toEqual({
       databasePath: '/data/workspace-registry.db',

--- a/packages/core/src/runtimes/workspace-registry/node/worker-spec.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/worker-spec.ts
@@ -1,3 +1,4 @@
+import { retrySchedule } from '@emdash/shared/scheduling';
 import type { ProvidedWireComponentRequirements } from '@emdash/wire/worker';
 import type { WireComponentWorkerCreateOptions } from '@emdash/wire/worker';
 import type { z } from 'zod';
@@ -23,10 +24,10 @@ export type WorkspaceRegistryWorkerSpecInput = {
 /**
  * Spawn spec for the workspace registry worker. The registry owns its database
  * exclusively (ADR 0005); the watcher feeds its freshness scheduler; the session
- * runtimes are deactivateWorkspace's kill-sessions plane. Default supervision
- * (restart on failure) is deliberate: a durable index should come back; its
- * runtime overlay is ephemeral by design. The 3s shutdown grace lets it close
- * its database cleanly before the host escalates.
+ * runtimes are deactivateWorkspace's kill-sessions plane. Supervision retries
+ * indefinitely with bounded backoff: a durable index should come back without
+ * requiring an application restart; its runtime overlay is ephemeral by design.
+ * The 3s shutdown grace lets it close its database cleanly before the host escalates.
  */
 export function workspaceRegistryWorkerSpec(
   input: WorkspaceRegistryWorkerSpecInput
@@ -39,6 +40,13 @@ export function workspaceRegistryWorkerSpec(
       env: input.env,
       dependencies: input.dependencies,
       config: { databasePath: input.databasePath },
+      supervision: {
+        restart: 'on-failure',
+        schedule: retrySchedule({
+          delaysMs: [250, 1_000, 2_500, 10_000, 30_000],
+          repeatLast: true,
+        }),
+      },
       shutdownGraceMs: 3_000,
     },
   ];


### PR DESCRIPTION
### Description

Recover the workspace registry when a native filesystem watcher cannot start.

Previously, a rejected `WatchHandle.ready()` promise escaped as an unhandled rejection and terminated the workspace-registry worker. After the generic supervision budget was exhausted, new workspace activation stayed unavailable until the entire desktop app was restarted.

This change:

- observes watcher startup failures and keeps the polling freshness floor active;
- retries failed native watches with bounded exponential backoff;
- supervises the workspace-registry worker indefinitely with a 30-second maximum delay;
- clears all retry state when targets disappear or the scheduler is disposed.

### Related issues

No existing issue found.

### Testing

- `pnpm --filter @emdash/core run format`
- `pnpm --filter @emdash/core run typecheck`
- `pnpm --filter @emdash/core run lint`
- `pnpm --filter @emdash/core exec vitest run --maxWorkers=1` (203 files, 1,369 tests)
- `pnpm run build` (9 projects)
- packaged an arm64 macOS Canary build
- local Codex review: clean after addressing its polling-fallback finding

### Screenshot/Recording (if applicable)

Not applicable; this is worker recovery behavior.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed, or docs were not required
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit message and PR title

</details>
