### PR TITLE
fix(desktop): add macOS local network permission

### DIFF
--- a/apps/emdash-desktop/electron-builder.canary.config.ts
+++ b/apps/emdash-desktop/electron-builder.canary.config.ts
@@ -47,6 +47,8 @@ const config: Configuration = {
     entitlements: 'build/entitlements.mac.plist',
     entitlementsInherit: 'build/entitlements.mac.plist',
     extendInfo: {
+      NSLocalNetworkUsageDescription:
+        'Emdash needs local network access to connect to SSH hosts on your network.',
       NSMicrophoneUsageDescription:
         'Emdash needs microphone access for voice dictation and voice mode features.',
     },

--- a/apps/emdash-desktop/electron-builder.config.ts
+++ b/apps/emdash-desktop/electron-builder.config.ts
@@ -41,6 +41,8 @@ const config: Configuration = {
     entitlements: 'build/entitlements.mac.plist',
     entitlementsInherit: 'build/entitlements.mac.plist',
     extendInfo: {
+      NSLocalNetworkUsageDescription:
+        'Emdash needs local network access to connect to SSH hosts on your network.',
       NSMicrophoneUsageDescription:
         'Emdash needs microphone access for voice dictation and voice mode features.',
     },

--- a/apps/emdash-desktop/scripts/release/electron-builder-config.test.ts
+++ b/apps/emdash-desktop/scripts/release/electron-builder-config.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import canaryConfig from '../../electron-builder.canary.config.ts';
+import stableConfig from '../../electron-builder.config.ts';
+
+const localNetworkUsageDescription =
+  'Emdash needs local network access to connect to SSH hosts on your network.';
+
+describe('macOS packaging permissions', () => {
+  it('includes local network access in stable and canary bundles', () => {
+    expect(stableConfig.mac?.extendInfo).toMatchObject({
+      NSLocalNetworkUsageDescription: localNetworkUsageDescription,
+    });
+    expect(canaryConfig.mac?.extendInfo).toMatchObject({
+      NSLocalNetworkUsageDescription: localNetworkUsageDescription,
+    });
+  });
+});


### PR DESCRIPTION
### Description

Adds `NSLocalNetworkUsageDescription` to the stable and canary macOS packaging configs so packaged builds can request Local Network access when connecting to SSH hosts on the LAN.

Adds a config test covering both bundle variants.

### Related issues

Fixes #2984.

### Testing

- `pnpm --dir apps/emdash-desktop exec vitest run --project scripts scripts/release/electron-builder-config.test.ts`
- `EMDASH_TEST_SKIP_BROWSER=1 pnpm --dir apps/emdash-desktop run test`
- `pnpm --dir apps/emdash-desktop run typecheck`
- `pnpm --dir apps/emdash-desktop run lint`
- `pnpm --dir apps/emdash-desktop exec oxfmt --check electron-builder.config.ts electron-builder.canary.config.ts scripts/release/electron-builder-config.test.ts`

The repository-wide formatting check still reports two pre-existing failures in unchanged files. The repository-wide browser tests require a Playwright browser that was not installed locally. The desktop non-browser suite passed 2,964 tests with one skipped.

### Screenshot/Recording (if applicable)

Not applicable. This changes the packaged macOS permission metadata and has no in-app visual change.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed (not applicable; no documentation change is needed)
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>
