### PR TITLE
feat(source-control): add commit details modal and truncated-subject tooltip

### DIFF
--- a/agents/architecture/overview.md
+++ b/agents/architecture/overview.md
@@ -12,12 +12,12 @@ All paths are relative to `apps/emdash-desktop/`.
 
 ## Boot Sequence
 
-`src/main/index.ts` → app lifecycle → IPC/RPC registration → window creation → renderer
+`src/entry/main.ts` → phased bootstrap → Wire gateway → window creation → renderer
 
-- `index.ts` — Loads `.env`, normalizes PATH, initializes database, registers all RPC controllers via `src/main/rpc.ts`, creates the main window.
-- `src/main/rpc.ts` — Assembles the typed RPC router from domain controllers (`src/main/core/*/controller.ts`).
-- `src/preload/index.ts` — Exposes `window.electronAPI` (`invoke`, `eventSend`, `eventOn`) via `contextBridge`.
-- `src/renderer/lib/ipc.ts` — Creates the typed RPC client and event emitter used throughout the renderer.
+- `src/entry/main.ts` — Electron entry point; runs the phased bootstrap in `src/main/bootstrap/` (environment, database, window creation, recovery).
+- `src/main/gateway/desktop-wire.ts` — Serves renderer-main Wire traffic from the contract assembled in `src/core/manifests/shared/desktop-wire-contract.ts` and the slice controllers aggregated in `src/core/manifests/node/controllers.ts`.
+- `src/entry/preload.ts` — Exposes only `requestWirePort` and `getPathForFile` via `contextBridge`.
+- `src/core/primitives/wire/browser/connection.ts` — Seeded Wire connection seam; the renderer bootstrap seeds it once at startup, and each slice builds its typed domain client on it.
 
 ## Build Tooling
 

--- a/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/commit-clipboard.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/commit-clipboard.ts
@@ -1,0 +1,19 @@
+import type { Commit } from '@emdash/core/runtimes/git/api';
+import { toast } from '@emdash/ui/react/primitives';
+
+/** Subject plus body, in the shape `git log` prints the message. */
+export function commitFullMessage(commit: Commit): string {
+  return commit.body ? `${commit.subject}\n\n${commit.body}` : commit.subject;
+}
+
+/** Shared by the commit context menu and the details modal so both report copies identically. */
+export async function copyCommitValue(value: string, label: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(value);
+    toast(`${label} copied`);
+  } catch {
+    toast.error('Copy failed', {
+      description: `The ${label.toLowerCase()} could not be copied to the clipboard.`,
+    });
+  }
+}

--- a/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/commit-context-menu.tsx
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/commit-context-menu.tsx
@@ -1,0 +1,36 @@
+import type { Commit } from '@emdash/core/runtimes/git/api';
+import { ContextMenu } from '@emdash/ui/react/primitives';
+import { Copy, FileText, Info } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { commitFullMessage, copyCommitValue } from './commit-clipboard';
+
+interface CommitContextMenuProps {
+  children: ReactNode;
+  commit: Commit;
+  onViewDetails: () => void;
+}
+
+export function CommitContextMenu({ children, commit, onViewDetails }: CommitContextMenuProps) {
+  return (
+    <ContextMenu.Root>
+      <ContextMenu.Trigger>{children}</ContextMenu.Trigger>
+      <ContextMenu.Content>
+        <ContextMenu.Item onClick={onViewDetails}>
+          <Info className="size-4" />
+          View commit details
+        </ContextMenu.Item>
+        <ContextMenu.Separator />
+        <ContextMenu.Item onClick={() => void copyCommitValue(commit.hash, 'Commit SHA')}>
+          <Copy className="size-4" />
+          Copy commit SHA
+        </ContextMenu.Item>
+        <ContextMenu.Item
+          onClick={() => void copyCommitValue(commitFullMessage(commit), 'Commit message')}
+        >
+          <FileText className="size-4" />
+          Copy commit message
+        </ContextMenu.Item>
+      </ContextMenu.Content>
+    </ContextMenu.Root>
+  );
+}

