### PR TITLE
fix(fs-watch): make watcher readiness failures explicit

### DIFF
--- a/apps/emdash-desktop/src/main/gateway/files-domain.integration.test.ts
+++ b/apps/emdash-desktop/src/main/gateway/files-domain.integration.test.ts
@@ -420,7 +420,7 @@ class ManualWatcher implements IWatchService {
   watch(root: string, onEvents: (events: WatchEvent[]) => void, options: WatchOptions = {}) {
     this.entries.set(root, { onEvents, options });
     return {
-      ready: async () => {},
+      ready: async () => ok(undefined),
       release: async () => {
         this.entries.delete(root);
       },

--- a/apps/workspace-server/src/api/controller.test.ts
+++ b/apps/workspace-server/src/api/controller.test.ts
@@ -225,7 +225,7 @@ describe('runtime domain forwarding', () => {
 function createNoopWatcher(): IWatchService {
   return {
     watch: () => ({
-      ready: async () => {},
+      ready: async () => ok(undefined),
       release: async () => {},
     }),
     dispose: async () => {},

--- a/packages/core/src/runtimes/file-search/node/file-search-runtime.test.ts
+++ b/packages/core/src/runtimes/file-search/node/file-search-runtime.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, mkdir, realpath, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { ok } from '@emdash/shared';
 import type Database from 'better-sqlite3';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { StoreHandle } from '#primitives/sqlite-store/api';
@@ -79,7 +80,7 @@ describe('FileSearchRuntime', () => {
 
 class NoopWatchService implements IWatchService {
   watch() {
-    return { ready: async () => {}, release: async () => {} };
+    return { ready: async () => ok(undefined), release: async () => {} };
   }
 
   async dispose(): Promise<void> {}

--- a/packages/core/src/runtimes/file-search/node/path/index/root-index.test.ts
+++ b/packages/core/src/runtimes/file-search/node/path/index/root-index.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, mkdir, realpath, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { err, ok, type Result } from '@emdash/shared';
 import { createScope } from '@emdash/shared/concurrency';
 import { deferred } from '@emdash/shared/testing';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -307,6 +308,35 @@ describe('RootIndex', () => {
     expect(index.status).toEqual({ kind: 'ready' });
   });
 
+  it('fails reconciliation when watcher readiness returns a failure Result', async () => {
+    const rootPath = await createRoot();
+    const store = createStore();
+    const root = store.upsertRoot({ rootKey: 'root-key', rootPath }).root;
+    const failure = Object.assign(new Error('watch root disappeared'), { code: 'ENOENT' });
+    const scanner = new RecordingScanner();
+    const scope = createScope({ label: 'root-index-watch-failure-test' });
+    const index = new RootIndex({
+      root,
+      store,
+      watcher: new FakeWatchService(err(failure)),
+      scanner,
+      exclusions: new DefaultFileSearchExclusions({ caseSensitive: true }),
+      scope,
+      runScan: async (_signal, operation) => operation(),
+    });
+    cleanups.push(() => scope.dispose());
+
+    await expect(index.reconcile()).rejects.toMatchObject({
+      name: 'RootWatchError',
+      cause: failure,
+    });
+    expect(scanner.scans).toEqual([]);
+    expect(index.status).toMatchObject({
+      kind: 'failed',
+      failure: { expected: { type: 'root-unavailable', reason: 'not-found' } },
+    });
+  });
+
   it('cancels active work and ignores later watcher events after disposal', async () => {
     const rootPath = await createRoot();
     const store = createStore();
@@ -559,6 +589,8 @@ class FakeWatchService implements IWatchService {
   private onResync: (() => void) | undefined;
   releaseCount = 0;
 
+  constructor(private readonly readyResult: Result<void, unknown> = ok(undefined)) {}
+
   watch(
     _root: string,
     onEvents: (events: WatchEvent[]) => void,
@@ -567,7 +599,7 @@ class FakeWatchService implements IWatchService {
     this.onEvents = onEvents;
     this.onResync = options.onResync;
     return {
-      ready: async () => {},
+      ready: async () => this.readyResult,
       release: async () => {
         this.releaseCount += 1;
       },

--- a/packages/core/src/runtimes/file-search/node/path/index/root-index.ts
+++ b/packages/core/src/runtimes/file-search/node/path/index/root-index.ts
@@ -114,11 +114,12 @@ export class RootIndex {
   private async reconcileOnce(signal: AbortSignal): Promise<void> {
     let build: PathIndexBuild | undefined;
     try {
-      try {
-        await waitWithSignal(this.watch.ready(), signal, 'Root index cancelled');
-      } catch (error) {
-        if (signal.aborted) throw error;
-        throw new RootWatchError('File-search watcher could not attach to the root', error);
+      const attached = await waitWithSignal(this.watch.ready(), signal, 'Root index cancelled');
+      if (!attached.success) {
+        throw new RootWatchError(
+          'File-search watcher could not attach to the root',
+          attached.error
+        );
       }
       throwIfAborted(signal, 'Root index cancelled');
       const activeBuild = this.options.store.beginBuild(this.options.root.id);

--- a/packages/core/src/runtimes/file-search/node/path/root-path-search.test.ts
+++ b/packages/core/src/runtimes/file-search/node/path/root-path-search.test.ts
@@ -1,3 +1,4 @@
+import { ok } from '@emdash/shared';
 import { createConcurrencyLimiter, createScope } from '@emdash/shared/concurrency';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { HostAbsolutePath } from '#primitives/path/api';
@@ -97,7 +98,7 @@ class FailingScanner implements PathScanner {
 
 class NoopWatchService implements IWatchService {
   watch() {
-    return { ready: async () => {}, release: async () => {} };
+    return { ready: async () => ok(undefined), release: async () => {} };
   }
 
   async dispose(): Promise<void> {}

--- a/packages/core/src/runtimes/files/node/allocation/allocation-graph.test.ts
+++ b/packages/core/src/runtimes/files/node/allocation/allocation-graph.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, realpath, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { err, ok } from '@emdash/shared';
 import { afterEach, describe, expect, it } from 'vitest';
 import { runtimeRoot } from '#runtimes/files/node/testing/paths';
 import type { IWatchService, WatchOptions } from '#services/fs-watch/api';
@@ -21,7 +22,7 @@ describe('FilesAllocationGraph', () => {
       watch: () => {
         watchCount += 1;
         return {
-          ready: async () => {},
+          ready: async () => ok(undefined),
           release: async () => {
             releaseCount += 1;
           },
@@ -52,9 +53,7 @@ describe('FilesAllocationGraph', () => {
     const errors: string[] = [];
     const watcher: IWatchService = {
       watch: () => ({
-        ready: async () => {
-          throw new Error('watch failed');
-        },
+        ready: async () => err(new Error('watch failed')),
         release: async () => {},
       }),
       dispose: async () => {},
@@ -82,7 +81,7 @@ describe('FilesAllocationGraph', () => {
       watch: (watchRoot, _onEvents, options) => {
         watched.push({ root: watchRoot, options });
         return {
-          ready: async () => {},
+          ready: async () => ok(undefined),
           release: async () => {},
         };
       },
@@ -110,7 +109,7 @@ describe('FilesAllocationGraph', () => {
       watch: (_root, _onEvents, options) => {
         watchOptions = options;
         return {
-          ready: async () => {},
+          ready: async () => ok(undefined),
           release: async () => {},
         };
       },

--- a/packages/core/src/runtimes/files/node/api/absolute-path-mutations.test.ts
+++ b/packages/core/src/runtimes/files/node/api/absolute-path-mutations.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { ok } from '@emdash/shared';
 import { client, connect, memoryTransportPair, serve } from '@emdash/wire/rpc';
 import { afterEach, describe, expect, it } from 'vitest';
 import { filesContract } from '#runtimes/files/api';
@@ -288,7 +289,7 @@ class SilentWatcher implements IWatchService {
   watch(root: string, onEvents: (events: WatchEvent[]) => void, options: WatchOptions = {}) {
     this.entries.set(root, { onEvents, options });
     return {
-      ready: async () => {},
+      ready: async () => ok(undefined),
       release: async () => {
         this.entries.delete(root);
       },

--- a/packages/core/src/runtimes/files/node/api/absolute-path.test.ts
+++ b/packages/core/src/runtimes/files/node/api/absolute-path.test.ts
@@ -1,6 +1,7 @@
 import { chmod, mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { ok } from '@emdash/shared';
 import { waitFor } from '@emdash/shared/testing';
 import { client, connect, memoryTransportPair, serve, type LiveUpdate } from '@emdash/wire/rpc';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -318,7 +319,7 @@ class ManualWatcher implements IWatchService {
   watch(root: string, onEvents: (events: WatchEvent[]) => void, options: WatchOptions = {}) {
     this.entries.set(root, { onEvents, options });
     return {
-      ready: async () => {},
+      ready: async () => ok(undefined),
       release: async () => {
         this.entries.delete(root);
       },

--- a/packages/core/src/runtimes/files/node/api/controller.test.ts
+++ b/packages/core/src/runtimes/files/node/api/controller.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from 'node
 import { homedir, tmpdir } from 'node:os';
 import path from 'node:path';
 import { PassThrough } from 'node:stream';
+import { ok } from '@emdash/shared';
 import { waitFor } from '@emdash/shared/testing';
 import { createLiveJobReplicaCache } from '@emdash/wire/live';
 import {
@@ -457,7 +458,7 @@ class ManualWatcher implements IWatchService {
   watch(root: string, onEvents: (events: WatchEvent[]) => void, options: WatchOptions = {}) {
     this.entries.set(root, { onEvents, options });
     return {
-      ready: async () => {},
+      ready: async () => ok(undefined),
       release: async () => {
         this.entries.delete(root);
       },

--- a/packages/core/src/runtimes/files/node/fs/file-system.test.ts
+++ b/packages/core/src/runtimes/files/node/fs/file-system.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { ok } from '@emdash/shared';
 import { afterEach, describe, expect, it } from 'vitest';
 import { FilesRuntime } from '#runtimes/files/node/files-runtime';
 import { runtimeRoot } from '#runtimes/files/node/testing/paths';
@@ -112,7 +113,7 @@ async function makeRoot(): Promise<string> {
 
 function noopWatcher(): IWatchService {
   return {
-    watch: () => ({ ready: async () => {}, release: async () => {} }),
+    watch: () => ({ ready: async () => ok(undefined), release: async () => {} }),
     dispose: async () => {},
   };
 }

--- a/packages/core/src/runtimes/files/node/root/root-resource.test.ts
+++ b/packages/core/src/runtimes/files/node/root/root-resource.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, realpath, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { err, ok, type Result } from '@emdash/shared';
 import { deferred } from '@emdash/shared/testing';
 import { afterEach, describe, expect, it } from 'vitest';
 import { resolveRootIdentity, type RootIdentity } from '#runtimes/files/node/allocation/identity';
@@ -36,7 +37,7 @@ describe('RootResource', () => {
     const batches: RootChange[][] = [];
     root.subscribe((changes) => batches.push(changes));
 
-    watcher.ready.resolve();
+    watcher.ready.resolve(ok(undefined));
     await root.watchReady();
 
     expect(batches).toEqual([[{ kind: 'resync' }]]);
@@ -53,7 +54,7 @@ describe('RootResource', () => {
     });
     cleanups.push(() => root.dispose());
 
-    watcher.ready.reject(new Error('native watcher startup failed'));
+    watcher.ready.resolve(err(new Error('native watcher startup failed')));
     await root.watchReady();
 
     expect(errors).toHaveLength(1);
@@ -76,7 +77,7 @@ describe('RootResource', () => {
     });
 
     await root.dispose();
-    watcher.ready.reject(new Error('released before ready'));
+    watcher.ready.resolve(err(new Error('released before ready')));
     await root.watchReady();
 
     expect(errors).toEqual([]);
@@ -85,7 +86,7 @@ describe('RootResource', () => {
 });
 
 class PendingWatcher implements IWatchService {
-  readonly ready = deferred<void>();
+  readonly ready = deferred<Result<void, unknown>>();
   released = false;
   readyResolved = false;
 

--- a/packages/core/src/runtimes/files/node/root/root-resource.ts
+++ b/packages/core/src/runtimes/files/node/root/root-resource.ts
@@ -64,15 +64,14 @@ export class RootResource {
         onResync: () => this.emit([{ kind: 'resync' }]),
       }
     );
-    this.watchReadyPromise = this.watch.ready().then(
-      () => {
+    this.watchReadyPromise = this.watch.ready().then((attached) => {
+      if (attached.success) {
         this.emit([{ kind: 'resync' }]);
-      },
-      (error: unknown) => {
-        if (this.disposed) return;
-        options.onError?.(`files root watch ${options.identity.rootId}`, error);
+        return;
       }
-    );
+      if (this.disposed) return;
+      options.onError?.(`files root watch ${options.identity.rootId}`, attached.error);
+    });
   }
 
   /**

--- a/packages/core/src/runtimes/files/node/tree/tree-resource.test.ts
+++ b/packages/core/src/runtimes/files/node/tree/tree-resource.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, realpath, rename, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { ok } from '@emdash/shared';
 import { deferred } from '@emdash/shared/testing';
 import { snapshot } from '@emdash/wire/state';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -265,7 +266,7 @@ class ManualWatcher implements IWatchService {
     this.onEvents = onEvents;
     this.onResync = options.onResync;
     return {
-      ready: async () => {},
+      ready: async () => ok(undefined),
       release: async () => {
         this.onEvents = undefined;
         this.onResync = undefined;

--- a/packages/core/src/runtimes/git/node/allocation/allocation-graph.test.ts
+++ b/packages/core/src/runtimes/git/node/allocation/allocation-graph.test.ts
@@ -1,4 +1,4 @@
-import { ok } from '@emdash/shared';
+import { err, ok } from '@emdash/shared';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { hostPath } from '#runtimes/git/node/testing/paths';
 import type { BoundExec } from '#services/exec/api';
@@ -49,7 +49,7 @@ describe('GitAllocationGraph', () => {
     const watcher: IWatchService = {
       watch: () => {
         if (fail) throw new Error('watch failed');
-        return { ready: async () => {}, release: async () => {} };
+        return { ready: async () => ok(undefined), release: async () => {} };
       },
       dispose: async () => {},
     };
@@ -66,12 +66,35 @@ describe('GitAllocationGraph', () => {
     await graph.dispose();
   });
 
+  it('evicts a mount when watcher readiness returns a failure Result', async () => {
+    const failure = new Error('watch attach failed');
+    let fail = true;
+    const watcher: IWatchService = {
+      watch: () => ({
+        ready: async () => (fail ? err(failure) : ok(undefined)),
+        release: async () => {},
+      }),
+      dispose: async () => {},
+    };
+    const graph = new GitAllocationGraph({ exec, watcher, identityResolver: resolver });
+    const selector = { repository: hostPath('/repo') };
+
+    await expect(graph.acquireRepository(selector).ready()).rejects.toBe(failure);
+    fail = false;
+    const retry = graph.acquireRepository(selector);
+    await expect(retry.ready()).resolves.toMatchObject({
+      identity: { repositoryId: identity.repositoryId },
+    });
+    await retry.release();
+    await graph.dispose();
+  });
+
   it('retains the parent repository until an idle checkout is disposed', async () => {
     vi.useFakeTimers();
     const released: string[] = [];
     const watcher: IWatchService = {
       watch: (root) => ({
-        ready: async () => {},
+        ready: async () => ok(undefined),
         release: async () => {
           released.push(root);
         },

--- a/packages/core/src/runtimes/git/node/api/controller.test.ts
+++ b/packages/core/src/runtimes/git/node/api/controller.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
-import type { Result } from '@emdash/shared';
+import { ok, type Result } from '@emdash/shared';
 import { createLiveJobReplicaCache } from '@emdash/wire/live';
 import {
   client,
@@ -49,7 +49,7 @@ function makeClient(runtime: GitRuntime) {
 function createNoopWatcher(onRelease?: () => void): IWatchService {
   return {
     watch: () => ({
-      ready: async () => {},
+      ready: async () => ok(undefined),
       release: async () => {
         onRelease?.();
       },
@@ -500,7 +500,7 @@ class ManualWatcher implements IWatchService {
   watch(root: string, onEvents: (events: WatchEvent[]) => void, _options: WatchOptions = {}) {
     this.entries.set(root, onEvents);
     return {
-      ready: async () => {},
+      ready: async () => ok(undefined),
       release: async () => {
         this.entries.delete(root);
       },

--- a/packages/core/src/runtimes/git/node/checkout/checkout-resource.ts
+++ b/packages/core/src/runtimes/git/node/checkout/checkout-resource.ts
@@ -23,7 +23,7 @@ import type { CheckoutIdentity } from '#runtimes/git/node/allocation/identity';
 import type { GitOperationContext } from '#runtimes/git/node/exec/operation-context';
 import type { RepositoryResource } from '#runtimes/git/node/repository/repository-resource';
 import type { WorktreeWatchEffects } from '#runtimes/git/node/repository/watch-classifier';
-import type { IWatchService, WatchHandle } from '#services/fs-watch/api';
+import { requireWatchReady, type IWatchService, type WatchHandle } from '#services/fs-watch/api';
 import { GitFileContentRegistry } from './file-content-registry';
 import type { GitCheckout } from './git-checkout';
 
@@ -67,7 +67,7 @@ export class CheckoutResource {
   static async create(options: CheckoutResourceOptions): Promise<CheckoutResource> {
     const resource = new CheckoutResource(options);
     try {
-      await resource.worktreeWatch.ready();
+      await requireWatchReady(resource.worktreeWatch);
       return resource;
     } catch (error) {
       await resource.dispose();

--- a/packages/core/src/runtimes/git/node/git-runtime.test.ts
+++ b/packages/core/src/runtimes/git/node/git-runtime.test.ts
@@ -3,6 +3,7 @@ import { chmod, mkdtemp, readFile, realpath, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
+import { ok } from '@emdash/shared';
 import { describe, expect, it } from 'vitest';
 import { gitContract } from '#runtimes/git/api';
 import { hostPath } from '#runtimes/git/node/testing/paths';
@@ -54,7 +55,7 @@ const repositorySelector = (root: string) => ({ repository: hostPath(root) });
 function createNoopWatcher(): IWatchService {
   return {
     watch: () => ({
-      ready: async () => {},
+      ready: async () => ok(undefined),
       release: async () => {},
     }),
     dispose: async () => {},
@@ -344,7 +345,7 @@ describe('GitRuntime', () => {
     let releaseStarted = 0;
     const watcher: IWatchService = {
       watch: () => ({
-        ready: async () => {},
+        ready: async () => ok(undefined),
         release: async () => {
           releaseStarted += 1;
           await releaseGate.promise;

--- a/packages/core/src/runtimes/git/node/repository/repository-resource.ts
+++ b/packages/core/src/runtimes/git/node/repository/repository-resource.ts
@@ -11,7 +11,7 @@ import {
 import type { CheckoutId, RepositoryIdentity } from '#runtimes/git/node/allocation/identity';
 import type { CheckoutResource } from '#runtimes/git/node/checkout/checkout-resource';
 import type { GitOperationContext } from '#runtimes/git/node/exec/operation-context';
-import type { IWatchService, WatchHandle } from '#services/fs-watch/api';
+import { requireWatchReady, type IWatchService, type WatchHandle } from '#services/fs-watch/api';
 import type { GitRepository } from './git-repository';
 import { RepositoryFamilyLane } from './repository-family-lane';
 import { classifyGitWatchEvents, type WorktreeWatchEffects } from './watch-classifier';
@@ -54,7 +54,7 @@ export class RepositoryResource {
   static async create(options: RepositoryResourceOptions): Promise<RepositoryResource> {
     const resource = new RepositoryResource(options);
     try {
-      await resource.commonDirWatch.ready();
+      await requireWatchReady(resource.commonDirWatch);
       return resource;
     } catch (error) {
       await resource.dispose();

--- a/packages/core/src/runtimes/workspace-registry/node/scan/scheduler.test.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/scan/scheduler.test.ts
@@ -1,5 +1,7 @@
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { err, ok, type Result } from '@emdash/shared';
+import { deferred, type Deferred } from '@emdash/shared/testing';
+import { describe, expect, it, vi } from 'vitest';
 import type { IWatchService, WatchEvent, WatchOptions } from '#services/fs-watch/api';
 import {
   DEFAULT_ACTIVE_SCAN_DEBOUNCE_MS,
@@ -13,23 +15,61 @@ import {
 // scan targets go in; coalesced scan requests come out. The scheduler never writes the
 // registry — its whole contract is which requests it emits and when.
 
+type FakeWatchAttempt = {
+  root: string;
+  onEvents: (events: WatchEvent[]) => void;
+  onError: ((error: unknown) => void) | undefined;
+  ready: Deferred<Result<void, unknown>>;
+  released: boolean;
+};
+
 class FakeWatchService implements IWatchService {
-  readonly roots = new Map<string, (events: WatchEvent[]) => void>();
-  watch(root: string, onEvents: (events: WatchEvent[]) => void, _options?: WatchOptions) {
-    this.roots.set(root, onEvents);
-    return {
-      ready: () => Promise.resolve(),
+  readonly roots = new Map<string, FakeWatchAttempt>();
+  readonly attempts: FakeWatchAttempt[] = [];
+
+  watch(root: string, onEvents: (events: WatchEvent[]) => void, options?: WatchOptions) {
+    const ready = deferred<Result<void, unknown>>();
+    const attempt: FakeWatchAttempt = {
+      root,
+      onEvents,
+      onError: options?.onError,
+      ready,
+      released: false,
+    };
+    const handle = {
+      ready: () => ready.promise,
       release: () => {
-        this.roots.delete(root);
+        attempt.released = true;
+        if (this.roots.get(root) === attempt) this.roots.delete(root);
         return Promise.resolve();
       },
     };
+    this.roots.set(root, attempt);
+    this.attempts.push(attempt);
+    void ready.promise.then((attached) => {
+      if (!attached.success && !attempt.released) attempt.onError?.(attached.error);
+    });
+    queueMicrotask(() => ready.resolve(ok(undefined)));
+    return handle;
   }
+
   dispose(): Promise<void> {
     return Promise.resolve();
   }
+
   emit(root: string, events: WatchEvent[]): void {
-    this.roots.get(root)?.(events);
+    this.roots.get(root)?.onEvents(events);
+  }
+
+  rejectReady(root: string, error: unknown): FakeWatchAttempt {
+    const attempt = this.roots.get(root);
+    if (!attempt) throw new Error(`No active watch for ${root}`);
+    attempt.ready.resolve(err(error));
+    return attempt;
+  }
+
+  watchCount(root: string): number {
+    return this.attempts.filter((attempt) => attempt.root === root).length;
   }
 }
 
@@ -253,6 +293,31 @@ describe('WorkspaceScanScheduler', () => {
         expect(requests).toContainEqual({ kind: 'workspace', id: 'dir-1', mode: 'full' });
       });
     } finally {
+      await scheduler.dispose();
+    }
+  });
+
+  it('drops a failed watch and retries it from the polling floor without an unhandled rejection', async () => {
+    const repo = repoTarget('repo-1', '/repos/main');
+    const unhandled = vi.fn();
+    process.on('unhandledRejection', unhandled);
+    const { watcher, scheduler } = createHarness([repo], { pollIntervalMs: 25 });
+
+    try {
+      expect(watcher.watchCount('/repos/main')).toBe(1);
+      const failed = watcher.rejectReady('/repos/main', new Error('watch attach failed'));
+
+      await eventually(() => {
+        expect(failed.released).toBe(true);
+        expect(watcher.roots.has('/repos/main')).toBe(false);
+      });
+      await eventually(() => expect(watcher.watchCount('/repos/main')).toBe(2));
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(watcher.roots.has('/repos/main')).toBe(true);
+      expect(unhandled).not.toHaveBeenCalled();
+    } finally {
+      process.off('unhandledRejection', unhandled);
       await scheduler.dispose();
     }
   });

--- a/packages/core/src/runtimes/workspace-registry/node/scan/scheduler.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/scan/scheduler.ts
@@ -115,20 +115,33 @@ export class WorkspaceScanScheduler {
     }
     for (const [key, { target, gitDir }] of desired) {
       if (this.watches.has(key)) continue;
+      const handleRef: { current?: WatchHandle } = {};
+      const onError = (error: unknown): void => {
+        this.logger.warn?.(`workspace watch failed: ${String(error)}`);
+        const failedHandle = handleRef.current;
+        if (failedHandle === undefined || this.watches.get(key) !== failedHandle) return;
+        this.watches.delete(key);
+        void failedHandle.release().catch(() => undefined);
+      };
       const handle = gitDir
         ? this.watcher.watch(
             path.join(target.path, '.git'),
             (events) => this.onGitDirEvents(target.id, target.path, events),
-            { onResync: () => this.request({ kind: 'repository', id: target.id }) }
+            {
+              onError,
+              onResync: () => this.request({ kind: 'repository', id: target.id }),
+            }
           )
         : this.watcher.watch(
             target.path,
             () => this.request({ kind: 'workspace', id: target.id, mode: 'full' }),
             {
               ignore: ['.git/**'],
+              onError,
               onResync: () => this.request({ kind: 'workspace', id: target.id, mode: 'full' }),
             }
           );
+      handleRef.current = handle;
       this.watches.set(key, handle);
     }
   }
@@ -289,6 +302,7 @@ export class WorkspaceScanScheduler {
 
   /** The staleness bound: rescan anything the event path has not touched recently. */
   private pollFloor(): void {
+    this.syncWatches();
     const cutoff = this.clock.now() - this.pollIntervalMs;
     for (const target of this.listTargets()) {
       if (target.lastObservedAt > cutoff) continue;

--- a/packages/core/src/services/fs-watch/api/index.ts
+++ b/packages/core/src/services/fs-watch/api/index.ts
@@ -8,6 +8,7 @@ export {
   type FsWatchKey,
   type FsWatchStreamEvent,
 } from './contract';
+export { requireWatchReady } from './models';
 export type {
   IWatchService,
   WatchEvent,

--- a/packages/core/src/services/fs-watch/api/models.ts
+++ b/packages/core/src/services/fs-watch/api/models.ts
@@ -1,3 +1,5 @@
+import type { Result } from '@emdash/shared';
+
 export type WatchEventKind = 'create' | 'update' | 'delete';
 
 export type WatchEvent = {
@@ -14,6 +16,11 @@ export type WatchOptions = {
   ignore?: string[];
   debounceMs?: number;
   /**
+   * Called when the native watcher cannot be attached. This is a best-effort notification;
+   * callers that require a live subscription should check the handle's ready result.
+   */
+  onError?: (error: unknown) => void;
+  /**
    * Called when the native watcher reports an event gap, after a native resubscribe, or after a
    * subprocess-backed watcher reconnects. Events may have been lost; consumers should treat all
    * derived state as stale and resync.
@@ -22,9 +29,14 @@ export type WatchOptions = {
 };
 
 export type WatchHandle = {
-  ready(): Promise<void>;
+  ready(): Promise<Result<void, unknown>>;
   release(): Promise<void>;
 };
+
+export async function requireWatchReady(handle: WatchHandle): Promise<void> {
+  const attached = await handle.ready();
+  if (!attached.success) throw attached.error;
+}
 
 export type IWatchService = {
   watch(

--- a/packages/core/src/services/fs-watch/impl/controller.ts
+++ b/packages/core/src/services/fs-watch/impl/controller.ts
@@ -2,7 +2,7 @@ import type { Scope } from '@emdash/shared/concurrency';
 import { stableStringify } from '@emdash/shared/util';
 import { createEventStreamHost } from '@emdash/wire/live';
 import { createController, type Controller } from '@emdash/wire/rpc';
-import { fsWatchContract, type FsWatchKey } from '#services/fs-watch/api';
+import { fsWatchContract, requireWatchReady, type FsWatchKey } from '#services/fs-watch/api';
 import type { IWatchService } from '#services/fs-watch/api';
 import { nativeWatchBackend } from './native-backend';
 import { createWatchService } from './watch-service';
@@ -32,7 +32,7 @@ export function createFsWatchController(options: CreateFsWatchControllerOptions)
         }
       );
       try {
-        await handle.ready();
+        await requireWatchReady(handle);
       } catch (error) {
         try {
           await handle.release();

--- a/packages/core/src/services/fs-watch/impl/process-backend.test.ts
+++ b/packages/core/src/services/fs-watch/impl/process-backend.test.ts
@@ -1,3 +1,4 @@
+import { err, ok, type Result } from '@emdash/shared';
 import { createScope } from '@emdash/shared/concurrency';
 import { retrySchedules } from '@emdash/shared/scheduling';
 import { createTestWire, FakeWorkerProcessSpawner } from '@emdash/wire/testing';
@@ -13,6 +14,7 @@ import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import {
   fsWatchContract,
+  requireWatchReady,
   type IWatchService,
   type WatchEvent,
   type WatchHandle,
@@ -39,14 +41,14 @@ describe('processWatchBackend', () => {
 
     const readyStates: string[] = [];
     const handle = service.watch('/tmp/project', () => {});
-    const ready = handle.ready().then(() => readyStates.push('ready'));
+    const ready = requireWatchReady(handle).then(() => readyStates.push('ready'));
     await waitFor(() => spawner.processes.length === 1);
     await startChild(spawner.latest(), childService);
     await flush();
 
     expect(readyStates).toEqual([]);
     await waitFor(() => childService.watches.length === 1);
-    childService.latest().readyDeferred.resolve();
+    childService.latest().readyDeferred.resolve(ok(undefined));
     await ready;
     expect(readyStates).toEqual(['ready']);
 
@@ -71,11 +73,11 @@ describe('processWatchBackend', () => {
     const handle = service.watch('/tmp/project', () => {}, {
       onResync: () => resyncs.push('resync'),
     });
-    const ready = handle.ready();
+    const ready = requireWatchReady(handle);
     await waitFor(() => spawner.processes.length === 1);
     await startChild(spawner.latest(), childService);
     await waitFor(() => childService.watches.length === 1);
-    childService.latest().readyDeferred.resolve();
+    childService.latest().readyDeferred.resolve(ok(undefined));
     await ready;
 
     spawner.latest().emitExit({ code: 1 });
@@ -85,7 +87,7 @@ describe('processWatchBackend', () => {
 
     expect(resyncs).toEqual([]);
     await waitFor(() => childService.watches.length === 2);
-    childService.latest().readyDeferred.resolve();
+    childService.latest().readyDeferred.resolve(ok(undefined));
     await waitFor(() => resyncs.length === 1);
     expect(resyncs).toEqual(['resync']);
 
@@ -117,11 +119,11 @@ describe('processWatchBackend', () => {
     await waitFor(() => spawner.processes.length === 1);
     await startChild(spawner.latest(), childService);
     await waitFor(() => childService.watches.length === 1);
-    childService.latest().readyDeferred.resolve();
+    childService.latest().readyDeferred.resolve(ok(undefined));
 
     await expect(Promise.all([first.ready(), second.ready()])).resolves.toEqual([
-      undefined,
-      undefined,
+      ok(undefined),
+      ok(undefined),
     ]);
     expect(childService.watches).toHaveLength(1);
 
@@ -143,7 +145,7 @@ describe('processWatchBackend', () => {
     const firstSubscription = firstWire.client.events.subscribe(key, { onEvent: () => {} });
     const secondSubscription = secondWire.client.events.subscribe(key, { onEvent: () => {} });
     await waitFor(() => service.watches.length === 1);
-    service.latest().readyDeferred.resolve();
+    service.latest().readyDeferred.resolve(ok(undefined));
 
     const [first, second] = await Promise.all([firstSubscription, secondSubscription]);
     expect(service.watches).toHaveLength(1);
@@ -167,7 +169,7 @@ describe('processWatchBackend', () => {
     );
 
     await waitFor(() => service.watches.length === 1);
-    service.latest().readyDeferred.reject(new Error('native startup failed'));
+    service.latest().readyDeferred.resolve(err(new Error('native startup failed')));
 
     await expect(subscription).rejects.toThrow('native startup failed');
     expect(service.latest().released).toBe(true);
@@ -253,7 +255,7 @@ class FakeWatchService implements IWatchService {
 }
 
 class FakeWatch implements WatchHandle {
-  readonly readyDeferred = createDeferred<void>();
+  readonly readyDeferred = createDeferred<Result<void, unknown>>();
   released = false;
 
   constructor(
@@ -262,7 +264,7 @@ class FakeWatch implements WatchHandle {
     readonly options?: WatchOptions
   ) {}
 
-  ready(): Promise<void> {
+  ready(): Promise<Result<void, unknown>> {
     return this.readyDeferred.promise;
   }
 

--- a/packages/core/src/services/fs-watch/impl/watch-service.test.ts
+++ b/packages/core/src/services/fs-watch/impl/watch-service.test.ts
@@ -1,10 +1,11 @@
 import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { err, ok } from '@emdash/shared';
 import type { Scope } from '@emdash/shared/concurrency';
 import type parcelWatcher from '@parcel/watcher';
 import { describe, expect, it, vi } from 'vitest';
-import type { WatchEvent } from '#services/fs-watch/api';
+import { requireWatchReady, type WatchEvent } from '#services/fs-watch/api';
 import type { WatchBackend, WatchKey, WatchSink } from './backend';
 import { nativeWatchBackend } from './native-backend';
 import { realpathOrResolve } from './paths';
@@ -39,7 +40,10 @@ describe('createWatchService', () => {
       const second = service.watch(root, (events) => secondEvents.push(...events), {
         ignore: ['a', 'b'],
       });
-      await Promise.all([first.ready(), second.ready()]);
+      await expect(Promise.all([first.ready(), second.ready()])).resolves.toEqual([
+        ok(undefined),
+        ok(undefined),
+      ]);
 
       expect(backend.subscribeCount).toBe(1);
       backend.emit({ root, ignore: ['a', 'b'] }, [{ kind: 'create', path: path.join(root, 'a') }]);
@@ -73,7 +77,7 @@ describe('createWatchService', () => {
           resyncs += 1;
         },
       });
-      await handle.ready();
+      await expect(handle.ready()).resolves.toEqual(ok(undefined));
 
       backend.emit({ root, ignore: [] }, [
         { kind: 'create', path: path.join(root, 'first') },
@@ -103,7 +107,10 @@ describe('createWatchService', () => {
     try {
       const first = watch.watch(root, (events) => firstEvents.push(...events));
       const second = watch.watch(root, (events) => secondEvents.push(...events));
-      await Promise.all([first.ready(), second.ready()]);
+      await expect(Promise.all([first.ready(), second.ready()])).resolves.toEqual([
+        ok(undefined),
+        ok(undefined),
+      ]);
 
       const file = path.join(root, 'created.txt');
       await writeFile(file, 'watch me\n', 'utf8');
@@ -146,10 +153,10 @@ describe('createWatchService', () => {
 
     try {
       const first = watch.watch(root, () => {});
-      await first.ready();
+      await expect(first.ready()).resolves.toEqual(ok(undefined));
       await first.release();
       const second = watch.watch(root, (incoming) => events.push(...incoming));
-      await second.ready();
+      await expect(second.ready()).resolves.toEqual(ok(undefined));
 
       await writeFile(path.join(root, 'after-rewatch.txt'), 'hi\n', 'utf8');
       await eventually(() =>
@@ -168,15 +175,106 @@ describe('createWatchService', () => {
     try {
       const handle = watch.watch(root, () => {});
 
-      await expect(handle.ready()).rejects.toThrow();
+      const failed = await handle.ready();
+      expect(failed.success).toBe(false);
       await handle.release();
 
       await mkdir(root, { recursive: true });
       const recovered = watch.watch(root, () => {});
-      await expect(recovered.ready()).resolves.toBeUndefined();
+      await expect(recovered.ready()).resolves.toEqual(ok(undefined));
       await recovered.release();
     } finally {
       await watch.dispose();
+    }
+  });
+
+  it('reports watcher subscription failures while ready() fulfills with a failure Result', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'emdash-watch-error-'));
+    const backend = new DeferredWatchBackend();
+    const service = createWatchService({ backend });
+    const onError = vi.fn();
+
+    try {
+      const handle = service.watch(root, () => {}, { onError });
+      const attempt = await eventually(() => backend.attempts[0]);
+      const failure = new Error('watch attach failed');
+
+      attempt.ready.reject(failure);
+
+      await expect(handle.ready()).resolves.toEqual(err(failure));
+      await expect(requireWatchReady(handle)).rejects.toBe(failure);
+      expect(onError).toHaveBeenCalledOnce();
+      expect(onError).toHaveBeenCalledWith(failure);
+      await handle.release();
+    } finally {
+      await service.dispose();
+    }
+  });
+
+  it('does not emit an unhandled rejection when ready() is not awaited', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'emdash-watch-unhandled-'));
+    const backend = new DeferredWatchBackend();
+    const service = createWatchService({ backend });
+    const unhandled = vi.fn();
+    process.on('unhandledRejection', unhandled);
+
+    try {
+      const handle = service.watch(root, () => {});
+      const attempt = await eventually(() => backend.attempts[0]);
+      const failure = new Error('watch attach failed');
+
+      attempt.ready.reject(failure);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(unhandled).not.toHaveBeenCalled();
+      await expect(handle.ready()).resolves.toEqual(err(failure));
+      await handle.release();
+    } finally {
+      process.off('unhandledRejection', unhandled);
+      await service.dispose();
+    }
+  });
+
+  it('suppresses watcher subscription errors after release', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'emdash-watch-released-'));
+    const backend = new DeferredWatchBackend();
+    const service = createWatchService({ backend });
+    const onError = vi.fn();
+
+    try {
+      const handle = service.watch(root, () => {}, { onError });
+      const attempt = await eventually(() => backend.attempts[0]);
+      const failure = new Error('watch attach failed after release');
+
+      await handle.release();
+      attempt.ready.reject(failure);
+
+      await expect(handle.ready()).resolves.toEqual(err(failure));
+      expect(onError).not.toHaveBeenCalled();
+    } finally {
+      await service.dispose();
+    }
+  });
+
+  it('contains errors thrown by the attach-failure observer', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'emdash-watch-error-observer-'));
+    const backend = new DeferredWatchBackend();
+    const service = createWatchService({ backend });
+    const failure = new Error('watch attach failed');
+
+    try {
+      const handle = service.watch(root, () => {}, {
+        onError: () => {
+          throw new Error('observer failed');
+        },
+      });
+      const attempt = await eventually(() => backend.attempts[0]);
+
+      attempt.ready.reject(failure);
+
+      await expect(handle.ready()).resolves.toEqual(err(failure));
+    } finally {
+      await service.dispose();
     }
   });
 
@@ -188,9 +286,12 @@ describe('createWatchService', () => {
 
     try {
       const first = service.watch(root, () => {});
-      const firstFailure = expect(first.ready()).rejects.toThrow('Operation timed out after 25ms');
+      const firstReady = first.ready();
       await vi.advanceTimersByTimeAsync(25);
-      await firstFailure;
+      const firstResult = await firstReady;
+      expect(firstResult.success).toBe(false);
+      if (firstResult.success) throw new Error('Expected watch startup to fail');
+      expect(firstResult.error).toMatchObject({ message: 'Operation timed out after 25ms' });
       await first.release();
       expect(backend.attempts).toHaveLength(1);
       expect(backend.attempts[0]?.disposed).toBe(true);
@@ -200,7 +301,7 @@ describe('createWatchService', () => {
       await vi.advanceTimersByTimeAsync(0);
       expect(backend.attempts).toHaveLength(2);
       backend.attempts[1]?.ready.resolve(undefined);
-      await expect(secondReady).resolves.toBeUndefined();
+      await expect(secondReady).resolves.toEqual(ok(undefined));
 
       backend.attempts[0]?.ready.resolve(undefined);
       await vi.advanceTimersByTimeAsync(0);
@@ -230,15 +331,16 @@ describe('createWatchService', () => {
 
     try {
       const first = service.watch(root, () => {});
-      const firstFailure = expect(first.ready()).rejects.toThrow(
-        'Operation timed out after 1000ms'
-      );
+      const firstReady = first.ready();
       await vi.advanceTimersByTimeAsync(1_000);
-      await firstFailure;
+      const firstResult = await firstReady;
+      expect(firstResult.success).toBe(false);
+      if (firstResult.success) throw new Error('Expected watch startup to fail');
+      expect(firstResult.error).toMatchObject({ message: 'Operation timed out after 1000ms' });
       await first.release();
 
       const second = service.watch(root, () => {});
-      const secondReady = expect(second.ready()).resolves.toBeUndefined();
+      const secondReady = expect(second.ready()).resolves.toEqual(ok(undefined));
       await vi.waitFor(() => expect(subscribe).toHaveBeenCalledTimes(2));
       secondSubscription.resolve({ unsubscribe: secondUnsubscribe });
       await secondReady;
@@ -259,7 +361,7 @@ describe('createWatchService', () => {
     const watch = createNativeWatchService();
     const handle = watch.watch(root, () => {});
 
-    await handle.ready();
+    await expect(handle.ready()).resolves.toEqual(ok(undefined));
     await expect(watch.dispose()).resolves.toBeUndefined();
     await expect(handle.release()).resolves.toBeUndefined();
   });
@@ -315,10 +417,16 @@ function keyOf(key: WatchKey): string {
   return JSON.stringify({ root: realpathOrResolve(key.root), ignore: [...key.ignore].sort() });
 }
 
-function deferred<T = void>(): { promise: Promise<T>; resolve(value: T): void } {
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error?: unknown): void;
+} {
   let resolve: (value: T) => void = () => {};
-  const promise = new Promise<T>((done) => {
+  let reject: (error?: unknown) => void = () => {};
+  const promise = new Promise<T>((done, fail) => {
     resolve = done;
+    reject = fail;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }

--- a/packages/core/src/services/fs-watch/impl/watch-service.ts
+++ b/packages/core/src/services/fs-watch/impl/watch-service.ts
@@ -1,4 +1,4 @@
-import { createEmitter, type Emitter } from '@emdash/shared';
+import { createEmitter, err, ok, type Emitter } from '@emdash/shared';
 import { createResourceCache, createScope, type Scope } from '@emdash/shared/concurrency';
 import { runWithTimeout } from '@emdash/shared/scheduling';
 import type { IWatchService, WatchEvent } from '#services/fs-watch/api';
@@ -72,16 +72,29 @@ export function createWatchService(options: CreateWatchServiceOptions): IWatchSe
       });
 
       let released = false;
-      const ready = lease.ready().then((channel) => {
-        if (released || consumerScope.disposed) return;
-        consumerScope.add(
-          channel.events.subscribe(
-            withDebounce(onEvents, watchOptions.debounceMs ?? 0, consumerScope)
-          )
-        );
-        if (watchOptions.onResync)
-          consumerScope.add(channel.resync.subscribe(watchOptions.onResync));
-      });
+      const ready = lease.ready().then(
+        (channel) => {
+          if (released || consumerScope.disposed) return ok(undefined);
+          consumerScope.add(
+            channel.events.subscribe(
+              withDebounce(onEvents, watchOptions.debounceMs ?? 0, consumerScope)
+            )
+          );
+          if (watchOptions.onResync)
+            consumerScope.add(channel.resync.subscribe(watchOptions.onResync));
+          return ok(undefined);
+        },
+        (error: unknown) => {
+          if (!released && !consumerScope.disposed) {
+            try {
+              watchOptions.onError?.(error);
+            } catch {
+              // Failure observers are best-effort and must not break the ready Result channel.
+            }
+          }
+          return err(error);
+        }
+      );
 
       return {
         ready: () => ready,


### PR DESCRIPTION
- makes watch readiness fulfill with an explicit success or failure result
- adds requireWatchReady() for consumers that require successful attachment
- prevents unhandled rejections and contains errors from failure observers
- retries failed workspace registry watches during polling
- preserves explicit failures for git file search and wire consumers