### PR TITLE
feat(workspace-server): publish protocol-compatible release channels

### DIFF
--- a/.github/workflows/release-workspace-server.yml
+++ b/.github/workflows/release-workspace-server.yml
@@ -2,6 +2,15 @@ name: Release Workspace Server
 
 on:
   workflow_dispatch:
+    inputs:
+      channel:
+        description: Release channel
+        required: true
+        type: choice
+        options:
+          - stable
+          - canary
+        default: canary
 
 permissions:
   contents: read
@@ -15,6 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.metadata.outputs.version }}
+      channel: ${{ steps.metadata.outputs.channel }}
+      matrix: ${{ steps.metadata.outputs.matrix }}
+      probeArtifact: ${{ steps.metadata.outputs.probeArtifact }}
     steps:
       - uses: actions/checkout@v4
 
@@ -26,31 +38,30 @@ jobs:
         id: metadata
         shell: bash
         run: |
-          version=$(node -p "require('./apps/workspace-server/package.json').version")
-          protocol_version=$(node <<'NODE'
-          const { readFileSync } = require('node:fs');
-          const source = readFileSync(
-            'packages/core/src/workspace-server/versions/index.ts',
-            'utf8'
-          );
-          const match = /export const PROTOCOL_VERSION = '([^']+)'/.exec(source);
-          if (!match) throw new Error('Could not read workspace-server protocol version');
-          process.stdout.write(match[1]);
-          NODE
-          )
-          echo "version=$version" >> "$GITHUB_OUTPUT"
+          channel="${{ inputs.channel }}"
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+          node --experimental-strip-types \
+            apps/workspace-server/scripts/print-release-metadata.ts \
+            "$channel" \
+            "${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+
+      - name: Summarize release metadata
+        shell: bash
+        run: |
+          channel="${{ steps.metadata.outputs.channel }}"
+          version="${{ steps.metadata.outputs.version }}"
           {
             echo "## Workspace-server release"
             echo
+            echo "- Channel: \`$channel\`"
             echo "- App version: \`$version\`"
-            echo "- Protocol version: \`$protocol_version\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Reject an existing immutable release
         shell: bash
         run: |
           version="${{ steps.metadata.outputs.version }}"
-          artifact="emdash-workspace-server-$version-linux-x64.tar.gz"
+          artifact="${{ steps.metadata.outputs.probeArtifact }}"
           url="https://releases.emdash.sh/workspace-server/$version/$artifact"
           if ! status=$(curl --silent --show-error --head --output /dev/null \
             --write-out '%{http_code}' "$url"); then
@@ -75,14 +86,7 @@ jobs:
     needs: version-guard
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - target: linux-x64
-            runner: ubuntu-latest
-          - target: linux-arm64
-            runner: ubuntu-24.04-arm
-          - target: darwin-arm64
-            runner: macos-latest
+      matrix: ${{ fromJSON(needs.version-guard.outputs.matrix) }}
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
@@ -111,7 +115,11 @@ jobs:
 
       - name: Build and verify ${{ matrix.target }}
         working-directory: apps/workspace-server
-        run: pnpm run package --target "${{ matrix.target }}" --verify
+        run: >-
+          pnpm run package
+          --target "${{ matrix.target }}"
+          --version "${{ needs.version-guard.outputs.version }}"
+          --verify
 
       - name: Upload ${{ matrix.target }} artifact
         uses: actions/upload-artifact@v4
@@ -142,6 +150,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 
+      - name: Build workspace-server release contract
+        run: pnpm exec nx build @emdash/core
+
       - name: Download packaged artifacts
         uses: actions/download-artifact@v4
         with:
@@ -153,9 +164,12 @@ jobs:
         shell: bash
         run: |
           version="${{ needs.version-guard.outputs.version }}"
+          channel="${{ needs.version-guard.outputs.channel }}"
           mirror="$RUNNER_TEMP/workspace-server-mirror"
           mkdir -p "$mirror/$version"
-          printf '%s\n' "$version" > "$mirror/latest.txt"
+          if [ "$channel" = stable ]; then
+            printf '%s\n' "$version" > "$mirror/latest.txt"
+          fi
           cp apps/workspace-server/dist-artifacts/* "$mirror/$version/"
 
           docker run --rm --platform linux/amd64 \
@@ -168,7 +182,7 @@ jobs:
               set -eu
               apt-get update
               apt-get install -y --no-install-recommends ca-certificates coreutils curl gzip tar
-              sh /install.sh --base-url file:///mirror
+              sh /install.sh --base-url file:///mirror --version "$VERSION"
               test -x "$HOME/.emdash/workspace-server/current/bin/emdash-workspace-server"
               test "$(readlink "$HOME/.emdash/workspace-server/current")" = "versions/$VERSION"
             '
@@ -180,4 +194,17 @@ jobs:
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
-        run: pnpm run upload:r2
+        run: |
+          channel="${{ needs.version-guard.outputs.channel }}"
+          version="${{ needs.version-guard.outputs.version }}"
+          pnpm run upload:r2 --channel "$channel" --version "$version"
+
+      - name: Verify published channel pointer
+        working-directory: apps/workspace-server
+        run: |
+          channel="${{ needs.version-guard.outputs.channel }}"
+          version="${{ needs.version-guard.outputs.version }}"
+          pnpm exec tsx scripts/verify-pointer.ts \
+            --base-url https://releases.emdash.sh \
+            --channel "$channel" \
+            --version "$version" | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-workspace-server.yml
+++ b/.github/workflows/release-workspace-server.yml
@@ -164,12 +164,8 @@ jobs:
         shell: bash
         run: |
           version="${{ needs.version-guard.outputs.version }}"
-          channel="${{ needs.version-guard.outputs.channel }}"
           mirror="$RUNNER_TEMP/workspace-server-mirror"
           mkdir -p "$mirror/$version"
-          if [ "$channel" = stable ]; then
-            printf '%s\n' "$version" > "$mirror/latest.txt"
-          fi
           cp apps/workspace-server/dist-artifacts/* "$mirror/$version/"
 
           docker run --rm --platform linux/amd64 \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,10 +92,13 @@ Deploy releases only when explicitly asked to do release work:
 ```bash
 gh workflow run release-prod.yml --ref main -f arch=both
 gh workflow run release-canary.yml --ref main -f arch=both
+gh workflow run release-workspace-server.yml --ref main -f channel=stable
 ```
 
 Production releases publish artifacts to GitHub Releases and Cloudflare R2. Canary
-releases currently publish to R2 only.
+releases currently publish to R2 only. See
+[workspace-server packaging](apps/workspace-server/docs/packaging.md) for its independent release
+and channel rules.
 
 ## Code Style & Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -425,6 +425,15 @@ Canary releases are dispatched through:
 gh workflow run release-canary.yml --ref main -f arch=both
 ```
 
+Workspace-server releases have an independent version and channel:
+
+```bash
+gh workflow run release-workspace-server.yml --ref main -f channel=stable
+```
+
+See [`apps/workspace-server/docs/packaging.md`](apps/workspace-server/docs/packaging.md) before
+bumping or publishing a workspace-server version.
+
 Production releases publish artifacts to GitHub Releases as the primary update
 feed and Cloudflare R2 as fallback. Canary releases currently publish to R2 only.
 

--- a/agents/architecture/workspace-server.md
+++ b/agents/architecture/workspace-server.md
@@ -24,7 +24,8 @@ version; equal and older pointer versions leave the running daemon alone.
 `EMDASH_WORKSPACE_SERVER_ARTIFACTS_URL` overrides the install-script and artifact base URL for
 development; the Docker remote dev setup publishes Linux builds to local minio and uses
 `http://minio:9000/emdash-releases/workspace-server` so remote installation exercises the same
-curl-based object-store path as production.
+curl-based object-store path as production. Provisioning verifies that every successful install
+selected the exact version named by the resolved channel pointer.
 
 The contract lives in `packages/core/src/workspace-server/`, shared by the server and every client so TypeScript clients stay in sync at build time. Non-TypeScript clients (e.g. a future mobile app) use the negotiation handshake at runtime — compile-time sharing is a convenience, not the contract.
 

--- a/agents/architecture/workspace-server.md
+++ b/agents/architecture/workspace-server.md
@@ -14,10 +14,13 @@ failures, exhausted SSH reconnects, and machine edits invalidate it.
 Managed Linux installations use `~/.emdash/workspace-server/` with immutable version directories,
 an atomic `current` symlink, staging and install-lock paths, and an explicitly selected socket under
 `run/`. When the daemon is absent or negotiation reports `upgrade-server`, the desktop downloads
-and executes the hosted `apps/workspace-server/install.sh` on the remote. The script resolves the
-latest published version, detects Linux architecture and glibc support, pulls the matching artifact,
-verifies its SHA-256 sidecar, and extracts it before `current` changes. There is no desktop-pinned
-server version: compatible same-major daemons remain installed until a future explicit update.
+the channel pointer for its protocol major, then downloads and executes that version's immutable
+`apps/workspace-server/install.sh` on the remote with the selected version pinned. Canary desktops
+fall back to the stable pointer when no canary pointer exists. The script detects Linux architecture
+and glibc support, pulls the matching artifact, verifies its SHA-256 sidecar, and extracts it before
+`current` changes. Compatible same-major daemons remain installed until a future explicit update.
+The desktop offers that update only when the channel pointer names a strictly newer SemVer artifact
+version; equal and older pointer versions leave the running daemon alone.
 `EMDASH_WORKSPACE_SERVER_ARTIFACTS_URL` overrides the install-script and artifact base URL for
 development; the Docker remote dev setup publishes Linux builds to local minio and uses
 `http://minio:9000/emdash-releases/workspace-server` so remote installation exercises the same
@@ -64,7 +67,7 @@ The wire contract is versioned with a single [semver](https://semver.org) string
 [`packages/core/src/workspace-server/versions/index.ts`](../../packages/core/src/workspace-server/versions/index.ts):
 
 ```ts
-export const PROTOCOL_VERSION = '9.0.0';
+export const PROTOCOL_VERSION = '1.0.0';
 ```
 
 ### What each component means
@@ -205,6 +208,7 @@ The desktop forwards the read-only agent hook-status procedure to the selected h
 | Path | Role |
 |------|------|
 | [`packages/core/src/workspace-server/versions/index.ts`](../../packages/core/src/workspace-server/versions/index.ts) | `PROTOCOL_VERSION`, `negotiateProtocol`, `protocolUpgradeMessage` |
+| [`packages/core/src/workspace-server/releases.ts`](../../packages/core/src/workspace-server/releases.ts) | Release channels, pointer schema, strict artifact versions, and pointer paths |
 | [`packages/core/src/workspace-server/wire/schemas.ts`](../../packages/core/src/workspace-server/wire/schemas.ts) | initialize/health schemas |
 | [`packages/core/src/workspace-server/wire/contract.ts`](../../packages/core/src/workspace-server/wire/contract.ts) | aggregate control-plane and core-runtime wire contract |
 | [`packages/core/src/workspace-server/port-forwards/contract.ts`](../../packages/core/src/workspace-server/port-forwards/contract.ts) | daemon-local preview port inspection contract |
@@ -216,4 +220,4 @@ The desktop forwards the read-only agent hook-status procedure to the selected h
 | [`apps/workspace-server/src/index.ts`](../../apps/workspace-server/src/index.ts) | CLI and daemon entry point |
 | [`apps/emdash-desktop/src/core/services/hosts/`](../../apps/emdash-desktop/src/core/services/hosts/) | Desktop orchestration and lifecycle policy for SSH hosts |
 | [`apps/emdash-desktop/src/core/services/hosts/node/workspace-server/`](../../apps/emdash-desktop/src/core/services/hosts/node/workspace-server/) | Wire connection manager, hosted-script installer, daemon control, and provisioner |
-| [`apps/workspace-server/install.sh`](../../apps/workspace-server/install.sh) | Remote platform detection and atomic latest-artifact installation |
+| [`apps/workspace-server/install.sh`](../../apps/workspace-server/install.sh) | Remote platform detection and atomic pinned-artifact installation |

--- a/agents/workflows/flows.md
+++ b/agents/workflows/flows.md
@@ -126,7 +126,7 @@ running (doctor reports it). See
 | Rebuild native deps | `pnpm run rebuild` | `apps/emdash-desktop/` |
 | Lint-infra allowlists | `pnpm run prune:boundary-allowlists` | root |
 | Task graph | `pnpm run graph` | root |
-| Releases (maintainers) | `gh workflow run release-prod.yml` / `release-canary.yml` | — |
+| Releases (maintainers) | `gh workflow run release-prod.yml` / `release-canary.yml` / `release-workspace-server.yml` | — |
 
 - Local packaging without signing identities still produces installable
   artifacts; mac builds are unsigned/un-notarized and Gatekeeper will warn.

--- a/agents/workflows/remote-development.md
+++ b/agents/workflows/remote-development.md
@@ -13,6 +13,8 @@ or shell-profile code.
 - `apps/workspace-server/src/` — daemon entry point, socket serving, runtime wiring
 - `packages/core/src/workspace-server/` — shared wire contract, schemas, protocol
   versioning, and workspace-server-specific APIs
+- `packages/core/src/workspace-server/releases.ts` — channel-pointer schema, strict
+  release versions, and protocol-major pointer paths
 - `src/core/services/ssh/` — desktop SSH connection management, credentials, config
   parsing, and transport setup
 - `src/core/services/hosts/` — managed remote install/ensure flow and the
@@ -30,6 +32,8 @@ or shell-profile code.
   `hostDependencies` component, not an Electron-side SSH execution context
 - the desktop owns the managed install under `~/.emdash/workspace-server`; remote
   runtime calls begin only after the workspace-server provisioner reports ready
+- managed installs read the desktop channel's pointer for its protocol major, then
+  run the immutable versioned `install.sh` with the pointer's artifact version pinned
 
 ## Rules
 

--- a/apps/emdash-desktop/src/core/features/machines/browser/components/workspace-server-card.tsx
+++ b/apps/emdash-desktop/src/core/features/machines/browser/components/workspace-server-card.tsx
@@ -63,9 +63,8 @@ function workspaceServerUpdateStatus(
   actions: WorkspaceServerActions
 ): UpdateStatus {
   if (
+    state.updateAvailable === true &&
     state.latestVersion !== undefined &&
-    state.version !== undefined &&
-    state.version !== state.latestVersion &&
     state.error?.code !== 'protocol-upgrade-client'
   ) {
     return {

--- a/apps/emdash-desktop/src/core/primitives/app-settings/api/app-settings.ts
+++ b/apps/emdash-desktop/src/core/primitives/app-settings/api/app-settings.ts
@@ -87,5 +87,4 @@ export type ChangesListViewMode = ChangesViewMode[ChangesSection];
 
 export type HostSettings = {
   installBaseUrl: string;
-  installCommand: string | null;
 };

--- a/apps/emdash-desktop/src/core/services/hosts/api/contract.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/api/contract.ts
@@ -14,6 +14,7 @@ export const hostServerStateSchema = z.object({
   status: hostServerStatusSchema,
   version: z.string().optional(),
   latestVersion: z.string().optional(),
+  updateAvailable: z.boolean().optional(),
   startedAt: z.number().optional(),
   detail: z.string().optional(),
   error: z

--- a/apps/emdash-desktop/src/core/services/hosts/contributions/settings.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/contributions/settings.ts
@@ -4,7 +4,6 @@ import { defineSettingsSchemaContribution } from '@core/primitives/settings/api'
 
 const hostSettingsSchema = z.object({
   installBaseUrl: z.string(),
-  installCommand: z.string().nullable(),
 });
 
 // The persisted settings key stays 'remoteMachine': it is stored in the app

--- a/apps/emdash-desktop/src/core/services/hosts/node/host-service.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/host-service.ts
@@ -1,3 +1,4 @@
+import type { ReleaseChannel } from '@emdash/core/workspace-server';
 import type { Scope } from '@emdash/shared/concurrency';
 import type { SshService } from '@core/primitives/ssh/api';
 import type { SshClientProxy } from '@core/primitives/ssh/api/node/ssh-client-proxy';
@@ -31,6 +32,7 @@ export type CreateHostServiceDeps = {
   machineEvents: MachineMutationEvents;
   installBaseUrl?: string;
   installCommand?: string;
+  releaseChannel?: ReleaseChannel;
   devAutoUpdate?: boolean;
   client?: { id: string; appVersion: string };
   logger?: HostServiceLog;
@@ -59,7 +61,12 @@ export function createHostService(deps: CreateHostServiceDeps): HostService {
   const ssh = createWorkspaceServerSshPort(deps.ssh);
   const host = new RemoteHostProbe(ssh);
   const wire = createWireConnectionManager({ scope, ssh, client: deps.client });
-  const installer = new WorkspaceServerInstaller(ssh, deps.installBaseUrl, deps.installCommand);
+  const installer = new WorkspaceServerInstaller({
+    ssh,
+    baseUrl: deps.installBaseUrl,
+    installCommand: deps.installCommand,
+    releaseChannel: deps.releaseChannel,
+  });
   const daemon = new RemoteWorkspaceServerDaemon(ssh);
   const provisioner = new WorkspaceServerProvisioner({
     scope,

--- a/apps/emdash-desktop/src/core/services/hosts/node/host-service.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/host-service.ts
@@ -31,7 +31,6 @@ export type CreateHostServiceDeps = {
   };
   machineEvents: MachineMutationEvents;
   installBaseUrl?: string;
-  installCommand?: string;
   releaseChannel?: ReleaseChannel;
   devAutoUpdate?: boolean;
   client?: { id: string; appVersion: string };
@@ -64,7 +63,6 @@ export function createHostService(deps: CreateHostServiceDeps): HostService {
   const installer = new WorkspaceServerInstaller({
     ssh,
     baseUrl: deps.installBaseUrl,
-    installCommand: deps.installCommand,
     releaseChannel: deps.releaseChannel,
   });
   const daemon = new RemoteWorkspaceServerDaemon(ssh);

--- a/apps/emdash-desktop/src/core/services/hosts/node/server-operations.test.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/server-operations.test.ts
@@ -27,6 +27,7 @@ describe('HostServerOperations', () => {
       status: 'stopped',
       version: '1.2.3',
       latestVersion: '1.2.4',
+      updateAvailable: true,
     });
     await fixture.dispose();
   });
@@ -40,6 +41,7 @@ describe('HostServerOperations', () => {
       status: 'healthy',
       version: '1.2.3',
       latestVersion: '1.2.4',
+      updateAvailable: true,
       startedAt: 100,
     });
     await fixture.dispose();
@@ -55,6 +57,7 @@ describe('HostServerOperations', () => {
       status: 'healthy',
       version: '1.2.3',
       latestVersion: '1.2.4',
+      updateAvailable: true,
       error: { code: 'protocol-upgrade-server' },
     });
     await fixture.dispose();
@@ -85,6 +88,23 @@ describe('HostServerOperations', () => {
     expect(fixture.status('ssh-1')).toEqual({
       status: 'healthy',
       version: '1.2.3',
+      startedAt: 100,
+    });
+    await fixture.dispose();
+  });
+
+  it('publishes an older fallback version without offering a downgrade', async () => {
+    const fixture = createFixture();
+    fixture.installer.installedVersion.mockResolvedValue('1.2.4-canary.42');
+    fixture.installer.availableVersion.mockResolvedValue('1.2.3');
+    fixture.wire.dialOnce.mockResolvedValue(handshake('1.2.4-canary.42'));
+
+    await fixture.operations.refresh('ssh-1');
+
+    expect(fixture.status('ssh-1')).toEqual({
+      status: 'healthy',
+      version: '1.2.4-canary.42',
+      latestVersion: '1.2.3',
       startedAt: 100,
     });
     await fixture.dispose();
@@ -178,13 +198,13 @@ function protocolError(action: 'upgrade-client' | 'upgrade-server'): WorkspaceSe
   });
 }
 
-function handshake(): WireInitializeResult {
+function handshake(appVersion = '1.2.3'): WireInitializeResult {
   return {
     protocolVersion: PROTOCOL_VERSION,
     agreedVersion: PROTOCOL_VERSION,
     agreedMinor: 0,
     server: {
-      appVersion: '1.2.3',
+      appVersion,
       daemonId: 'daemon-1',
       startedAt: 100,
     },

--- a/apps/emdash-desktop/src/core/services/hosts/node/server-operations.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/server-operations.ts
@@ -1,4 +1,4 @@
-import type { WireInitializeResult } from '@emdash/core/workspace-server';
+import { isNewerRelease, type WireInitializeResult } from '@emdash/core/workspace-server';
 import type { Scope } from '@emdash/shared/concurrency';
 import { retry, retrySchedules, systemClock, type Clock } from '@emdash/shared/scheduling';
 import type { HostStateModel } from './state-model';
@@ -109,7 +109,7 @@ export class HostServerOperations {
       this.deps.state.set(connectionId, {
         status: 'stopped',
         version,
-        ...latestVersionState(this.cachedLatestVersion(connectionId)),
+        ...latestVersionState(this.cachedLatestVersion(connectionId), version),
       });
     });
   }
@@ -193,7 +193,7 @@ export class HostServerOperations {
           this.deps.state.set(connectionId, {
             status: 'stopped',
             version,
-            ...latestVersionState(latestVersion),
+            ...latestVersionState(latestVersion, version),
           });
         }
       }
@@ -248,7 +248,7 @@ export class HostServerOperations {
     this.deps.state.set(connectionId, {
       status: 'healthy',
       version: handshake.server.appVersion,
-      ...latestVersionState(latestVersion),
+      ...latestVersionState(latestVersion, handshake.server.appVersion),
       startedAt: handshake.server.startedAt,
     });
   }
@@ -267,7 +267,7 @@ export class HostServerOperations {
       this.deps.state.set(connectionId, {
         status: 'healthy',
         ...versionState(version),
-        ...latestVersionState(latestVersion),
+        ...latestVersionState(latestVersion, version),
         ...startedAtState(current?.startedAt),
         error: failure,
       });
@@ -276,7 +276,7 @@ export class HostServerOperations {
     this.deps.state.set(connectionId, {
       status: 'failed',
       ...versionState(version),
-      ...latestVersionState(latestVersion),
+      ...latestVersionState(latestVersion, version),
       error: failure,
     });
   }
@@ -367,8 +367,15 @@ function isProtocolFailure(code: string): boolean {
   return code === 'protocol-upgrade-client' || code === 'protocol-upgrade-server';
 }
 
-function latestVersionState(latestVersion: string | undefined): { latestVersion?: string } {
-  return latestVersion === undefined ? {} : { latestVersion };
+function latestVersionState(
+  latestVersion: string | undefined,
+  installedVersion: string | undefined
+): { latestVersion?: string; updateAvailable?: true } {
+  if (latestVersion === undefined) return {};
+  if (installedVersion === undefined || !isNewerRelease(latestVersion, installedVersion)) {
+    return { latestVersion };
+  }
+  return { latestVersion, updateAvailable: true };
 }
 
 function versionState(version: string | undefined): { version?: string } {

--- a/apps/emdash-desktop/src/core/services/hosts/node/server-operations.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/server-operations.ts
@@ -69,7 +69,7 @@ export class HostServerOperations {
         status: 'booting',
         detail: 'Installing workspace server',
       });
-      await this.deps.installer.install(connectionId, signal);
+      await this.deps.installer.install({ connectionId, layout, signal });
       const version = await this.deps.installer.installedVersion(connectionId, layout, signal);
       this.deps.state.set(connectionId, {
         status: 'booting',
@@ -143,7 +143,7 @@ export class HostServerOperations {
         status: 'booting',
         detail: 'Updating workspace server',
       });
-      await this.deps.installer.install(connectionId, signal);
+      await this.deps.installer.install({ connectionId, layout, signal });
       const version = await this.deps.installer.installedVersion(connectionId, layout, signal);
       this.deps.state.set(connectionId, {
         status: 'shutting-down',

--- a/apps/emdash-desktop/src/core/services/hosts/node/settings.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/settings.ts
@@ -11,6 +11,5 @@ export const hostSettingsContribution = defineSettingsContribution<'remoteMachin
     installBaseUrl:
       process.env['EMDASH_WORKSPACE_SERVER_ARTIFACTS_URL'] ??
       'https://releases.emdash.sh/workspace-server',
-    installCommand: process.env['EMDASH_WORKSPACE_SERVER_INSTALL_COMMAND'] ?? null,
   }),
 });

--- a/apps/emdash-desktop/src/core/services/hosts/node/state-model.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/state-model.ts
@@ -44,6 +44,7 @@ export class HostStateModel {
           status: 'stopped',
           version: current.version,
           latestVersion: current.latestVersion,
+          updateAvailable: current.updateAvailable,
         };
       })
     );

--- a/apps/emdash-desktop/src/core/services/hosts/node/workspace-server/provision/installer.test.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/workspace-server/provision/installer.test.ts
@@ -172,7 +172,23 @@ describe('workspace-server installer command', () => {
     await installer.install('ssh-1', undefined, '0.1.0-dev.abc123');
 
     expect(execScript).toHaveBeenCalledWith(
-      `curl -fsSL ${installBaseUrl}/install.sh | sh -s -- --base-url ${installBaseUrl} --version 0.1.0-dev.abc123`,
+      `curl -fsSL ${installBaseUrl}/0.1.0-dev.abc123/install.sh | sh -s -- --base-url ${installBaseUrl} --version 0.1.0-dev.abc123`,
+      expect.objectContaining({ timeoutMs: 300_000 })
+    );
+  });
+
+  it('pins legacy custom install commands that omit the version placeholder', async () => {
+    const execScript = vi.fn().mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+    const installer = new WorkspaceServerInstaller({
+      ssh: { ensureProxy: vi.fn(async () => ({ execScript }) as never) },
+      baseUrl: installBaseUrl,
+      installCommand: 'curl -fsSL {{scriptUrl}} | sh -s -- --base-url {{baseUrl}}',
+    });
+
+    await installer.install('ssh-1', undefined, '0.1.1-canary.42');
+
+    expect(execScript).toHaveBeenCalledWith(
+      `curl -fsSL ${installBaseUrl}/0.1.1-canary.42/install.sh | sh -s -- --base-url ${installBaseUrl} --version 0.1.1-canary.42`,
       expect.objectContaining({ timeoutMs: 300_000 })
     );
   });

--- a/apps/emdash-desktop/src/core/services/hosts/node/workspace-server/provision/installer.test.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/workspace-server/provision/installer.test.ts
@@ -65,13 +65,21 @@ describe('workspace-server installer command', () => {
 
   it('executes a pinned hosted installer through the SSH proxy', async () => {
     const execScript = vi.fn().mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
-    const ensureProxy = vi.fn(async () => ({ execScript }) as never);
+    const exec = vi
+      .fn()
+      .mockResolvedValue({ stdout: 'versions/0.1.0-dev.abc123\n', stderr: '', exitCode: 0 });
+    const ensureProxy = vi.fn(async () => ({ exec, execScript }) as never);
     const installer = new WorkspaceServerInstaller({
       ssh: { ensureProxy },
       baseUrl: installBaseUrl,
     });
+    const layout = workspaceServerLayout('/home/devuser');
 
-    await installer.install('ssh-1', undefined, '0.1.0-dev.abc123');
+    await installer.install({
+      connectionId: 'ssh-1',
+      layout,
+      version: '0.1.0-dev.abc123',
+    });
 
     expect(ensureProxy).toHaveBeenCalledWith('ssh-1');
     expect(execScript).toHaveBeenCalledWith(
@@ -79,6 +87,10 @@ describe('workspace-server installer command', () => {
       expect.objectContaining({ timeoutMs: 300_000 })
     );
     expect(execScript.mock.calls[0]?.[0]).toContain('--version 0.1.0-dev.abc123');
+    expect(exec).toHaveBeenCalledWith(
+      { command: 'readlink', args: ['--', layout.currentLink] },
+      expect.objectContaining({ timeoutMs: 10_000 })
+    );
   });
 
   it('resolves the channel pointer before installing when no version is provided', async () => {
@@ -86,13 +98,21 @@ describe('workspace-server installer command', () => {
       .fn()
       .mockResolvedValueOnce({ stdout: pointerBody('0.1.0'), stderr: '', exitCode: 0 })
       .mockResolvedValueOnce({ stdout: '', stderr: '', exitCode: 0 });
-    const ensureProxy = vi.fn(async () => ({ execScript }) as never);
+    const exec = vi.fn().mockResolvedValue({
+      stdout: 'versions/0.1.0\n',
+      stderr: '',
+      exitCode: 0,
+    });
+    const ensureProxy = vi.fn(async () => ({ exec, execScript }) as never);
     const installer = new WorkspaceServerInstaller({
       ssh: { ensureProxy },
       baseUrl: installBaseUrl,
     });
 
-    await installer.install('ssh-1');
+    await installer.install({
+      connectionId: 'ssh-1',
+      layout: workspaceServerLayout('/home/devuser'),
+    });
 
     expect(execScript).toHaveBeenCalledTimes(2);
     expect(execScript.mock.calls[0]?.[0]).toContain(
@@ -160,37 +180,28 @@ describe('workspace-server installer command', () => {
     });
   });
 
-  it('uses a custom install command with substituted placeholders when configured', async () => {
+  it('rejects an install that does not select the requested version', async () => {
     const execScript = vi.fn().mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+    const exec = vi.fn().mockResolvedValue({
+      stdout: 'versions/1.2.2\n',
+      stderr: '',
+      exitCode: 0,
+    });
     const installer = new WorkspaceServerInstaller({
-      ssh: { ensureProxy: vi.fn(async () => ({ execScript }) as never) },
+      ssh: { ensureProxy: vi.fn(async () => ({ exec, execScript }) as never) },
       baseUrl: installBaseUrl,
-      installCommand:
-        'curl -fsSL {{scriptUrl}} | sh -s -- --base-url {{baseUrl}} --version {{version}}',
     });
 
-    await installer.install('ssh-1', undefined, '0.1.0-dev.abc123');
-
-    expect(execScript).toHaveBeenCalledWith(
-      `curl -fsSL ${installBaseUrl}/0.1.0-dev.abc123/install.sh | sh -s -- --base-url ${installBaseUrl} --version 0.1.0-dev.abc123`,
-      expect.objectContaining({ timeoutMs: 300_000 })
-    );
-  });
-
-  it('pins legacy custom install commands that omit the version placeholder', async () => {
-    const execScript = vi.fn().mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
-    const installer = new WorkspaceServerInstaller({
-      ssh: { ensureProxy: vi.fn(async () => ({ execScript }) as never) },
-      baseUrl: installBaseUrl,
-      installCommand: 'curl -fsSL {{scriptUrl}} | sh -s -- --base-url {{baseUrl}}',
+    await expect(
+      installer.install({
+        connectionId: 'ssh-1',
+        layout: workspaceServerLayout('/home/devuser'),
+        version: '1.2.3',
+      })
+    ).rejects.toMatchObject({
+      code: 'install-failed',
+      message: expect.stringContaining('installed 1.2.2 instead of 1.2.3'),
     });
-
-    await installer.install('ssh-1', undefined, '0.1.1-canary.42');
-
-    expect(execScript).toHaveBeenCalledWith(
-      `curl -fsSL ${installBaseUrl}/0.1.1-canary.42/install.sh | sh -s -- --base-url ${installBaseUrl} --version 0.1.1-canary.42`,
-      expect.objectContaining({ timeoutMs: 300_000 })
-    );
   });
 
   it.each([
@@ -204,7 +215,13 @@ describe('workspace-server installer command', () => {
       baseUrl: 'https://releases.example.test/workspace-server',
     });
 
-    await expect(installer.install('ssh-1', undefined, '1.2.3')).rejects.toMatchObject({ code });
+    await expect(
+      installer.install({
+        connectionId: 'ssh-1',
+        layout: workspaceServerLayout('/home/devuser'),
+        version: '1.2.3',
+      })
+    ).rejects.toMatchObject({ code });
   });
 
   it('rejects a current link that points outside the managed versions directory', async () => {

--- a/apps/emdash-desktop/src/core/services/hosts/node/workspace-server/provision/installer.test.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/workspace-server/provision/installer.test.ts
@@ -1,110 +1,178 @@
+import { protocolMajor, PROTOCOL_VERSION } from '@emdash/core/workspace-server';
 import { describe, expect, it, vi } from 'vitest';
 import { workspaceServerLayout } from '../layout';
 import {
-  buildWorkspaceServerAvailableVersionCommand,
+  buildWorkspaceServerChannelPointerCommand,
   buildWorkspaceServerInstallCommand,
   WorkspaceServerInstaller,
 } from './installer';
 
+const installBaseUrl = 'http://minio:9000/emdash-releases/workspace-server';
+
 describe('workspace-server installer command', () => {
-  it('downloads the hosted script to a temporary file before executing it', () => {
+  it('downloads the immutable hosted script and pins the selected version', () => {
     const command = buildWorkspaceServerInstallCommand(
-      "http://minio:9000/emdash artifact's/$(printf injected)"
+      "http://minio:9000/emdash artifact's/$(printf injected)",
+      '1.2.3-canary.4'
     );
 
     expect(command).toContain(
-      "curl -fsSL --output \"$install_script\" -- 'http://minio:9000/emdash%20artifact'\\''s/$(printf%20injected)/install.sh'"
+      "curl -fsSL --output \"$install_script\" -- 'http://minio:9000/emdash%20artifact'\\''s/$(printf%20injected)/1.2.3-canary.4/install.sh'"
     );
     expect(command).toContain(
-      "sh \"$install_script\" --base-url 'http://minio:9000/emdash%20artifact'\\''s/$(printf%20injected)'"
+      "sh \"$install_script\" --base-url 'http://minio:9000/emdash%20artifact'\\''s/$(printf%20injected)' --version 1.2.3-canary.4"
     );
     expect(command).toContain('if ! curl');
     expect(command).toContain('exit 41');
   });
 
   it('rejects unsupported install base URL protocols', () => {
-    expect(() => buildWorkspaceServerInstallCommand('ftp://releases.example.test')).toThrow(
-      expect.objectContaining({ code: 'artifact-download-failed' })
+    expect(() =>
+      buildWorkspaceServerInstallCommand('ftp://releases.example.test', '1.2.3')
+    ).toThrow(expect.objectContaining({ code: 'artifact-download-failed' }));
+    expect(() =>
+      buildWorkspaceServerInstallCommand('file:///opt/emdash-artifacts', '1.2.3')
+    ).toThrow(expect.objectContaining({ code: 'artifact-download-failed' }));
+  });
+
+  it('builds the stable channel pointer command for the desktop protocol major', () => {
+    const command = buildWorkspaceServerChannelPointerCommand(
+      'https://releases.example.test/workspace-server',
+      'stable',
+      protocolMajor()
     );
-    expect(() => buildWorkspaceServerInstallCommand('file:///opt/emdash-artifacts')).toThrow(
-      expect.objectContaining({ code: 'artifact-download-failed' })
+
+    expect(command).toContain(
+      `curl -fsSL -- https://releases.example.test/workspace-server/channels/stable/protocol-${protocolMajor()}.json`
+    );
+    expect(command).not.toContain('/channels/canary/');
+  });
+
+  it('falls back from the canary pointer to the stable pointer in the remote script', () => {
+    const command = buildWorkspaceServerChannelPointerCommand(
+      'https://releases.example.test/workspace-server',
+      'canary',
+      protocolMajor()
+    );
+
+    expect(command).toContain(
+      `curl -fsSL -- https://releases.example.test/workspace-server/channels/canary/protocol-${protocolMajor()}.json 2>/dev/null || curl -fsSL -- https://releases.example.test/workspace-server/channels/stable/protocol-${protocolMajor()}.json`
+    );
+    expect(command).toContain(
+      `wget -qO- -- https://releases.example.test/workspace-server/channels/canary/protocol-${protocolMajor()}.json 2>/dev/null || wget -qO- -- https://releases.example.test/workspace-server/channels/stable/protocol-${protocolMajor()}.json`
     );
   });
 
-  it('builds latest-version commands for hosted artifact URLs', () => {
-    expect(
-      buildWorkspaceServerAvailableVersionCommand('https://releases.example.test/workspace-server')
-    ).toContain('curl -fsSL -- https://releases.example.test/workspace-server/latest.txt');
-  });
-
-  it('executes the hosted installer through the SSH proxy', async () => {
+  it('executes a pinned hosted installer through the SSH proxy', async () => {
     const execScript = vi.fn().mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
     const ensureProxy = vi.fn(async () => ({ execScript }) as never);
-    const installer = new WorkspaceServerInstaller(
-      { ensureProxy },
-      'http://minio:9000/emdash-releases/workspace-server'
-    );
+    const installer = new WorkspaceServerInstaller({
+      ssh: { ensureProxy },
+      baseUrl: installBaseUrl,
+    });
 
-    await installer.install('ssh-1');
+    await installer.install('ssh-1', undefined, '0.1.0-dev.abc123');
 
     expect(ensureProxy).toHaveBeenCalledWith('ssh-1');
     expect(execScript).toHaveBeenCalledWith(
-      expect.stringContaining('http://minio:9000/emdash-releases/workspace-server/install.sh'),
+      expect.stringContaining(`${installBaseUrl}/0.1.0-dev.abc123/install.sh`),
       expect.objectContaining({ timeoutMs: 300_000 })
     );
+    expect(execScript.mock.calls[0]?.[0]).toContain('--version 0.1.0-dev.abc123');
   });
 
-  it('resolves the available version through the SSH proxy', async () => {
+  it('resolves the channel pointer before installing when no version is provided', async () => {
+    const execScript = vi
+      .fn()
+      .mockResolvedValueOnce({ stdout: pointerBody('0.1.0'), stderr: '', exitCode: 0 })
+      .mockResolvedValueOnce({ stdout: '', stderr: '', exitCode: 0 });
+    const ensureProxy = vi.fn(async () => ({ execScript }) as never);
+    const installer = new WorkspaceServerInstaller({
+      ssh: { ensureProxy },
+      baseUrl: installBaseUrl,
+    });
+
+    await installer.install('ssh-1');
+
+    expect(execScript).toHaveBeenCalledTimes(2);
+    expect(execScript.mock.calls[0]?.[0]).toContain(
+      `${installBaseUrl}/channels/stable/protocol-${protocolMajor()}.json`
+    );
+    expect(execScript.mock.calls[1]?.[0]).toContain(`${installBaseUrl}/0.1.0/install.sh`);
+    expect(execScript.mock.calls[1]?.[0]).toContain('--version 0.1.0');
+  });
+
+  it('parses the available version from the channel pointer', async () => {
     const execScript = vi.fn().mockResolvedValue({
-      stdout: '0.1.0-dev.abc123\n',
+      stdout: pointerBody('0.1.0-dev.abc123'),
       stderr: '',
       exitCode: 0,
     });
     const ensureProxy = vi.fn(async () => ({ execScript }) as never);
-    const installer = new WorkspaceServerInstaller(
-      { ensureProxy },
-      'http://minio:9000/emdash-releases/workspace-server'
-    );
+    const installer = new WorkspaceServerInstaller({
+      ssh: { ensureProxy },
+      baseUrl: installBaseUrl,
+    });
 
     await expect(installer.availableVersion('ssh-1')).resolves.toBe('0.1.0-dev.abc123');
 
     expect(ensureProxy).toHaveBeenCalledWith('ssh-1');
     expect(execScript).toHaveBeenCalledWith(
       expect.stringContaining(
-        'curl -fsSL -- http://minio:9000/emdash-releases/workspace-server/latest.txt'
+        `curl -fsSL -- ${installBaseUrl}/channels/stable/protocol-${protocolMajor()}.json`
       ),
       expect.objectContaining({ timeoutMs: 10_000 })
     );
   });
 
-  it('rejects invalid available versions', async () => {
+  it('rejects an invalid channel pointer body', async () => {
     const execScript = vi.fn().mockResolvedValue({
-      stdout: 'not a version\n',
+      stdout: 'not JSON\n',
       stderr: '',
       exitCode: 0,
     });
     const installer = new WorkspaceServerInstaller({
-      ensureProxy: vi.fn(async () => ({ execScript }) as never),
+      ssh: { ensureProxy: vi.fn(async () => ({ execScript }) as never) },
     });
 
     await expect(installer.availableVersion('ssh-1')).rejects.toMatchObject({
       code: 'artifact-download-failed',
-      message: expect.stringContaining('invalid'),
+      message: expect.stringContaining('channel pointer is invalid'),
+    });
+  });
+
+  it('rejects a channel pointer for a different protocol major', async () => {
+    const wrongMajor = protocolMajor() + 1;
+    const execScript = vi.fn().mockResolvedValue({
+      stdout: pointerBody('0.2.0', `${wrongMajor}.0.0`),
+      stderr: '',
+      exitCode: 0,
+    });
+    const installer = new WorkspaceServerInstaller({
+      ssh: { ensureProxy: vi.fn(async () => ({ execScript }) as never) },
+    });
+
+    await expect(installer.availableVersion('ssh-1')).rejects.toMatchObject({
+      code: 'artifact-download-failed',
+      message: expect.stringContaining(
+        `expected protocol major ${protocolMajor()}, received ${wrongMajor}`
+      ),
     });
   });
 
   it('uses a custom install command with substituted placeholders when configured', async () => {
     const execScript = vi.fn().mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
-    const installer = new WorkspaceServerInstaller(
-      { ensureProxy: vi.fn(async () => ({ execScript }) as never) },
-      'http://minio:9000/emdash-releases/workspace-server',
-      'curl -fsSL {{scriptUrl}} | sh -s -- --base-url {{baseUrl}}'
-    );
+    const installer = new WorkspaceServerInstaller({
+      ssh: { ensureProxy: vi.fn(async () => ({ execScript }) as never) },
+      baseUrl: installBaseUrl,
+      installCommand:
+        'curl -fsSL {{scriptUrl}} | sh -s -- --base-url {{baseUrl}} --version {{version}}',
+    });
 
-    await installer.install('ssh-1');
+    await installer.install('ssh-1', undefined, '0.1.0-dev.abc123');
 
     expect(execScript).toHaveBeenCalledWith(
-      'curl -fsSL http://minio:9000/emdash-releases/workspace-server/install.sh | sh -s -- --base-url http://minio:9000/emdash-releases/workspace-server',
+      `curl -fsSL ${installBaseUrl}/install.sh | sh -s -- --base-url ${installBaseUrl} --version 0.1.0-dev.abc123`,
       expect.objectContaining({ timeoutMs: 300_000 })
     );
   });
@@ -115,12 +183,12 @@ describe('workspace-server installer command', () => {
     [42, 'install-failed'],
   ] as const)('maps installer exit %i to %s', async (exitCode, code) => {
     const execScript = vi.fn().mockResolvedValue({ stdout: '', stderr: 'failed', exitCode });
-    const installer = new WorkspaceServerInstaller(
-      { ensureProxy: vi.fn(async () => ({ execScript }) as never) },
-      'https://releases.example.test/workspace-server'
-    );
+    const installer = new WorkspaceServerInstaller({
+      ssh: { ensureProxy: vi.fn(async () => ({ execScript }) as never) },
+      baseUrl: 'https://releases.example.test/workspace-server',
+    });
 
-    await expect(installer.install('ssh-1')).rejects.toMatchObject({ code });
+    await expect(installer.install('ssh-1', undefined, '1.2.3')).rejects.toMatchObject({ code });
   });
 
   it('rejects a current link that points outside the managed versions directory', async () => {
@@ -130,7 +198,7 @@ describe('workspace-server installer command', () => {
       exitCode: 0,
     }));
     const installer = new WorkspaceServerInstaller({
-      ensureProxy: vi.fn(async () => ({ exec }) as never),
+      ssh: { ensureProxy: vi.fn(async () => ({ exec }) as never) },
     });
 
     await expect(
@@ -141,3 +209,7 @@ describe('workspace-server installer command', () => {
     });
   });
 });
+
+function pointerBody(artifactVersion: string, protocolVersion = PROTOCOL_VERSION): string {
+  return `${JSON.stringify({ artifactVersion, protocolVersion })}\n`;
+}

--- a/apps/emdash-desktop/src/core/services/hosts/node/workspace-server/provision/installer.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/workspace-server/provision/installer.ts
@@ -6,6 +6,7 @@ import {
   protocolMajor,
   type ReleaseChannel,
 } from '@emdash/core/workspace-server';
+import type { SshClientProxy } from '@core/primitives/ssh/api/node/ssh-client-proxy';
 import { validateWorkspaceServerVersion, type WorkspaceServerLayout } from '../layout';
 import type { WorkspaceServerSshPort } from '../ports';
 
@@ -32,20 +33,24 @@ export class WorkspaceServerInstallError extends Error {
 export type WorkspaceServerInstallerOptions = {
   ssh: WorkspaceServerSshPort;
   baseUrl?: string;
-  installCommand?: string;
   releaseChannel?: ReleaseChannel;
+};
+
+export type WorkspaceServerInstallOptions = {
+  connectionId: string;
+  layout: WorkspaceServerLayout;
+  signal?: AbortSignal;
+  version?: string;
 };
 
 export class WorkspaceServerInstaller {
   private readonly ssh: WorkspaceServerSshPort;
   private readonly baseUrl: string;
-  private readonly installCommand?: string;
   private readonly releaseChannel: ReleaseChannel;
 
   constructor(options: WorkspaceServerInstallerOptions) {
     this.ssh = options.ssh;
     this.baseUrl = options.baseUrl ?? DEFAULT_WORKSPACE_SERVER_INSTALL_BASE_URL;
-    this.installCommand = options.installCommand;
     this.releaseChannel = options.releaseChannel ?? 'stable';
   }
 
@@ -55,6 +60,53 @@ export class WorkspaceServerInstaller {
     signal?: AbortSignal
   ): Promise<string | undefined> {
     const proxy = await this.ssh.ensureProxy(connectionId);
+    return await this.installedVersionFromProxy(proxy, layout, signal);
+  }
+
+  async install(options: WorkspaceServerInstallOptions): Promise<void> {
+    const selectedVersion =
+      options.version ?? (await this.availableVersion(options.connectionId, options.signal));
+    const command = buildWorkspaceServerInstallCommand(this.baseUrl, selectedVersion);
+    const proxy = await this.ssh.ensureProxy(options.connectionId);
+    const result = await proxy.execScript(command, {
+      signal: options.signal,
+      timeoutMs: 5 * 60_000,
+      maxStdoutBytes: 256 * 1_024,
+      maxStderrBytes: 256 * 1_024,
+    });
+    if (result.exitCode !== 0) {
+      const code =
+        result.exitCode === 40
+          ? 'unsupported-platform'
+          : result.exitCode === 41
+            ? 'artifact-download-failed'
+            : 'install-failed';
+      throw new WorkspaceServerInstallError(
+        code,
+        `Workspace-server installation failed: ${result.stderr.trim() || `exit ${result.exitCode}`}`
+      );
+    }
+
+    const installedVersion = await this.installedVersionFromProxy(
+      proxy,
+      options.layout,
+      options.signal
+    );
+    if (installedVersion !== selectedVersion) {
+      throw new WorkspaceServerInstallError(
+        'install-failed',
+        installedVersion === undefined
+          ? `Workspace-server installation did not select requested version ${selectedVersion}`
+          : `Workspace-server installation installed ${installedVersion} instead of ${selectedVersion}`
+      );
+    }
+  }
+
+  private async installedVersionFromProxy(
+    proxy: SshClientProxy,
+    layout: WorkspaceServerLayout,
+    signal?: AbortSignal
+  ): Promise<string | undefined> {
     const result = await proxy.exec(
       { command: 'readlink', args: ['--', layout.currentLink] },
       {
@@ -84,32 +136,6 @@ export class WorkspaceServerInstaller {
       );
     }
     return version;
-  }
-
-  async install(connectionId: string, signal?: AbortSignal, version?: string): Promise<void> {
-    const selectedVersion = version ?? (await this.availableVersion(connectionId, signal));
-    const proxy = await this.ssh.ensureProxy(connectionId);
-    const command = this.installCommand
-      ? renderCustomInstallCommand(this.installCommand, this.baseUrl, selectedVersion)
-      : buildWorkspaceServerInstallCommand(this.baseUrl, selectedVersion);
-    const result = await proxy.execScript(command, {
-      signal,
-      timeoutMs: 5 * 60_000,
-      maxStdoutBytes: 256 * 1_024,
-      maxStderrBytes: 256 * 1_024,
-    });
-    if (result.exitCode === 0) return;
-
-    const code =
-      result.exitCode === 40
-        ? 'unsupported-platform'
-        : result.exitCode === 41
-          ? 'artifact-download-failed'
-          : 'install-failed';
-    throw new WorkspaceServerInstallError(
-      code,
-      `Workspace-server installation failed: ${result.stderr.trim() || `exit ${result.exitCode}`}`
-    );
   }
 
   async availableVersion(connectionId: string, signal?: AbortSignal): Promise<string> {
@@ -230,18 +256,4 @@ function validateInstallBaseUrl(value: string): string {
 
 function ensureTrailingSlash(value: string): string {
   return value.endsWith('/') ? value : `${value}/`;
-}
-
-function renderCustomInstallCommand(command: string, baseUrl: string, version: string): string {
-  const normalizedBaseUrl = validateInstallBaseUrl(baseUrl);
-  const selectedVersion = validateWorkspaceServerVersion(version);
-  const scriptUrl = new URL(`${selectedVersion}/install.sh`, ensureTrailingSlash(normalizedBaseUrl))
-    .href;
-  const hasVersionPlaceholder = command.includes('{{version}}');
-  const quotedVersion = quoteArg(selectedVersion, 'posix');
-  const rendered = command
-    .replaceAll('{{scriptUrl}}', quoteArg(scriptUrl, 'posix'))
-    .replaceAll('{{baseUrl}}', quoteArg(normalizedBaseUrl, 'posix'))
-    .replaceAll('{{version}}', quotedVersion);
-  return hasVersionPlaceholder ? rendered : `${rendered} --version ${quotedVersion}`;
 }

--- a/apps/emdash-desktop/src/core/services/hosts/node/workspace-server/provision/installer.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/workspace-server/provision/installer.ts
@@ -1,5 +1,11 @@
 import path from 'node:path';
 import { quoteArg } from '@emdash/core/primitives/exec/api';
+import {
+  channelPointerPath,
+  parseChannelPointer,
+  protocolMajor,
+  type ReleaseChannel,
+} from '@emdash/core/workspace-server';
 import { validateWorkspaceServerVersion, type WorkspaceServerLayout } from '../layout';
 import type { WorkspaceServerSshPort } from '../ports';
 
@@ -23,12 +29,25 @@ export class WorkspaceServerInstallError extends Error {
   }
 }
 
+export type WorkspaceServerInstallerOptions = {
+  ssh: WorkspaceServerSshPort;
+  baseUrl?: string;
+  installCommand?: string;
+  releaseChannel?: ReleaseChannel;
+};
+
 export class WorkspaceServerInstaller {
-  constructor(
-    private readonly ssh: WorkspaceServerSshPort,
-    private readonly baseUrl = DEFAULT_WORKSPACE_SERVER_INSTALL_BASE_URL,
-    private readonly installCommand?: string
-  ) {}
+  private readonly ssh: WorkspaceServerSshPort;
+  private readonly baseUrl: string;
+  private readonly installCommand?: string;
+  private readonly releaseChannel: ReleaseChannel;
+
+  constructor(options: WorkspaceServerInstallerOptions) {
+    this.ssh = options.ssh;
+    this.baseUrl = options.baseUrl ?? DEFAULT_WORKSPACE_SERVER_INSTALL_BASE_URL;
+    this.installCommand = options.installCommand;
+    this.releaseChannel = options.releaseChannel ?? 'stable';
+  }
 
   async installedVersion(
     connectionId: string,
@@ -67,11 +86,12 @@ export class WorkspaceServerInstaller {
     return version;
   }
 
-  async install(connectionId: string, signal?: AbortSignal): Promise<void> {
+  async install(connectionId: string, signal?: AbortSignal, version?: string): Promise<void> {
+    const selectedVersion = version ?? (await this.availableVersion(connectionId, signal));
     const proxy = await this.ssh.ensureProxy(connectionId);
     const command = this.installCommand
-      ? renderCustomInstallCommand(this.installCommand, this.baseUrl)
-      : buildWorkspaceServerInstallCommand(this.baseUrl);
+      ? renderCustomInstallCommand(this.installCommand, this.baseUrl, selectedVersion)
+      : buildWorkspaceServerInstallCommand(this.baseUrl, selectedVersion);
     const result = await proxy.execScript(command, {
       signal,
       timeoutMs: 5 * 60_000,
@@ -93,9 +113,14 @@ export class WorkspaceServerInstaller {
   }
 
   async availableVersion(connectionId: string, signal?: AbortSignal): Promise<string> {
+    const expectedProtocolMajor = protocolMajor();
     const proxy = await this.ssh.ensureProxy(connectionId);
     const result = await proxy.execScript(
-      buildWorkspaceServerAvailableVersionCommand(this.baseUrl),
+      buildWorkspaceServerChannelPointerCommand(
+        this.baseUrl,
+        this.releaseChannel,
+        expectedProtocolMajor
+      ),
       {
         signal,
         timeoutMs: 10_000,
@@ -106,46 +131,73 @@ export class WorkspaceServerInstaller {
     if (result.exitCode !== 0) {
       throw new WorkspaceServerInstallError(
         'artifact-download-failed',
-        `Could not resolve the latest workspace-server version: ${
+        `Could not resolve the workspace-server ${this.releaseChannel} channel pointer: ${
           result.stderr.trim() || `exit ${result.exitCode}`
         }`
       );
     }
 
-    const version = result.stdout.trim();
-    try {
-      validateWorkspaceServerVersion(version);
-    } catch (error) {
+    const pointer = parseChannelPointer(result.stdout, expectedProtocolMajor);
+    if (!pointer.success) {
+      const reason =
+        pointer.error.type === 'invalid'
+          ? pointer.error.reason
+          : `expected protocol major ${pointer.error.expected}, received ${pointer.error.actual}`;
       throw new WorkspaceServerInstallError(
         'artifact-download-failed',
-        `The latest workspace-server version is invalid: ${version}`,
-        { cause: error }
+        `The workspace-server ${this.releaseChannel} channel pointer is invalid: ${reason}`
       );
     }
-    return version;
+    return pointer.data.artifactVersion;
   }
 }
 
-export function buildWorkspaceServerAvailableVersionCommand(baseUrl: string): string {
+export function buildWorkspaceServerChannelPointerCommand(
+  baseUrl: string,
+  channel: ReleaseChannel,
+  expectedProtocolMajor: number
+): string {
   const normalizedBaseUrl = validateInstallBaseUrl(baseUrl);
-  const latestUrl = new URL('latest.txt', ensureTrailingSlash(normalizedBaseUrl));
-  const quotedLatestUrl = quoteArg(latestUrl.href, 'posix');
+  const pointerUrl = new URL(
+    channelPointerPath(channel, expectedProtocolMajor),
+    ensureTrailingSlash(normalizedBaseUrl)
+  );
+  const quotedPointerUrl = quoteArg(pointerUrl.href, 'posix');
+  const stableFallbackUrl =
+    channel === 'canary'
+      ? quoteArg(
+          new URL(
+            channelPointerPath('stable', expectedProtocolMajor),
+            ensureTrailingSlash(normalizedBaseUrl)
+          ).href,
+          'posix'
+        )
+      : undefined;
+  const curlCommand = stableFallbackUrl
+    ? `curl -fsSL -- ${quotedPointerUrl} 2>/dev/null || curl -fsSL -- ${stableFallbackUrl}`
+    : `curl -fsSL -- ${quotedPointerUrl}`;
+  const wgetCommand = stableFallbackUrl
+    ? `wget -qO- -- ${quotedPointerUrl} 2>/dev/null || wget -qO- -- ${stableFallbackUrl}`
+    : `wget -qO- -- ${quotedPointerUrl}`;
   return `set -eu
 if command -v curl >/dev/null 2>&1; then
-  curl -fsSL -- ${quotedLatestUrl}
+  ${curlCommand}
 elif command -v wget >/dev/null 2>&1; then
-  wget -qO- -- ${quotedLatestUrl}
+  ${wgetCommand}
 else
   echo "curl or wget is required to download workspace-server metadata" >&2
   exit 41
 fi`;
 }
 
-export function buildWorkspaceServerInstallCommand(baseUrl: string): string {
+export function buildWorkspaceServerInstallCommand(baseUrl: string, version: string): string {
   const normalizedBaseUrl = validateInstallBaseUrl(baseUrl);
-  const scriptUrl = new URL('install.sh', ensureTrailingSlash(normalizedBaseUrl)).href;
+  const selectedVersion = validateWorkspaceServerVersion(version);
+  const scriptUrl = new URL(`${selectedVersion}/install.sh`, ensureTrailingSlash(normalizedBaseUrl))
+    .href;
   const quotedScriptUrl = quoteArg(scriptUrl, 'posix');
   const quotedBaseUrl = quoteArg(normalizedBaseUrl, 'posix');
+  const quotedVersion = quoteArg(selectedVersion, 'posix');
   return `set -eu
 install_script=\${TMPDIR:-/tmp}/emdash-workspace-server-install-$$.sh
 cleanup() { rm -f -- "$install_script"; }
@@ -153,7 +205,7 @@ trap cleanup EXIT HUP INT TERM
 if ! curl -fsSL --output "$install_script" -- ${quotedScriptUrl}; then
   exit 41
 fi
-sh "$install_script" --base-url ${quotedBaseUrl}`;
+sh "$install_script" --base-url ${quotedBaseUrl} --version ${quotedVersion}`;
 }
 
 function validateInstallBaseUrl(value: string): string {
@@ -180,10 +232,12 @@ function ensureTrailingSlash(value: string): string {
   return value.endsWith('/') ? value : `${value}/`;
 }
 
-function renderCustomInstallCommand(command: string, baseUrl: string): string {
+function renderCustomInstallCommand(command: string, baseUrl: string, version: string): string {
   const normalizedBaseUrl = validateInstallBaseUrl(baseUrl);
+  const selectedVersion = validateWorkspaceServerVersion(version);
   const scriptUrl = new URL('install.sh', ensureTrailingSlash(normalizedBaseUrl)).href;
   return command
     .replaceAll('{{scriptUrl}}', quoteArg(scriptUrl, 'posix'))
-    .replaceAll('{{baseUrl}}', quoteArg(normalizedBaseUrl, 'posix'));
+    .replaceAll('{{baseUrl}}', quoteArg(normalizedBaseUrl, 'posix'))
+    .replaceAll('{{version}}', quoteArg(selectedVersion, 'posix'));
 }

--- a/apps/emdash-desktop/src/core/services/hosts/node/workspace-server/provision/installer.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/workspace-server/provision/installer.ts
@@ -235,9 +235,13 @@ function ensureTrailingSlash(value: string): string {
 function renderCustomInstallCommand(command: string, baseUrl: string, version: string): string {
   const normalizedBaseUrl = validateInstallBaseUrl(baseUrl);
   const selectedVersion = validateWorkspaceServerVersion(version);
-  const scriptUrl = new URL('install.sh', ensureTrailingSlash(normalizedBaseUrl)).href;
-  return command
+  const scriptUrl = new URL(`${selectedVersion}/install.sh`, ensureTrailingSlash(normalizedBaseUrl))
+    .href;
+  const hasVersionPlaceholder = command.includes('{{version}}');
+  const quotedVersion = quoteArg(selectedVersion, 'posix');
+  const rendered = command
     .replaceAll('{{scriptUrl}}', quoteArg(scriptUrl, 'posix'))
     .replaceAll('{{baseUrl}}', quoteArg(normalizedBaseUrl, 'posix'))
-    .replaceAll('{{version}}', quoteArg(selectedVersion, 'posix'));
+    .replaceAll('{{version}}', quotedVersion);
+  return hasVersionPlaceholder ? rendered : `${rendered} --version ${quotedVersion}`;
 }

--- a/apps/emdash-desktop/src/core/services/hosts/node/workspace-server/provision/provisioner.test.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/workspace-server/provision/provisioner.test.ts
@@ -105,9 +105,11 @@ describe('WorkspaceServerProvisioner', () => {
       expect.any(AbortSignal)
     );
     expect(fixture.installer.install).toHaveBeenCalledWith(
-      'ssh-1',
-      expect.any(AbortSignal),
-      '1.2.4-dev.abc123'
+      expect.objectContaining({
+        connectionId: 'ssh-1',
+        signal: expect.any(AbortSignal),
+        version: '1.2.4-dev.abc123',
+      })
     );
     expect(fixture.daemon.restart).toHaveBeenCalledOnce();
     expect(fixture.daemon.start).not.toHaveBeenCalled();

--- a/apps/emdash-desktop/src/core/services/hosts/node/workspace-server/provision/provisioner.test.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/workspace-server/provision/provisioner.test.ts
@@ -91,7 +91,7 @@ describe('WorkspaceServerProvisioner', () => {
     await fixture.dispose();
   });
 
-  it('dev auto-updates a compatible running daemon when latest.txt advertises a newer version', async () => {
+  it('dev auto-updates a compatible running daemon when its channel pointer advertises a newer version', async () => {
     const fixture = createProvisionerFixture({ devAutoUpdate: true });
     fixture.installer.availableVersion.mockResolvedValue('1.2.4-dev.abc123');
     fixture.dialOnce
@@ -104,7 +104,11 @@ describe('WorkspaceServerProvisioner', () => {
       'ssh-1',
       expect.any(AbortSignal)
     );
-    expect(fixture.installer.install).toHaveBeenCalledOnce();
+    expect(fixture.installer.install).toHaveBeenCalledWith(
+      'ssh-1',
+      expect.any(AbortSignal),
+      '1.2.4-dev.abc123'
+    );
     expect(fixture.daemon.restart).toHaveBeenCalledOnce();
     expect(fixture.daemon.start).not.toHaveBeenCalled();
     expect(fixture.status('ssh-1')).toMatchObject({

--- a/apps/emdash-desktop/src/core/services/hosts/node/workspace-server/provision/provisioner.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/workspace-server/provision/provisioner.ts
@@ -207,19 +207,25 @@ export class WorkspaceServerProvisioner {
       return null;
     }
 
+    // Dev versions put a commit SHA before their timestamp, so SemVer order does not represent
+    // build recency. Any different published dev artifact must replace the running one.
     if (availableVersion === handshake.server.appVersion) return null;
-    await this.install(connectionId, signal);
+    await this.install(connectionId, signal, availableVersion);
     await this.restart(connectionId, layout, signal);
     return await this.waitUntilReady(target, signal);
   }
 
-  private async install(connectionId: string, signal: AbortSignal): Promise<void> {
+  private async install(
+    connectionId: string,
+    signal: AbortSignal,
+    version?: string
+  ): Promise<void> {
     this.deps.model.set(connectionId, {
       status: 'booting',
       detail: 'Installing workspace server',
     });
     try {
-      await this.deps.installer.install(connectionId, signal);
+      await this.deps.installer.install(connectionId, signal, version);
     } catch (error) {
       if (error instanceof WorkspaceServerInstallError) {
         throw provisionError(error.code, error.message, error);

--- a/apps/emdash-desktop/src/core/services/hosts/node/workspace-server/provision/provisioner.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/workspace-server/provision/provisioner.ts
@@ -160,7 +160,7 @@ export class WorkspaceServerProvisioner {
         case 'client-outdated':
           throw protocolError(outcome.error);
         case 'server-outdated':
-          await this.install(connectionId, signal);
+          await this.install(connectionId, layout, signal);
           await this.restart(connectionId, layout, signal);
           this.publishHealthy(connectionId, await this.waitUntilReady(target, signal));
           return target;
@@ -168,7 +168,7 @@ export class WorkspaceServerProvisioner {
           break;
       }
 
-      await this.install(connectionId, signal);
+      await this.install(connectionId, layout, signal);
       await this.start(connectionId, layout, signal);
 
       this.publishHealthy(connectionId, await this.waitUntilReady(target, signal));
@@ -210,13 +210,14 @@ export class WorkspaceServerProvisioner {
     // Dev versions put a commit SHA before their timestamp, so SemVer order does not represent
     // build recency. Any different published dev artifact must replace the running one.
     if (availableVersion === handshake.server.appVersion) return null;
-    await this.install(connectionId, signal, availableVersion);
+    await this.install(connectionId, layout, signal, availableVersion);
     await this.restart(connectionId, layout, signal);
     return await this.waitUntilReady(target, signal);
   }
 
   private async install(
     connectionId: string,
+    layout: WorkspaceServerLayout,
     signal: AbortSignal,
     version?: string
   ): Promise<void> {
@@ -225,7 +226,7 @@ export class WorkspaceServerProvisioner {
       detail: 'Installing workspace server',
     });
     try {
-      await this.deps.installer.install(connectionId, signal, version);
+      await this.deps.installer.install({ connectionId, layout, signal, version });
     } catch (error) {
       if (error instanceof WorkspaceServerInstallError) {
         throw provisionError(error.code, error.message, error);

--- a/apps/emdash-desktop/src/main/bootstrap/boot/phases/infrastructure.ts
+++ b/apps/emdash-desktop/src/main/bootstrap/boot/phases/infrastructure.ts
@@ -1,6 +1,7 @@
 import { eq } from 'drizzle-orm';
 import { app } from 'electron';
 import type { SshServiceHandle } from '@core/manifests/node/ssh-service-handle';
+import { IS_CANARY } from '@core/primitives/app-identity/api/app-identity';
 import type { SshService } from '@core/primitives/ssh/api';
 import type { AppDb } from '@core/services/app-db/node/db';
 import { sshConnections } from '@core/services/app-db/node/schema';
@@ -36,6 +37,7 @@ export async function bootInfrastructure(database: DatabaseBundle): Promise<Infr
     machineEvents: ssh.machines,
     installBaseUrl: hostSettings.installBaseUrl,
     installCommand: hostSettings.installCommand ?? undefined,
+    releaseChannel: IS_CANARY ? 'canary' : 'stable',
     devAutoUpdate: process.env['EMDASH_WORKSPACE_SERVER_DEV_AUTO_UPDATE'] === '1',
     client: { id: clientId, appVersion: app.getVersion() },
     logger: log,

--- a/apps/emdash-desktop/src/main/bootstrap/boot/phases/infrastructure.ts
+++ b/apps/emdash-desktop/src/main/bootstrap/boot/phases/infrastructure.ts
@@ -36,7 +36,6 @@ export async function bootInfrastructure(database: DatabaseBundle): Promise<Infr
     ssh: { manager: ssh.manager, connect: ssh.ssh },
     machineEvents: ssh.machines,
     installBaseUrl: hostSettings.installBaseUrl,
-    installCommand: hostSettings.installCommand ?? undefined,
     releaseChannel: IS_CANARY ? 'canary' : 'stable',
     devAutoUpdate: process.env['EMDASH_WORKSPACE_SERVER_DEV_AUTO_UPDATE'] === '1',
     client: { id: clientId, appVersion: app.getVersion() },

--- a/apps/emdash-desktop/src/main/gateway/workspace-server.remote.test.ts
+++ b/apps/emdash-desktop/src/main/gateway/workspace-server.remote.test.ts
@@ -2,6 +2,7 @@ import type { Command } from '@emdash/core/primitives/exec/api';
 import { hostRef } from '@emdash/core/primitives/host/api';
 import { joinAbsolute, parsePortableRelativePath } from '@emdash/core/primitives/path/api';
 import { fileSearchContract } from '@emdash/core/runtimes/file-search/api';
+import { parseChannelPointer, protocolMajor } from '@emdash/core/workspace-server';
 import { createScope } from '@emdash/shared/concurrency';
 import { deferred } from '@emdash/shared/testing';
 import { createLiveJobReplicaCache } from '@emdash/wire/live';
@@ -14,8 +15,7 @@ import { createDesktopRuntimeBroker } from './runtime-broker';
 
 const remoteTestEnabled = process.env['EMDASH_TEST_REMOTE_WSS'] === '1';
 const defaultRemoteInstallBaseUrl = 'http://minio:9000/emdash-releases/workspace-server';
-const defaultPublishedVersionUrl =
-  'http://localhost:9000/emdash-releases/workspace-server/latest.txt';
+const defaultPublishedPointerUrl = `http://localhost:9000/emdash-releases/workspace-server/channels/stable/protocol-${protocolMajor()}.json`;
 
 describe.skipIf(!remoteTestEnabled)('workspace-server cold install over Docker SSH', () => {
   it('installs, resolves a runtime, and preserves the session across an SSH reconnect', async () => {
@@ -42,7 +42,7 @@ describe.skipIf(!remoteTestEnabled)('workspace-server cold install over Docker S
     const installBaseUrl =
       process.env['EMDASH_TEST_REMOTE_WSS_INSTALL_BASE_URL'] ?? defaultRemoteInstallBaseUrl;
     const expectedVersion = await readPublishedVersion(
-      process.env['EMDASH_TEST_REMOTE_WSS_LATEST_URL'] ?? defaultPublishedVersionUrl
+      process.env['EMDASH_TEST_REMOTE_WSS_POINTER_URL'] ?? defaultPublishedPointerUrl
     );
     const hosts = createHostService({
       scope,
@@ -206,12 +206,12 @@ async function readPublishedVersion(url: string): Promise<string> {
   const response = await fetch(url);
   if (!response.ok) {
     throw new Error(
-      `Could not read workspace-server latest.txt from ${url} (HTTP ${response.status})`
+      `Could not read workspace-server channel pointer from ${url} (HTTP ${response.status})`
     );
   }
-  const version = (await response.text()).trim();
-  if (version.length === 0) {
-    throw new Error(`workspace-server latest.txt from ${url} was empty`);
+  const pointer = parseChannelPointer(await response.text(), protocolMajor());
+  if (!pointer.success) {
+    throw new Error(`Workspace-server channel pointer from ${url} was invalid`);
   }
-  return version;
+  return pointer.data.artifactVersion;
 }

--- a/apps/workspace-server/docs/docker-remote.md
+++ b/apps/workspace-server/docs/docker-remote.md
@@ -51,8 +51,9 @@ pnpm run dev:remote
 The script packages a Linux artifact for the host's native architecture (`linux-arm64` on Apple
 Silicon, `linux-x64` otherwise), starts the Compose services (`minio`, `minio-setup`, and
 `workspace-remote`), uploads the artifact layout to `http://localhost:9000/emdash-releases`, and
-verifies that minio's `workspace-server/latest.txt` points at the new version. Override the target
-with `EMDASH_WS_DEV_REMOTE_TARGET=linux-x64` or `EMDASH_WS_DEV_REMOTE_TARGET=linux-arm64`.
+verifies that minio's stable and canary `workspace-server/channels/*/protocol-1.json` pointers name
+the new version. Override the target with `EMDASH_WS_DEV_REMOTE_TARGET=linux-x64` or
+`EMDASH_WS_DEV_REMOTE_TARGET=linux-arm64`.
 
 The remote container is no longer recreated to ingest artifacts. It stays a bare SSH host; the
 desktop provisioner installs the workspace server by curling the same `install.sh` that production
@@ -76,10 +77,10 @@ The `minio` hostname is resolved by the `workspace-remote` container. The host c
 objects through `http://localhost:9000/emdash-releases/workspace-server/`.
 
 `EMDASH_WORKSPACE_SERVER_DEV_AUTO_UPDATE=1` makes the desktop compare the running daemon's
-`appVersion` with `latest.txt` from the configured artifact URL. If they differ, the desktop
-reinstalls and restarts the remote daemon during the next ensure/reconnect. This is development-only;
-production provisioning still keeps compatible running daemons installed until an explicit update or
-protocol upgrade.
+`appVersion` with the artifact version in its channel pointer for the desktop protocol major. If
+they differ, the desktop reinstalls that exact version and restarts the remote daemon during the next
+ensure/reconnect. This is development-only; production provisioning still keeps compatible running
+daemons installed until an explicit update or protocol upgrade.
 
 ## Re-publish Without Restarting Docker
 
@@ -94,7 +95,8 @@ pnpm run upload:dev
 
 Use `EMDASH_WS_DEV_REMOTE_TARGET=linux-x64` when publishing an x64 artifact from Apple Silicon, or
 pass `--version` / `--target` to override detection. With the desktop running in dev-auto-update
-mode, the next ensure/reconnect sees the new `latest.txt`, reinstalls, and restarts the daemon.
+mode, the next ensure/reconnect sees the updated channel pointer, installs its pinned artifact
+version, and restarts the daemon.
 
 Run the desktop connection smoke test against the installed daemon:
 

--- a/apps/workspace-server/docs/docker-remote.md
+++ b/apps/workspace-server/docs/docker-remote.md
@@ -56,8 +56,8 @@ the new version. Override the target with `EMDASH_WS_DEV_REMOTE_TARGET=linux-x64
 `EMDASH_WS_DEV_REMOTE_TARGET=linux-arm64`.
 
 The remote container is no longer recreated to ingest artifacts. It stays a bare SSH host; the
-desktop provisioner installs the workspace server by curling the same `install.sh` that production
-uses, with the artifact source URL pointed at minio.
+desktop provisioner resolves a minio channel pointer, then curls that version's immutable
+`install.sh` with the artifact source URL pointed at minio.
 
 When testing the desktop app interactively against this remote, launch it with:
 

--- a/apps/workspace-server/docs/packaging.md
+++ b/apps/workspace-server/docs/packaging.md
@@ -59,8 +59,6 @@ All workspace-server objects live under the `workspace-server/` prefix:
 
 ```text
 workspace-server/
-  install.sh
-  latest.txt
   channels/
     stable/protocol-1.json
     canary/protocol-1.json
@@ -82,9 +80,9 @@ publishes its own immutable artifacts; releases are not promoted between channel
 Both channels build and smoke-verify all three targets, test `install.sh` against a local
 `file://` mirror, and move only their own protocol-major pointer after every immutable object is
 available. Existing versioned objects may only be skipped when their contents have the same
-SHA-256; the uploader refuses to replace different contents. Stable releases also update the
-legacy root `install.sh` and `latest.txt`. Canary releases never change those root objects, so
-`curl | sh` without an explicit version remains on stable.
+SHA-256; the uploader refuses to replace different contents. Channel pointers are the only mutable
+release objects. Installation scripts exist only under immutable version directories, require
+`--version`, and never select a release channel.
 
 The workflow build matrix is derived from `releaseTargets` and its runner mapping in
 `scripts/package-helpers.ts`. Adding or removing a release target there changes both the required
@@ -105,16 +103,24 @@ For a canary build, no package-version change is required: select `canary` or pa
 `-f channel=canary`. Canary versions are derived from the package version and GitHub run number;
 do not write the canary suffix into `package.json`.
 
-For manual recovery, download `install.sh` and pin the immutable artifact version explicitly:
+For manual recovery, download the immutable versioned installer and pin that same version
+explicitly:
 
 ```bash
-sh install.sh --version <version>
+version=<version>
+curl -fsSL "https://releases.emdash.sh/workspace-server/$version/install.sh" |
+  sh -s -- --version "$version"
 ```
 
 The workflow fails before building if the version's Linux x64 archive already exists at
 `https://releases.emdash.sh/workspace-server/`. Pull requests and pushes to `main` that affect the
 workspace server or its bundled workspace packages also run
 `.github/workflows/workspace-server-package-check.yml`, which packages and verifies Linux x64.
+If the publish job fails after immutable artifacts are uploaded, use **Re-run failed jobs** on that
+same GitHub Actions run. This reuses the retained build artifacts byte for byte; do not dispatch a
+new run or choose **Re-run all jobs**. The upload is idempotent: equal immutable objects are skipped
+and mutable selectors converge to the same release. Do not repair a partial publication by editing
+R2 objects manually.
 
 ## Publish to Local Minio
 
@@ -136,10 +142,8 @@ pnpm run upload:dev
 `upload:dev` points the S3 uploader at `http://localhost:9000/emdash-releases` with the local minio
 credentials. It defaults to the host's Linux target, picks the newest matching artifact under
 `dist-artifacts/`, uploads `workspace-server/<version>/<artifact>` and its `.sha256` sidecar, then
-advances the stable channel pointer. Stable uploads then update `workspace-server/install.sh` and
-`workspace-server/latest.txt`; pass `--channel canary` for a canary-only upload that leaves those
-root objects unchanged. `pnpm run dev:remote` publishes both channel pointers for its dev artifact.
-Pass `--version` and `--target` when you need an explicit override.
+advances the selected channel pointer. `pnpm run dev:remote` publishes both channel pointers for its
+dev artifact. Pass `--version` and `--target` when you need an explicit override.
 
 Downloaded Node archives are cached under `~/.cache/emdash/workspace-server/`. Set
 `EMDASH_WS_PACKAGE_CACHE_DIR` to use another cache directory.

--- a/apps/workspace-server/docs/packaging.md
+++ b/apps/workspace-server/docs/packaging.md
@@ -136,10 +136,10 @@ pnpm run upload:dev
 `upload:dev` points the S3 uploader at `http://localhost:9000/emdash-releases` with the local minio
 credentials. It defaults to the host's Linux target, picks the newest matching artifact under
 `dist-artifacts/`, uploads `workspace-server/<version>/<artifact>` and its `.sha256` sidecar, then
-updates the stable channel pointer last. Stable uploads also update `workspace-server/install.sh`
-and `workspace-server/latest.txt`; pass `--channel canary` for a canary-only upload that leaves
-those root objects unchanged. `pnpm run dev:remote` publishes both channel pointers for its dev
-artifact. Pass `--version` and `--target` when you need an explicit override.
+advances the stable channel pointer. Stable uploads then update `workspace-server/install.sh` and
+`workspace-server/latest.txt`; pass `--channel canary` for a canary-only upload that leaves those
+root objects unchanged. `pnpm run dev:remote` publishes both channel pointers for its dev artifact.
+Pass `--version` and `--target` when you need an explicit override.
 
 Downloaded Node archives are cached under `~/.cache/emdash/workspace-server/`. Set
 `EMDASH_WS_PACKAGE_CACHE_DIR` to use another cache directory.

--- a/apps/workspace-server/docs/packaging.md
+++ b/apps/workspace-server/docs/packaging.md
@@ -61,7 +61,11 @@ All workspace-server objects live under the `workspace-server/` prefix:
 workspace-server/
   install.sh
   latest.txt
+  channels/
+    stable/protocol-1.json
+    canary/protocol-1.json
   <version>/
+    install.sh
     emdash-workspace-server-<version>-linux-x64.tar.gz
     emdash-workspace-server-<version>-linux-x64.tar.gz.sha256
     emdash-workspace-server-<version>-linux-arm64.tar.gz
@@ -70,20 +74,41 @@ workspace-server/
     emdash-workspace-server-<version>-darwin-arm64.tar.gz.sha256
 ```
 
-The release workflow builds and smoke-verifies all three targets, tests `install.sh` against a
-local `file://` mirror of the assembled release, and publishes the versioned artifacts. Existing
-versioned objects may only be skipped when their contents have the same SHA-256; the uploader
-refuses to replace different contents. It uploads `latest.txt` last so an incomplete release is
-never selected by a new installation.
+The release workflow has `stable` and `canary` channels. Stable uses the version from
+`apps/workspace-server/package.json`. Canary increments that version's patch and appends the
+workflow run number: package version `0.1.0` becomes `0.1.1-canary.<run>`. Every run builds and
+publishes its own immutable artifacts; releases are not promoted between channels.
 
-To release:
+Both channels build and smoke-verify all three targets, test `install.sh` against a local
+`file://` mirror, and move only their own protocol-major pointer after every immutable object is
+available. Existing versioned objects may only be skipped when their contents have the same
+SHA-256; the uploader refuses to replace different contents. Stable releases also update the
+legacy root `install.sh` and `latest.txt`. Canary releases never change those root objects, so
+`curl | sh` without an explicit version remains on stable.
+
+The workflow build matrix is derived from `releaseTargets` and its runner mapping in
+`scripts/package-helpers.ts`. Adding or removing a release target there changes both the required
+artifact set and the CI build matrix.
+
+To publish stable:
 
 1. Bump `version` in `apps/workspace-server/package.json`. Never reuse a published version.
 2. Merge the change to `main`.
-3. Dispatch `.github/workflows/release-workspace-server.yml` from GitHub Actions, or run:
+3. Dispatch `.github/workflows/release-workspace-server.yml` from GitHub Actions and select the
+   `stable` channel, or run:
 
 ```bash
-gh workflow run release-workspace-server.yml --ref main
+gh workflow run release-workspace-server.yml --ref main -f channel=stable
+```
+
+For a canary build, no package-version change is required: select `canary` or pass
+`-f channel=canary`. Canary versions are derived from the package version and GitHub run number;
+do not write the canary suffix into `package.json`.
+
+For manual recovery, download `install.sh` and pin the immutable artifact version explicitly:
+
+```bash
+sh install.sh --version <version>
 ```
 
 The workflow fails before building if the version's Linux x64 archive already exists at
@@ -111,8 +136,10 @@ pnpm run upload:dev
 `upload:dev` points the S3 uploader at `http://localhost:9000/emdash-releases` with the local minio
 credentials. It defaults to the host's Linux target, picks the newest matching artifact under
 `dist-artifacts/`, uploads `workspace-server/<version>/<artifact>` and its `.sha256` sidecar, then
-updates `workspace-server/install.sh` and `workspace-server/latest.txt` last. Pass `--version` and
-`--target` when you need an explicit override.
+updates the stable channel pointer last. Stable uploads also update `workspace-server/install.sh`
+and `workspace-server/latest.txt`; pass `--channel canary` for a canary-only upload that leaves
+those root objects unchanged. `pnpm run dev:remote` publishes both channel pointers for its dev
+artifact. Pass `--version` and `--target` when you need an explicit override.
 
 Downloaded Node archives are cached under `~/.cache/emdash/workspace-server/`. Set
 `EMDASH_WS_PACKAGE_CACHE_DIR` to use another cache directory.

--- a/apps/workspace-server/install.sh
+++ b/apps/workspace-server/install.sh
@@ -62,6 +62,7 @@ case "$base_url" in
   https://* | http://* | file://*) ;;
   *) fail 41 "base URL must use https, http, or file" ;;
 esac