--- a/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/commit-details-modal.tsx
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/commit-details-modal.tsx
@@ -1,0 +1,252 @@
+import type { Commit, GitChange } from '@emdash/core/runtimes/git/api';
+import { AbsoluteTime, Badge, Button, Dialog, Spinner } from '@emdash/ui/react/primitives';
+import { Copy } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { FileIcon } from '@core/features/editor/contributions/browser/file-icon';
+import { splitPath } from '@core/features/tasks/api/browser/utils';
+import { formatDiffLineCount } from '@core/primitives/formatting/browser/format-diff-line-count';
+import { defineModal } from '@core/primitives/modals/react';
+import { GitChangeStatusIcon } from '../changes-list-item';
+import { commitFullMessage, copyCommitValue } from './commit-clipboard';
+import { useCommitFiles } from './use-commit-files';
+
+export interface CommitDetailsModalProps {
+  commit: Commit;
+  projectId: string;
+  workspaceId: string;
+}
+
+/**
+ * Read-only view of a single commit. The commit itself is already loaded by the
+ * surrounding log query, so only the file list is fetched here.
+ */
+export function CommitDetailsModal({ commit, projectId, workspaceId }: CommitDetailsModalProps) {
+  const filesQuery = useCommitFiles(projectId, workspaceId, commit.hash, true);
+  const files = filesQuery.data ?? [];
+
+  return (
+    <>
+      <Dialog.Header>
+        <Dialog.Title className="font-sans text-base tracking-normal text-foreground normal-case">
+          {commit.subject}
+        </Dialog.Title>
+        <div className="mt-1 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-xs text-foreground-muted">
+          <span className="font-medium">{commit.author}</span>
+          {'·'}
+          <AbsoluteTime value={commit.date} />
+          {'·'}
+          <span className="font-mono text-foreground-passive">{commit.hash.slice(0, 7)}</span>
+          <Badge variant="soft" tone={commit.isPushed ? 'success' : 'neutral'}>
+            {commit.isPushed ? 'Pushed' : 'Local only'}
+          </Badge>
+        </div>
+      </Dialog.Header>
+
+      <Dialog.Body className="space-y-4">
+        <CommitMessageBody commit={commit} />
+        <CommitMetadata commit={commit} />
+        <CommitFilesSection
+          files={files}
+          isLoading={filesQuery.isLoading}
+          isError={filesQuery.isError}
+        />
+      </Dialog.Body>
+
+      <Dialog.Footer className="gap-2 sm:gap-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => void copyCommitValue(commit.hash, 'Commit SHA')}
+        >
+          <Copy className="mr-1.5 h-3.5 w-3.5" />
+          Copy SHA
+        </Button>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => void copyCommitValue(commitFullMessage(commit), 'Commit message')}
+        >
+          <Copy className="mr-1.5 h-3.5 w-3.5" />
+          Copy message
+        </Button>
+      </Dialog.Footer>
+    </>
+  );
+}
+
+function CommitMessageBody({ commit }: { commit: Commit }) {
+  if (!commit.body) {
+    return (
+      <p className="text-xs text-foreground-passive">
+        This commit has no message body beyond its subject.
+      </p>
+    );
+  }
+
+  return (
+    <pre className="max-h-64 overflow-y-auto rounded-md bg-background-quaternary-1 px-3 py-2 font-mono text-xs wrap-break-word whitespace-pre-wrap text-foreground">
+      {commit.body}
+    </pre>
+  );
+}
+
+function CommitMetadata({ commit }: { commit: Commit }) {
+  return (
+    <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-4 gap-y-1.5 text-xs">
+      <MetadataRow label="Author">
+        <IdentityValue name={commit.author} email={commit.authorEmail} />
+        {' · '}
+        <AbsoluteTime value={commit.date} includeYear />
+      </MetadataRow>
+      {commit.committer && (
+        <MetadataRow label="Committer">
+          <IdentityValue name={commit.committer} email={commit.committerEmail} />
+          {commit.committerDate !== undefined && (
+            <>
+              {' · '}
+              <AbsoluteTime value={commit.committerDate} includeYear />
+            </>
+          )}
+        </MetadataRow>
+      )}
+      <MetadataRow label="Commit">
+        <span className="font-mono break-all select-text">{commit.hash}</span>
+      </MetadataRow>
+      <MetadataRow label={commit.parents.length === 1 ? 'Parent' : 'Parents'}>
+        {commit.parents.length === 0 ? (
+          <span className="text-foreground-passive">None (root commit)</span>
+        ) : (
+          <span className="font-mono break-all select-text">
+            {commit.parents.map((parent) => parent.slice(0, 7)).join(', ')}
+          </span>
+        )}
+      </MetadataRow>
+      {commit.tags.length > 0 && (
+        <MetadataRow label={commit.tags.length === 1 ? 'Tag' : 'Tags'}>
+          <span className="flex flex-wrap gap-1">
+            {commit.tags.map((tag) => (
+              <Badge key={tag} variant="outline" tone="info">
+                {tag}
+              </Badge>
+            ))}
+          </span>
+        </MetadataRow>
+      )}
+    </dl>
+  );
+}
+
+function MetadataRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <>
+      <dt className="text-foreground-muted">{label}</dt>
+      <dd className="min-w-0 text-foreground">{children}</dd>
+    </>
+  );
+}
+
+function IdentityValue({ name, email }: { name: string; email?: string }) {
+  return (
+    <span className="break-all select-text">
+      {name}
+      {email ? ` <${email}>` : ''}
+    </span>
+  );
+}
+
+function CommitFilesSection({
+  files,
+  isLoading,
+  isError,
+}: {
+  files: readonly GitChange[];
+  isLoading: boolean;
+  isError: boolean;
+}) {
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 py-2 text-xs text-foreground-passive">
+        <Spinner size="sm" />
+        Loading files...
+      </div>
+    );
+  }
+
+  if (isError) {
+    return <p className="py-2 text-xs text-foreground-passive">Unable to load changed files.</p>;
+  }
+
+  if (files.length === 0) {
+    return <p className="py-2 text-xs text-foreground-passive">No file changes.</p>;
+  }
+
+  const additions = files.reduce((total, file) => total + file.additions, 0);
+  const deletions = files.reduce((total, file) => total + file.deletions, 0);
+
+  return (
+    <section className="space-y-1">
+      <div className="flex items-center justify-between text-xs text-foreground-muted">
+        <span>
+          {files.length} {files.length === 1 ? 'file changed' : 'files changed'}
+        </span>
+        <span className="flex items-center gap-1 tabular-nums">
+          {additions > 0 && (
+            <span className="text-foreground-diff-added">+{formatDiffLineCount(additions)}</span>
+          )}
+          {deletions > 0 && (
+            <span className="text-foreground-diff-deleted">-{formatDiffLineCount(deletions)}</span>
+          )}
+        </span>
+      </div>
+      <ul className="max-h-56 overflow-y-auto rounded-md border border-border">
+        {files.map((file) => (
+          <CommitFileRow key={file.path} file={file} />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function CommitFileRow({ file }: { file: GitChange }) {
+  const { filename, directory } = splitPath(file.path);
+
+  return (
+    <li className="flex h-7 items-center justify-between gap-2 px-2">
+      <span className="flex min-w-0 flex-1 items-center gap-1.5">
+        <FileIcon filename={filename} size={12} />
+        <span className="flex min-w-0 flex-1 items-baseline gap-1.5">
+          <span className="max-w-full shrink-0 truncate text-sm">{filename}</span>
+          {directory && (
+            <span className="min-w-0 shrink truncate text-xs text-foreground-muted">
+              {directory}
+            </span>
+          )}
+        </span>
+      </span>
+      <span
+        className="flex shrink-0 items-center gap-1.5"
+        aria-label={`${file.additions} lines added, ${file.deletions} lines removed`}
+      >
+        <span className="flex items-center gap-1 text-xs leading-none tabular-nums">
+          {file.additions > 0 && (
+            <span className="text-foreground-diff-added">
+              +{formatDiffLineCount(file.additions)}
+            </span>
+          )}
+          {file.deletions > 0 && (
+            <span className="text-foreground-diff-deleted">
+              -{formatDiffLineCount(file.deletions)}
+            </span>
+          )}
+        </span>
+        <GitChangeStatusIcon status={file.status} />
+      </span>
+    </li>
+  );
+}
+
+export const commitDetailsModal = defineModal<void>()({
+  id: 'commitDetailsModal',
+  component: CommitDetailsModal,
+  size: 'lg',
+});

--- a/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/commit-row-button.tsx
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/commit-row-button.tsx
@@ -1,0 +1,64 @@
+import type { Commit } from '@emdash/core/runtimes/git/api';
+import { RelativeTime, Tooltip } from '@emdash/ui/react/primitives';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { useRef, useState } from 'react';
+import { cn } from '@core/primitives/styling/browser/cn';
+
+interface CommitRowButtonProps {
+  commit: Commit;
+  isExpanded: boolean;
+  onToggleExpanded: () => void;
+}
+
+/**
+ * The clickable commit row. Hovering it shows the full subject in a tooltip,
+ * but only when the subject line is actually truncated; truncation is measured
+ * when the tooltip asks to open, so panel resizes never leave the answer stale.
+ */
+export function CommitRowButton({ commit, isExpanded, onToggleExpanded }: CommitRowButtonProps) {
+  const subjectRef = useRef<HTMLSpanElement>(null);
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+  const shortHash = commit.hash.slice(0, 7);
+
+  return (
+    <Tooltip.Root
+      open={tooltipOpen}
+      onOpenChange={(open) => {
+        const subject = subjectRef.current;
+        setTooltipOpen(open && subject !== null && subject.scrollWidth > subject.clientWidth);
+      }}
+    >
+      <Tooltip.Trigger
+        render={
+          <button
+            className={cn(
+              'group flex w-full rounded-md px-1.5 py-1 text-left hover:bg-background-1',
+              isExpanded && 'bg-background-1'
+            )}
+            onClick={onToggleExpanded}
+            onContextMenu={() => setTooltipOpen(false)}
+          />
+        }
+      >
+        <span className="min-w-0 flex-1">
+          <span ref={subjectRef} className="block truncate text-sm">
+            {commit.subject}
+          </span>
+          <span className="flex min-w-0 items-center gap-1 text-xs text-foreground-muted">
+            <span className="min-w-0 truncate font-medium">{commit.author}</span>
+            {'·'}
+            <RelativeTime compact value={commit.date} className="text-foreground-muted" />
+            {'·'}
+            <span className="font-mono text-foreground-passive">{shortHash}</span>
+            {isExpanded ? (
+              <ChevronDown className="size-3.5 shrink-0 text-foreground-muted" />
+            ) : (
+              <ChevronRight className="size-3.5 shrink-0 text-foreground-muted" />
+            )}
+          </span>
+        </span>
+      </Tooltip.Trigger>
+      <Tooltip.Content className="wrap-break-word">{commit.subject}</Tooltip.Content>
+    </Tooltip.Root>
+  );
+}

--- a/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/commits-list.tsx
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/commits-list.tsx
@@ -10,11 +10,13 @@ import {
   useTaskComposition,
   useWorkspaceId,
 } from '@core/features/workbench/api/browser/task-composition-context';
+import { useOpenModal } from '@core/manifests/browser/modal-api';
 import { commitRef, refsEqual } from '@core/primitives/git/api';
 import { cn } from '@core/primitives/styling/browser/cn';
 import { activeDiffEntry } from '../../../pane-selectors';
 import { usePrefetchDiffModels } from '../../hooks/use-prefetch-diff-models';
 import { ChangesListItem } from '../changes-list-item';
+import { CommitContextMenu } from './commit-context-menu';
 import { useCommitFiles } from './use-commit-files';
 import { type CommitRange, useCommits } from './use-commits';
 
@@ -52,6 +54,7 @@ export const CommitRangeCommitsList = observer(function CommitRangeCommitsList({
 }) {
   const { projectId } = useTaskViewContext();
   const workspaceId = useWorkspaceId();
+  const openCommitDetails = useOpenModal('commitDetailsModal');
   const rangeIdentity = commitRangeIdentity(range);
   const [expanded, setExpanded] = useState<ExpandedCommitState>(() => ({
     rangeIdentity,
@@ -118,6 +121,7 @@ export const CommitRangeCommitsList = observer(function CommitRangeCommitsList({
                 isFirst={virtualItem.index === 0}
                 isLast={virtualItem.index === commits.length - 1}
                 onToggleExpanded={() => toggleExpanded(commit.hash)}
+                onViewDetails={() => void openCommitDetails({ commit, projectId, workspaceId })}
               />
             </div>
           );
@@ -144,12 +148,14 @@ function CommitItem({
   isFirst,
   isLast,
   onToggleExpanded,
+  onViewDetails,
 }: {
   commit: Commit;
   isExpanded: boolean;
   isFirst: boolean;
   isLast: boolean;
   onToggleExpanded: () => void;
+  onViewDetails: () => void;
 }) {
   const shortHash = commit.hash.slice(0, 7);
 
@@ -171,29 +177,31 @@ function CommitItem({
         />
       </div>
       <div className="min-w-0 flex-1">
-        <button
-          className={cn(
-            'group flex w-full rounded-md px-1.5 py-1 text-left hover:bg-background-1',
-            isExpanded && 'bg-background-1'
-          )}
-          onClick={onToggleExpanded}
-        >
-          <span className="min-w-0 flex-1">
-            <span className="block truncate text-sm">{commit.subject}</span>
-            <span className="flex min-w-0 items-center gap-1 text-xs text-foreground-muted">
-              <span className="min-w-0 truncate font-medium">{commit.author}</span>
-              {'·'}
-              <RelativeTime compact value={commit.date} className="text-foreground-muted" />
-              {'·'}
-              <span className="font-mono text-foreground-passive">{shortHash}</span>
-              {isExpanded ? (
-                <ChevronDown className="size-3.5 shrink-0 text-foreground-muted" />
-              ) : (
-                <ChevronRight className="size-3.5 shrink-0 text-foreground-muted" />
-              )}
+        <CommitContextMenu commit={commit} onViewDetails={onViewDetails}>
+          <button
+            className={cn(
+              'group flex w-full rounded-md px-1.5 py-1 text-left hover:bg-background-1',
+              isExpanded && 'bg-background-1'
+            )}
+            onClick={onToggleExpanded}
+          >
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-sm">{commit.subject}</span>
+              <span className="flex min-w-0 items-center gap-1 text-xs text-foreground-muted">
+                <span className="min-w-0 truncate font-medium">{commit.author}</span>
+                {'·'}
+                <RelativeTime compact value={commit.date} className="text-foreground-muted" />
+                {'·'}
+                <span className="font-mono text-foreground-passive">{shortHash}</span>
+                {isExpanded ? (
+                  <ChevronDown className="size-3.5 shrink-0 text-foreground-muted" />
+                ) : (
+                  <ChevronRight className="size-3.5 shrink-0 text-foreground-muted" />
+                )}
+              </span>
             </span>
-          </span>
-        </button>
+          </button>
+        </CommitContextMenu>
         {isExpanded && <CommitFilesList commit={commit} />}
       </div>
     </div>

--- a/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/commits-list.tsx
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/commits-list.tsx
@@ -1,8 +1,6 @@
 import type { Commit, GitChange, GitObjectRef } from '@emdash/core/runtimes/git/api';
 import { EmptyState } from '@emdash/ui/react/components';
-import { RelativeTime } from '@emdash/ui/react/primitives';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { ChevronDown, ChevronRight } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { useMemo, useRef, useState } from 'react';
 import { useTaskViewContext } from '@core/features/tasks/contributions/browser/task-view-context';
@@ -17,6 +15,7 @@ import { activeDiffEntry } from '../../../pane-selectors';
 import { usePrefetchDiffModels } from '../../hooks/use-prefetch-diff-models';
 import { ChangesListItem } from '../changes-list-item';
 import { CommitContextMenu } from './commit-context-menu';
+import { CommitRowButton } from './commit-row-button';
 import { useCommitFiles } from './use-commit-files';
 import { type CommitRange, useCommits } from './use-commits';
 
@@ -157,8 +156,6 @@ function CommitItem({
   onToggleExpanded: () => void;
   onViewDetails: () => void;
 }) {
-  const shortHash = commit.hash.slice(0, 7);
-
   return (
     <div className="flex items-stretch">
       <div className="relative w-3.5 shrink-0">
@@ -178,29 +175,11 @@ function CommitItem({
       </div>
       <div className="min-w-0 flex-1">
         <CommitContextMenu commit={commit} onViewDetails={onViewDetails}>
-          <button
-            className={cn(
-              'group flex w-full rounded-md px-1.5 py-1 text-left hover:bg-background-1',
-              isExpanded && 'bg-background-1'
-            )}
-            onClick={onToggleExpanded}
-          >
-            <span className="min-w-0 flex-1">
-              <span className="block truncate text-sm">{commit.subject}</span>
-              <span className="flex min-w-0 items-center gap-1 text-xs text-foreground-muted">
-                <span className="min-w-0 truncate font-medium">{commit.author}</span>
-                {'·'}
-                <RelativeTime compact value={commit.date} className="text-foreground-muted" />
-                {'·'}
-                <span className="font-mono text-foreground-passive">{shortHash}</span>
-                {isExpanded ? (
-                  <ChevronDown className="size-3.5 shrink-0 text-foreground-muted" />
-                ) : (
-                  <ChevronRight className="size-3.5 shrink-0 text-foreground-muted" />
-                )}
-              </span>
-            </span>
-          </button>
+          <CommitRowButton
+            commit={commit}
+            isExpanded={isExpanded}
+            onToggleExpanded={onToggleExpanded}
+          />
         </CommitContextMenu>
         {isExpanded && <CommitFilesList commit={commit} />}
       </div>

--- a/apps/emdash-desktop/src/core/features/source-control/contributions/browser.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/contributions/browser.ts
@@ -1,5 +1,6 @@
+import { commitDetailsModal } from '../browser/diff-view/changes-panel/components/pr-entry/commit-details-modal';
 import { createPrModal } from '../browser/diff-view/changes-panel/components/pr-entry/create-pr-modal';
 
 export const sourceControlBrowserContributions = {
-  modalDefs: [createPrModal],
+  modalDefs: [commitDetailsModal, createPrModal],
 } as const;

--- a/apps/emdash-desktop/src/renderer/tests/browser/commit-details-modal.test.tsx
+++ b/apps/emdash-desktop/src/renderer/tests/browser/commit-details-modal.test.tsx
@@ -1,0 +1,206 @@
+import '@emdash/ui/style.css';
+import type { Commit, GitChange } from '@emdash/core/runtimes/git/api';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CommitContextMenu } from '@core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/commit-context-menu';
+import { commitFilesQueryKey } from '@core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/use-commit-files';
+import { openModal } from '@core/manifests/browser/modal-api';
+import { modalStore } from '@core/primitives/modals/react/modal-store';
+import { ThemeProvider } from '@core/primitives/theme/browser/theme-provider';
+import { ModalRenderer } from '@renderer/lib/modal/modal-renderer';
+
+// Test fixtures only need the brand, not real path validation.
+const gitPath = (path: string) => path as GitChange['path'];
+
+const commit: Commit = {
+  hash: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0',
+  parents: ['0123456789abcdef0123456789abcdef01234567'],
+  subject: 'feat(scope): add the commit details modal',
+  body: 'Longer explanation of the change.\n\n- first detail\n- second detail',
+  author: 'Ada Lovelace',
+  authorEmail: 'ada@example.com',
+  date: Date.UTC(2026, 0, 15, 12, 30),
+  committer: 'Grace Hopper',
+  committerEmail: 'grace@example.com',
+  committerDate: Date.UTC(2026, 0, 16, 9, 0),
+  isPushed: false,
+  tags: ['v1.2.3'],
+};
+
+const commitFiles: GitChange[] = [
+  { path: gitPath('src/feature/thing.ts'), status: 'modified', additions: 12, deletions: 3 },
+  { path: gitPath('src/feature/created.ts'), status: 'added', additions: 40, deletions: 0 },
+];
+
+beforeAll(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+async function flushOpen() {
+  // Let Base UI mount the popup and run its initial-focus pass.
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  });
+}
+
+describe('commit context menu', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    host.remove();
+  });
+
+  it('opens on right-click with details and copy actions', async () => {
+    const onViewDetails = vi.fn();
+    await act(async () => {
+      root.render(
+        <ThemeProvider theme="emlight" onThemeChange={vi.fn()}>
+          <CommitContextMenu commit={commit} onViewDetails={onViewDetails}>
+            <button>{commit.subject}</button>
+          </CommitContextMenu>
+        </ThemeProvider>
+      );
+    });
+
+    const trigger = host.querySelector('button');
+    expect(trigger).not.toBeNull();
+    const rect = trigger!.getBoundingClientRect();
+    await act(async () => {
+      trigger!.dispatchEvent(
+        new MouseEvent('contextmenu', {
+          bubbles: true,
+          cancelable: true,
+          clientX: rect.x + 4,
+          clientY: rect.y + 4,
+        })
+      );
+    });
+    await flushOpen();
+
+    const items = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-slot="context-menu-item"]')
+    );
+    expect(items.map((item) => item.textContent)).toEqual([
+      'View commit details',
+      'Copy commit SHA',
+      'Copy commit message',
+    ]);
+
+    await act(async () => items[0]!.click());
+    expect(onViewDetails).toHaveBeenCalledOnce();
+  });
+});
+
+describe('commit details modal', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    queryClient = new QueryClient();
+  });
+
+  afterEach(async () => {
+    for (const entry of [...modalStore.stack]) modalStore.removeEntry(entry.key);
+    queryClient.clear();
+    await act(async () => root.unmount());
+    host.remove();
+  });
+
+  it('renders the full message, identities, metadata, and file stats', async () => {
+    // Seed the files query so the modal renders without a wire connection; the
+    // query's 5-minute staleTime keeps the seeded data from being refetched.
+    queryClient.setQueryData(
+      commitFilesQueryKey('project-1', 'workspace-1', commit.hash),
+      commitFiles
+    );
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <ThemeProvider theme="emlight" onThemeChange={vi.fn()}>
+            <ModalRenderer />
+          </ThemeProvider>
+        </QueryClientProvider>
+      );
+    });
+
+    await act(async () => {
+      void openModal('commitDetailsModal', {
+        commit,
+        projectId: 'project-1',
+        workspaceId: 'workspace-1',
+      });
+    });
+    await flushOpen();
+
+    const popup = document.querySelector<HTMLElement>('[data-slot="dialog-content"]');
+    expect(popup).not.toBeNull();
+    const text = popup!.textContent ?? '';
+
+    expect(text).toContain(commit.subject);
+    expect(text).toContain('Longer explanation of the change.');
+    expect(text).toContain('Ada Lovelace <ada@example.com>');
+    expect(text).toContain('Grace Hopper <grace@example.com>');
+    expect(text).toContain(commit.hash);
+    expect(text).toContain('0123456');
+    expect(text).toContain('v1.2.3');
+    expect(text).toContain('Local only');
+    expect(text).toContain('2 files changed');
+    expect(text).toContain('thing.ts');
+    expect(text).toContain('created.ts');
+    expect(text).toContain('+12');
+    expect(text).toContain('-3');
+    expect(text).toContain('Copy SHA');
+    expect(text).toContain('Copy message');
+
+    // The file list is display-only: no interactive elements inside it.
+    const fileList = popup!.querySelector('ul');
+    expect(fileList).not.toBeNull();
+    expect(fileList!.querySelector('button, a')).toBeNull();
+  });
+
+  it('falls back to a placeholder when the commit has no body', async () => {
+    const bodylessCommit: Commit = { ...commit, hash: 'b'.repeat(40), body: '' };
+    queryClient.setQueryData(
+      commitFilesQueryKey('project-1', 'workspace-1', bodylessCommit.hash),
+      []
+    );
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <ThemeProvider theme="emlight" onThemeChange={vi.fn()}>
+            <ModalRenderer />
+          </ThemeProvider>
+        </QueryClientProvider>
+      );
+    });
+
+    await act(async () => {
+      void openModal('commitDetailsModal', {
+        commit: bodylessCommit,
+        projectId: 'project-1',
+        workspaceId: 'workspace-1',
+      });
+    });
+    await flushOpen();
+
+    const text = document.querySelector<HTMLElement>('[data-slot="dialog-content"]')?.textContent;
+    expect(text).toContain('This commit has no message body beyond its subject.');
+    expect(text).toContain('No file changes.');
+  });
+});

--- a/apps/emdash-desktop/src/renderer/tests/browser/commit-row-tooltip.test.tsx
+++ b/apps/emdash-desktop/src/renderer/tests/browser/commit-row-tooltip.test.tsx
@@ -1,0 +1,102 @@
+import '@emdash/ui/style.css';
+import type { Commit } from '@emdash/core/runtimes/git/api';
+import { Tooltip } from '@emdash/ui/react/primitives';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import { CommitRowButton } from '@core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/commit-row-button';
+import { ThemeProvider } from '@core/primitives/theme/browser/theme-provider';
+
+const commit: Commit = {
+  hash: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0',
+  parents: ['0123456789abcdef0123456789abcdef01234567'],
+  subject:
+    'feat(source-control): a deliberately long commit subject that cannot fit inside a narrow panel',
+  body: '',
+  author: 'Ada Lovelace',
+  authorEmail: 'ada@example.com',
+  date: Date.UTC(2026, 0, 15, 12, 30),
+  committer: 'Ada Lovelace',
+  committerEmail: 'ada@example.com',
+  committerDate: Date.UTC(2026, 0, 15, 12, 30),
+  isPushed: false,
+  tags: [],
+};
+
+beforeAll(() => {
+  // The browser-test harness compiles no app-level Tailwind (vitest.config.ts
+  // has no @tailwindcss/vite plugin), so the layout utilities that produce
+  // real truncation geometry are shimmed here; without them the subject would
+  // wrap instead of overflowing and scrollWidth would never exceed clientWidth.
+  const style = document.createElement('style');
+  style.textContent = [
+    '.flex{display:flex}',
+    '.block{display:block}',
+    '.w-full{width:100%}',
+    '.min-w-0{min-width:0}',
+    '.flex-1{flex:1 1 0%}',
+    '.truncate{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}',
+  ].join('');
+  document.head.appendChild(style);
+});
+
+describe('commit row tooltip', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(() => {
+    root.unmount();
+    host.remove();
+  });
+
+  async function renderRow(width: number) {
+    host.style.width = `${width}px`;
+    root.render(
+      <ThemeProvider theme="emlight" onThemeChange={vi.fn()}>
+        <Tooltip.Provider delay={0} closeDelay={0}>
+          <CommitRowButton commit={commit} isExpanded={false} onToggleExpanded={vi.fn()} />
+        </Tooltip.Provider>
+      </ThemeProvider>
+    );
+    return await vi.waitFor(() => {
+      const trigger = host.querySelector('button');
+      expect(trigger).not.toBeNull();
+      return trigger!;
+    });
+  }
+
+  it('shows the full subject on hover when the subject is truncated', async () => {
+    const trigger = await renderRow(200);
+    const subjectEl = trigger.querySelector('span > span')!;
+    expect(subjectEl.scrollWidth).toBeGreaterThan(subjectEl.clientWidth);
+
+    await userEvent.hover(trigger);
+    await vi.waitFor(() => {
+      const content = document.querySelector('[data-slot="tooltip-content"]');
+      expect(content?.textContent).toContain(commit.subject);
+    });
+
+    await userEvent.unhover(trigger);
+    await vi.waitFor(() => {
+      expect(document.querySelector('[data-slot="tooltip-content"]')).toBeNull();
+    });
+  });
+
+  it('does not show a tooltip when the subject fits', async () => {
+    const trigger = await renderRow(900);
+    const subjectEl = trigger.querySelector('span > span')!;
+    expect(subjectEl.scrollWidth).toBeLessThanOrEqual(subjectEl.clientWidth);
+
+    await userEvent.hover(trigger);
+    // Give an incorrectly gated tooltip ample time to appear before asserting.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(document.querySelector('[data-slot="tooltip-content"]')).toBeNull();
+    await userEvent.unhover(trigger);
+  });
+});

--- a/apps/emdash-desktop/src/renderer/tests/browser/modal-catalog.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/browser/modal-catalog.test.ts
@@ -12,6 +12,7 @@ const expectedModalIds = [
   'addSshConnModal',
   'agentSignInModal',
   'commandPaletteModal',
+  'commitDetailsModal',
   'confirmActionModal',
   'confirmExternalLinkModal',
   'conflictDialog',

--- a/packages/core/src/runtimes/git/api/checkout/schemas.ts
+++ b/packages/core/src/runtimes/git/api/checkout/schemas.ts
@@ -38,14 +38,23 @@ export type FileChange = z.infer<typeof fileChangeSchema>;
 export const gitChangeSchema = fileChangeSchema;
 export type GitChange = z.infer<typeof gitChangeSchema>;
 
+/**
+ * Identity and authorship fields added at protocol 1.1.0 are optional so that a
+ * newer client stays a tolerant reader of a pre-1.1.0 host, which omits them.
+ */
 export const commitSchema = z.object({
   hash: z.string(),
   parents: z.array(z.string()),
   subject: z.string(),
   body: z.string(),
   author: z.string(),
+  authorEmail: z.string().optional(),
   /** Author date as epoch milliseconds (convention 4). */
   date: z.number().int(),
+  committer: z.string().optional(),
+  committerEmail: z.string().optional(),
+  /** Committer date as epoch milliseconds (convention 4). */
+  committerDate: z.number().int().optional(),
   isPushed: z.boolean(),
   tags: z.array(z.string()),
 });

--- a/packages/core/src/runtimes/git/node/checkout/git-checkout.test.ts
+++ b/packages/core/src/runtimes/git/node/checkout/git-checkout.test.ts
@@ -197,7 +197,19 @@ describe('GitCheckout', () => {
       const log = await checkout.getLog();
       expect(log.commits).toHaveLength(2);
       expect(log.totalCount).toBe(2);
-      expect(log.commits[0]).toMatchObject({ subject: 'second commit', isPushed: false });
+      const [headCommit] = log.commits;
+      expect(headCommit).toMatchObject({
+        subject: 'second commit',
+        isPushed: false,
+        author: 'Test User',
+        authorEmail: 'test@example.com',
+        committer: 'Test User',
+        committerEmail: 'test@example.com',
+      });
+      // Dates cross the wire as epoch milliseconds; a raw `%at`/`%ct` seconds
+      // value would be three orders of magnitude smaller.
+      expect(headCommit?.date).toBeGreaterThan(1e12);
+      expect(headCommit?.committerDate).toBeGreaterThan(1e12);
 
       const commit = await checkout.getCommit(commitResult.data.hash);
       expect(commit).toMatchObject({ hash: commitResult.data.hash, subject: 'second commit' });

--- a/packages/core/src/runtimes/git/node/checkout/ops/log.test.ts
+++ b/packages/core/src/runtimes/git/node/checkout/ops/log.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { LOG_FORMAT, parseLogRecords } from './log';
+
+const FIELD_SEP = '\x1f';
+const RECORD_SEP = '\x1e';
+
+/** Field values in `LOG_FORMAT` order. */
+const FIELDS = [
+  'a'.repeat(40),
+  `${'b'.repeat(40)} ${'c'.repeat(40)}`,
+  'feat(replay): require explicit replay-visibility',
+  'Portal mounts now opt in.\n\nRefs #1777',
+  'Juan Lopez',
+  'juan@example.com',
+  '1760000000',
+  'Release Bot',
+  'bot@example.com',
+  '1760000600',
+  'tag: refs/tags/v2.1.228, refs/heads/main',
+];
+
+function buildRecord(fields: readonly string[]): string {
+  return `${fields.join(FIELD_SEP)}${RECORD_SEP}`;
+}
+
+describe('parseLogRecords', () => {
+  it('destructures exactly the placeholders LOG_FORMAT emits', () => {
+    expect(LOG_FORMAT.split(FIELD_SEP)).toHaveLength(FIELDS.length);
+  });
+
+  it('maps every field to its commit property', () => {
+    const [commit] = parseLogRecords(buildRecord(FIELDS), new Set([FIELDS[0]!]));
+
+    expect(commit).toEqual({
+      hash: 'a'.repeat(40),
+      parents: ['b'.repeat(40), 'c'.repeat(40)],
+      subject: 'feat(replay): require explicit replay-visibility',
+      body: 'Portal mounts now opt in.\n\nRefs #1777',
+      author: 'Juan Lopez',
+      authorEmail: 'juan@example.com',
+      date: 1_760_000_000_000,
+      committer: 'Release Bot',
+      committerEmail: 'bot@example.com',
+      committerDate: 1_760_000_600_000,
+      isPushed: true,
+      tags: ['v2.1.228'],
+    });
+  });
+
+  it('omits the optional identity fields when git emits them empty', () => {
+    const fields = [...FIELDS];
+    fields[5] = '';
+    fields[7] = '';
+    fields[8] = '';
+    fields[9] = '';
+
+    const [commit] = parseLogRecords(buildRecord(fields), new Set());
+
+    expect(commit?.authorEmail).toBeUndefined();
+    expect(commit?.committer).toBeUndefined();
+    expect(commit?.committerEmail).toBeUndefined();
+    expect(commit?.committerDate).toBeUndefined();
+    expect(commit?.author).toBe('Juan Lopez');
+  });
+
+  it('reads multiple records and reports unpushed commits', () => {
+    const second = [...FIELDS];
+    second[0] = 'd'.repeat(40);
+
+    const commits = parseLogRecords(
+      `${buildRecord(FIELDS)}${buildRecord(second)}`,
+      new Set([FIELDS[0]!])
+    );
+
+    expect(commits).toHaveLength(2);
+    expect(commits[0]?.isPushed).toBe(true);
+    expect(commits[1]?.isPushed).toBe(false);
+  });
+});

--- a/packages/core/src/runtimes/git/node/checkout/ops/log.ts
+++ b/packages/core/src/runtimes/git/node/checkout/ops/log.ts
@@ -14,8 +14,13 @@ export type Numstat = Map<string, { additions: number; deletions: number }>;
 
 const FIELD_SEP = '\x1f';
 const RECORD_SEP = '\x1e';
-// `%at` is the author date as unix epoch seconds; the wire carries epoch ms.
-export const LOG_FORMAT = `%H${FIELD_SEP}%P${FIELD_SEP}%s${FIELD_SEP}%b${FIELD_SEP}%an${FIELD_SEP}%at${FIELD_SEP}%D${RECORD_SEP}`;
+// `%at` and `%ct` are the author and committer dates as unix epoch seconds; the
+// wire carries epoch ms. Field order here is positional — it must stay in step
+// with the destructuring in `parseLogRecords`.
+export const LOG_FORMAT =
+  `%H${FIELD_SEP}%P${FIELD_SEP}%s${FIELD_SEP}%b${FIELD_SEP}` +
+  `%an${FIELD_SEP}%ae${FIELD_SEP}%at${FIELD_SEP}` +
+  `%cn${FIELD_SEP}%ce${FIELD_SEP}%ct${FIELD_SEP}%D${RECORD_SEP}`;
 
 export async function getLog(exec: BoundExec, options: GitLogOptions = {}): Promise<GitLogResult> {
   const maxCount = typeof options.limit === 'number' ? Math.max(1, Math.floor(options.limit)) : 50;
@@ -95,7 +100,11 @@ export function parseLogRecords(stdout: string, remoteReachable: Set<string>): C
         subject = '',
         body = '',
         author = '',
+        authorEmail = '',
         date = '',
+        committer = '',
+        committerEmail = '',
+        committerDate = '',
         decorations = '',
       ] = record.split(FIELD_SEP);
       return {
@@ -104,11 +113,22 @@ export function parseLogRecords(stdout: string, remoteReachable: Set<string>): C
         subject,
         body: body.trim(),
         author,
-        date: (Number.parseInt(date, 10) || 0) * 1000,
+        // The optional identity fields stay absent rather than empty so a
+        // consumer never renders a blank name or an epoch-zero date.
+        authorEmail: authorEmail || undefined,
+        date: toEpochMs(date),
+        committer: committer || undefined,
+        committerEmail: committerEmail || undefined,
+        committerDate: committerDate ? toEpochMs(committerDate) : undefined,
         isPushed: remoteReachable.has(hash),
         tags: parseDecoratedTags(decorations),
       };
     });
+}
+
+/** Git emits epoch seconds; the wire carries epoch milliseconds (convention 4). */
+function toEpochMs(epochSeconds: string): number {
+  return (Number.parseInt(epochSeconds, 10) || 0) * 1000;
 }
 
 export function parseDecoratedTags(decorations: string): string[] {

--- a/packages/core/src/workspace-server/releases.test.ts
+++ b/packages/core/src/workspace-server/releases.test.ts
@@ -100,7 +100,7 @@ describe('workspace-server release contracts', () => {
   );
 
   it('extracts a protocol major and rejects invalid protocol versions', () => {
-    expect(PROTOCOL_VERSION).toBe('1.0.0');
+    expect(PROTOCOL_VERSION).toBe('1.1.0');
     expect(protocolMajor()).toBe(1);
     expect(protocolMajor('2.3.4')).toBe(2);
     expect(() => protocolMajor('not-a-version')).toThrow(

--- a/packages/core/src/workspace-server/versions/index.ts
+++ b/packages/core/src/workspace-server/versions/index.ts
@@ -1,6 +1,6 @@
 import semver from 'semver';
 
-export const PROTOCOL_VERSION = '1.0.0';
+export const PROTOCOL_VERSION = '1.1.0';
 
 export function protocolMajor(version: string = PROTOCOL_VERSION): number {
   const parsed = semver.parse(version);


### PR DESCRIPTION
### Description

Branch commit rows in the source-control panel are currently click-to-expand only, and a long
subject is silently cut off with no way to read it. This adds three things to that surface:

- **Right-click context menu** on a commit row: *View commit details*, *Copy commit SHA*,
  *Copy commit message*.
- **Commit details modal**: full message body, author/committer identity and dates, full SHA
  with parents and tags, pushed status, and the changed files with +/− stats. Files in the
  modal are display-only for now — wiring them to open the diff is a small follow-up
  (`CommitFilesList` in `commits-list.tsx` already has the `openDiff` logic).
- **Truncated-subject tooltip**: hovering a row shows the full subject, but only when the
  subject is actually truncated. Truncation is measured when the tooltip asks to open
  (controlled `open` + `scrollWidth > clientWidth` on the subject span), so a panel resize
  never leaves a stale answer and no `useEffect` is needed.

Supporting change in the git runtime: `git log` only captured `%an`/`%at`, so author email,
committer identity, and commit date were never available to render. `LOG_FORMAT` now also
captures `%ae %cn %ce %ct`.

#### High-risk callout (per `AGENTS.md`)

This touches the workspace-server wire contract, so flagging it explicitly:

- **`commitSchema` is wire-visible** — the git runtime mounts on `workspaceWireContract` and is
  served by remote workspace-server daemons. Every new field is therefore `.optional()`, so a
  newer desktop stays a tolerant reader of a daemon that omits them; a required field would make
  `.parse()` throw against any non-upgraded daemon.
- **`PROTOCOL_VERSION` `1.0.0` → `1.1.0`.** Minor only, deliberately: the *major* keys the
  release-channel artifact paths introduced in 8950a1d30, and these additions are backward
  compatible. Happy to drop the bump entirely if you would rather reserve minors for changes
  something actually negotiates on.
- **`LOG_FORMAT` parsing is positional** — `parseLogRecords` splits on `\x1f` and destructures by
  index, so the format string and the destructuring have to move together. The new
  `ops/log.test.ts` pins the placeholder count and the field mapping so they cannot drift apart.

### Related issues

None — this came out of using the branch commits panel, not from a filed issue.

### Testing

Full local gate against current `main`:

- `pnpm run format`, `pnpm run lint`, `pnpm run typecheck` — clean across all 9 projects.
- `packages/core`: 1414 passed / 12 skipped, including the new `ops/log.test.ts` and real-repo
  identity + epoch-ms assertions added to `git-checkout.test.ts`.
- App `node` project: 2820 passed / 1 skipped.
- App `browser` project: the two new files pass in real Chromium —
  `commit-details-modal.test.tsx` (context menu, modal content, display-only file list, no-body
  fallback, through the real `openModal` path) and `commit-row-tooltip.test.tsx` (real CDP hover;
  tooltip present in a 200px container, absent at 900px).

Manual verification in the running desktop app: right-click → menu → modal on a real commit;
both copy actions confirmed by pasting (SHA exact, message arrives as `subject\n\nbody`); tooltip
appears only when the subject is truncated, re-measures correctly after narrowing the panel, and
closes when the context menu opens; click-to-expand still works.

### Screenshot/Recording (if applicable)

Screenshots of the context menu, the details modal, and the tooltip can be added on request.

<img width="466" height="437" alt="Screenshot from 2026-08-13 12-57-21" src="https://github.com/user-attachments/assets/1ebcc63a-cb0b-4c20-b21f-f192ba0e3940" />
<img width="859" height="585" alt="image" src="https://github.com/user-attachments/assets/027788df-c83b-4f3a-8633-3b484b96fd2b" />
<img width="560" height="271" alt="Screenshot from 2026-08-13 14-01-33" src="https://github.com/user-attachments/assets/02018c73-d684-4ff6-90e1-972ec5698c44" />



<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
