### PR TITLE
fix(conversations): open chat file links in adjacent pane

### DIFF
--- a/apps/emdash-desktop/src/core/features/conversations/api/browser/conversation-manager.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/api/browser/conversation-manager.ts
@@ -516,7 +516,9 @@ export class ConversationManagerStore implements Disposable {
   }
 
   private createSession(conversation: Conversation): PtySession {
-    const handlers = makeFileLinkHandlers(conversation.projectId, conversation.taskId);
+    const handlers = makeFileLinkHandlers(conversation.projectId, conversation.taskId, {
+      target: 'right',
+    });
     const connector =
       conversation.type === 'acp'
         ? createNoopConnector()

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-panel.tsx
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-panel.tsx
@@ -24,11 +24,6 @@ import type {
   ChatView,
 } from '@core/features/conversations/api/browser/chat/chat-transcript';
 import { conversationRegistry } from '@core/features/conversations/api/browser/stores/conversation-registry';
-// TODO(conversations-extraction): Inject task editor/file-opening behavior into ACP chat.
-import {
-  openFileInAdjacentPane,
-  openFileInTaskEditor,
-} from '@core/features/editor/api/browser/open-file-in-file-editor';
 import { useConnectedIssueProviders } from '@core/features/integrations/api/browser/use-connected-issue-providers';
 import { IntegrationIcon } from '@core/features/integrations/contributions/browser/integration-icon';
 import { getIssuesClient } from '@core/features/issues/api/browser/client';
@@ -62,6 +57,7 @@ import type { AcpChatStore, AcpPromptAttachment } from './acp-chat-store';
 import type { AcpChatTabResource } from './acp-chat-tab-resource';
 import { chatViewCommandForShortcut, executeChatViewCommand } from './acp-chat-view-commands';
 import { buildIssueMentionHiddenContext } from './issue-mention-context';
+import { createTranscriptFileCommands } from './transcript-file-commands';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -779,8 +775,11 @@ export const AcpChatPanel = observer(function AcpChatPanel() {
     setViewer({ src, alt });
   }, []);
 
-  const transcriptCommands = useMemo<ChatCommands>(
-    () => ({
+  const transcriptCommands = useMemo<ChatCommands>(() => {
+    const fileCommands = store
+      ? createTranscriptFileCommands({ projectId: store.projectId, taskId: store.taskId })
+      : null;
+    return {
       onViewImage: (arg) => {
         if (arg.attachment.dataUrl || !store) {
           handleViewerOpen(arg.attachment.dataUrl, arg.attachment.name);
@@ -797,15 +796,12 @@ export const AcpChatPanel = observer(function AcpChatPanel() {
           svg: store?.chatContext.sharedCaches.renderMermaid(arg.chart) ?? null,
         });
       },
-      onOpenFile: (arg) => {
-        if (!store) return;
-        const open = arg.source === 'diff' ? openFileInAdjacentPane : openFileInTaskEditor;
-        void open(store.projectId, store.taskId, arg.path);
-      },
+      classifyLink: fileCommands?.classifyLink,
+      onOpenFile: fileCommands?.onOpenFile,
       onClickMention: (arg: Parameters<NonNullable<ChatCommands['onClickMention']>>[0]) => {
         if (!store) return;
         if (arg.kind === 'file') {
-          void openFileInTaskEditor(store.projectId, store.taskId, arg.id);
+          fileCommands?.openMentionFile(arg.id);
           return;
         }
         if (arg.kind === 'issue') {
@@ -825,9 +821,8 @@ export const AcpChatPanel = observer(function AcpChatPanel() {
             });
         }
       },
-    }),
-    [store, handleViewerOpen]
-  );
+    };
+  }, [store, handleViewerOpen]);
 
   if (!store) return null;
 

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/transcript-file-commands.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/transcript-file-commands.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { classifyTranscriptLink, createTranscriptFileCommands } from './transcript-file-commands';
+
+describe('classifyTranscriptLink', () => {
+  it.each([
+    ['src/auth/jwt.ts', 'src/auth/jwt.ts'],
+    ['./src/app.ts', './src/app.ts'],
+    ['../shared/types.ts', '../shared/types.ts'],
+    ['/home/dev/repo/src/app.ts', '/home/dev/repo/src/app.ts'],
+    ['C:\\Users\\dev\\repo\\src\\app.ts', 'C:\\Users\\dev\\repo\\src\\app.ts'],
+    ['D:/repo/src/app.ts', 'D:/repo/src/app.ts'],
+    ['\\\\server\\share\\repo\\src\\app.ts', '\\\\server\\share\\repo\\src\\app.ts'],
+    ['docs/Architecture Notes.md', 'docs/Architecture Notes.md'],
+    ['README', 'README'],
+    ['src/app.ts:42', 'src/app.ts'],
+    ['src/app.ts:42:7', 'src/app.ts'],
+    ['/home/dev/repo/src/app.ts:42', '/home/dev/repo/src/app.ts'],
+    ['C:\\repo\\src\\app.ts:42:7', 'C:\\repo\\src\\app.ts'],
+    ['README.md:42', 'README.md'],
+    ['src/app.ts#L42', 'src/app.ts'],
+    ['src/app.ts#L42C7', 'src/app.ts'],
+  ])('classifies the path-like href %s as a workspace file', (href, path) => {
+    expect(classifyTranscriptLink(href)).toEqual({ kind: 'workspace-file', path });
+  });
+
+  it.each([
+    'https://example.com/docs',
+    'HTTP://example.com/docs',
+    'mailto:support@example.com',
+    'file:///tmp/report.md',
+    'mcp://server/resource',
+    'vscode://file/tmp/report.md:42',
+    'urn:isbn:123',
+    'custom:42',
+    '//example.com/docs',
+    '#section',
+    '?view=raw',
+    '',
+    '   ',
+  ])('keeps the non-file href %j external', (href) => {
+    expect(classifyTranscriptLink(href)).toEqual({ kind: 'external' });
+  });
+});
+
+describe('createTranscriptFileCommands', () => {
+  it('opens every chat file source and file mention in the adjacent pane', () => {
+    const openFile = vi.fn(async () => {});
+    const commands = createTranscriptFileCommands(
+      { projectId: 'project-1', taskId: 'task-1' },
+      openFile
+    );
+
+    for (const source of ['diff', 'file-op', 'resource-link', 'prose-link'] as const) {
+      commands.onOpenFile({ path: `src/${source}.ts`, itemId: source, source });
+    }
+    commands.openMentionFile('src/mention.ts');
+
+    expect(openFile.mock.calls).toEqual([
+      ['project-1', 'task-1', 'src/diff.ts'],
+      ['project-1', 'task-1', 'src/file-op.ts'],
+      ['project-1', 'task-1', 'src/resource-link.ts'],
+      ['project-1', 'task-1', 'src/prose-link.ts'],
+      ['project-1', 'task-1', 'src/mention.ts'],
+    ]);
+  });
+});

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/transcript-file-commands.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/transcript-file-commands.ts
@@ -1,0 +1,65 @@
+import type { ChatCommands } from '@core/features/conversations/api/browser/chat/chat-transcript';
+// TODO(conversations-extraction): Inject task editor/file-opening behavior into ACP chat.
+import { openFileInAdjacentPane } from '@core/features/editor/api/browser/open-file-in-file-editor';
+
+const EXPLICIT_SCHEME_RE = /^[A-Za-z][A-Za-z\d+.-]*:/u;
+const EDITOR_LOCATION_SUFFIX_RE = /(?::\d+(?::\d+)?|#L\d+(?:C\d+)?)$/u;
+const BASENAME_WITH_LINE_SUFFIX_RE = /^[^/\\:]+\.[^/\\:]+:\d+(?::\d+)?$/u;
+const WINDOWS_ABSOLUTE_PATH_RE = /^[A-Za-z]:[\\/]/u;
+const WINDOWS_UNC_PATH_RE = /^\\\\[^\\]+\\[^\\]+/u;
+
+type TranscriptLinkClassification = ReturnType<NonNullable<ChatCommands['classifyLink']>>;
+
+type TranscriptFileContext = {
+  projectId: string;
+  taskId: string;
+};
+
+type TranscriptFileOpener = (projectId: string, taskId: string, filePath: string) => Promise<void>;
+
+export type TranscriptFileCommands = {
+  classifyLink: NonNullable<ChatCommands['classifyLink']>;
+  onOpenFile: NonNullable<ChatCommands['onOpenFile']>;
+  openMentionFile: (filePath: string) => void;
+};
+
+/**
+ * Classifies markdown links at the Emdash host boundary. A scheme-less href is
+ * a file path in a desktop agent transcript; explicit URI schemes, anchors,
+ * query-only links, and protocol-relative URLs keep browser behavior. Editor
+ * location suffixes are removed because the file opener accepts paths, not
+ * line/column annotations.
+ */
+export function classifyTranscriptLink(href: string): TranscriptLinkClassification {
+  const target = href.trim();
+  if (!target || target.startsWith('#') || target.startsWith('?') || target.startsWith('//')) {
+    return { kind: 'external' };
+  }
+  const filePath = target.replace(EDITOR_LOCATION_SUFFIX_RE, '');
+  if (
+    target.startsWith('/') ||
+    WINDOWS_ABSOLUTE_PATH_RE.test(target) ||
+    WINDOWS_UNC_PATH_RE.test(target) ||
+    BASENAME_WITH_LINE_SUFFIX_RE.test(target)
+  ) {
+    return { kind: 'workspace-file', path: filePath };
+  }
+  if (EXPLICIT_SCHEME_RE.test(target)) return { kind: 'external' };
+  return { kind: 'workspace-file', path: filePath };
+}
+
+/** All file affordances originating in chat preserve the transcript and open to its right. */
+export function createTranscriptFileCommands(
+  context: TranscriptFileContext,
+  openFile: TranscriptFileOpener = openFileInAdjacentPane
+): TranscriptFileCommands {
+  const open = (filePath: string) => {
+    void openFile(context.projectId, context.taskId, filePath);
+  };
+
+  return {
+    classifyLink: classifyTranscriptLink,
+    onOpenFile: ({ path }) => open(path),
+    openMentionFile: open,
+  };
+}

--- a/apps/emdash-desktop/src/core/features/editor/api/browser/open-file-in-file-editor.test.ts
+++ b/apps/emdash-desktop/src/core/features/editor/api/browser/open-file-in-file-editor.test.ts
@@ -124,16 +124,35 @@ describe('makeFileLinkHandlers', () => {
     mocks.openPath.mockResolvedValue({ success: true, data: undefined });
   });
 
-  it('routes onOpenFile through the seam with no existence precheck', async () => {
-    const handlers = makeFileLinkHandlers('project-1', 'task-1');
+  it('routes conversation file links to the adjacent pane with no existence precheck', async () => {
+    const handlers = makeFileLinkHandlers('project-1', 'task-1', { target: 'right' });
     handlers.onOpenFile('docs/spec-the-agent-mentioned.md');
     await flushMicrotasks();
 
     expect(mocks.openFile).toHaveBeenCalledWith(
       hostFileRefFromNativePath('/repo/docs/spec-the-agent-mentioned.md'),
-      expect.anything()
+      {
+        context: { projectId: 'project-1', taskId: 'task-1' },
+        target: 'right',
+        reveal: true,
+      }
     );
     expect(mocks.openPath).not.toHaveBeenCalled();
+  });
+
+  it('keeps the active-pane default for non-conversation terminal links', async () => {
+    const handlers = makeFileLinkHandlers('project-1', 'task-1');
+    handlers.onOpenFile('src/terminal-link.ts');
+    await flushMicrotasks();
+
+    expect(mocks.openFile).toHaveBeenCalledWith(
+      hostFileRefFromNativePath('/repo/src/terminal-link.ts'),
+      {
+        context: { projectId: 'project-1', taskId: 'task-1' },
+        target: 'active',
+        reveal: true,
+      }
+    );
   });
 
   it('routes onOpenExternal to the explicit openWithOS verb', async () => {

--- a/apps/emdash-desktop/src/core/features/editor/api/browser/open-file-in-file-editor.test.ts
+++ b/apps/emdash-desktop/src/core/features/editor/api/browser/open-file-in-file-editor.test.ts
@@ -92,6 +92,21 @@ describe('task file opening', () => {
     expect(mocks.openPath).not.toHaveBeenCalled();
   });
 
+  it('resolves parent-relative paths outside the workspace through the same seam', async () => {
+    mocks.getWorkspace.mockReturnValue({
+      workspaceId: 'workspace-1',
+      path: '/repo/worktree',
+    });
+
+    await openFileInTaskEditor('project-1', 'task-1', '../shared/types.ts');
+
+    expect(mocks.openFile).toHaveBeenCalledWith(
+      hostFileRefFromNativePath('/repo/shared/types.ts'),
+      expect.anything()
+    );
+    expect(mocks.openPath).not.toHaveBeenCalled();
+  });
+
   it('resolves absolute paths outside a remote workspace onto the remote host', async () => {
     mocks.getWorkspace.mockReturnValue({
       workspaceId: 'workspace-1',

--- a/apps/emdash-desktop/src/core/features/editor/api/browser/open-file-in-file-editor.ts
+++ b/apps/emdash-desktop/src/core/features/editor/api/browser/open-file-in-file-editor.ts
@@ -67,9 +67,9 @@ export async function openFileInTaskEditor(
 
 /**
  * Opens a file in the pane immediately to the right of the currently focused
- * pane. If no right pane exists it is created by splitting. Intended for
- * diff-header clicks so the file appears beside the chat without replacing the
- * active editor tab.
+ * pane. If no right pane exists it is created by splitting. Intended for chat
+ * file affordances so the file appears beside the transcript without replacing
+ * it.
  */
 export async function openFileInAdjacentPane(
   projectId: string,
@@ -80,17 +80,18 @@ export async function openFileInAdjacentPane(
 }
 
 /**
- * Chat/terminal-slice sugar over the seam (spec §10): file links resolve at
- * this edge and open through {@link openFile}; the explicit "open external"
- * affordance hands off to the OS via {@link openWithOS}.
+ * Terminal sugar over the seam (spec §10). Callers choose the pane target;
+ * the explicit "open external" affordance hands off to the OS via
+ * {@link openWithOS}.
  */
 export function makeFileLinkHandlers(
   projectId: string,
-  taskId: string
+  taskId: string,
+  options: { target?: 'active' | 'right' } = {}
 ): { onOpenFile: (filePath: string) => void; onOpenExternal: (filePath: string) => void } {
   return {
     onOpenFile: (filePath) => {
-      void openFileInTaskEditor(projectId, taskId, filePath);
+      void openFileInTaskEditor(projectId, taskId, filePath, options);
     },
     onOpenExternal: (filePath) => {
       void openWithOS(filePath);

--- a/apps/emdash-desktop/src/core/primitives/desktop-runtime/api/paths.test.ts
+++ b/apps/emdash-desktop/src/core/primitives/desktop-runtime/api/paths.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { hostFileRefFromNativePath } from './paths';
+import {
+  absoluteRuntimePath,
+  hostFileRefFromNativePath,
+  hostPathFromNative,
+  nativePathFromHost,
+} from './paths';
 
 describe('hostFileRefFromNativePath', () => {
   it('uses the local host by default', () => {
@@ -14,5 +19,25 @@ describe('hostFileRefFromNativePath', () => {
       host: { type: 'remote', id: 'ssh-1' },
       path: { root: { kind: 'posix' }, segments: ['repo'] },
     });
+  });
+});
+
+describe('absoluteRuntimePath', () => {
+  it.each([
+    ['/repo/worktree', '../shared/types.ts', '/repo/shared/types.ts'],
+    ['C:\\repo\\worktree', '..\\shared\\types.ts', 'C:\\repo\\shared\\types.ts'],
+    [
+      '\\\\server\\share\\repo\\worktree',
+      '../shared/types.ts',
+      '\\\\server\\share\\repo\\shared\\types.ts',
+    ],
+  ])('resolves parent-relative paths using the host path style', (root, input, expected) => {
+    expect(nativePathFromHost(absoluteRuntimePath(hostPathFromNative(root), input))).toBe(expected);
+  });
+
+  it('rejects parent traversal above the host filesystem root', () => {
+    expect(() =>
+      absoluteRuntimePath(hostPathFromNative('/repo/worktree'), '../../../etc/passwd')
+    ).toThrow('Path escapes its root');
   });
 });

--- a/apps/emdash-desktop/src/core/primitives/desktop-runtime/api/paths.ts
+++ b/apps/emdash-desktop/src/core/primitives/desktop-runtime/api/paths.ts
@@ -67,7 +67,13 @@ export function relativeRuntimePath(root: HostAbsolutePath, input: string): Port
 
 export function absoluteRuntimePath(root: HostAbsolutePath, input: string): HostAbsolutePath {
   if (input.startsWith('/') || isWindowsAbsolute(input)) return hostPathFromNative(input);
-  return resolveRelativePath(root, portablePath(input.replaceAll('\\', '/')));
+  const separator = root.root.kind === 'posix' ? '/' : '\\';
+  const base = nativePathFromHost(root);
+  const relative = root.root.kind === 'posix' ? input.replaceAll('\\', '/') : input;
+  const combined = base.endsWith(separator)
+    ? `${base}${relative}`
+    : `${base}${separator}${relative}`;
+  return hostPathFromNative(combined);
 }
 
 function isWindowsAbsolute(input: string): boolean {

--- a/packages/chat-ui/src/open-file.contract.test.tsx
+++ b/packages/chat-ui/src/open-file.contract.test.tsx
@@ -1,0 +1,172 @@
+import { DEFAULT_THEME } from '@core/theme';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createChatContext } from '@/chat-context';
+import { createChatView } from '@/chat-view';
+import type { ChatCommands, ChatItem, MentionProvider, TranscriptTurn } from '@/index';
+import { createChatState } from '@/state/chat-state';
+
+const nextPaint = (): Promise<void> =>
+  new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups.splice(0)) cleanup();
+});
+
+function mount(items: ChatItem[], commands: ChatCommands, mentionProvider?: MentionProvider) {
+  const context = createChatContext({ theme: DEFAULT_THEME, mentionProvider });
+  const state = createChatState(context);
+  const turn: TranscriptTurn = {
+    id: 'turn-1',
+    seq: 0,
+    initiator: 'agent',
+    items: items.map((item, seq) => ({ ...item, seq })) as TranscriptTurn['items'],
+  };
+  state.transcript.history.seed([turn]);
+
+  const host = document.createElement('div');
+  host.style.cssText = 'position:fixed;top:0;left:0;width:800px;height:700px;';
+  document.body.appendChild(host);
+  const view = createChatView({ context, state, parent: host, commands });
+
+  cleanups.push(() => {
+    view.dispose();
+    state.dispose();
+    context.dispose();
+    host.remove();
+  });
+  return host;
+}
+
+/** Observe whether chat-ui cancelled navigation, then cancel it before the browser acts. */
+function dispatchLinkClick(target: HTMLElement): boolean {
+  let preventedByChatUi = false;
+  const safetyNet = (event: MouseEvent) => {
+    preventedByChatUi = event.defaultPrevented;
+    event.preventDefault();
+  };
+  window.addEventListener('click', safetyNet, { once: true });
+  target.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+  return preventedByChatUi;
+}
+
+function clickableRowForPath(host: HTMLElement, path: string): HTMLElement {
+  const label = host.querySelector(`[title="${path}"]`);
+  const row = label?.closest('[role="button"]') as HTMLElement | null;
+  if (!row) throw new Error(`No clickable row found for ${path}`);
+  return row;
+}
+
+describe('open-file command contract', () => {
+  it('intercepts workspace prose links while retaining browser behavior for external links', async () => {
+    const onOpenFile = vi.fn();
+    const host = mount(
+      [
+        {
+          kind: 'message',
+          id: 'message-1',
+          role: 'assistant',
+          text: '[workspace](src/prose.ts) and [external](https://example.com/docs)',
+        },
+      ],
+      {
+        classifyLink: (href) =>
+          href === 'src/prose.ts' ? { kind: 'workspace-file', path: href } : { kind: 'external' },
+        onOpenFile,
+      }
+    );
+    await nextPaint();
+
+    const workspaceLink = host.querySelector('a[href="src/prose.ts"]') as HTMLElement | null;
+    const externalLink = host.querySelector(
+      'a[href="https://example.com/docs"]'
+    ) as HTMLElement | null;
+    expect(workspaceLink).not.toBeNull();
+    expect(externalLink).not.toBeNull();
+
+    expect(dispatchLinkClick(workspaceLink!)).toBe(true);
+    expect(onOpenFile).toHaveBeenCalledWith({
+      path: 'src/prose.ts',
+      itemId: 'message-1#0',
+      source: 'prose-link',
+    });
+
+    expect(dispatchLinkClick(externalLink!)).toBe(false);
+    expect(onOpenFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes diff, file-operation, and resource file rows through onOpenFile', async () => {
+    const onOpenFile = vi.fn();
+    const host = mount(
+      [
+        {
+          kind: 'diff',
+          id: 'edit-1:src/diff.ts',
+          path: 'src/diff.ts',
+          oldText: 'before',
+          newText: 'after',
+          status: 'done',
+        },
+        {
+          kind: 'file-op',
+          id: 'file-op-1',
+          op: 'read',
+          status: 'done',
+          ops: [{ path: 'src/file-op.ts' }],
+        },
+        {
+          kind: 'resource-link',
+          id: 'resource-1',
+          uri: 'src/resource.ts',
+          name: 'resource.ts',
+          target: { kind: 'workspace-file', path: 'src/resource.ts' },
+          status: 'done',
+        },
+      ],
+      { onOpenFile }
+    );
+    await nextPaint();
+
+    clickableRowForPath(host, 'src/diff.ts').click();
+    clickableRowForPath(host, 'src/file-op.ts').click();
+    const resourceRow = Array.from(host.querySelectorAll<HTMLElement>('[role="button"]')).find(
+      (element) => element.textContent?.includes('src/resource.ts')
+    );
+    expect(resourceRow).toBeDefined();
+    resourceRow!.click();
+
+    expect(onOpenFile.mock.calls.map(([arg]) => arg)).toEqual([
+      { path: 'src/diff.ts', itemId: 'edit-1:src/diff.ts', source: 'diff' },
+      { path: 'src/file-op.ts', itemId: 'file-op-1', source: 'file-op' },
+      { path: 'src/resource.ts', itemId: 'resource-1', source: 'resource-link' },
+    ]);
+  });
+
+  it('routes file mentions through onClickMention', async () => {
+    const onClickMention = vi.fn();
+    const mentionProvider: MentionProvider = {
+      resolve: (token) => ({ id: token, label: token, name: 'mention.ts', kind: 'file' }),
+    };
+    const host = mount(
+      [{ kind: 'message', id: 'message-1', role: 'assistant', text: 'Open @src/mention.ts' }],
+      { onClickMention },
+      mentionProvider
+    );
+    await nextPaint();
+
+    const mention = Array.from(host.querySelectorAll<HTMLElement>('span')).find(
+      (element) => element.textContent === 'mention.ts' && element.style.cursor === 'pointer'
+    );
+    expect(mention).toBeDefined();
+    mention!.click();
+
+    expect(onClickMention).toHaveBeenCalledWith({
+      id: 'src/mention.ts',
+      label: 'mention.ts',
+      kind: 'file',
+      itemId: 'message-1#0',
+      source: 'prose-mention',
+    });
+  });
+});


### PR DESCRIPTION
- routes every chat-originated file affordance through consistent adjacent-pane opening
- classifies workspace paths separately from external links and prevents unintended electron windows
- supports relative posix windows and unc paths with line and column annotations
- preserves existing active-pane behavior for ordinary task-terminal links
- verifies markdown links file operations resource links diffs and file mentions through focused browser and unit coverage