+[ -n "$version" ] || fail 42 "--version is required"
 
 case "$(uname -s 2>/dev/null || true)" in
   Linux) os=linux ;;
@@ -104,12 +105,6 @@ cleanup_metadata() {
 }
 trap cleanup_metadata EXIT HUP INT TERM
 
-if [ -z "$version" ]; then
-  if ! download "$base_url/latest.txt" "$temporary_metadata"; then
-    fail 41 "could not download the latest workspace-server version"
-  fi
-  version=$(tr -d '\r\n' < "$temporary_metadata")
-fi
 if ! printf '%s\n' "$version" |
   grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?(\+[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$'; then
   fail 41 "invalid workspace-server version '$version'"
@@ -117,13 +112,9 @@ fi
 
 artifact=emdash-workspace-server-$version-$os-$arch.tar.gz
 artifact_url=$base_url/$version/$artifact
-fallback_artifact_url=$base_url/$artifact
 if [ -z "$sha256" ]; then
   if ! download "$artifact_url.sha256" "$temporary_metadata"; then
-    if ! download "$fallback_artifact_url.sha256" "$temporary_metadata"; then
-      fail 41 "could not download the checksum for $artifact"
-    fi
-    artifact_url=$fallback_artifact_url
+    fail 41 "could not download the checksum for $artifact"
   fi
   sha256=$(awk -v expected="$artifact" '
     NF == 2 {
@@ -210,11 +201,7 @@ fi
 rm -rf -- "$staging" "$archive"
 mkdir -p -- "$staging"
 if ! download "$artifact_url" "$archive"; then
-  if [ "$artifact_url" = "$fallback_artifact_url" ] ||
-    ! download "$fallback_artifact_url" "$archive"; then
-    fail 41 "could not download $artifact"
-  fi
-  artifact_url=$fallback_artifact_url
+  fail 41 "could not download $artifact"
 fi
 if ! printf '%s  %s\n' "$sha256" "$archive" | sha256sum -c - >/dev/null; then
   fail 41 "checksum verification failed for $artifact"

--- a/apps/workspace-server/scripts/dev-remote.ts
+++ b/apps/workspace-server/scripts/dev-remote.ts
@@ -2,7 +2,13 @@ import { spawn, type StdioOptions } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  parseChannelPointer,
+  protocolMajor,
+  type ReleaseChannel,
+} from '@emdash/core/workspace-server';
 import { createDevPackageVersion } from './package-helpers.ts';
+import { channelPointerUrl } from './upload-helpers.ts';
 
 const linuxTargets = ['linux-arm64', 'linux-x64'] as const;
 type LinuxTarget = (typeof linuxTargets)[number];
@@ -44,7 +50,17 @@ async function main(): Promise<void> {
   process.stdout.write(`Uploading workspace-server ${expectedVersion} to local minio...\n`);
   await runCommand(
     'tsx',
-    ['scripts/upload-r2.ts', '--version', expectedVersion, '--target', target],
+    [
+      'scripts/upload-r2.ts',
+      '--version',
+      expectedVersion,
+      '--target',
+      target,
+      '--channel',
+      'stable',
+      '--channel',
+      'canary',
+    ],
     {
       cwd: appDirectory,
       env: {
@@ -103,23 +119,40 @@ async function devBuildIdentifier(): Promise<string> {
 }
 
 async function verifyPublishedVersion(expectedVersion: string): Promise<void> {
-  process.stdout.write('Verifying the published minio latest.txt...\n');
+  const channels = ['stable', 'canary'] as const satisfies readonly ReleaseChannel[];
+  const major = protocolMajor();
+  process.stdout.write(`Verifying the published minio protocol-${major} channel pointers...\n`);
   const deadline = Date.now() + 30_000;
-  const latestUrl = `${minioHostEndpoint.replace(/\/$/, '')}/workspace-server/latest.txt`;
-  let lastError = 'latest.txt was never checked';
+  let lastError = 'channel pointers were never checked';
 
   while (Date.now() < deadline) {
     try {
-      const response = await fetch(latestUrl);
-      if (!response.ok) {
-        lastError = `latest.txt returned HTTP ${response.status}`;
-      } else {
-        const version = (await response.text()).trim();
-        if (version === expectedVersion) {
-          process.stdout.write(`Published latest.txt points at ${version}\n`);
-          return;
+      let allPointersMatch = true;
+      for (const channel of channels) {
+        const pointerUrl = channelPointerUrl(minioHostEndpoint, channel, major);
+        const response = await fetch(pointerUrl);
+        if (!response.ok) {
+          lastError = `${channel} pointer returned HTTP ${response.status}`;
+          allPointersMatch = false;
+          break;
         }
-        lastError = `latest.txt reports ${version}, expected ${expectedVersion}`;
+
+        const pointer = parseChannelPointer(await response.text(), major);
+        if (!pointer.success) {
+          lastError = `${channel} pointer is invalid: ${JSON.stringify(pointer.error)}`;
+          allPointersMatch = false;
+          break;
+        }
+        if (pointer.data.artifactVersion !== expectedVersion) {
+          lastError = `${channel} pointer reports ${pointer.data.artifactVersion}, expected ${expectedVersion}`;
+          allPointersMatch = false;
+          break;
+        }
+      }
+
+      if (allPointersMatch) {
+        process.stdout.write(`Published stable and canary pointers point at ${expectedVersion}\n`);
+        return;
       }
     } catch (error) {
       lastError = error instanceof Error ? error.message : String(error);

--- a/apps/workspace-server/scripts/install.test.ts
+++ b/apps/workspace-server/scripts/install.test.ts
@@ -30,7 +30,14 @@ describe('workspace-server install.sh', () => {
     expect(result.stderr.toString()).toContain('base URL must use https, http, or file');
   });
 
-  it('installs latest atomically and skips the artifact on a repeated run', async () => {
+  it('requires an explicit immutable version', () => {
+    const result = spawnSync('sh', [installScript]);
+
+    expect(result.status).toBe(42);
+    expect(result.stderr.toString()).toContain('--version is required');
+  });
+
+  it('installs a pinned version atomically and skips the artifact on a repeated run', async () => {
     const directory = await mkdtemp(resolve(tmpdir(), 'emdash-install-script-'));
     const source = resolve(directory, 'source');
     const home = resolve(directory, 'home');
@@ -44,7 +51,6 @@ describe('workspace-server install.sh', () => {
       mkdir(bin, { recursive: true }),
     ]);
     await Promise.all([
-      writeFile(resolve(source, 'latest.txt'), `${version}\n`),
       writeFile(resolve(source, version, artifact), 'fixture archive'),
       writeFile(resolve(source, version, `${artifact}.sha256`), `${'a'.repeat(64)}  ${artifact}\n`),
       writeExecutable(
@@ -105,15 +111,16 @@ fi`
 
     try {
       const baseUrl = pathToFileURL(source).href;
-      const first = spawnSync('sh', [installScript, '--base-url', baseUrl], { env });
+      const args = [installScript, '--base-url', baseUrl, '--version', version];
+      const first = spawnSync('sh', args, { env });
       expect(first.status, first.stderr.toString()).toBe(0);
       expect(await readlink(resolve(home, '.emdash/workspace-server/current'))).toBe(
         `versions/${version}`
       );
 
-      const second = spawnSync('sh', [installScript, '--base-url', baseUrl], { env });
+      const second = spawnSync('sh', args, { env });
       expect(second.status, second.stderr.toString()).toBe(0);
-      expect((await readFile(curlLog, 'utf8')).trim().split('\n')).toHaveLength(5);
+      expect((await readFile(curlLog, 'utf8')).trim().split('\n')).toHaveLength(3);
     } finally {
       await rm(directory, { recursive: true, force: true });
     }

--- a/apps/workspace-server/scripts/package-helpers.ts
+++ b/apps/workspace-server/scripts/package-helpers.ts
@@ -24,6 +24,19 @@ const targetDefinitions = {
 
 export type PackageTargetId = keyof typeof targetDefinitions;
 export type PackageTarget = (typeof targetDefinitions)[PackageTargetId];
+export type ReleaseChannel = 'stable' | 'canary';
+
+const releaseRunners: Record<PackageTargetId, string> = {
+  'darwin-arm64': 'macos-latest',
+  'linux-arm64': 'ubuntu-24.04-arm',
+  'linux-x64': 'ubuntu-latest',
+};
+
+export const releaseTargets = [
+  targetDefinitions['linux-x64'],
+  targetDefinitions['linux-arm64'],
+  targetDefinitions['darwin-arm64'],
+] as const satisfies readonly PackageTarget[];
 
 const ripgrepReleaseTargets: Record<
   PackageTargetId,
@@ -45,6 +58,7 @@ const ripgrepReleaseTargets: Record<
 
 export type PackageCliOptions = {
   targets: PackageTarget[];
+  version?: string;
   verify: boolean;
   help: boolean;
 };
@@ -78,6 +92,7 @@ export function parsePackageTarget(value: string): PackageTarget {
 
 export function parsePackageArgs(args: string[]): PackageCliOptions {
   const targets: PackageTarget[] = [];
+  let version: string | undefined;
   let verify = false;
   let help = false;
 
@@ -102,6 +117,17 @@ export function parsePackageArgs(args: string[]): PackageCliOptions {
       targets.push(parsePackageTarget(argument.slice('--target='.length)));
       continue;
     }
+    if (argument === '--version') {
+      const value = args[index + 1];
+      if (value === undefined) throw new Error('--version requires a value');
+      version = value;
+      index += 1;
+      continue;
+    }
+    if (argument.startsWith('--version=')) {
+      version = argument.slice('--version='.length);
+      continue;
+    }
     throw new Error(`Unknown packaging option '${argument}'`);
   }
 
@@ -109,6 +135,7 @@ export function parsePackageArgs(args: string[]): PackageCliOptions {
     targets: targets.filter(
       (target, index) => targets.findIndex((candidate) => candidate.id === target.id) === index
     ),
+    version,
     verify,
     help,
   };
@@ -147,6 +174,17 @@ export function artifactArchiveName(version: string, target: PackageTarget): str
   return `${artifactRootName}-${version}-${target.os}-${target.arch}.tar.gz`;
 }
 
+export function releaseBuildMatrix(): {
+  include: { target: string; runner: string }[];
+} {
+  return {
+    include: releaseTargets.map((target) => ({
+      target: target.id,
+      runner: releaseRunners[target.id],
+    })),
+  };
+}
+
 export function createDevPackageVersion(baseVersion: string, identifier: string): string {
   validatePackageVersion(baseVersion);
   const normalizedIdentifier = identifier.trim();
@@ -159,6 +197,43 @@ export function createDevPackageVersion(baseVersion: string, identifier: string)
   const version = `${baseVersion}-dev.${normalizedIdentifier}`;
   validatePackageVersion(version);
   return version;
+}
+
+export function resolveReleaseVersion(
+  channel: ReleaseChannel,
+  baseVersion: string,
+  runNumber: number
+): string {
+  validatePackageVersion(baseVersion);
+  if (channel === 'stable') return baseVersion;
+  if (!Number.isSafeInteger(runNumber) || runNumber <= 0) {
+    throw new Error('Canary run number must be a positive safe integer');
+  }
+
+  const base = baseVersion.split('-')[0];
+  const parts = base?.split('.').map(Number);
+  if (parts === undefined || parts.length !== 3 || parts.some(Number.isNaN)) {
+    throw new Error(`Cannot parse workspace-server version '${baseVersion}' as major.minor.patch`);
+  }
+  const [major, minor, patch] = parts;
+  if (major === undefined || minor === undefined || patch === undefined) {
+    throw new Error(`Cannot parse workspace-server version '${baseVersion}' as major.minor.patch`);
+  }
+  return validatePackageVersion(`${major}.${minor}.${patch + 1}-canary.${runNumber}`);
+}
+
+export function releaseMetadataOutput(
+  channel: ReleaseChannel,
+  baseVersion: string,
+  runNumber: number
+): string {
+  const version = resolveReleaseVersion(channel, baseVersion, runNumber);
+  return [
+    `version=${version}`,
+    `matrix=${JSON.stringify(releaseBuildMatrix())}`,
+    `probeArtifact=${artifactArchiveName(version, releaseTargets[0])}`,
+    '',
+  ].join('\n');
 }
 
 export function validatePackageVersion(version: string): string {

--- a/apps/workspace-server/scripts/package.test.ts
+++ b/apps/workspace-server/scripts/package.test.ts
@@ -10,6 +10,9 @@ import {
   parseAdapterAssetInfos,
   parsePackageArgs,
   parsePackageTarget,
+  releaseBuildMatrix,
+  releaseMetadataOutput,
+  resolveReleaseVersion,
   ripgrepArchiveChecksum,
   ripgrepArchiveName,
   ripgrepDistributionName,
@@ -29,14 +32,21 @@ describe('workspace-server package helpers', () => {
       ])
     ).toEqual({
       targets: [parsePackageTarget('linux-x64'), parsePackageTarget('darwin-arm64')],
+      version: undefined,
       verify: true,
       help: false,
     });
   });
 
+  it('parses both explicit package version forms', () => {
+    expect(parsePackageArgs(['--version', '1.2.3']).version).toBe('1.2.3');
+    expect(parsePackageArgs(['--version=1.2.4-canary.42']).version).toBe('1.2.4-canary.42');
+  });
+
   it('rejects unsupported targets and missing target values', () => {
     expect(() => parsePackageTarget('win32-x64')).toThrow(/Unsupported target/);
     expect(() => parsePackageArgs(['--target'])).toThrow(/requires a value/);
+    expect(() => parsePackageArgs(['--version'])).toThrow(/requires a value/);
     expect(() => parsePackageArgs(['--wat'])).toThrow(/Unknown packaging option/);
   });
 
@@ -94,6 +104,34 @@ describe('workspace-server package helpers', () => {
     );
     expect(() => createDevPackageVersion('0.1.0', 'not valid')).toThrow(
       /Invalid workspace-server package version/
+    );
+  });
+
+  it('resolves stable and monotonically newer canary release versions', () => {
+    expect(resolveReleaseVersion('stable', '0.1.0', 42)).toBe('0.1.0');
+    expect(resolveReleaseVersion('canary', '0.1.0', 42)).toBe('0.1.1-canary.42');
+    expect(resolveReleaseVersion('canary', '1.2.3-rc.1', 43)).toBe('1.2.4-canary.43');
+    expect(() => resolveReleaseVersion('canary', '0.1.0', 0)).toThrow(/positive safe integer/);
+  });
+
+  it('derives the release build matrix from the shared target list', () => {
+    expect(releaseBuildMatrix()).toEqual({
+      include: [
+        { target: 'linux-x64', runner: 'ubuntu-latest' },
+        { target: 'linux-arm64', runner: 'ubuntu-24.04-arm' },
+        { target: 'darwin-arm64', runner: 'macos-latest' },
+      ],
+    });
+  });
+
+  it('prints one-line GitHub release metadata outputs', () => {
+    expect(releaseMetadataOutput('canary', '0.1.0', 42)).toBe(
+      [
+        'version=0.1.1-canary.42',
+        'matrix={"include":[{"target":"linux-x64","runner":"ubuntu-latest"},{"target":"linux-arm64","runner":"ubuntu-24.04-arm"},{"target":"darwin-arm64","runner":"macos-latest"}]}',
+        'probeArtifact=emdash-workspace-server-0.1.1-canary.42-linux-x64.tar.gz',
+        '',
+      ].join('\n')
     );
   });
 

--- a/apps/workspace-server/scripts/package.ts
+++ b/apps/workspace-server/scripts/package.ts
@@ -33,6 +33,7 @@ import {
   ripgrepDistributionName,
   ripgrepDistributionUrl,
   RIPGREP_VERSION,
+  validatePackageVersion,
   type PackageTarget,
   type PackageAdapterAssetInfo,
 } from './package-helpers.ts';
@@ -82,7 +83,7 @@ async function main(): Promise<void> {
 
   validateTargetHosts(options.targets);
 
-  const packageMetadata = await readPackageMetadata();
+  const packageMetadata = await readPackageMetadata(options.version);
   process.stdout.write(`Workspace-server package version: ${packageMetadata.version}\n`);
   const nodeVersion = (await readFile(join(repositoryDirectory, '.nvmrc'), 'utf8')).trim();
   if (!/^\d+\.\d+\.\d+$/.test(nodeVersion)) {
@@ -191,18 +192,31 @@ async function packageTarget(options: {
   }
 }
 
-async function readPackageMetadata(): Promise<PackageMetadata> {
+async function readPackageMetadata(explicitVersion?: string): Promise<PackageMetadata> {
   const raw: unknown = JSON.parse(await readFile(join(appDirectory, 'package.json'), 'utf8'));
   if (!isRecord(raw) || typeof raw['name'] !== 'string' || typeof raw['version'] !== 'string') {
     throw new Error('workspace-server package.json must contain string name and version fields');
   }
-  const version = await resolvePackageVersion(raw['version']);
+  const version = await resolvePackageVersion(raw['version'], explicitVersion);
   return { name: raw['name'], version: version.value, devBuild: version.devBuild };
 }
 
 async function resolvePackageVersion(
-  baseVersion: string
+  baseVersion: string,
+  explicitVersion?: string
 ): Promise<{ value: string; devBuild: boolean }> {
+  if (explicitVersion !== undefined) {
+    if (
+      process.env['EMDASH_WS_DEV_BUILD'] === '1' ||
+      process.env['EMDASH_WS_DEV_VERSION'] !== undefined
+    ) {
+      throw new Error(
+        '--version cannot be combined with EMDASH_WS_DEV_BUILD or EMDASH_WS_DEV_VERSION'
+      );
+    }
+    return { value: validatePackageVersion(explicitVersion), devBuild: false };
+  }
+
   const explicitDevVersion = process.env['EMDASH_WS_DEV_VERSION']?.trim();
   if (explicitDevVersion !== undefined && explicitDevVersion.length > 0) {
     return { value: createDevPackageVersion(baseVersion, explicitDevVersion), devBuild: true };
@@ -825,7 +839,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function printUsage(): void {
-  process.stdout.write(`Usage: pnpm run package --target <target> [--target <target> ...] [--verify]
+  process.stdout
+    .write(`Usage: pnpm run package --target <target> [--target <target> ...] [--version <version>] [--verify]
 
 Targets:
   linux-x64

--- a/apps/workspace-server/scripts/print-release-metadata.ts
+++ b/apps/workspace-server/scripts/print-release-metadata.ts
@@ -1,0 +1,40 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { releaseMetadataOutput, type ReleaseChannel } from './package-helpers.ts';
+
+const appDirectory = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+async function main(): Promise<void> {
+  const [channelValue, runNumberValue, extra] = process.argv.slice(2);
+  if (channelValue === undefined || runNumberValue === undefined || extra !== undefined) {
+    throw new Error('Usage: print-release-metadata.ts <stable|canary> <run-number>');
+  }
+  const channel = parseReleaseChannel(channelValue);
+  const runNumber = Number(runNumberValue);
+  if (!Number.isSafeInteger(runNumber) || runNumber <= 0 || String(runNumber) !== runNumberValue) {
+    throw new Error(`Invalid release run number '${runNumberValue}'`);
+  }
+
+  const raw: unknown = JSON.parse(await readFile(join(appDirectory, 'package.json'), 'utf8'));
+  if (!isRecord(raw) || typeof raw['version'] !== 'string') {
+    throw new Error('workspace-server package.json must contain a string version');
+  }
+  process.stdout.write(releaseMetadataOutput(channel, raw['version'], runNumber));
+}
+
+function parseReleaseChannel(value: string): ReleaseChannel {
+  if (value === 'stable' || value === 'canary') return value;
+  throw new Error(`Invalid workspace-server release channel '${value}'`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+void main().catch((error: unknown) => {
+  process.stderr.write(
+    `workspace-server release metadata failed: ${error instanceof Error ? error.message : String(error)}\n`
+  );
+  process.exit(1);
+});

--- a/apps/workspace-server/scripts/upload-helpers.ts
+++ b/apps/workspace-server/scripts/upload-helpers.ts
@@ -14,8 +14,6 @@ import {
 } from './package-helpers';
 
 export const workspaceServerObjectPrefix = 'workspace-server';
-export const installScriptObjectKey = `${workspaceServerObjectPrefix}/install.sh`;
-export const latestVersionObjectKey = `${workspaceServerObjectPrefix}/latest.txt`;
 
 const mutableCacheControl = 'no-cache';
 const immutableCacheControl = 'public, max-age=31536000, immutable';
@@ -137,16 +135,7 @@ export function mutableReleaseObjectKeys(
   channels: readonly ReleaseChannel[],
   major: number
 ): string[] {
-  const rootKeys = publishesStableRootObjects(channels)
-    ? [installScriptObjectKey, latestVersionObjectKey]
-    : [];
-  const pointerKeys = channels.map((channel) => channelPointerObjectKey(channel, major));
-  return [...pointerKeys, ...rootKeys];
-}
-
-export function latestVersionContents(version: string): string {
-  validateReleaseVersion(version);
-  return `${version}\n`;
+  return channels.map((channel) => channelPointerObjectKey(channel, major));
 }
 
 export function contentTypeForObjectKey(key: string): string {
@@ -157,11 +146,7 @@ export function contentTypeForObjectKey(key: string): string {
 }
 
 export function cacheControlForObjectKey(key: string): string {
-  if (
-    key === installScriptObjectKey ||
-    key === latestVersionObjectKey ||
-    key.startsWith(`${workspaceServerObjectPrefix}/channels/`)
-  ) {
+  if (key.startsWith(`${workspaceServerObjectPrefix}/channels/`)) {
     return mutableCacheControl;
   }
 
@@ -174,10 +159,6 @@ export function cacheControlForObjectKey(key: string): string {
   }
   validateReleaseVersion(relativeKey.slice(0, separatorIndex));
   return immutableCacheControl;
-}
-
-export function publishesStableRootObjects(channels: readonly ReleaseChannel[]): boolean {
-  return channels.includes('stable');
 }
 
 export function assertPointerVersionPublishedInRun(

--- a/apps/workspace-server/scripts/upload-helpers.ts
+++ b/apps/workspace-server/scripts/upload-helpers.ts
@@ -133,6 +133,17 @@ export function channelPointerUrl(baseUrl: string, channel: ReleaseChannel, majo
   return new URL(channelPointerObjectKey(channel, major), normalizedBaseUrl).toString();
 }
 
+export function mutableReleaseObjectKeys(
+  channels: readonly ReleaseChannel[],
+  major: number
+): string[] {
+  const rootKeys = publishesStableRootObjects(channels)
+    ? [installScriptObjectKey, latestVersionObjectKey]
+    : [];
+  const pointerKeys = channels.map((channel) => channelPointerObjectKey(channel, major));
+  return [...pointerKeys, ...rootKeys];
+}
+
 export function latestVersionContents(version: string): string {
   validateReleaseVersion(version);
   return `${version}\n`;

--- a/apps/workspace-server/scripts/upload-helpers.ts
+++ b/apps/workspace-server/scripts/upload-helpers.ts
@@ -1,7 +1,15 @@
 import {
+  channelPointerPath,
+  releaseChannelSchema,
+  releaseVersionSchema,
+  type ChannelPointer,
+  type ReleaseChannel,
+} from '@emdash/core/workspace-server';
+import {
   artifactArchiveName,
   artifactRootName,
   parsePackageTarget,
+  releaseTargets,
   type PackageTarget,
 } from './package-helpers';
 
@@ -9,17 +17,77 @@ export const workspaceServerObjectPrefix = 'workspace-server';
 export const installScriptObjectKey = `${workspaceServerObjectPrefix}/install.sh`;
 export const latestVersionObjectKey = `${workspaceServerObjectPrefix}/latest.txt`;
 
-const releaseVersionPattern =
-  /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?(?:\+[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?$/;
+const mutableCacheControl = 'no-cache';
+const immutableCacheControl = 'public, max-age=31536000, immutable';
+
 const sha256Pattern = /^[a-f\d]{64}$/;
 
-export const releaseTargets: readonly PackageTarget[] = [
-  parsePackageTarget('linux-x64'),
-  parsePackageTarget('linux-arm64'),
-  parsePackageTarget('darwin-arm64'),
-];
-
 export type ImmutableUploadDecision = 'skip' | 'upload';
+
+export type UploadOptions = {
+  version?: string;
+  targets?: PackageTarget[];
+  channels: ReleaseChannel[];
+};
+
+export function parseUploadArgs(args: string[]): UploadOptions {
+  const targets: PackageTarget[] = [];
+  const channels: ReleaseChannel[] = [];
+  let version: string | undefined;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === '--target') {
+      const value = args[index + 1];
+      if (value === undefined) throw new Error('--target requires a value');
+      targets.push(parsePackageTarget(value));
+      index += 1;
+      continue;
+    }
+    if (argument.startsWith('--target=')) {
+      targets.push(parsePackageTarget(argument.slice('--target='.length)));
+      continue;
+    }
+    if (argument === '--channel') {
+      const value = args[index + 1];
+      if (value === undefined) throw new Error('--channel requires a value');
+      channels.push(parseReleaseChannel(value));
+      index += 1;
+      continue;
+    }
+    if (argument.startsWith('--channel=')) {
+      channels.push(parseReleaseChannel(argument.slice('--channel='.length)));
+      continue;
+    }
+    if (argument === '--version') {
+      const value = args[index + 1];
+      if (value === undefined) throw new Error('--version requires a value');
+      version = value;
+      index += 1;
+      continue;
+    }
+    if (argument.startsWith('--version=')) {
+      version = argument.slice('--version='.length);
+      continue;
+    }
+    throw new Error(`Unknown upload option '${argument}'`);
+  }
+
+  return {
+    version,
+    targets:
+      targets.length === 0
+        ? undefined
+        : targets.filter(
+            (target, index) =>
+              targets.findIndex((candidate) => candidate.id === target.id) === index
+          ),
+    channels:
+      channels.length === 0
+        ? ['stable']
+        : channels.filter((channel, index) => channels.indexOf(channel) === index),
+  };
+}
 
 export function expectedArtifactNames(
   version: string,
@@ -52,6 +120,19 @@ export function versionedArtifactObjectKey(version: string, artifactName: string
   return `${workspaceServerObjectPrefix}/${version}/${artifactName}`;
 }
 
+export function versionedInstallScriptObjectKey(version: string): string {
+  return versionedArtifactObjectKey(version, 'install.sh');
+}
+
+export function channelPointerObjectKey(channel: ReleaseChannel, major: number): string {
+  return `${workspaceServerObjectPrefix}/${channelPointerPath(channel, major)}`;
+}
+
+export function channelPointerUrl(baseUrl: string, channel: ReleaseChannel, major: number): string {
+  const normalizedBaseUrl = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+  return new URL(channelPointerObjectKey(channel, major), normalizedBaseUrl).toString();
+}
+
 export function latestVersionContents(version: string): string {
   validateReleaseVersion(version);
   return `${version}\n`;
@@ -59,8 +140,44 @@ export function latestVersionContents(version: string): string {
 
 export function contentTypeForObjectKey(key: string): string {
   if (key.endsWith('.sh')) return 'text/x-shellscript';
+  if (key.endsWith('.json')) return 'application/json';
   if (key.endsWith('.txt') || key.endsWith('.sha256')) return 'text/plain';
   return 'application/octet-stream';
+}
+
+export function cacheControlForObjectKey(key: string): string {
+  if (
+    key === installScriptObjectKey ||
+    key === latestVersionObjectKey ||
+    key.startsWith(`${workspaceServerObjectPrefix}/channels/`)
+  ) {
+    return mutableCacheControl;
+  }
+
+  const relativeKey = key.startsWith(`${workspaceServerObjectPrefix}/`)
+    ? key.slice(workspaceServerObjectPrefix.length + 1)
+    : '';
+  const separatorIndex = relativeKey.indexOf('/');
+  if (separatorIndex <= 0 || separatorIndex === relativeKey.length - 1) {
+    throw new Error(`Unknown workspace-server release object key '${key}'`);
+  }
+  validateReleaseVersion(relativeKey.slice(0, separatorIndex));
+  return immutableCacheControl;
+}
+
+export function publishesStableRootObjects(channels: readonly ReleaseChannel[]): boolean {
+  return channels.includes('stable');
+}
+
+export function assertPointerVersionPublishedInRun(
+  pointer: ChannelPointer,
+  publishedVersions: ReadonlySet<string>
+): void {
+  if (!publishedVersions.has(pointer.artifactVersion)) {
+    throw new Error(
+      `Refusing to publish channel pointer for workspace-server ${pointer.artifactVersion}: version was not published in this run`
+    );
+  }
 }
 
 export function parseArtifactChecksum(contents: string, expectedArchiveName: string): string {
@@ -85,9 +202,17 @@ export function immutableUploadDecision(
 }
 
 export function validateReleaseVersion(version: string): void {
-  if (!releaseVersionPattern.test(version)) {
+  if (!releaseVersionSchema.safeParse(version).success) {
     throw new Error(`Invalid workspace-server release version '${version}'`);
   }
+}
+
+function parseReleaseChannel(value: string): ReleaseChannel {
+  const parsed = releaseChannelSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new Error(`Invalid workspace-server release channel '${value}'`);
+  }
+  return parsed.data;
 }
 
 function validateSha256(checksum: string): void {

--- a/apps/workspace-server/scripts/upload-r2.test.ts
+++ b/apps/workspace-server/scripts/upload-r2.test.ts
@@ -2,14 +2,21 @@ import { describe, expect, it } from 'vitest';
 import { parsePackageTarget } from './package-helpers';
 import {
   artifactVersionFromArchiveName,
+  assertPointerVersionPublishedInRun,
+  cacheControlForObjectKey,
+  channelPointerObjectKey,
+  channelPointerUrl,
   contentTypeForObjectKey,
   expectedArtifactNames,
   immutableUploadDecision,
   installScriptObjectKey,
   latestVersionContents,
   latestVersionObjectKey,
+  parseUploadArgs,
   parseArtifactChecksum,
+  publishesStableRootObjects,
   versionedArtifactObjectKey,
+  versionedInstallScriptObjectKey,
 } from './upload-helpers';
 
 describe('workspace-server R2 upload helpers', () => {
@@ -50,14 +57,31 @@ describe('workspace-server R2 upload helpers', () => {
   it('places every object under the workspace-server prefix', () => {
     expect(installScriptObjectKey).toBe('workspace-server/install.sh');
     expect(latestVersionObjectKey).toBe('workspace-server/latest.txt');
+    expect(channelPointerObjectKey('stable', 1)).toBe(
+      'workspace-server/channels/stable/protocol-1.json'
+    );
+    expect(channelPointerObjectKey('canary', 1)).toBe(
+      'workspace-server/channels/canary/protocol-1.json'
+    );
     expect(versionedArtifactObjectKey('1.2.3', 'server.tar.gz')).toBe(
       'workspace-server/1.2.3/server.tar.gz'
     );
+    expect(versionedInstallScriptObjectKey('1.2.3')).toBe('workspace-server/1.2.3/install.sh');
     expect(latestVersionContents('1.2.3')).toBe('1.2.3\n');
+  });
+
+  it('builds public channel pointer URLs from a bucket root', () => {
+    expect(channelPointerUrl('https://releases.example.test', 'stable', 1)).toBe(
+      'https://releases.example.test/workspace-server/channels/stable/protocol-1.json'
+    );
+    expect(channelPointerUrl('http://localhost:9000/emdash-releases/', 'canary', 2)).toBe(
+      'http://localhost:9000/emdash-releases/workspace-server/channels/canary/protocol-2.json'
+    );
   });
 
   it('rejects unsafe versions and artifact names', () => {
     expect(() => latestVersionContents('../latest')).toThrow(/Invalid workspace-server/);
+    expect(() => latestVersionContents('1.2.3+build.1')).toThrow(/Invalid workspace-server/);
     expect(() => versionedArtifactObjectKey('1.2.3', '../server.tar.gz')).toThrow(
       /single non-empty path component/
     );
@@ -66,11 +90,51 @@ describe('workspace-server R2 upload helpers', () => {
   it('assigns content types for release objects', () => {
     expect(contentTypeForObjectKey(installScriptObjectKey)).toBe('text/x-shellscript');
     expect(contentTypeForObjectKey(latestVersionObjectKey)).toBe('text/plain');
+    expect(contentTypeForObjectKey(channelPointerObjectKey('stable', 1))).toBe('application/json');
     expect(contentTypeForObjectKey('workspace-server/1.2.3/server.tar.gz.sha256')).toBe(
       'text/plain'
     );
     expect(contentTypeForObjectKey('workspace-server/1.2.3/server.tar.gz')).toBe(
       'application/octet-stream'
+    );
+  });
+
+  it('assigns cache policy from object mutability', () => {
+    expect(cacheControlForObjectKey(channelPointerObjectKey('stable', 1))).toBe('no-cache');
+    expect(cacheControlForObjectKey(installScriptObjectKey)).toBe('no-cache');
+    expect(cacheControlForObjectKey(latestVersionObjectKey)).toBe('no-cache');
+    expect(cacheControlForObjectKey(versionedInstallScriptObjectKey('1.2.3'))).toBe(
+      'public, max-age=31536000, immutable'
+    );
+    expect(cacheControlForObjectKey(versionedArtifactObjectKey('1.2.3', 'server.tar.gz'))).toBe(
+      'public, max-age=31536000, immutable'
+    );
+  });
+
+  it('defaults uploads to stable and accepts unique repeatable channels', () => {
+    expect(parseUploadArgs([]).channels).toEqual(['stable']);
+    expect(
+      parseUploadArgs(['--channel', 'canary', '--channel=stable', '--channel', 'canary']).channels
+    ).toEqual(['canary', 'stable']);
+  });
+
+  it('rejects unknown or missing release channels', () => {
+    expect(() => parseUploadArgs(['--channel', 'preview'])).toThrow(
+      "Invalid workspace-server release channel 'preview'"
+    );
+    expect(() => parseUploadArgs(['--channel'])).toThrow('--channel requires a value');
+  });
+
+  it('does not select legacy root objects for a canary-only upload', () => {
+    expect(publishesStableRootObjects(['canary'])).toBe(false);
+    expect(publishesStableRootObjects(['canary', 'stable'])).toBe(true);
+  });
+
+  it('only permits pointers to versions published in the current run', () => {
+    const pointer = { artifactVersion: '1.2.3', protocolVersion: '1.0.0' };
+    expect(() => assertPointerVersionPublishedInRun(pointer, new Set(['1.2.3']))).not.toThrow();
+    expect(() => assertPointerVersionPublishedInRun(pointer, new Set(['1.2.2']))).toThrow(
+      /version was not published in this run/
     );
   });
 

--- a/apps/workspace-server/scripts/upload-r2.test.ts
+++ b/apps/workspace-server/scripts/upload-r2.test.ts
@@ -12,6 +12,7 @@ import {
   installScriptObjectKey,
   latestVersionContents,
   latestVersionObjectKey,
+  mutableReleaseObjectKeys,
   parseUploadArgs,
   parseArtifactChecksum,
   publishesStableRootObjects,
@@ -128,6 +129,14 @@ describe('workspace-server R2 upload helpers', () => {
   it('does not select legacy root objects for a canary-only upload', () => {
     expect(publishesStableRootObjects(['canary'])).toBe(false);
     expect(publishesStableRootObjects(['canary', 'stable'])).toBe(true);
+  });
+
+  it('publishes the stable channel pointer before legacy root selectors', () => {
+    expect(mutableReleaseObjectKeys(['stable'], 1)).toEqual([
+      channelPointerObjectKey('stable', 1),
+      installScriptObjectKey,
+      latestVersionObjectKey,
+    ]);
   });
 
   it('only permits pointers to versions published in the current run', () => {

--- a/apps/workspace-server/scripts/upload-r2.test.ts
+++ b/apps/workspace-server/scripts/upload-r2.test.ts
@@ -9,13 +9,9 @@ import {
   contentTypeForObjectKey,
   expectedArtifactNames,
   immutableUploadDecision,
-  installScriptObjectKey,
-  latestVersionContents,
-  latestVersionObjectKey,
   mutableReleaseObjectKeys,
   parseUploadArgs,
   parseArtifactChecksum,
-  publishesStableRootObjects,
   versionedArtifactObjectKey,
   versionedInstallScriptObjectKey,
 } from './upload-helpers';
@@ -56,8 +52,6 @@ describe('workspace-server R2 upload helpers', () => {
   });
 
   it('places every object under the workspace-server prefix', () => {
-    expect(installScriptObjectKey).toBe('workspace-server/install.sh');
-    expect(latestVersionObjectKey).toBe('workspace-server/latest.txt');
     expect(channelPointerObjectKey('stable', 1)).toBe(
       'workspace-server/channels/stable/protocol-1.json'
     );
@@ -68,7 +62,6 @@ describe('workspace-server R2 upload helpers', () => {
       'workspace-server/1.2.3/server.tar.gz'
     );
     expect(versionedInstallScriptObjectKey('1.2.3')).toBe('workspace-server/1.2.3/install.sh');
-    expect(latestVersionContents('1.2.3')).toBe('1.2.3\n');
   });
 
   it('builds public channel pointer URLs from a bucket root', () => {
@@ -81,16 +74,12 @@ describe('workspace-server R2 upload helpers', () => {
   });
 
   it('rejects unsafe versions and artifact names', () => {
-    expect(() => latestVersionContents('../latest')).toThrow(/Invalid workspace-server/);
-    expect(() => latestVersionContents('1.2.3+build.1')).toThrow(/Invalid workspace-server/);
     expect(() => versionedArtifactObjectKey('1.2.3', '../server.tar.gz')).toThrow(
       /single non-empty path component/
     );
   });
 
   it('assigns content types for release objects', () => {
-    expect(contentTypeForObjectKey(installScriptObjectKey)).toBe('text/x-shellscript');
-    expect(contentTypeForObjectKey(latestVersionObjectKey)).toBe('text/plain');
     expect(contentTypeForObjectKey(channelPointerObjectKey('stable', 1))).toBe('application/json');
     expect(contentTypeForObjectKey('workspace-server/1.2.3/server.tar.gz.sha256')).toBe(
       'text/plain'
@@ -102,8 +91,6 @@ describe('workspace-server R2 upload helpers', () => {
 
   it('assigns cache policy from object mutability', () => {
     expect(cacheControlForObjectKey(channelPointerObjectKey('stable', 1))).toBe('no-cache');
-    expect(cacheControlForObjectKey(installScriptObjectKey)).toBe('no-cache');
-    expect(cacheControlForObjectKey(latestVersionObjectKey)).toBe('no-cache');
     expect(cacheControlForObjectKey(versionedInstallScriptObjectKey('1.2.3'))).toBe(
       'public, max-age=31536000, immutable'
     );
@@ -126,16 +113,11 @@ describe('workspace-server R2 upload helpers', () => {
     expect(() => parseUploadArgs(['--channel'])).toThrow('--channel requires a value');
   });
 
-  it('does not select legacy root objects for a canary-only upload', () => {
-    expect(publishesStableRootObjects(['canary'])).toBe(false);
-    expect(publishesStableRootObjects(['canary', 'stable'])).toBe(true);
-  });
-
-  it('publishes the stable channel pointer before legacy root selectors', () => {
-    expect(mutableReleaseObjectKeys(['stable'], 1)).toEqual([
+  it('publishes one mutable selector per channel and protocol major', () => {
+    expect(mutableReleaseObjectKeys(['stable'], 1)).toEqual([channelPointerObjectKey('stable', 1)]);
+    expect(mutableReleaseObjectKeys(['canary', 'stable'], 1)).toEqual([
+      channelPointerObjectKey('canary', 1),
       channelPointerObjectKey('stable', 1),
-      installScriptObjectKey,
-      latestVersionObjectKey,
     ]);
   });
 

--- a/apps/workspace-server/scripts/upload-r2.ts
+++ b/apps/workspace-server/scripts/upload-r2.ts
@@ -19,16 +19,15 @@ import {
   artifactVersionFromArchiveName,
   assertPointerVersionPublishedInRun,
   cacheControlForObjectKey,
-  channelPointerObjectKey,
   contentTypeForObjectKey,
   expectedArtifactNames,
   immutableUploadDecision,
   installScriptObjectKey,
   latestVersionContents,
   latestVersionObjectKey,
+  mutableReleaseObjectKeys,
   parseUploadArgs,
   parseArtifactChecksum,
-  publishesStableRootObjects,
   versionedArtifactObjectKey,
   versionedInstallScriptObjectKey,
   type UploadOptions,
@@ -87,18 +86,16 @@ async function main(): Promise<void> {
   }
   const publishedVersions = new Set([version]);
 
-  if (publishesStableRootObjects(options.channels)) {
-    await uploadMutableObject(s3, installScriptObjectKey, installScriptData);
-    await uploadMutableObject(
-      s3,
-      latestVersionObjectKey,
-      new TextEncoder().encode(latestVersionContents(version))
-    );
-  }
-
   assertPointerVersionPublishedInRun(pointer, publishedVersions);
-  for (const channel of options.channels) {
-    await uploadMutableObject(s3, channelPointerObjectKey(channel, protocolMajor()), pointerData);
+  const latestVersionData = new TextEncoder().encode(latestVersionContents(version));
+  for (const key of mutableReleaseObjectKeys(options.channels, protocolMajor())) {
+    const data =
+      key === installScriptObjectKey
+        ? installScriptData
+        : key === latestVersionObjectKey
+          ? latestVersionData
+          : pointerData;
+    await uploadMutableObject(s3, key, data);
   }
 
   process.stdout.write(

--- a/apps/workspace-server/scripts/upload-r2.ts
+++ b/apps/workspace-server/scripts/upload-r2.ts
@@ -22,9 +22,6 @@ import {
   contentTypeForObjectKey,
   expectedArtifactNames,
   immutableUploadDecision,
-  installScriptObjectKey,
-  latestVersionContents,
-  latestVersionObjectKey,
   mutableReleaseObjectKeys,
   parseUploadArgs,
   parseArtifactChecksum,
@@ -87,15 +84,8 @@ async function main(): Promise<void> {
   const publishedVersions = new Set([version]);
 
   assertPointerVersionPublishedInRun(pointer, publishedVersions);
-  const latestVersionData = new TextEncoder().encode(latestVersionContents(version));
   for (const key of mutableReleaseObjectKeys(options.channels, protocolMajor())) {
-    const data =
-      key === installScriptObjectKey
-        ? installScriptData
-        : key === latestVersionObjectKey
-          ? latestVersionData
-          : pointerData;
-    await uploadMutableObject(s3, key, data);
+    await uploadMutableObject(s3, key, pointerData);
   }
 
   process.stdout.write(

--- a/apps/workspace-server/scripts/upload-r2.ts
+++ b/apps/workspace-server/scripts/upload-r2.ts
@@ -2,29 +2,41 @@ import { createHash } from 'node:crypto';
 import { readFile, readdir, stat } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  protocolMajor,
+  PROTOCOL_VERSION,
+  serializeChannelPointer,
+  type ChannelPointer,
+} from '@emdash/core/workspace-server';
 import { S3mini } from 's3mini';
-import { artifactArchiveName, parsePackageTarget, type PackageTarget } from './package-helpers';
+import {
+  artifactArchiveName,
+  parsePackageTarget,
+  releaseTargets,
+  type PackageTarget,
+} from './package-helpers';
 import {
   artifactVersionFromArchiveName,
+  assertPointerVersionPublishedInRun,
+  cacheControlForObjectKey,
+  channelPointerObjectKey,
   contentTypeForObjectKey,
   expectedArtifactNames,
   immutableUploadDecision,
   installScriptObjectKey,
   latestVersionContents,
   latestVersionObjectKey,
+  parseUploadArgs,
   parseArtifactChecksum,
-  releaseTargets,
+  publishesStableRootObjects,
   versionedArtifactObjectKey,
+  versionedInstallScriptObjectKey,
+  type UploadOptions,
 } from './upload-helpers';
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const appDirectory = resolve(scriptDirectory, '..');
 const artifactsDirectory = join(appDirectory, 'dist-artifacts');
-
-type UploadOptions = {
-  version?: string;
-  targets?: PackageTarget[];
-};
 
 type UploadConfig = {
   label: string;
@@ -51,6 +63,17 @@ async function main(): Promise<void> {
     targets,
     !devUpload && options.targets === undefined
   );
+  const installScriptData = new Uint8Array(await readFile(join(appDirectory, 'install.sh')));
+  const versionedInstallScript: ValidatedArtifact = {
+    path: join(appDirectory, 'install.sh'),
+    key: versionedInstallScriptObjectKey(version),
+    sha256: sha256(installScriptData),
+  };
+  const pointer: ChannelPointer = {
+    artifactVersion: version,
+    protocolVersion: PROTOCOL_VERSION,
+  };
+  const pointerData = new TextEncoder().encode(serializeChannelPointer(pointer));
   const config = resolveUploadConfig();
   const s3 = new S3mini({
     accessKeyId: config.accessKeyId,
@@ -59,65 +82,28 @@ async function main(): Promise<void> {
     region: 'auto',
   });
 
-  for (const artifact of artifacts) {
+  for (const artifact of [...artifacts, versionedInstallScript]) {
     await uploadImmutableArtifact(s3, artifact);
   }
+  const publishedVersions = new Set([version]);
 
-  await uploadMutableObject(
-    s3,
-    installScriptObjectKey,
-    new Uint8Array(await readFile(join(appDirectory, 'install.sh')))
-  );
-  await uploadMutableObject(
-    s3,
-    latestVersionObjectKey,
-    new TextEncoder().encode(latestVersionContents(version))
-  );
-
-  process.stdout.write(`Published workspace-server ${version} to ${config.label}\n`);
-}
-
-function parseUploadArgs(args: string[]): UploadOptions {
-  const targets: PackageTarget[] = [];
-  let version: string | undefined;
-
-  for (let index = 0; index < args.length; index += 1) {
-    const argument = args[index];
-    if (argument === '--target') {
-      const value = args[index + 1];
-      if (value === undefined) throw new Error('--target requires a value');
-      targets.push(parsePackageTarget(value));
-      index += 1;
-      continue;
-    }
-    if (argument.startsWith('--target=')) {
-      targets.push(parsePackageTarget(argument.slice('--target='.length)));
-      continue;
-    }
-    if (argument === '--version') {
-      const value = args[index + 1];
-      if (value === undefined) throw new Error('--version requires a value');
-      version = value;
-      index += 1;
-      continue;
-    }
-    if (argument.startsWith('--version=')) {
-      version = argument.slice('--version='.length);
-      continue;
-    }
-    throw new Error(`Unknown upload option '${argument}'`);
+  if (publishesStableRootObjects(options.channels)) {
+    await uploadMutableObject(s3, installScriptObjectKey, installScriptData);
+    await uploadMutableObject(
+      s3,
+      latestVersionObjectKey,
+      new TextEncoder().encode(latestVersionContents(version))
+    );
   }
 
-  return {
-    version,
-    targets:
-      targets.length === 0
-        ? undefined
-        : targets.filter(
-            (target, index) =>
-              targets.findIndex((candidate) => candidate.id === target.id) === index
-          ),
-  };
+  assertPointerVersionPublishedInRun(pointer, publishedVersions);
+  for (const channel of options.channels) {
+    await uploadMutableObject(s3, channelPointerObjectKey(channel, protocolMajor()), pointerData);
+  }
+
+  process.stdout.write(
+    `Published workspace-server ${version} to ${config.label} (${options.channels.join(', ')})\n`
+  );
 }
 
 function resolveUploadTargets(options: UploadOptions, devUpload: boolean): PackageTarget[] {
@@ -241,10 +227,12 @@ async function uploadImmutableArtifact(s3: S3mini, artifact: ValidatedArtifact):
   }
 
   process.stdout.write(`Uploading ${artifact.key}\n`);
-  const response = await s3.putAnyObject(
+  const response = await s3.putObject(
     artifact.key,
     localData,
-    contentTypeForObjectKey(artifact.key)
+    contentTypeForObjectKey(artifact.key),
+    undefined,
+    uploadHeadersForObjectKey(artifact.key)
   );
   if (!response.ok) {
     throw new Error(`Upload failed for ${artifact.key} with HTTP ${response.status}`);
@@ -252,14 +240,14 @@ async function uploadImmutableArtifact(s3: S3mini, artifact: ValidatedArtifact):
 }
 
 async function uploadMutableObject(s3: S3mini, key: string, data: Uint8Array): Promise<void> {
-  const remoteData = await s3.getObjectArrayBuffer(key);
-  if (remoteData !== null && sha256(new Uint8Array(remoteData)) === sha256(data)) {
-    process.stdout.write(`Skipping unchanged object ${key}\n`);
-    return;
-  }
-
   process.stdout.write(`Uploading ${key}\n`);
-  const response = await s3.putObject(key, data, contentTypeForObjectKey(key));
+  const response = await s3.putObject(
+    key,
+    data,
+    contentTypeForObjectKey(key),
+    undefined,
+    uploadHeadersForObjectKey(key)
+  );
   if (!response.ok) {
     throw new Error(`Upload failed for ${key} with HTTP ${response.status}`);
   }
@@ -303,6 +291,11 @@ function requireEnv(name: string): string {
 
 function sha256(data: Uint8Array): string {
   return createHash('sha256').update(data).digest('hex');
+}
+
+function uploadHeadersForObjectKey(key: string): Parameters<S3mini['putObject']>[4] {
+  // s3mini forwards arbitrary additional headers but narrows this parameter to x-amz-* headers.
+  return { 'Cache-Control': cacheControlForObjectKey(key) } as Parameters<S3mini['putObject']>[4];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/workspace-server/scripts/verify-pointer.ts
+++ b/apps/workspace-server/scripts/verify-pointer.ts
@@ -1,0 +1,98 @@
+import {
+  parseChannelPointer,
+  protocolMajor,
+  releaseChannelSchema,
+  releaseVersionSchema,
+  type ReleaseChannel,
+} from '@emdash/core/workspace-server';
+import { channelPointerUrl } from './upload-helpers.ts';
+
+type VerifyOptions = {
+  baseUrl: string;
+  channel: ReleaseChannel;
+  version: string;
+};
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const major = protocolMajor();
+  const pointerUrl = channelPointerUrl(options.baseUrl, options.channel, major);
+  const deadline = Date.now() + 30_000;
+  let lastError = 'pointer was never checked';
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(pointerUrl, { cache: 'no-store' });
+      if (!response.ok) {
+        lastError = `HTTP ${response.status}`;
+      } else {
+        const pointer = parseChannelPointer(await response.text(), major);
+        if (!pointer.success) {
+          lastError = `invalid pointer: ${JSON.stringify(pointer.error)}`;
+        } else if (pointer.data.artifactVersion !== options.version) {
+          lastError = `pointer reports ${pointer.data.artifactVersion}, expected ${options.version}`;
+        } else {
+          process.stdout.write(
+            `Verified ${options.channel} workspace-server pointer ${pointerUrl} -> ${options.version}\n`
+          );
+          return;
+        }
+      }
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    await delay(1_000);
+  }
+
+  throw new Error(`Could not verify workspace-server pointer ${pointerUrl}: ${lastError}`);
+}
+
+function parseArgs(args: string[]): VerifyOptions {
+  let baseUrl: string | undefined;
+  let channel: ReleaseChannel | undefined;
+  let version: string | undefined;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    const next = args[index + 1];
+    if (argument === '--base-url') {
+      if (next === undefined) throw new Error('--base-url requires a value');
+      baseUrl = next;
+      index += 1;
+      continue;
+    }
+    if (argument === '--channel') {
+      if (next === undefined) throw new Error('--channel requires a value');
+      const parsed = releaseChannelSchema.safeParse(next);
+      if (!parsed.success) throw new Error(`Invalid workspace-server release channel '${next}'`);
+      channel = parsed.data;
+      index += 1;
+      continue;
+    }
+    if (argument === '--version') {
+      if (next === undefined) throw new Error('--version requires a value');
+      const parsed = releaseVersionSchema.safeParse(next);
+      if (!parsed.success) throw new Error(`Invalid workspace-server release version '${next}'`);
+      version = parsed.data;
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown pointer verification option '${argument}'`);
+  }
+
+  if (baseUrl === undefined || channel === undefined || version === undefined) {
+    throw new Error('--base-url, --channel and --version are required');
+  }
+  return { baseUrl, channel, version };
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolvePromise) => setTimeout(resolvePromise, ms));
+}
+
+void main().catch((error: unknown) => {
+  process.stderr.write(
+    `workspace-server pointer verification failed: ${error instanceof Error ? error.message : String(error)}\n`
+  );
+  process.exit(1);
+});

--- a/packages/core/src/workspace-server/index.ts
+++ b/packages/core/src/workspace-server/index.ts
@@ -1,5 +1,6 @@
 export * from './versions/schemas';
 export * from './versions';
+export * from './releases';
 export * from './wire';
 export * from './shared/schemas';
 export * from './port-forwards/contract';

--- a/packages/core/src/workspace-server/releases.test.ts
+++ b/packages/core/src/workspace-server/releases.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import {
+  channelPointerPath,
+  channelPointerSchema,
+  isNewerRelease,
+  parseChannelPointer,
+  releaseChannelSchema,
+  releaseVersionSchema,
+  serializeChannelPointer,
+} from './releases';
+import { protocolMajor, PROTOCOL_VERSION } from './versions';
+
+describe('workspace-server release contracts', () => {
+  const pointer = {
+    artifactVersion: '0.1.0',
+    protocolVersion: '1.0.0',
+  };
+
+  it('round-trips a channel pointer with byte-stable serialization', () => {
+    const serialized = serializeChannelPointer(pointer);
+
+    expect(serialized).toBe('{\n  "artifactVersion": "0.1.0",\n  "protocolVersion": "1.0.0"\n}\n');
+    expect(
+      serializeChannelPointer({
+        protocolVersion: pointer.protocolVersion,
+        artifactVersion: pointer.artifactVersion,
+      })
+    ).toBe(serialized);
+    expect(parseChannelPointer(serialized, 1)).toEqual({ success: true, data: pointer });
+  });
+
+  it('rejects a pointer for another protocol major', () => {
+    expect(
+      parseChannelPointer(JSON.stringify({ artifactVersion: '0.2.0', protocolVersion: '2.0.0' }), 1)
+    ).toEqual({
+      success: false,
+      error: {
+        type: 'protocol-major-mismatch',
+        expected: 1,
+        actual: 2,
+      },
+    });
+  });
+
+  it('ignores unknown pointer fields for append-only evolution', () => {
+    const result = parseChannelPointer(
+      JSON.stringify({ ...pointer, publishedAt: '2026-08-14T00:00:00Z' }),
+      1
+    );
+
+    expect(result).toEqual({ success: true, data: pointer });
+  });
+
+  it.each([
+    ['invalid JSON', '{'],
+    ['a missing field', JSON.stringify({ artifactVersion: '0.1.0' })],
+    [
+      'an invalid artifact version',
+      JSON.stringify({ artifactVersion: 'v0.1.0', protocolVersion: '1.0.0' }),
+    ],
+    [
+      'an invalid protocol version',
+      JSON.stringify({ artifactVersion: '0.1.0', protocolVersion: '01.0.0' }),
+    ],
+  ])('returns an invalid result for %s', (_label, contents) => {
+    expect(parseChannelPointer(contents, 1)).toEqual({
+      success: false,
+      error: { type: 'invalid', reason: expect.any(String) },
+    });
+  });
+
+  it('rejects invalid data before serialization', () => {
+    expect(() =>
+      serializeChannelPointer({ artifactVersion: 'v0.1.0', protocolVersion: '1.0.0' })
+    ).toThrow();
+  });
+
+  it('constructs relative channel pointer paths', () => {
+    expect(channelPointerPath('stable', 1)).toBe('channels/stable/protocol-1.json');
+    expect(channelPointerPath('canary', 2)).toBe('channels/canary/protocol-2.json');
+  });
+
+  it.each([
+    ['a newer prerelease line', '0.1.1-canary.42', '0.1.0', true],
+    ['a stable release over its prerelease', '0.1.1', '0.1.1-canary.42', true],
+    ['a stable downgrade from an installed canary', '0.1.0', '0.1.1-canary.42', false],
+    ['equal releases', '0.1.0', '0.1.0', false],
+    ['candidate build metadata only', '0.1.0+candidate', '0.1.0+installed', false],
+    ['invalid candidate input', 'not-a-version', '0.1.0', false],
+    ['invalid installed input', '0.1.0', 'not-a-version', false],
+  ])('compares %s by SemVer precedence', (_label, candidate, installed, expected) => {
+    expect(isNewerRelease(candidate, installed)).toBe(expected);
+  });
+
+  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, 2 ** 53])(
+    'rejects invalid protocol major %s in a channel pointer path',
+    (major) => {
+      expect(() => channelPointerPath('stable', major)).toThrow('positive safe integer');
+    }
+  );
+
+  it('extracts a protocol major and rejects invalid protocol versions', () => {
+    expect(PROTOCOL_VERSION).toBe('1.0.0');
+    expect(protocolMajor()).toBe(1);
+    expect(protocolMajor('2.3.4')).toBe(2);
+    expect(() => protocolMajor('not-a-version')).toThrow(
+      "Invalid protocol version 'not-a-version'"
+    );
+  });
+
+  it.each(['stable', 'canary'])('accepts the %s release channel', (channel) => {
+    expect(releaseChannelSchema.safeParse(channel).success).toBe(true);
+  });
+
+  it('rejects an unknown release channel', () => {
+    expect(releaseChannelSchema.safeParse('preview').success).toBe(false);
+  });
+
+  it.each(['0.1.0', '1.2.3-canary.42', '0.1.0-dev.abc123.1234567890'])(
+    'accepts strict release semver %s',
+    (version) => {
+      expect(releaseVersionSchema.safeParse(version).success).toBe(true);
+    }
+  );
+
+  it.each(['1.2', 'v1.2.3', '1.2.3 ', '01.2.3', '1.02.3', '1.2.03', '1.2.3-01', '1.2.3+build.42'])(
+    'rejects non-orderable or non-strict semver %s',
+    (version) => {
+      expect(releaseVersionSchema.safeParse(version).success).toBe(false);
+    }
+  );
+
+  it('defines the pointer as separate artifact and protocol versions', () => {
+    expect(channelPointerSchema.parse(pointer)).toEqual(pointer);
+  });
+});

--- a/packages/core/src/workspace-server/releases.ts
+++ b/packages/core/src/workspace-server/releases.ts
@@ -1,0 +1,92 @@
+import { err, ok, type Result } from '@emdash/shared';
+import semver from 'semver';
+import { z } from 'zod';
+import { protocolMajor } from './versions';
+
+// Core is intentionally stricter than install.sh until its validator is tightened. The regex
+// rejects normalized inputs and build metadata; semver.valid rejects forms with leading zeroes.
+// Build metadata is excluded because SemVer ignores it when deciding update precedence.
+const releaseVersionPattern = /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?$/;
+
+export const releaseChannelSchema = z.enum(['stable', 'canary']);
+export type ReleaseChannel = z.infer<typeof releaseChannelSchema>;
+
+export const releaseVersionSchema = z
+  .string()
+  .regex(releaseVersionPattern, 'Release version must be a full SemVer string')
+  .refine((version) => semver.valid(version) !== null, 'Release version must be valid SemVer');
+
+export const channelPointerSchema = z.object({
+  artifactVersion: releaseVersionSchema,
+  protocolVersion: releaseVersionSchema,
+});
+export type ChannelPointer = z.infer<typeof channelPointerSchema>;
+
+export type ChannelPointerParseError =
+  | { type: 'invalid'; reason: string }
+  | {
+      type: 'protocol-major-mismatch';
+      expected: number;
+      actual: number;
+    };
+
+export function channelPointerPath(channel: ReleaseChannel, major: number): string {
+  assertPositiveProtocolMajor(major);
+  return `channels/${channel}/protocol-${major}.json`;
+}
+
+export function isNewerRelease(candidate: string, installed: string): boolean {
+  if (semver.valid(candidate) === null || semver.valid(installed) === null) return false;
+  return semver.gt(candidate, installed);
+}
+
+export function parseChannelPointer(
+  text: string,
+  expectedProtocolMajor: number
+): Result<ChannelPointer, ChannelPointerParseError> {
+  assertPositiveProtocolMajor(expectedProtocolMajor);
+
+  let value: unknown;
+  try {
+    value = JSON.parse(text) as unknown;
+  } catch (error) {
+    return err({
+      type: 'invalid',
+      reason: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  const parsed = channelPointerSchema.safeParse(value);
+  if (!parsed.success) {
+    return err({ type: 'invalid', reason: z.prettifyError(parsed.error) });
+  }
+
+  const actualProtocolMajor = protocolMajor(parsed.data.protocolVersion);
+  if (actualProtocolMajor !== expectedProtocolMajor) {
+    return err({
+      type: 'protocol-major-mismatch',
+      expected: expectedProtocolMajor,
+      actual: actualProtocolMajor,
+    });
+  }
+
+  return ok(parsed.data);
+}
+
+export function serializeChannelPointer(pointer: ChannelPointer): string {
+  const parsed = channelPointerSchema.parse(pointer);
+  return `${JSON.stringify(
+    {
+      artifactVersion: parsed.artifactVersion,
+      protocolVersion: parsed.protocolVersion,
+    },
+    undefined,
+    2
+  )}\n`;
+}
+
+function assertPositiveProtocolMajor(major: number): void {
+  if (!Number.isSafeInteger(major) || major <= 0) {
+    throw new Error('Protocol major must be a positive safe integer');
+  }
+}

--- a/packages/core/src/workspace-server/versions/index.ts
+++ b/packages/core/src/workspace-server/versions/index.ts
@@ -1,6 +1,12 @@
 import semver from 'semver';
 
-export const PROTOCOL_VERSION = '9.0.0';
+export const PROTOCOL_VERSION = '1.0.0';
+
+export function protocolMajor(version: string = PROTOCOL_VERSION): number {
+  const parsed = semver.parse(version);
+  if (!parsed) throw new Error(`Invalid protocol version '${version}'`);
+  return parsed.major;
+}
 
 export type ProtocolNegotiation =
   | { compatible: true; agreedVersion: string; agreedMinor: number }

--- a/packages/core/src/workspace-server/versions/versions.test.ts
+++ b/packages/core/src/workspace-server/versions/versions.test.ts
@@ -80,23 +80,23 @@ describe('negotiateProtocol', () => {
       expect(result.compatible).toBe(true);
     });
 
-    it('rejects v7 clients against the v8 default with upgrade-client', () => {
-      const result = negotiateProtocol('7.6.0');
+    it('rejects pre-1.0 clients against the default with upgrade-client', () => {
+      const result = negotiateProtocol('0.9.0');
       expect(result).toEqual({
         compatible: false,
         action: 'upgrade-client',
-        clientProtocolVersion: '7.6.0',
+        clientProtocolVersion: '0.9.0',
         serverProtocolVersion: PROTOCOL_VERSION,
       });
     });
 
     it('requires older major clients to upgrade for breaking contract changes', () => {
-      const result = negotiateProtocol('3.0.0');
+      const result = negotiateProtocol('0.1.0');
 
       expect(result).toEqual({
         compatible: false,
         action: 'upgrade-client',
-        clientProtocolVersion: '3.0.0',
+        clientProtocolVersion: '0.1.0',
         serverProtocolVersion: PROTOCOL_VERSION,
       });
     });


### PR DESCRIPTION
- adds shared release channel contracts and resets the initial public protocol version to 1.0.0
- publishes immutable artifacts through stable and canary protocol-specific pointers
- derives the release matrix and immutability probe from shared target metadata
- installs the exact protocol-compatible artifact selected by the desktop
- offers updates only when the channel artifact is newer by semver precedence
- documents the release workflow and local minio rehearsal process