### PR TITLE
fix(acp): preserve chats across session rematerialization

### DIFF
--- a/apps/emdash-desktop/src/core/features/conversations/api/contract.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/api/contract.ts
@@ -3,7 +3,19 @@ import {
   runtimeResolveErrorSchema,
   type RuntimeResolveError,
 } from '@emdash/core/primitives/runtime-resolution/api';
-import { acpApiContract, sessionSummarySchema } from '@emdash/core/runtimes/acp/api/client';
+import {
+  acpApiContract,
+  changeQueuePromptOrderInputSchema,
+  deleteQueuedPromptInputSchema,
+  editQueuedPromptInputSchema,
+  exportAcpTranscriptInputSchema,
+  historyPageDesktopInputSchema,
+  resolvePermissionInputSchema,
+  sendPromptInputSchema,
+  sessionSummarySchema,
+  setModeOptionInputSchema,
+  setModelOptionInputSchema,
+} from '@emdash/core/runtimes/acp/api/client';
 import { tuiAgentsContract, tuiSessionListSchema } from '@emdash/core/runtimes/tui-agents/api';
 import type { Result } from '@emdash/shared';
 import {
@@ -91,20 +103,17 @@ const conversationsAcpContract = defineContract({
   start: runtimeFallibleProcedure(conversationKey, acpApiContract.start.output),
   resume: runtimeFallibleProcedure(conversationKey, acpApiContract.resume.output),
   kill: runtimeFallibleProcedure(acpApiContract.kill.input, acpApiContract.kill.output),
-  sendPrompt: runtimeFallibleProcedure(
-    acpApiContract.sendPrompt.input,
-    acpApiContract.sendPrompt.output
-  ),
+  sendPrompt: runtimeFallibleProcedure(sendPromptInputSchema, acpApiContract.sendPrompt.output),
   editQueuedPrompt: runtimeFallibleProcedure(
-    acpApiContract.editQueuedPrompt.input,
+    editQueuedPromptInputSchema,
     acpApiContract.editQueuedPrompt.output
   ),
   deleteQueuedPrompt: runtimeFallibleProcedure(
-    acpApiContract.deleteQueuedPrompt.input,
+    deleteQueuedPromptInputSchema,
     acpApiContract.deleteQueuedPrompt.output
   ),
   changeQueuePromptOrder: runtimeFallibleProcedure(
-    acpApiContract.changeQueuePromptOrder.input,
+    changeQueuePromptOrderInputSchema,
     acpApiContract.changeQueuePromptOrder.output
   ),
   cancelTurn: runtimeFallibleProcedure(
@@ -112,27 +121,23 @@ const conversationsAcpContract = defineContract({
     acpApiContract.cancelTurn.output
   ),
   setModelOption: runtimeFallibleProcedure(
-    acpApiContract.setModelOption.input,
+    setModelOptionInputSchema,
     acpApiContract.setModelOption.output
   ),
   setModeOption: runtimeFallibleProcedure(
-    acpApiContract.setModeOption.input,
+    setModeOptionInputSchema,
     acpApiContract.setModeOption.output
   ),
   resolvePermission: runtimeFallibleProcedure(
-    acpApiContract.resolvePermission.input,
+    resolvePermissionInputSchema,
     acpApiContract.resolvePermission.output
   ),
-  setPromptDraft: runtimeFallibleProcedure(
-    acpApiContract.setPromptDraft.input,
-    acpApiContract.setPromptDraft.output
-  ),
   exportAcpTranscript: runtimeFallibleProcedure(
-    acpApiContract.exportAcpTranscript.input,
+    exportAcpTranscriptInputSchema,
     acpApiContract.exportAcpTranscript.output
   ),
   exportRawAcpLog: runtimeFallibleProcedure(
-    acpApiContract.exportRawAcpLog.input,
+    exportAcpTranscriptInputSchema,
     acpApiContract.exportRawAcpLog.output
   ),
   uploadAttachment: uploadFile({
@@ -148,7 +153,7 @@ const conversationsAcpContract = defineContract({
   }),
   deleteAttachment: runtimeFallibleProcedure(attachmentKey, acpApiContract.deleteAttachment.output),
   getHistory: runtimeFallibleProcedure(
-    acpApiContract.getHistory.input,
+    historyPageDesktopInputSchema,
     acpApiContract.getHistory.output
   ),
   sessions: desktopAcpSessions,

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
@@ -3,11 +3,12 @@ import type {
   AttachmentMimeType,
   AttachmentRef,
   PromptAttachment,
-  PromptDraft,
   PromptInput,
   QueuedPrompt,
   SessionMcpServer,
 } from '@emdash/core/runtimes/acp/api/client';
+import type { Result } from '@emdash/shared';
+import { createScope, type Scope } from '@emdash/shared/concurrency';
 import type {
   CommandItem,
   ComposerEffortOption,
@@ -26,12 +27,25 @@ import {
 import { getChatUiRuntime } from '@core/features/conversations/api/browser/chat/chat-ui-runtime';
 import { getSharedChatContext } from '@core/features/conversations/api/browser/chat/shared-chat-context';
 import { conversationRegistry } from '@core/features/conversations/api/browser/stores/conversation-registry';
+import {
+  ACP_DRAFT_MAX_LENGTH,
+  acpDraftMemento,
+  type AcpDraftState,
+} from '@core/features/conversations/contributions/mementos';
+import { conversationSubject } from '@core/features/conversations/contributions/subject';
 import type { ProjectHostAccess } from '@core/features/projects/api/browser/stores/project-context';
 import { getProjectSshConnectionId } from '@core/features/projects/api/browser/stores/project-selectors';
 import { getHostClient } from '@core/primitives/desktop-host/browser/host-client';
 import { log } from '@core/primitives/logging/browser/logger';
+import {
+  getMementoClient,
+  type MementoHandle,
+  type SubjectSpace,
+} from '@core/primitives/mementos/browser';
+import { seedNonEmptyHistory } from './acp-history';
 import { AcpLiveSession, AcpStartError, asValueSource } from './acp-live-session';
 import { bindSessionTerminalOutputs } from './acp-terminal-output-binding';
+import { isActivationLostError } from './activation-errors';
 
 export interface AgentAffordances {
   isWorking: boolean;
@@ -57,6 +71,7 @@ type PermissionQueueItem = {
 export type AcpLoadError =
   | { kind: 'auth_required'; message: string }
   | { kind: 'unavailable'; message: string }
+  | { kind: 'inactive'; message: string }
   | { kind: 'generic'; message: string };
 
 export class AcpChatStore {
@@ -72,10 +87,12 @@ export class AcpChatStore {
   private _view: ChatView | null = null;
   private _bootstrapped = false;
   private _unsubs: Array<() => void> = [];
-  private _draftRev = 0;
-  private _pendingDraftRev: number | null = null;
-  private _draftTimer: number | null = null;
+  private readonly _scope: Scope;
+  private readonly _draftSpace: SubjectSpace<'conversation'>;
+  private readonly _draftHandle: MementoHandle<AcpDraftState>;
   private readonly _disposeHostReaction: () => void;
+  private _connectPromise: Promise<AcpLiveSession> | null = null;
+  private _disposed = false;
 
   constructor(
     readonly conversationId: string,
@@ -84,9 +101,12 @@ export class AcpChatStore {
     readonly hostAccess?: ProjectHostAccess
   ) {
     this.chatContext = getSharedChatContext();
+    this._scope = createScope({ label: `acp-chat:${conversationId}` });
     this.chatState = getChatUiRuntime().createChatState(this.chatContext, {
       uri: conversationId,
     });
+    this._draftSpace = getMementoClient().subject(conversationSubject({ conversationId }));
+    this._draftHandle = this._draftSpace.handle(acpDraftMemento);
     registerConversationCommands(conversationId, () =>
       this.commands.map((command) => command.name)
     );
@@ -138,6 +158,21 @@ export class AcpChatStore {
           void this._runBootstrap();
         }
       }
+    );
+    this._draftHandle.autoPersist(
+      () => ({
+        version: '1' as const,
+        text: this.draftText.slice(0, ACP_DRAFT_MAX_LENGTH),
+      }),
+      this._scope
+    );
+    void this._draftSpace.ready.then(
+      () => {
+        runInAction(() => {
+          this.draftText = this._draftHandle.value.text;
+        });
+      },
+      (error: unknown) => getMementoClient().reportError(error)
     );
   }
 
@@ -233,7 +268,7 @@ export class AcpChatStore {
       isWorking: state?.isGenerating ?? false,
       isBusy: state?.isGenerating ?? false,
       hasPendingPermission: (state?.pendingPermissions.length ?? 0) > 0,
-      canSubmit: liveActionsEnabled && (state?.canSubmit ?? false),
+      canSubmit: liveActionsEnabled && (state?.canSubmit ?? this.loadError?.kind === 'inactive'),
       canCancel: liveActionsEnabled && (state?.canCancel ?? false),
     };
   }
@@ -301,6 +336,7 @@ export class AcpChatStore {
   ): void {
     if (this.hostAccess?.liveAction.kind === 'disabled') return;
     const promptAttachments = attachments.map((attachment) => attachment.ref);
+    this.draftText = '';
     if (!this.affordances.isWorking) {
       const optimisticId = `optimistic:user:${Date.now()}`;
       this.chatState.session.setPendingPrompt({
@@ -320,9 +356,6 @@ export class AcpChatStore {
   setDraftText(text: string): void {
     if (text === this.draftText) return;
     this.draftText = text;
-    this._draftRev += 1;
-    this._pendingDraftRev = this._draftRev;
-    this._scheduleDraftWrite(text, this._draftRev);
   }
 
   stop(): void {
@@ -335,36 +368,29 @@ export class AcpChatStore {
   }
 
   setModel(model: string): void {
-    void this.session
-      ?.setModelOption('model', model)
-      .then((result) => {
-        if (!result.success) this._toastError('Failed to change model', result.error);
-      })
-      .catch((error: unknown) => this._toastError('Failed to change model', error));
+    void this._withConnectedSession('Failed to change model', (session) =>
+      session.setModelOption('model', model)
+    );
   }
 
   setMode(modeId: string): void {
-    void this.session
-      ?.setModeOption(modeId)
-      .then((result) => {
-        if (!result.success) this._toastError('Failed to change session mode', result.error);
-      })
-      .catch((error: unknown) => this._toastError('Failed to change session mode', error));
+    void this._withConnectedSession('Failed to change session mode', (session) =>
+      session.setModeOption(modeId)
+    );
   }
 
   setEffort(effort: string): void {
-    void this.session
-      ?.setModelOption('effort', effort)
-      .then((result) => {
-        if (!result.success) this._toastError('Failed to change effort', result.error);
-      })
-      .catch((error: unknown) => this._toastError('Failed to change effort', error));
+    void this._withConnectedSession('Failed to change effort', (session) =>
+      session.setModelOption('effort', effort)
+    );
   }
 
   resolvePermission(optionId: string): void {
     const request = this.permissionQueue[0];
     if (!request) return;
-    void this.session?.resolvePermission(request.requestId, optionId);
+    void this._withConnectedSession('Failed to resolve permission', (session) =>
+      session.resolvePermission(request.requestId, optionId)
+    );
   }
 
   editQueuedPrompt(id: string, text: string): void {
@@ -375,30 +401,21 @@ export class AcpChatStore {
       hiddenContext: existing.hiddenContext,
       attachments: existing.attachments,
     };
-    void this.session
-      ?.editQueuedPrompt(id, input)
-      .then((result) => {
-        if (!result.success) this._toastError('Failed to edit queued prompt', result.error);
-      })
-      .catch((error: unknown) => this._toastError('Failed to edit queued prompt', error));
+    void this._withConnectedSession('Failed to edit queued prompt', (session) =>
+      session.editQueuedPrompt(id, input)
+    );
   }
 
   deleteQueuedPrompt(id: string): void {
-    void this.session
-      ?.deleteQueuedPrompt(id)
-      .then((result) => {
-        if (!result.success) this._toastError('Failed to delete queued prompt', result.error);
-      })
-      .catch((error: unknown) => this._toastError('Failed to delete queued prompt', error));
+    void this._withConnectedSession('Failed to delete queued prompt', (session) =>
+      session.deleteQueuedPrompt(id)
+    );
   }
 
   reorderQueuedPrompts(ids: string[]): void {
-    void this.session
-      ?.changeQueuePromptOrder(ids)
-      .then((result) => {
-        if (!result.success) this._toastError('Failed to reorder queued prompts', result.error);
-      })
-      .catch((error: unknown) => this._toastError('Failed to reorder queued prompts', error));
+    void this._withConnectedSession('Failed to reorder queued prompts', (session) =>
+      session.changeQueuePromptOrder(ids)
+    );
   }
 
   sendQueuedPromptNow(id: string): void {
@@ -410,15 +427,89 @@ export class AcpChatStore {
   }
 
   dispose(): void {
+    this._disposed = true;
     this._disposeHostReaction();
     unregisterConversationCommands(this.conversationId);
-    if (this._draftTimer !== null) {
-      window.clearTimeout(this._draftTimer);
-      this._draftTimer = null;
-    }
     this._unsubs.splice(0).forEach((unsub) => unsub());
     this.session?.dispose();
     this.chatState.dispose();
+    void this._scope
+      .dispose()
+      .then(() => this._draftSpace.release())
+      .catch((error: unknown) => getMementoClient().reportError(error));
+  }
+
+  private _connectSession(): Promise<AcpLiveSession> {
+    const current = this.session;
+    if (
+      current &&
+      current.activationId.current() !== null &&
+      current.sessionState.current().lifecycle !== 'closed'
+    ) {
+      return Promise.resolve(current);
+    }
+    if (this._connectPromise) return this._connectPromise;
+
+    const pending = (async () => {
+      const clientSession = await AcpLiveSession.create(this.conversationId);
+      try {
+        const history = await clientSession.getHistory(undefined, 100);
+        if (!history.success) throw resultError(history.error);
+        if (this._disposed) throw new Error('ACP chat store was disposed while connecting');
+
+        runInAction(() => {
+          this.session?.dispose();
+          this.session = clientSession;
+          seedNonEmptyHistory(history.data.turns, (turns) =>
+            this.chatState.transcript.history.seed(turns)
+          );
+          this._subscribeLiveSession(clientSession);
+          this.historyLoading = false;
+          this.loadError = null;
+          this._syncMessageCount();
+        });
+        return clientSession;
+      } catch (error) {
+        clientSession.dispose();
+        throw error;
+      }
+    })().finally(() => {
+      if (this._connectPromise === pending) this._connectPromise = null;
+    });
+    this._connectPromise = pending;
+    return pending;
+  }
+
+  private _loseSession(session: AcpLiveSession): void {
+    if (this.session !== session) return;
+    this._unsubs.splice(0).forEach((unsub) => unsub());
+    this.session = null;
+    session.dispose();
+    this.historyLoading = false;
+    this.loadError = {
+      kind: 'inactive',
+      message: 'This chat is inactive. Retry or send a message to reconnect it.',
+    };
+    this._syncMessageCount();
+  }
+
+  private async _withConnectedSession<T>(
+    title: string,
+    work: (session: AcpLiveSession) => Promise<Result<T, unknown>>
+  ): Promise<void> {
+    if (this.hostAccess?.liveAction.kind === 'disabled') return;
+    try {
+      const session = await this._connectSession();
+      const result = await work(session);
+      if (result.success) return;
+      if (isActivationLostError(result.error)) {
+        runInAction(() => this._loseSession(session));
+        return;
+      }
+      this._toastError(title, result.error);
+    } catch (error) {
+      this._toastError(title, error);
+    }
   }
 
   private async _runBootstrap(): Promise<void> {
@@ -435,21 +526,7 @@ export class AcpChatStore {
     const providerId = conversationRegistry.get(this.taskId)?.conversations.get(this.conversationId)
       ?.data.providerId;
     try {
-      const clientSession = await AcpLiveSession.create(this.conversationId);
-
-      const history = await clientSession.getHistory(undefined, 100);
-      if (!history.success) throw resultError(history.error);
-
-      runInAction(() => {
-        this.session?.dispose();
-        this.session = clientSession;
-        this.chatState.transcript.history.seed(history.data.turns);
-        this._subscribeLiveSession(clientSession);
-        this._applyDraftSnapshot(clientSession.draft.current());
-        this.historyLoading = false;
-        this.loadError = null;
-        this._syncMessageCount();
-      });
+      await this._connectSession();
     } catch (error) {
       log.error('ACP chat bootstrap failed', {
         conversationId: this.conversationId,
@@ -502,12 +579,6 @@ export class AcpChatStore {
     hiddenContext?: string | Promise<string | undefined>
   ): Promise<void> {
     if (this.hostAccess?.liveAction.kind === 'disabled') return;
-    const session = this.session;
-    if (!session) {
-      this._toastError('Failed to send message', new Error('ACP session is not connected'));
-      return;
-    }
-
     let resolvedHiddenContext: string | undefined;
     try {
       resolvedHiddenContext = await hiddenContext;
@@ -519,11 +590,18 @@ export class AcpChatStore {
     }
 
     try {
-      const result = await session.sendPrompt({
+      let session = await this._connectSession();
+      const prompt: PromptInput = {
         text,
         ...(resolvedHiddenContext ? { hiddenContext: resolvedHiddenContext } : {}),
         ...(attachments.length > 0 ? { attachments } : {}),
-      });
+      };
+      let result = await session.sendPrompt(prompt);
+      if (!result.success && isActivationLostError(result.error)) {
+        runInAction(() => this._loseSession(session));
+        session = await this._connectSession();
+        result = await session.sendPrompt(prompt);
+      }
       if (!result.success) this._toastError('Failed to send message', result.error);
     } catch (error) {
       this._toastError('Failed to send message', error);
@@ -536,27 +614,29 @@ export class AcpChatStore {
 
     const shouldCancelActiveTurn = this.affordances.isWorking;
     const ids = [id, ...current.map((prompt) => prompt.id).filter((promptId) => promptId !== id)];
-    const reorderResult = await this.session?.changeQueuePromptOrder(ids);
-    if (!reorderResult?.success) {
-      this._toastError('Failed to send queued prompt', reorderResult?.error);
+    let session: AcpLiveSession;
+    try {
+      session = await this._connectSession();
+    } catch (error) {
+      this._toastError('Failed to send queued prompt', error);
+      return;
+    }
+    const reorderResult = await session.changeQueuePromptOrder(ids);
+    if (!reorderResult.success) {
+      this._toastError('Failed to send queued prompt', reorderResult.error);
       return;
     }
 
     if (!shouldCancelActiveTurn) return;
-    const cancelResult = await this.session?.cancelTurn();
-    if (!cancelResult?.success) {
-      this._toastError('Failed to send queued prompt', cancelResult?.error);
+    const cancelResult = await session.cancelTurn();
+    if (!cancelResult.success) {
+      this._toastError('Failed to send queued prompt', cancelResult.error);
     }
   }
 
   private async _exportTranscript(kind: 'parsed' | 'raw'): Promise<void> {
-    const session = this.session;
-    if (!session) {
-      this._toastError('Failed to export transcript', new Error('Chat is not loaded.'));
-      return;
-    }
-
     try {
+      const session = await this._connectSession();
       const result =
         kind === 'raw' ? await session.exportRawAcpLog() : await session.exportTranscript();
       if (!result.success) {
@@ -597,64 +677,30 @@ export class AcpChatStore {
         onTurnCommitted: () => void this._refreshHistory(),
       }
     );
+    const activationId = session.activationId.current();
+    const detectHandleLoss = (): void => {
+      if (this.session !== session) return;
+      const currentActivationId = session.activationId.current();
+      if (
+        currentActivationId !== activationId ||
+        currentActivationId === null ||
+        session.sessionState.current().lifecycle === 'closed'
+      ) {
+        this._loseSession(session);
+      }
+    };
     this._unsubs.push(
       disconnectChatSession,
       this._bindTerminalOutputs(session),
       session.sessionState.onChange(() =>
         runInAction(() => {
           this._syncMessageCount();
+          detectHandleLoss();
         })
       ),
       session.activeTurn.onChange(() => runInAction(() => this._syncMessageCount())),
-      session.draft.onChange((draft) =>
-        runInAction(() => {
-          this._applyDraftSnapshot(draft);
-        })
-      )
+      session.activationId.onChange(() => runInAction(detectHandleLoss))
     );
-  }
-
-  private _scheduleDraftWrite(text: string, rev: number): void {
-    if (this._draftTimer !== null) window.clearTimeout(this._draftTimer);
-    this._draftTimer = window.setTimeout(() => {
-      this._draftTimer = null;
-      const draft = { rev, input: text.trim().length > 0 ? { text } : null };
-      void this.session
-        ?.setPromptDraft(draft)
-        .then((result) => {
-          if (!result.success) this._toastError('Failed to sync draft', result.error);
-          if (result.success && draft.input === null && this._pendingDraftRev === rev) {
-            runInAction(() => {
-              this._pendingDraftRev = null;
-            });
-          }
-        })
-        .catch((error: unknown) => this._toastError('Failed to sync draft', error));
-    }, 300);
-  }
-
-  private _applyDraftSnapshot(draft: PromptDraft | null | undefined): void {
-    if (draft === undefined) return;
-    if (draft === null) {
-      if (this._pendingDraftRev === null) {
-        this._draftRev += 1;
-        this.draftText = '';
-      }
-      return;
-    }
-
-    if (this._pendingDraftRev !== null) {
-      if (draft.rev >= this._pendingDraftRev) {
-        this._draftRev = Math.max(this._draftRev, draft.rev);
-        this._pendingDraftRev = null;
-      }
-      return;
-    }
-
-    if (draft.rev >= this._draftRev) {
-      this._draftRev = draft.rev;
-      this.draftText = draft.text;
-    }
   }
 
   private _bindTerminalOutputs(session: AcpLiveSession): () => void {
@@ -667,8 +713,14 @@ export class AcpChatStore {
     const history = await this.session?.getHistory(undefined, 100);
     if (!history?.success) return;
     runInAction(() => {
+      if (
+        !seedNonEmptyHistory(history.data.turns, (turns) =>
+          this.chatState.transcript.history.seed(turns)
+        )
+      ) {
+        return;
+      }
       this.chatState.session.setPendingPrompt(null);
-      this.chatState.transcript.history.seed(history.data.turns);
       this._syncMessageCount();
     });
   }

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-history.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-history.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { seedNonEmptyHistory } from './acp-history';
+
+describe('seedNonEmptyHistory', () => {
+  it('does not clear an existing transcript when rematerialization returns no turns', () => {
+    let transcript = ['existing turn'];
+
+    const seeded = seedNonEmptyHistory<string>([], (turns) => {
+      transcript = turns;
+    });
+
+    expect(seeded).toBe(false);
+    expect(transcript).toEqual(['existing turn']);
+  });
+
+  it('replaces the transcript when provider history contains turns', () => {
+    let transcript = ['existing turn'];
+
+    const seeded = seedNonEmptyHistory(['replayed turn'], (turns) => {
+      transcript = turns;
+    });
+
+    expect(seeded).toBe(true);
+    expect(transcript).toEqual(['replayed turn']);
+  });
+});

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-history.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-history.ts
@@ -1,0 +1,5 @@
+export function seedNonEmptyHistory<T>(turns: T[], seed: (turns: T[]) => void): boolean {
+  if (turns.length === 0) return false;
+  seed(turns);
+  return true;
+}

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.test.ts
@@ -2,14 +2,13 @@ import { createScope } from '@emdash/shared/concurrency';
 import { cell, flushStateTurn } from '@emdash/wire/state';
 import { reaction } from 'mobx';
 import { describe, expect, it, vi } from 'vitest';
-import { z } from 'zod';
 import { AcpLiveSession, remoteValueState } from './acp-live-session';
 
 describe('remoteValueState', () => {
   it('invalidates MobX reactions when the Wire state changes', async () => {
     const source = cell<number | undefined>(1);
     const scope = createScope({ label: 'remote-value-state-test' });
-    const state = remoteValueState(source, z.number(), scope);
+    const state = remoteValueState(source, scope);
     await state.ready;
 
     const seen: number[] = [];
@@ -29,14 +28,28 @@ describe('remoteValueState', () => {
     dispose();
     await scope.dispose();
   });
+
+  it('preserves the identity of contract-decoded snapshots', async () => {
+    const initial = { nested: { value: 1 } };
+    const source = cell<typeof initial | undefined>(initial);
+    const scope = createScope({ label: 'remote-value-state-identity-test' });
+    const state = remoteValueState(source, scope);
+    await state.ready;
+
+    expect(state.current()).toBe(initial);
+    expect(state.current().nested).toBe(initial.nested);
+    await scope.dispose();
+  });
 });
 
 describe('AcpLiveSession.sendPrompt', () => {
-  it('disables the Wire deadline for the turn-long prompt call', async () => {
+  it('uses its captured activation fence and disables the Wire deadline', async () => {
     const sendPrompt = vi.fn(async () => ({ success: true, data: { queued: false } }));
     const session = Object.assign(Object.create(AcpLiveSession.prototype), {
       conversationId: 'conversation-1',
       client: { sendPrompt },
+      activationFence: 'activation-1',
+      activationId: { current: () => 'replacement-activation' },
     }) as AcpLiveSession;
 
     await session.sendPrompt({ text: 'hello' });
@@ -46,8 +59,21 @@ describe('AcpLiveSession.sendPrompt', () => {
         conversationId: 'conversation-1',
         prompt: { text: 'hello' },
         placement: undefined,
+        activationId: 'activation-1',
       },
       { timeoutMs: 0 }
     );
+  });
+
+  it('rejects terminal reads after its activation has been replaced', async () => {
+    const session = Object.assign(Object.create(AcpLiveSession.prototype), {
+      conversationId: 'conversation-1',
+      activationFence: 'activation-1',
+      activationId: { current: () => 'replacement-activation' },
+      disposed: false,
+      terminalLogs: new Map(),
+    }) as AcpLiveSession;
+
+    await expect(session.terminalOutput('terminal-1')).rejects.toThrow(/activation changed/i);
   });
 });

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.ts
@@ -1,21 +1,17 @@
-import {
-  planStateSchema,
-  promptDraftSchema,
-  sessionUsageSchema,
-  sessionConfigStateSchema,
-  sessionMcpServerSchema,
-  sessionStateSchema,
-  terminalStateSchema,
-  transcriptTurnSchema,
-  type AttachmentMimeType,
-  type AttachmentRef,
-  type AcpRuntimeError,
-  type HistoryPage,
-  type PromptDraftUpdate,
-  type PromptInput,
-  type PromptPlacement,
-  type SessionState,
-  type TerminalState,
+import type {
+  AttachmentMimeType,
+  AttachmentRef,
+  AcpRuntimeError,
+  HistoryPage,
+  PlanState,
+  PromptInput,
+  PromptPlacement,
+  SessionConfigState,
+  SessionMcpServer,
+  SessionState,
+  SessionUsage,
+  TerminalState,
+  TranscriptTurn,
 } from '@emdash/core/runtimes/acp/api/client';
 import type { RuntimeResolveError } from '@emdash/core/services/runtime-broker/api';
 import { createEmitter, type Result, type Unsubscribe } from '@emdash/shared';
@@ -25,7 +21,6 @@ import { ReplicaLog, createLineLogStore } from '@emdash/wire/live';
 import { type BlobSource } from '@emdash/wire/rpc';
 import { observe, remote, whenReady, type Readable } from '@emdash/wire/state';
 import { observable, runInAction } from 'mobx';
-import { z } from 'zod';
 import {
   getConversationsClient,
   type ConversationsClient,
@@ -83,14 +78,14 @@ export class AcpStartError extends Error {
 }
 
 export class AcpLiveSession {
+  readonly activationId: RemoteValueState<string | null>;
   readonly sessionState: RemoteValueState<SessionState>;
-  readonly config: RemoteValueState<z.infer<typeof sessionConfigStateSchema>>;
-  readonly usage: RemoteValueState<z.infer<typeof sessionUsageSchema> | null>;
-  readonly plan: RemoteValueState<z.infer<typeof planStateSchema> | null>;
-  readonly activeTurn: RemoteValueState<z.infer<typeof transcriptTurnSchema> | null>;
-  readonly draft: RemoteValueState<z.infer<typeof promptDraftSchema> | null>;
+  readonly config: RemoteValueState<SessionConfigState>;
+  readonly usage: RemoteValueState<SessionUsage | null>;
+  readonly plan: RemoteValueState<PlanState | null>;
+  readonly activeTurn: RemoteValueState<TranscriptTurn | null>;
   readonly terminals: RemoteValueState<TerminalState[]>;
-  readonly mcpServers: RemoteValueState<Array<z.infer<typeof sessionMcpServerSchema>>>;
+  readonly mcpServers: RemoteValueState<SessionMcpServer[]>;
   private readonly scope = createScope({ label: 'acp-live-session' });
   private readonly terminalLogs = new Map<
     string,
@@ -100,7 +95,8 @@ export class AcpLiveSession {
 
   private constructor(
     readonly conversationId: string,
-    private readonly client: ConversationsClient['acp']
+    private readonly client: ConversationsClient['acp'],
+    private readonly activationFence: string
   ) {
     const key = { conversationId };
     const sessionRemote = remote(conversationsContract.acp.session, client.session, {
@@ -108,26 +104,14 @@ export class AcpLiveSession {
       lingerMs: 15_000,
     });
     const member = sessionRemote(key);
-    this.sessionState = remoteValueState(member.states.state, sessionStateSchema, this.scope);
-    this.config = remoteValueState(member.states.config, sessionConfigStateSchema, this.scope);
-    this.usage = remoteValueState(member.states.usage, sessionUsageSchema.nullable(), this.scope);
-    this.plan = remoteValueState(member.states.plan, planStateSchema.nullable(), this.scope);
-    this.activeTurn = remoteValueState(
-      member.states.activeTurn,
-      transcriptTurnSchema.nullable(),
-      this.scope
-    );
-    this.draft = remoteValueState(member.states.draft, promptDraftSchema.nullable(), this.scope);
-    this.terminals = remoteValueState(
-      member.states.terminals,
-      z.array(terminalStateSchema),
-      this.scope
-    );
-    this.mcpServers = remoteValueState(
-      member.states.mcpServers,
-      z.array(sessionMcpServerSchema),
-      this.scope
-    );
+    this.activationId = remoteValueState(member.states.activationId, this.scope);
+    this.sessionState = remoteValueState(member.states.state, this.scope);
+    this.config = remoteValueState(member.states.config, this.scope);
+    this.usage = remoteValueState(member.states.usage, this.scope);
+    this.plan = remoteValueState(member.states.plan, this.scope);
+    this.activeTurn = remoteValueState(member.states.activeTurn, this.scope);
+    this.terminals = remoteValueState(member.states.terminals, this.scope);
+    this.mcpServers = remoteValueState(member.states.mcpServers, this.scope);
   }
 
   static async create(conversationId: string): Promise<AcpLiveSession> {
@@ -139,21 +123,27 @@ export class AcpLiveSession {
     if (!result.success) {
       throw new AcpStartError(result.error);
     }
-    const session = new AcpLiveSession(conversationId, client);
+    const session = new AcpLiveSession(conversationId, client, result.data.activationId);
     try {
       await withTimeout(
         Promise.all([
+          session.activationId.ready,
           session.sessionState.ready,
           session.config.ready,
           session.usage.ready,
           session.plan.ready,
           session.activeTurn.ready,
-          session.draft.ready,
           session.terminals.ready,
           session.mcpServers.ready,
         ]),
         'Timed out connecting ACP live models'
       );
+      if (
+        session.activationId.current() !== result.data.activationId ||
+        session.sessionState.current().lifecycle === 'closed'
+      ) {
+        throw new Error('ACP activation changed while connecting live models');
+      }
       return session;
     } catch (error) {
       session.dispose();
@@ -161,7 +151,7 @@ export class AcpLiveSession {
     }
   }
 
-  start(): Promise<Result<{ sessionId: string }, unknown>> {
+  start(): Promise<Result<{ sessionId: string; activationId: string }, unknown>> {
     return this.client.start({ conversationId: this.conversationId });
   }
 
@@ -178,19 +168,28 @@ export class AcpLiveSession {
   }
 
   getHistory(before?: number, limit = 50): Promise<Result<HistoryPage, unknown>> {
-    return this.client.getHistory({ conversationId: this.conversationId, before, limit });
+    return this.client.getHistory({
+      conversationId: this.conversationId,
+      before,
+      limit,
+      activationId: this.activationFence,
+    });
   }
 
   async exportTranscript(): Promise<Result<string, unknown>> {
     const result = await this.client.exportAcpTranscript({
       conversationId: this.conversationId,
+      activationId: this.activationFence,
     });
     if (!result.success) return result;
     return { success: true, data: result.data.transcript };
   }
 
   async exportRawAcpLog(): Promise<Result<string, unknown>> {
-    const result = await this.client.exportRawAcpLog({ conversationId: this.conversationId });
+    const result = await this.client.exportRawAcpLog({
+      conversationId: this.conversationId,
+      activationId: this.activationFence,
+    });
     if (!result.success) return result;
     return { success: true, data: result.data.log };
   }
@@ -244,37 +243,60 @@ export class AcpLiveSession {
     placement?: PromptPlacement
   ): Promise<Result<{ queued: boolean }, unknown>> {
     return this.client.sendPrompt(
-      { conversationId: this.conversationId, prompt, placement },
+      {
+        conversationId: this.conversationId,
+        prompt,
+        placement,
+        activationId: this.activationFence,
+      },
       { timeoutMs: 0 }
     );
   }
 
   editQueuedPrompt(id: string, input: PromptInput): Promise<Result<void, unknown>> {
-    return this.client.editQueuedPrompt({ conversationId: this.conversationId, id, input });
+    return this.client.editQueuedPrompt({
+      conversationId: this.conversationId,
+      id,
+      input,
+      activationId: this.activationFence,
+    });
   }
 
   deleteQueuedPrompt(id: string): Promise<Result<void, unknown>> {
-    return this.client.deleteQueuedPrompt({ conversationId: this.conversationId, id });
+    return this.client.deleteQueuedPrompt({
+      conversationId: this.conversationId,
+      id,
+      activationId: this.activationFence,
+    });
   }
 
   changeQueuePromptOrder(ids: string[]): Promise<Result<void, unknown>> {
-    return this.client.changeQueuePromptOrder({ conversationId: this.conversationId, ids });
+    return this.client.changeQueuePromptOrder({
+      conversationId: this.conversationId,
+      ids,
+      activationId: this.activationFence,
+    });
   }
 
   cancelTurn(): Promise<Result<void, unknown>> {
     return this.client.cancelTurn({ conversationId: this.conversationId });
   }
 
-  setPromptDraft(draft: PromptDraftUpdate): Promise<Result<void, unknown>> {
-    return this.client.setPromptDraft({ conversationId: this.conversationId, draft });
-  }
-
   setModelOption(dimension: 'model' | 'effort', value: string): Promise<Result<void, unknown>> {
-    return this.client.setModelOption({ conversationId: this.conversationId, dimension, value });
+    return this.client.setModelOption({
+      conversationId: this.conversationId,
+      dimension,
+      value,
+      activationId: this.activationFence,
+    });
   }
 
   setModeOption(value: string): Promise<Result<void, unknown>> {
-    return this.client.setModeOption({ conversationId: this.conversationId, value });
+    return this.client.setModeOption({
+      conversationId: this.conversationId,
+      value,
+      activationId: this.activationFence,
+    });
   }
 
   resolvePermission(requestId: string, optionId: string): Promise<Result<void, unknown>> {
@@ -282,10 +304,14 @@ export class AcpLiveSession {
       conversationId: this.conversationId,
       requestId,
       optionId,
+      activationId: this.activationFence,
     });
   }
 
   async terminalOutput(terminalId: string): Promise<AcpTerminalOutput> {
+    if (this.disposed || this.activationId.current() !== this.activationFence) {
+      throw new Error('ACP activation changed before terminal output could be attached');
+    }
     const existing = this.terminalLogs.get(terminalId);
     if (existing) return existing.output;
     const store = createLineLogStore();
@@ -301,7 +327,11 @@ export class AcpLiveSession {
     };
     this.terminalLogs.set(terminalId, { replica, output });
     await replica.ready;
-    if (this.disposed) void replica.dispose();
+    if (this.disposed || this.activationId.current() !== this.activationFence) {
+      this.terminalLogs.delete(terminalId);
+      await replica.dispose();
+      throw new Error('ACP activation changed while terminal output was attaching');
+    }
     return output;
   }
 
@@ -321,7 +351,6 @@ async function* singleChunk(data: Uint8Array): AsyncIterable<Uint8Array> {
 
 export function remoteValueState<T>(
   source: Readable<T | undefined>,
-  schema: z.ZodType<T>,
   parentScope: Scope
 ): RemoteValueState<T> {
   const scope = parentScope.child('remote-value-state');
@@ -334,13 +363,13 @@ export function remoteValueState<T>(
     if (settled.status === 'error' && settled.value === undefined) {
       throw readableError(settled.error);
     }
-    if (settled.value !== undefined) update(schema.parse(settled.value));
+    if (settled.value !== undefined) update(settled.value);
   });
   observe(
     source,
     (snapshot) => {
       if (snapshot.value !== undefined) {
-        const next = schema.parse(snapshot.value);
+        const next = snapshot.value;
         update(next);
         changes.emit(next);
       }

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/activation-errors.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/activation-errors.ts
@@ -1,0 +1,5 @@
+export function isActivationLostError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const type = (error as { type?: unknown }).type;
+  return type === 'stale_activation' || type === 'activation_missing';
+}

--- a/apps/emdash-desktop/src/core/features/conversations/contributions/mementos.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/contributions/mementos.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { ACP_DRAFT_MAX_LENGTH, acpDraftMemento, acpDraftSchema } from './mementos';
+
+describe('ACP draft memento', () => {
+  it('retains up to 5000 conversation drafts for 90 days', () => {
+    expect(acpDraftMemento.retention).toEqual({
+      tier: 'persisted',
+      maxAge: 90 * 24 * 60 * 60 * 1_000,
+      maxEntries: 5_000,
+    });
+  });
+
+  it('rejects draft text over 64 KiB', () => {
+    expect(
+      acpDraftSchema.schema.safeParse({ version: '1', text: 'a'.repeat(ACP_DRAFT_MAX_LENGTH) })
+        .success
+    ).toBe(true);
+    expect(
+      acpDraftSchema.schema.safeParse({
+        version: '1',
+        text: 'a'.repeat(ACP_DRAFT_MAX_LENGTH + 1),
+      }).success
+    ).toBe(false);
+  });
+});

--- a/apps/emdash-desktop/src/core/features/conversations/contributions/mementos.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/contributions/mementos.ts
@@ -1,0 +1,25 @@
+import { defineVersionedSchema } from '@emdash/core/primitives/versioned-schema/api';
+import { z } from 'zod';
+import { days, defineMemento } from '@core/primitives/mementos/api';
+import { conversationSubject } from './subject';
+
+export const ACP_DRAFT_MAX_LENGTH = 65_536;
+
+const acpDraftV1Schema = z.object({
+  version: z.literal('1'),
+  text: z.string().max(ACP_DRAFT_MAX_LENGTH),
+});
+
+export const acpDraftSchema = defineVersionedSchema().initial('1', acpDraftV1Schema).build();
+export type AcpDraftState = typeof acpDraftSchema.Type;
+
+export const acpDraftMemento = defineMemento({
+  id: 'conversations.acp-draft',
+  subject: conversationSubject,
+  schema: acpDraftSchema,
+  default: {
+    version: '1' as const,
+    text: '',
+  },
+  retention: { tier: 'persisted', maxAge: days(90), maxEntries: 5_000 },
+});

--- a/apps/emdash-desktop/src/core/features/conversations/contributions/subject.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/contributions/subject.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+import { defineSubject } from '@core/primitives/subjects/api';
+
+export const conversationSubject = defineSubject({
+  kind: 'conversation',
+  key: z.object({ conversationId: z.string().min(1) }),
+  encode: ({ conversationId }) => conversationId,
+});

--- a/apps/emdash-desktop/src/core/features/conversations/node/controller.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/controller.ts
@@ -3,6 +3,7 @@ import type { ConversationsRuntimeBroker } from '@core/features/conversations/ap
 import type { TaskSessionManager } from '@core/features/tasks/api/node/task-session-manager';
 import type { TelemetryService } from '@core/primitives/telemetry/api/telemetry';
 import type { AppDb } from '@core/services/app-db/node/db';
+import type { MementosRuntimeClient } from '@core/services/runtime-broker/api/clients';
 import type {
   CompensationRunner,
   ConversationWorkspaceIdentityResolver,
@@ -28,6 +29,7 @@ export function createConversationOperations(dependencies: {
   runtimes: ConversationsRuntimeBroker;
   hostIsReachable: (hostRef: SerializedHostRef) => boolean;
   workspaceIdentity: ConversationWorkspaceIdentityResolver;
+  getMementosRuntimeClient(): Promise<MementosRuntimeClient>;
 }) {
   const { db, telemetry, withCompensation } = dependencies;
   return {
@@ -43,7 +45,15 @@ export function createConversationOperations(dependencies: {
         workspaceIdentity: dependencies.workspaceIdentity,
       }),
     deleteConversation: (projectId: string, taskId: string, conversationId: string) =>
-      deleteConversation(db, dependencies.runtimes, projectId, taskId, conversationId, telemetry),
+      deleteConversation(
+        db,
+        dependencies.runtimes,
+        projectId,
+        taskId,
+        conversationId,
+        telemetry,
+        dependencies.getMementosRuntimeClient
+      ),
     hydrateConversation: (
       projectId: string,
       taskId: string,
@@ -80,6 +90,12 @@ export function createConversationOperations(dependencies: {
     linkConversationToTask: (input: Parameters<typeof linkConversationToTask>[1]) =>
       linkConversationToTask(db, input),
     deleteHostConversation: (conversationId: string) =>
-      deleteHostConversation(db, dependencies.runtimes, conversationId, telemetry),
+      deleteHostConversation(
+        db,
+        dependencies.runtimes,
+        conversationId,
+        telemetry,
+        dependencies.getMementosRuntimeClient
+      ),
   };
 }

--- a/apps/emdash-desktop/src/core/features/conversations/node/delete-host-conversation.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/delete-host-conversation.ts
@@ -1,9 +1,11 @@
 import { conversationEvents } from '@core/features/conversations/api/node/conversation-events';
 import type { ConversationRemovalBroker } from '@core/features/conversations/api/node/operations/conversation-removal';
 import { createConversationRegistry } from '@core/features/conversations/api/node/registry';
+import { conversationSubject } from '@core/features/conversations/contributions/subject';
 import type { TelemetryService } from '@core/primitives/telemetry/api/telemetry';
 import type { AppDb } from '@core/services/app-db/node/db';
 import { appDbPokes } from '@core/services/app-db/node/pokes';
+import type { MementosRuntimeClient } from '@core/services/runtime-broker/api/clients';
 import { removeConversationOrTombstone } from './remove-conversation';
 
 /**
@@ -16,13 +18,17 @@ export async function deleteHostConversation(
   db: AppDb,
   runtimes: ConversationRemovalBroker,
   conversationId: string,
-  telemetry: Pick<TelemetryService, 'capture'>
+  telemetry: Pick<TelemetryService, 'capture'>,
+  getMementosRuntimeClient: () => Promise<MementosRuntimeClient>
 ): Promise<void> {
   const row = createConversationRegistry(db).getLive(conversationId);
   // Idempotent toward the caller: an absent row is a no-op.
   if (!row) return;
 
   await removeConversationOrTombstone(db, runtimes, row);
+  const mementos = await getMementosRuntimeClient();
+  const deletedDraft = await mementos.deleteBySubject(conversationSubject({ conversationId }));
+  if (!deletedDraft.success) throw new Error(deletedDraft.error.message);
 
   conversationEvents._emit('conversation:deleted', conversationId);
   appDbPokes.conversations.poke({

--- a/apps/emdash-desktop/src/core/features/conversations/node/deleteConversation.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/deleteConversation.ts
@@ -5,9 +5,11 @@ import {
   conversationRegistryTable as conversations,
   liveConversations,
 } from '@core/features/conversations/api/node/registry';
+import { conversationSubject } from '@core/features/conversations/contributions/subject';
 import type { TelemetryService } from '@core/primitives/telemetry/api/telemetry';
 import type { AppDb } from '@core/services/app-db/node/db';
 import { appDbPokes } from '@core/services/app-db/node/pokes';
+import type { MementosRuntimeClient } from '@core/services/runtime-broker/api/clients';
 import { removeConversationOrTombstone } from './remove-conversation';
 
 /**
@@ -22,7 +24,8 @@ export async function deleteConversation(
   projectId: string,
   taskId: string,
   conversationId: string,
-  telemetry: Pick<TelemetryService, 'capture'>
+  telemetry: Pick<TelemetryService, 'capture'>,
+  getMementosRuntimeClient: () => Promise<MementosRuntimeClient>
 ): Promise<void> {
   const [convRow] = await db
     .select({
@@ -44,6 +47,9 @@ export async function deleteConversation(
   if (!convRow) return;
 
   await removeConversationOrTombstone(db, runtimes, convRow);
+  const mementos = await getMementosRuntimeClient();
+  const deletedDraft = await mementos.deleteBySubject(conversationSubject({ conversationId }));
+  if (!deletedDraft.success) throw new Error(deletedDraft.error.message);
 
   conversationEvents._emit('conversation:deleted', conversationId);
   appDbPokes.conversations.poke({ projectId, taskId });

--- a/apps/emdash-desktop/src/core/features/conversations/node/wire-controller.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/wire-controller.test.ts
@@ -48,14 +48,14 @@ type TestRuntimeTarget = typeof target;
 
 describe('createConversationsWireController', () => {
   it('passes ACP session start through without a client session id write', async () => {
-    const start = vi.fn(async () => ok({ sessionId: 'session-1' }));
+    const start = vi.fn(async () => ok({ sessionId: 'session-1', activationId: 'activation-1' }));
     const controller = setupController({
       client: { acp: { start } },
     });
 
     await expect(
       controller.call('acp.start', { conversationId: target.conversationId })
-    ).resolves.toEqual(ok({ sessionId: 'session-1' }));
+    ).resolves.toEqual(ok({ sessionId: 'session-1', activationId: 'activation-1' }));
 
     // The ACP runtime reports the session id into the conversation index (spec §3.3);
     // the desktop no longer persists it from the response.
@@ -74,7 +74,10 @@ describe('createConversationsWireController', () => {
 
     await expect(controller.call('acp.sendPrompt', input)).resolves.toEqual(ok({ queued: false }));
 
-    expect(sendPrompt).toHaveBeenCalledWith(input, { timeoutMs: 0 });
+    expect(sendPrompt).toHaveBeenCalledWith(
+      { ...input, activation: target.acpInput },
+      { timeoutMs: 0 }
+    );
   });
 
   it('records submitted TUI input only after a successful carriage return', async () => {
@@ -320,6 +323,7 @@ function setupController(options: {
     taskSessions: { getTask: vi.fn() },
     withCompensation: async ({ action }) => action(),
     hostIsReachable: () => true,
+    getMementosRuntimeClient: async () => ({}) as never,
     resolveTarget: async () => target,
     hooks,
   });

--- a/apps/emdash-desktop/src/core/features/conversations/node/wire-controller.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/wire-controller.ts
@@ -23,6 +23,7 @@ import type { TaskSessionManager } from '@core/features/tasks/api/node/task-sess
 import type { TelemetryService } from '@core/primitives/telemetry/api/telemetry';
 import type { AppDb } from '@core/services/app-db/node/db';
 import { tasks } from '@core/services/app-db/node/schema';
+import type { MementosRuntimeClient } from '@core/services/runtime-broker/api/clients';
 import { forwardLiveModel } from '@core/services/runtime-clients/node/forward-live-model';
 import { conversationsContract } from '../api';
 import {
@@ -69,6 +70,7 @@ export type CreateConversationsWireControllerOptions = Readonly<{
   taskSessions: Pick<TaskSessionManager, 'getTask'>;
   withCompensation: CompensationRunner;
   hostIsReachable: (hostRef: SerializedHostRef) => boolean;
+  getMementosRuntimeClient(): Promise<MementosRuntimeClient>;
 }>;
 
 export function createConversationsWireController(
@@ -92,6 +94,7 @@ export function createConversationsWireController(
     runtimes: options.runtimes,
     hostIsReachable: options.hostIsReachable,
     workspaceIdentity: options.workspaceIdentity,
+    getMementosRuntimeClient: options.getMementosRuntimeClient,
   });
   const target = (conversationId: string) => resolveTarget(conversationId);
   const run = <T, E>(
@@ -190,29 +193,49 @@ export function createConversationsWireController(
       kill: (input, meta) =>
         run(input.conversationId, (client) => client.acp.kill(input, callOptions(meta))),
       sendPrompt: (input, meta) =>
-        run(input.conversationId, (client) =>
-          client.acp.sendPrompt(input, { ...callOptions(meta), timeoutMs: 0 })
+        run(input.conversationId, (client, runtimeTarget) =>
+          client.acp.sendPrompt(
+            { ...input, activation: requireAcpInput(runtimeTarget) },
+            { ...callOptions(meta), timeoutMs: 0 }
+          )
         ),
       editQueuedPrompt: (input, meta) =>
-        run(input.conversationId, (client) =>
-          client.acp.editQueuedPrompt(input, callOptions(meta))
+        run(input.conversationId, (client, runtimeTarget) =>
+          client.acp.editQueuedPrompt(
+            { ...input, activation: requireAcpInput(runtimeTarget) },
+            callOptions(meta)
+          )
         ),
       deleteQueuedPrompt: (input, meta) =>
-        run(input.conversationId, (client) =>
-          client.acp.deleteQueuedPrompt(input, callOptions(meta))
+        run(input.conversationId, (client, runtimeTarget) =>
+          client.acp.deleteQueuedPrompt(
+            { ...input, activation: requireAcpInput(runtimeTarget) },
+            callOptions(meta)
+          )
         ),
       changeQueuePromptOrder: (input, meta) =>
-        run(input.conversationId, (client) =>
-          client.acp.changeQueuePromptOrder(input, callOptions(meta))
+        run(input.conversationId, (client, runtimeTarget) =>
+          client.acp.changeQueuePromptOrder(
+            { ...input, activation: requireAcpInput(runtimeTarget) },
+            callOptions(meta)
+          )
         ),
       cancelTurn: (input, meta) =>
         run(input.conversationId, (client) => client.acp.cancelTurn(input, callOptions(meta))),
       setModelOption: (input, meta) =>
-        run(input.conversationId, (client) => client.acp.setModelOption(input, callOptions(meta))),
+        run(input.conversationId, (client, runtimeTarget) =>
+          client.acp.setModelOption(
+            { ...input, activation: requireAcpInput(runtimeTarget) },
+            callOptions(meta)
+          )
+        ),
       setModeOption: async (input, meta) => {
         const runtimeTarget = await target(input.conversationId);
         return withConversationRuntime(options, Promise.resolve(runtimeTarget), async (client) => {
-          const result = await client.acp.setModeOption(input, callOptions(meta));
+          const result = await client.acp.setModeOption(
+            { ...input, activation: requireAcpInput(runtimeTarget) },
+            callOptions(meta)
+          );
           if (result.success) {
             await hooks.persistAcpMode(runtimeTarget, input.value);
           }
@@ -220,17 +243,26 @@ export function createConversationsWireController(
         });
       },
       resolvePermission: (input, meta) =>
-        run(input.conversationId, (client) =>
-          client.acp.resolvePermission(input, callOptions(meta))
+        run(input.conversationId, (client, runtimeTarget) =>
+          client.acp.resolvePermission(
+            { ...input, activation: requireAcpInput(runtimeTarget) },
+            callOptions(meta)
+          )
         ),
-      setPromptDraft: (input, meta) =>
-        run(input.conversationId, (client) => client.acp.setPromptDraft(input, callOptions(meta))),
       exportAcpTranscript: (input, meta) =>
-        run(input.conversationId, (client) =>
-          client.acp.exportAcpTranscript(input, callOptions(meta))
+        run(input.conversationId, (client, runtimeTarget) =>
+          client.acp.exportAcpTranscript(
+            { ...input, activation: requireAcpInput(runtimeTarget) },
+            callOptions(meta)
+          )
         ),
       exportRawAcpLog: (input, meta) =>
-        run(input.conversationId, (client) => client.acp.exportRawAcpLog(input, callOptions(meta))),
+        run(input.conversationId, (client, runtimeTarget) =>
+          client.acp.exportRawAcpLog(
+            { ...input, activation: requireAcpInput(runtimeTarget) },
+            callOptions(meta)
+          )
+        ),
       uploadAttachment: ({ conversationId, originalPath }, file, meta) =>
         run(conversationId, (client) =>
           client.acp.uploadAttachment({ conversationId, originalPath }, file, callOptions(meta))
@@ -242,7 +274,12 @@ export function createConversationsWireController(
           client.acp.deleteAttachment({ conversationId, attachmentId }, callOptions(meta))
         ),
       getHistory: (input, meta) =>
-        run(input.conversationId, (client) => client.acp.getHistory(input, callOptions(meta))),
+        run(input.conversationId, (client, runtimeTarget) =>
+          client.acp.getHistory(
+            { ...input, activation: requireAcpInput(runtimeTarget) },
+            callOptions(meta)
+          )
+        ),
       sessions: acpSessions,
       session: acpSession,
       terminalOutput: async ({ conversationId, terminalId }) =>
@@ -335,6 +372,11 @@ function missingAcpInputError(target: ConversationRuntimeTarget): Error {
     );
   }
   return new Error(`Conversation '${target.conversationId}' is not an ACP conversation`);
+}
+
+function requireAcpInput(target: ConversationRuntimeTarget): ConversationsAcpStartInput {
+  if (!target.acpInput) throw missingAcpInputError(target);
+  return target.acpInput;
 }
 
 async function resolveConversationRuntimeTarget(

--- a/apps/emdash-desktop/src/core/manifests/node/controllers.ts
+++ b/apps/emdash-desktop/src/core/manifests/node/controllers.ts
@@ -378,6 +378,7 @@ export const desktopNodeControllers = {
       logger,
       projects,
       providerSettings,
+      runtimeClients,
       runtimes,
       taskSessions,
       telemetry,
@@ -394,6 +395,7 @@ export const desktopNodeControllers = {
         workspaceIdentity,
         withCompensation: compensation,
         hostIsReachable,
+        getMementosRuntimeClient: runtimeClients.getMementosRuntimeClient,
       }),
   },
   previewServers: {

--- a/apps/emdash-desktop/src/core/manifests/shared/memento-catalog.ts
+++ b/apps/emdash-desktop/src/core/manifests/shared/memento-catalog.ts
@@ -1,3 +1,4 @@
+import { acpDraftMemento } from '@core/features/conversations/contributions/mementos';
 import {
   projectPanelLayoutsMemento,
   projectViewMemento,
@@ -24,6 +25,7 @@ import { workbenchHistoryMemento } from '@core/primitives/navigation/api/memento
  * subject-level prefetch.
  */
 export const mementoCatalog: readonly MementoCatalogEntry[] = [
+  acpDraftMemento,
   projectViewMemento,
   projectPanelLayoutsMemento,
   workspaceChromeMemento,

--- a/apps/emdash-desktop/src/main/bootstrap/boot/phases/runtimes.ts
+++ b/apps/emdash-desktop/src/main/bootstrap/boot/phases/runtimes.ts
@@ -1,4 +1,11 @@
 import { sql } from 'drizzle-orm';
+import {
+  conversationRegistryTable as conversations,
+  liveConversations,
+} from '@core/features/conversations/api/node/registry';
+import { conversationSubject } from '@core/features/conversations/contributions/subject';
+import { projectSubject } from '@core/features/projects/contributions/subject';
+import { taskSubject } from '@core/features/tasks/contributions/subject';
 import { projects, tasks } from '@core/services/app-db/node/schema';
 import { desktopRuntimes, type DesktopRuntimes } from '@main/gateway/desktop-runtimes';
 import { startDesktopWorkers, type DesktopWorkersHandle } from '@main/gateway/desktop-workers';
@@ -51,14 +58,26 @@ function runMementosOrphanPruning(
   runInBackground(
     'mementos-orphan-pruning',
     async () => {
-      const [taskRows, projectRows] = await Promise.all([
+      const [conversationRows, taskRows, projectRows] = await Promise.all([
+        database.db.select({ id: conversations.id }).from(conversations).where(liveConversations()),
         database.db.select({ id: tasks.id }).from(tasks),
         database.db.select({ id: projects.id }).from(projects),
       ]);
-      const [taskResult, projectResult] = await Promise.all([
-        mementos.deleteOrphans({ kind: 'task', validKeys: taskRows.map(({ id }) => id) }),
-        mementos.deleteOrphans({ kind: 'project', validKeys: projectRows.map(({ id }) => id) }),
+      const [conversationResult, taskResult, projectResult] = await Promise.all([
+        mementos.deleteOrphans({
+          kind: conversationSubject.kind,
+          validKeys: conversationRows.map(({ id }) => id),
+        }),
+        mementos.deleteOrphans({
+          kind: taskSubject.kind,
+          validKeys: taskRows.map(({ id }) => id),
+        }),
+        mementos.deleteOrphans({
+          kind: projectSubject.kind,
+          validKeys: projectRows.map(({ id }) => id),
+        }),
       ]);
+      if (!conversationResult.success) throw new Error(conversationResult.error.message);
       if (!taskResult.success) throw new Error(taskResult.error.message);
       if (!projectResult.success) throw new Error(projectResult.error.message);
       database.db.run(sql`DELETE FROM kv WHERE key LIKE 'view-state:%'`);

--- a/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
@@ -2,9 +2,34 @@ import type { SessionState } from '@emdash/core/runtimes/acp/api/client';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { installChatUiRuntime } from '@core/features/conversations/api/browser/chat/chat-ui-runtime';
 import { AcpChatStore } from '@core/features/conversations/browser/acp/acp-chat-store';
+import { ACP_DRAFT_MAX_LENGTH } from '@core/features/conversations/contributions/mementos';
+
+const mementoTestState = vi.hoisted(() => ({
+  value: { version: '1' as const, text: '' },
+  producer: null as null | (() => { version: '1'; text: string }),
+}));
 
 vi.mock('@core/features/conversations/api/browser/chat/shared-chat-context', () => ({
   getSharedChatContext: () => ({}),
+}));
+
+vi.mock('@core/primitives/mementos/browser', () => ({
+  getMementoClient: () => ({
+    reportError: vi.fn(),
+    subject: () => ({
+      ready: Promise.resolve(),
+      release: vi.fn(async () => {}),
+      handle: () => ({
+        get value() {
+          return mementoTestState.value;
+        },
+        autoPersist: vi.fn((producer) => {
+          mementoTestState.producer = producer;
+          return vi.fn();
+        }),
+      }),
+    }),
+  }),
 }));
 
 const setPendingPrompt = vi.fn();
@@ -34,6 +59,8 @@ describe('AcpChatStore prompt submission', () => {
 
   beforeEach(() => {
     setPendingPrompt.mockClear();
+    mementoTestState.value = { version: '1', text: '' };
+    mementoTestState.producer = null;
   });
 
   it('stages the optimistic prompt before hidden context finishes resolving', async () => {
@@ -85,13 +112,115 @@ describe('AcpChatStore prompt submission', () => {
     await vi.waitFor(() => expect(changeQueuePromptOrder).toHaveBeenCalledWith(['queued-1']));
     expect(cancelTurn).not.toHaveBeenCalled();
   });
+
+  it('allows an explicit send to reconnect an inactive conversation', () => {
+    const store = createStore(idleState(), vi.fn());
+    store.session = null;
+    store.loadError = {
+      kind: 'inactive',
+      message: 'This chat is inactive.',
+    };
+
+    expect(store.affordances.canSubmit).toBe(true);
+  });
+
+  it('reconnects and resends a prompt once when its activation was lost', async () => {
+    const firstSession = {
+      sendPrompt: vi.fn(async () => ({
+        success: false as const,
+        error: { type: 'stale_activation' as const, activationId: 'activation-old' },
+      })),
+    };
+    const replacementSession = {
+      sendPrompt: vi.fn(async () => ({ success: true as const, data: { queued: false } })),
+    };
+    const connectSession = vi
+      .fn()
+      .mockResolvedValueOnce(firstSession)
+      .mockResolvedValueOnce(replacementSession);
+    const loseSession = vi.fn();
+    const toastError = vi.fn();
+    const store = Object.assign(Object.create(AcpChatStore.prototype), {
+      conversationId: 'conversation-1',
+      hostAccess: undefined,
+      _connectSession: connectSession,
+      _loseSession: loseSession,
+      _toastError: toastError,
+    }) as AcpChatStore;
+
+    await privateStore(store)._submitPrompt('hello', []);
+
+    expect(loseSession).toHaveBeenCalledWith(firstSession);
+    expect(connectSession).toHaveBeenCalledTimes(2);
+    expect(firstSession.sendPrompt).toHaveBeenCalledWith({ text: 'hello' });
+    expect(replacementSession.sendPrompt).toHaveBeenCalledWith({ text: 'hello' });
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it('treats an activation-lost mutation as silent handle loss', async () => {
+    const session = {};
+    const connectSession = vi.fn(async () => session);
+    const loseSession = vi.fn();
+    const toastError = vi.fn();
+    const store = Object.assign(Object.create(AcpChatStore.prototype), {
+      hostAccess: undefined,
+      _connectSession: connectSession,
+      _loseSession: loseSession,
+      _toastError: toastError,
+    }) as AcpChatStore;
+
+    await privateStore(store)._withConnectedSession('Failed to mutate', async () => ({
+      success: false,
+      error: { type: 'activation_missing', conversationId: 'conversation-1' },
+    }));
+
+    expect(loseSession).toHaveBeenCalledWith(session);
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it('keeps a persisted draft across idle handle loss and store recreation', async () => {
+    const store = createStore(idleState(), vi.fn());
+    await Promise.resolve();
+    const draft = 'd'.repeat(ACP_DRAFT_MAX_LENGTH + 10);
+    store.setDraftText(draft);
+    const currentSession = store.session!;
+
+    privateStore(store)._loseSession(currentSession);
+    expect(store.draftText).toBe(draft);
+    if (!mementoTestState.producer) throw new Error('expected draft producer');
+    mementoTestState.value = mementoTestState.producer();
+
+    const replacement = new AcpChatStore('conversation-1', 'project-1', 'task-1');
+    await vi.waitFor(() => expect(replacement.draftText).toHaveLength(ACP_DRAFT_MAX_LENGTH));
+    expect(replacement.draftText).toBe(draft.slice(0, ACP_DRAFT_MAX_LENGTH));
+    store.dispose();
+    replacement.dispose();
+  });
 });
+
+type PrivateStore = {
+  _submitPrompt(text: string, attachments: []): Promise<void>;
+  _loseSession(session: NonNullable<AcpChatStore['session']>): void;
+  _withConnectedSession(
+    title: string,
+    work: (session: unknown) => Promise<{
+      success: false;
+      error: { type: 'activation_missing'; conversationId: string };
+    }>
+  ): Promise<void>;
+};
+
+function privateStore(store: AcpChatStore): PrivateStore {
+  return store as unknown as PrivateStore;
+}
 
 function createStore(state: SessionState, sendPrompt: ReturnType<typeof vi.fn>) {
   const store = new AcpChatStore('conversation-1', 'project-1', 'task-1');
   store.session = {
+    activationId: { current: () => 'activation-1' },
     sessionState: { current: () => state },
     sendPrompt,
+    dispose: vi.fn(),
   } as never;
   return store;
 }

--- a/packages/core/src/runtimes/acp/api/client.ts
+++ b/packages/core/src/runtimes/acp/api/client.ts
@@ -1,7 +1,16 @@
 export * from './contract';
 export * from './errors';
 export {
+  changeQueuePromptOrderInputSchema,
+  deleteQueuedPromptInputSchema,
+  editQueuedPromptInputSchema,
+  exportAcpTranscriptInputSchema,
+  historyPageDesktopInputSchema,
   promptPlacementSchema,
+  resolvePermissionInputSchema,
+  sendPromptInputSchema,
+  setModeOptionInputSchema,
+  setModelOptionInputSchema,
   type AcpStartInputWire,
   type HistoryPage,
   type PromptPlacement,

--- a/packages/core/src/runtimes/acp/api/contract.ts
+++ b/packages/core/src/runtimes/acp/api/contract.ts
@@ -20,7 +20,6 @@ import {
   sessionUsageSchema,
 } from '#runtimes/acp/api/models/config';
 import { planStateSchema } from '#runtimes/acp/api/models/plan';
-import { promptDraftSchema } from '#runtimes/acp/api/models/prompt';
 import { sessionStateSchema, sessionSummarySchema } from '#runtimes/acp/api/models/session';
 import { transcriptTurnSchema } from '#runtimes/acp/api/models/turns';
 import {
@@ -38,7 +37,6 @@ import {
   acpSendPromptErrorSchema,
   acpSetModeOptionErrorSchema,
   acpSetModelOptionErrorSchema,
-  acpSetPromptDraftErrorSchema,
   acpStartErrorSchema,
 } from './errors';
 import {
@@ -62,12 +60,11 @@ import {
   sendPromptResponseSchema,
   setModeOptionCommandSchema,
   setModelOptionCommandSchema,
-  setPromptDraftCommandSchema,
   uploadAttachmentCommandSchema,
   uploadAttachmentResponseSchema,
 } from './schemas';
 
-const startResultSchema = z.object({ sessionId: z.string() });
+const startResultSchema = z.object({ sessionId: z.string(), activationId: z.string() });
 const sessionKeySchema = z.object({ conversationId: z.string() });
 const terminalOutputKeySchema = z.object({ terminalId: z.string() });
 
@@ -124,10 +121,6 @@ export const acpApiContract = defineContract({
     input: resolvePermissionCommandSchema,
     error: acpResolvePermissionErrorSchema,
   }),
-  setPromptDraft: fallible({
-    input: setPromptDraftCommandSchema,
-    error: acpSetPromptDraftErrorSchema,
-  }),
   exportAcpTranscript: fallible({
     input: exportAcpTranscriptCommandSchema,
     data: z.object({ transcript: z.string() }),
@@ -176,13 +169,13 @@ export const acpApiContract = defineContract({
   session: liveModel({
     key: sessionKeySchema,
     states: {
+      activationId: liveState({ data: z.string().nullable() }),
       state: liveState({ data: sessionStateSchema }),
       config: liveState({ data: sessionConfigStateSchema }),
       usage: liveState({ data: sessionUsageSchema.nullable() }),
       plan: liveState({ data: planStateSchema.nullable() }),
       agents: liveState({ data: z.array(agentStateSchema) }),
       activeTurn: liveState({ data: transcriptTurnSchema.nullable() }),
-      draft: liveState({ data: promptDraftSchema.nullable() }),
       terminals: liveState({ data: z.array(terminalStateSchema) }),
       mcpServers: liveState({ data: z.array(sessionMcpServerSchema) }),
     },

--- a/packages/core/src/runtimes/acp/api/errors.ts
+++ b/packages/core/src/runtimes/acp/api/errors.ts
@@ -14,6 +14,12 @@ export type ProviderUnsupportedError = BaseError<'provider_unsupported'>;
 /** No conversation with the given id is tracked in the runtime. */
 export type ConversationNotFoundError = BaseError<'conversation_not_found'>;
 
+/** The durable conversation exists, but no activation descriptor was supplied. */
+export type ActivationMissingError = BaseError<'activation_missing'>;
+
+/** The command addressed an activation that has already been replaced. */
+export type StaleActivationError = BaseError<'stale_activation'>;
+
 /**
  * A command was issued but the current lifecycle state does not allow it,
  * e.g. Prompt while already working.
@@ -47,6 +53,8 @@ export type SetModeFailedError = BaseError<'set_mode_failed', SerializedError>;
 export type AcpRuntimeError =
   | ProviderUnsupportedError
   | ConversationNotFoundError
+  | ActivationMissingError
+  | StaleActivationError
   | InvalidStateError
   | SpawnFailedError
   | InitializeFailedError
@@ -66,26 +74,23 @@ export type AcpStartError =
   | InvalidStateError;
 export type AcpResumeError = AcpStartError;
 export type AcpKillError = never;
-export type AcpSendPromptError = ConversationNotFoundError | InvalidStateError | PromptFailedError;
-export type AcpQueueMutationError = ConversationNotFoundError | InvalidStateError;
+export type AcpActivationError = AcpStartError | ActivationMissingError;
+export type AcpSendPromptError = AcpActivationError | StaleActivationError | PromptFailedError;
+export type AcpQueueMutationError = AcpActivationError | StaleActivationError;
 export type AcpEditQueuedPromptError = AcpQueueMutationError;
 export type AcpDeleteQueuedPromptError = AcpQueueMutationError;
 export type AcpChangeQueuePromptOrderError = AcpQueueMutationError;
 export type AcpResolvePermissionError = AcpQueueMutationError;
-export type AcpSetPromptDraftError = ConversationNotFoundError;
 export type AcpCancelTurnError = InvalidStateError | CancelFailedError;
 export type AcpSetModelOptionError =
-  | ConversationNotFoundError
-  | InvalidStateError
+  | AcpActivationError
+  | StaleActivationError
   | SetConfigFailedError;
-export type AcpSetModeOptionError =
-  | ConversationNotFoundError
-  | InvalidStateError
-  | SetModeFailedError;
-export type AcpExportTranscriptError = ConversationNotFoundError;
-export type AcpExportRawLogError = ConversationNotFoundError;
+export type AcpSetModeOptionError = AcpActivationError | StaleActivationError | SetModeFailedError;
+export type AcpExportTranscriptError = AcpActivationError | StaleActivationError;
+export type AcpExportRawLogError = AcpActivationError | StaleActivationError;
 export type AcpAttachmentError = InvalidStateError;
-export type AcpGetHistoryError = never;
+export type AcpGetHistoryError = AcpActivationError | StaleActivationError;
 
 export const acpErr = {
   providerUnsupported: (providerId: string) =>
@@ -93,6 +98,12 @@ export const acpErr = {
 
   conversationNotFound: (conversationId: string) =>
     fail('conversation_not_found', { message: conversationId }),
+
+  activationMissing: (conversationId: string) =>
+    fail('activation_missing', { message: `Conversation '${conversationId}' is inactive` }),
+
+  staleActivation: (activationId: string) =>
+    fail('stale_activation', { message: `ACP activation '${activationId}' is stale` }),
 
   invalidState: (message: string) => fail('invalid_state', { message }),
 
@@ -131,6 +142,8 @@ const failedErrorSchema = <T extends string>(type: T) =>
 
 export const providerUnsupportedErrorSchema = plainTagErrorSchema('provider_unsupported');
 export const conversationNotFoundErrorSchema = plainTagErrorSchema('conversation_not_found');
+export const activationMissingErrorSchema = plainTagErrorSchema('activation_missing');
+export const staleActivationErrorSchema = plainTagErrorSchema('stale_activation');
 export const invalidStateErrorSchema = plainTagErrorSchema('invalid_state');
 export const spawnFailedErrorSchema = failedErrorSchema('spawn_failed');
 export const initializeFailedErrorSchema = failedErrorSchema('initialize_failed');
@@ -151,42 +164,55 @@ export const acpStartErrorSchema = z.discriminatedUnion('type', [
 ]);
 export const acpResumeErrorSchema = acpStartErrorSchema;
 export const acpKillErrorSchema = z.never();
-export const acpSendPromptErrorSchema = z.discriminatedUnion('type', [
-  conversationNotFoundErrorSchema,
+const acpActivationErrorSchemas = [
+  providerUnsupportedErrorSchema,
+  authRequiredErrorSchema,
+  spawnFailedErrorSchema,
+  initializeFailedErrorSchema,
+  newSessionFailedErrorSchema,
   invalidStateErrorSchema,
+  activationMissingErrorSchema,
+] as const;
+export const acpSendPromptErrorSchema = z.discriminatedUnion('type', [
+  ...acpActivationErrorSchemas,
+  staleActivationErrorSchema,
   promptFailedErrorSchema,
 ]);
 export const acpQueueMutationErrorSchema = z.discriminatedUnion('type', [
-  conversationNotFoundErrorSchema,
-  invalidStateErrorSchema,
+  ...acpActivationErrorSchemas,
+  staleActivationErrorSchema,
 ]);
 export const acpEditQueuedPromptErrorSchema = acpQueueMutationErrorSchema;
 export const acpDeleteQueuedPromptErrorSchema = acpQueueMutationErrorSchema;
 export const acpChangeQueuePromptOrderErrorSchema = acpQueueMutationErrorSchema;
 export const acpResolvePermissionErrorSchema = acpQueueMutationErrorSchema;
-export const acpSetPromptDraftErrorSchema = conversationNotFoundErrorSchema;
 export const acpCancelTurnErrorSchema = z.discriminatedUnion('type', [
   invalidStateErrorSchema,
   cancelFailedErrorSchema,
 ]);
 export const acpSetModelOptionErrorSchema = z.discriminatedUnion('type', [
-  conversationNotFoundErrorSchema,
-  invalidStateErrorSchema,
+  ...acpActivationErrorSchemas,
+  staleActivationErrorSchema,
   setConfigFailedErrorSchema,
 ]);
 export const acpSetModeOptionErrorSchema = z.discriminatedUnion('type', [
-  conversationNotFoundErrorSchema,
-  invalidStateErrorSchema,
+  ...acpActivationErrorSchemas,
+  staleActivationErrorSchema,
   setModeFailedErrorSchema,
 ]);
-export const acpExportTranscriptErrorSchema = conversationNotFoundErrorSchema;
-export const acpExportRawLogErrorSchema = conversationNotFoundErrorSchema;
+export const acpExportTranscriptErrorSchema = z.discriminatedUnion('type', [
+  ...acpActivationErrorSchemas,
+  staleActivationErrorSchema,
+]);
+export const acpExportRawLogErrorSchema = acpExportTranscriptErrorSchema;
 export const acpAttachmentErrorSchema = invalidStateErrorSchema;
-export const acpGetHistoryErrorSchema = z.never();
+export const acpGetHistoryErrorSchema = acpExportTranscriptErrorSchema;
 
 export const acpRuntimeErrorSchema = z.discriminatedUnion('type', [
   providerUnsupportedErrorSchema,
   conversationNotFoundErrorSchema,
+  activationMissingErrorSchema,
+  staleActivationErrorSchema,
   invalidStateErrorSchema,
   spawnFailedErrorSchema,
   initializeFailedErrorSchema,

--- a/packages/core/src/runtimes/acp/api/models/prompt.ts
+++ b/packages/core/src/runtimes/acp/api/models/prompt.ts
@@ -9,25 +9,6 @@ export const promptInputSchema = z.object({
 });
 export type PromptInput = z.infer<typeof promptInputSchema>;
 
-export const promptDraftInputSchema = promptInputSchema.extend({
-  /** Monotonic writer revision used by clients to suppress stale draft echoes. */
-  rev: z.number(),
-});
-export type PromptDraftInput = z.infer<typeof promptDraftInputSchema>;
-
-export const promptDraftSchema = promptDraftInputSchema.extend({
-  /** Epoch ms when the runtime last accepted this draft revision. */
-  updatedAt: z.number(),
-});
-export type PromptDraft = z.infer<typeof promptDraftSchema>;
-
-export const promptDraftUpdateSchema = z.object({
-  /** Monotonic writer revision used to ignore stale draft updates, including clears. */
-  rev: z.number(),
-  input: promptInputSchema.nullable(),
-});
-export type PromptDraftUpdate = z.infer<typeof promptDraftUpdateSchema>;
-
 export const queuedPromptSchema = promptInputSchema.extend({
   /** Runtime-generated id used for queue removal and stable UI keys. */
   id: z.string(),

--- a/packages/core/src/runtimes/acp/api/schemas.ts
+++ b/packages/core/src/runtimes/acp/api/schemas.ts
@@ -1,11 +1,7 @@
 import { z } from 'zod';
 import { attachmentRefSchema } from '#runtimes/acp/api/models/attachments';
 import { permissionDecisionSchema } from '#runtimes/acp/api/models/permissions';
-import {
-  promptDraftUpdateSchema,
-  promptInputSchema,
-  queuedPromptSchema,
-} from '#runtimes/acp/api/models/prompt';
+import { promptInputSchema, queuedPromptSchema } from '#runtimes/acp/api/models/prompt';
 import { transcriptTurnSchema } from '#runtimes/acp/api/models/turns';
 
 export const acpStartInputSchema = z.object({
@@ -27,43 +23,82 @@ export const sendPromptResponseSchema = z.object({ queued: z.boolean() });
 export const killCommandSchema = z.object({ conversationId: z.string() });
 export const promptPlacementSchema = z.enum(['auto', 'queue']);
 export type PromptPlacement = z.infer<typeof promptPlacementSchema>;
-export const sendPromptCommandSchema = z.object({
-  conversationId: z.string(),
-  prompt: promptInputSchema,
-  /** 'queue' always queues; 'auto' (default) delivers if idle and queues while a turn is active. */
-  placement: promptPlacementSchema.optional(),
-});
-export const editQueuedPromptCommandSchema = z.object({
-  conversationId: z.string(),
-  id: z.string(),
-  input: promptInputSchema,
-});
-export const deleteQueuedPromptCommandSchema = z.object({
-  conversationId: z.string(),
-  id: z.string(),
-});
-export const changeQueuePromptOrderCommandSchema = z.object({
-  conversationId: z.string(),
-  ids: z.array(z.string()),
-});
+const activationFenceSchema = z.object({ activationId: z.string().optional() });
+const activationDescriptorSchema = z.object({ activation: acpStartInputSchema });
+
+export const sendPromptInputSchema = z
+  .object({
+    conversationId: z.string(),
+    prompt: promptInputSchema,
+    /** 'queue' always queues; 'auto' (default) delivers if idle and queues while a turn is active. */
+    placement: promptPlacementSchema.optional(),
+  })
+  .extend(activationFenceSchema.shape);
+export const sendPromptCommandSchema = sendPromptInputSchema.extend(
+  activationDescriptorSchema.shape
+);
+export const editQueuedPromptInputSchema = z
+  .object({
+    conversationId: z.string(),
+    id: z.string(),
+    input: promptInputSchema,
+  })
+  .extend(activationFenceSchema.shape);
+export const editQueuedPromptCommandSchema = editQueuedPromptInputSchema.extend(
+  activationDescriptorSchema.shape
+);
+export const deleteQueuedPromptInputSchema = z
+  .object({
+    conversationId: z.string(),
+    id: z.string(),
+  })
+  .extend(activationFenceSchema.shape);
+export const deleteQueuedPromptCommandSchema = deleteQueuedPromptInputSchema.extend(
+  activationDescriptorSchema.shape
+);
+export const changeQueuePromptOrderInputSchema = z
+  .object({
+    conversationId: z.string(),
+    ids: z.array(z.string()),
+  })
+  .extend(activationFenceSchema.shape);
+export const changeQueuePromptOrderCommandSchema = changeQueuePromptOrderInputSchema.extend(
+  activationDescriptorSchema.shape
+);
 export const cancelTurnCommandSchema = z.object({ conversationId: z.string() });
-export const setModelOptionCommandSchema = z.object({
-  conversationId: z.string(),
-  dimension: z.enum(['model', 'effort']),
-  value: z.string(),
-});
-export const setModeOptionCommandSchema = z.object({
-  conversationId: z.string(),
-  value: z.string(),
-});
-export const resolvePermissionCommandSchema = permissionDecisionSchema.extend({
-  conversationId: z.string(),
-});
-export const setPromptDraftCommandSchema = z.object({
-  conversationId: z.string(),
-  draft: promptDraftUpdateSchema,
-});
-export const exportAcpTranscriptCommandSchema = z.object({ conversationId: z.string() });
+export const setModelOptionInputSchema = z
+  .object({
+    conversationId: z.string(),
+    dimension: z.enum(['model', 'effort']),
+    value: z.string(),
+  })
+  .extend(activationFenceSchema.shape);
+export const setModelOptionCommandSchema = setModelOptionInputSchema.extend(
+  activationDescriptorSchema.shape
+);
+export const setModeOptionInputSchema = z
+  .object({
+    conversationId: z.string(),
+    value: z.string(),
+  })
+  .extend(activationFenceSchema.shape);
+export const setModeOptionCommandSchema = setModeOptionInputSchema.extend(
+  activationDescriptorSchema.shape
+);
+export const resolvePermissionInputSchema = permissionDecisionSchema
+  .extend({
+    conversationId: z.string(),
+  })
+  .extend(activationFenceSchema.shape);
+export const resolvePermissionCommandSchema = resolvePermissionInputSchema.extend(
+  activationDescriptorSchema.shape
+);
+export const exportAcpTranscriptInputSchema = z
+  .object({ conversationId: z.string() })
+  .extend(activationFenceSchema.shape);
+export const exportAcpTranscriptCommandSchema = exportAcpTranscriptInputSchema.extend(
+  activationDescriptorSchema.shape
+);
 export const exportRawAcpLogCommandSchema = exportAcpTranscriptCommandSchema;
 
 export const uploadAttachmentCommandSchema = z.object({
@@ -82,11 +117,16 @@ export const deleteAttachmentsCommandSchema = z.object({
   conversationId: z.string(),
 });
 
-export const historyPageInputSchema = z.object({
-  conversationId: z.string(),
-  before: z.number().int().optional(),
-  limit: z.number().int(),
-});
+export const historyPageDesktopInputSchema = z
+  .object({
+    conversationId: z.string(),
+    before: z.number().int().optional(),
+    limit: z.number().int(),
+  })
+  .extend(activationFenceSchema.shape);
+export const historyPageInputSchema = historyPageDesktopInputSchema.extend(
+  activationDescriptorSchema.shape
+);
 
 export const historyPageSchema = z.object({
   turns: z.array(transcriptTurnSchema),
@@ -96,6 +136,7 @@ export type HistoryPage = z.infer<typeof historyPageSchema>;
 
 export const resumeResultSchema = historyPageSchema.extend({
   sessionId: z.string(),
+  activationId: z.string(),
 });
 export type ResumeResult = z.infer<typeof resumeResultSchema>;
 

--- a/packages/core/src/runtimes/acp/node/api/contract.test.ts
+++ b/packages/core/src/runtimes/acp/node/api/contract.test.ts
@@ -1,11 +1,11 @@
 import { isOk } from '@emdash/shared';
+import { createManualClock } from '@emdash/shared/testing';
 import { peek, remote, snapshot } from '@emdash/wire/state';
 import { createTestWire } from '@emdash/wire/testing';
 import { describe, expect, it, vi } from 'vitest';
 import {
   acpApiContract,
   acpRuntimeErrorSchema,
-  promptDraftSchema,
   sessionConfigStateSchema,
   sessionStateSchema,
   sessionUsageSchema,
@@ -31,7 +31,6 @@ describe('ACP API contract schemas', () => {
     expect(() => sessionConfigStateSchema.parse(peek(live.states.config))).not.toThrow();
     expect(() => sessionUsageSchema.nullable().parse(peek(live.states.usage))).not.toThrow();
     expect(() => transcriptTurnSchema.nullable().parse(peek(live.states.activeTurn))).not.toThrow();
-    expect(() => promptDraftSchema.nullable().parse(peek(live.states.draft))).not.toThrow();
   });
 
   it('round-trips procedures and live state over a wire transport', async () => {
@@ -47,7 +46,10 @@ describe('ACP API contract schemas', () => {
       await summaries.states.list.refresh();
       const input = makeStartInput({ conversationId: 'conv-wire' });
       const started = await contractClient.start(input);
-      expect(started).toEqual({ success: true, data: { sessionId: 'session-1' } });
+      expect(started).toEqual({
+        success: true,
+        data: { sessionId: 'session-1', activationId: expect.any(String) },
+      });
 
       await vi.waitFor(() => {
         expect(snapshot(summaries.states.list).value?.['conv-wire']).toMatchObject({
@@ -61,6 +63,85 @@ describe('ACP API contract schemas', () => {
       expect(snapshot(session.states.state).value).toMatchObject({ lifecycle: 'ready' });
     } finally {
       await sessions.dispose();
+      await sessionRemote.dispose();
+      wire.dispose();
+    }
+  });
+
+  it('publishes idle eviction through an attached Wire projection and rematerializes atomically', async () => {
+    const clock = createManualClock(0);
+    const h = makeAcpHarness({
+      clock,
+      lifecycle: {
+        session: { kind: 'idle-after', outputMs: 1_000 },
+        sweepIntervalMs: 10_000,
+      },
+    });
+    const rt = new AcpRuntime(h.deps);
+    const wire = createTestWire(acpApiContract, createAcpController(rt));
+    const sessionRemote = remote(acpApiContract.session, wire.client.session);
+    const member = sessionRemote({ conversationId: 'conv-wire-idle' });
+    const input = makeStartInput({ conversationId: 'conv-wire-idle' });
+
+    try {
+      await member.states.state.refresh();
+      await member.states.activationId.refresh();
+      expect(snapshot(member.states.state).value?.lifecycle).toBe('closed');
+
+      const started = await wire.client.start(input);
+      if (!started.success) throw new Error('expected ACP activation');
+      await vi.waitFor(() => {
+        expect(snapshot(member.states.state).value?.lifecycle).toBe('ready');
+        expect(snapshot(member.states.activationId).value).toBe(started.data.activationId);
+      });
+
+      await clock.advanceBy(1_200);
+      await rt.manager.sweepNow();
+      await vi.waitFor(() => {
+        expect(snapshot(member.states.state).value?.lifecycle).toBe('closed');
+        expect(snapshot(member.states.activationId).value).toBeNull();
+      });
+
+      const history = await wire.client.getHistory({
+        conversationId: input.conversationId,
+        before: undefined,
+        limit: 100,
+        activation: input,
+      });
+      expect(history).toEqual({ success: true, data: { turns: [], nextCursor: null } });
+      expect(h.agent.newSession).toHaveBeenCalledTimes(2);
+      await vi.waitFor(() => expect(snapshot(member.states.state).value?.lifecycle).toBe('ready'));
+    } finally {
+      await sessionRemote.dispose();
+      wire.dispose();
+    }
+  });
+
+  it('reconnects a new Wire client to an inactive conversation', async () => {
+    const h = makeAcpHarness();
+    const rt = new AcpRuntime(h.deps);
+    const input = makeStartInput({ conversationId: 'conv-wire-reconnect' });
+    await rt.startSession(input);
+    await rt.stopSession(input.conversationId);
+
+    const wire = createTestWire(acpApiContract, createAcpController(rt));
+    const sessionRemote = remote(acpApiContract.session, wire.client.session);
+    const member = sessionRemote({ conversationId: input.conversationId });
+    try {
+      await member.states.state.refresh();
+      expect(snapshot(member.states.state).value?.lifecycle).toBe('closed');
+
+      h.agent.newSession.mockResolvedValueOnce({ sessionId: 'session-reconnected' });
+      const history = await wire.client.getHistory({
+        conversationId: input.conversationId,
+        before: undefined,
+        limit: 100,
+        activation: input,
+      });
+
+      expect(history.success).toBe(true);
+      await vi.waitFor(() => expect(snapshot(member.states.state).value?.lifecycle).toBe('ready'));
+    } finally {
       await sessionRemote.dispose();
       wire.dispose();
     }

--- a/packages/core/src/runtimes/acp/node/api/procedures.ts
+++ b/packages/core/src/runtimes/acp/node/api/procedures.ts
@@ -15,13 +15,11 @@ import type {
   AcpSendPromptError,
   AcpSetModeOptionError,
   AcpSetModelOptionError,
-  AcpSetPromptDraftError,
   AcpStartError,
   AcpStartInputWire,
   AttachmentMimeType,
   AttachmentRef,
   HistoryPage,
-  PromptDraftUpdate,
   PromptInput,
   PromptPlacement,
   ResumeResult,
@@ -32,7 +30,9 @@ export type StartSessionInput = AcpStartInputWire;
 
 export function createAcpProcedures(runtime: AcpRuntime) {
   return {
-    start(input: StartSessionInput): Promise<Result<{ sessionId: string }, AcpStartError>> {
+    start(
+      input: StartSessionInput
+    ): Promise<Result<{ sessionId: string; activationId: string }, AcpStartError>> {
       return runtime.startSession(input);
     },
     resume(
@@ -47,68 +47,121 @@ export function createAcpProcedures(runtime: AcpRuntime) {
       conversationId: string;
       prompt: PromptInput;
       placement?: PromptPlacement;
+      activation: StartSessionInput;
+      activationId?: string;
     }): Promise<Result<{ queued: boolean }, AcpSendPromptError>> {
-      return runtime.sendPrompt(input.conversationId, input.prompt, input.placement);
+      return runtime.sendPrompt(
+        input.conversationId,
+        input.prompt,
+        input.placement,
+        input.activation,
+        input.activationId
+      );
     },
     editQueuedPrompt(input: {
       conversationId: string;
       id: string;
       input: PromptInput;
-    }): Result<void, AcpEditQueuedPromptError> {
-      return runtime.editQueuedPrompt(input.conversationId, input.id, input.input);
+      activation: StartSessionInput;
+      activationId?: string;
+    }): Promise<Result<void, AcpEditQueuedPromptError>> {
+      return runtime.editQueuedPrompt(
+        input.conversationId,
+        input.id,
+        input.input,
+        input.activation,
+        input.activationId
+      );
     },
     deleteQueuedPrompt(input: {
       conversationId: string;
       id: string;
-    }): Result<void, AcpDeleteQueuedPromptError> {
-      return runtime.deleteQueuedPrompt(input.conversationId, input.id);
+      activation: StartSessionInput;
+      activationId?: string;
+    }): Promise<Result<void, AcpDeleteQueuedPromptError>> {
+      return runtime.deleteQueuedPrompt(
+        input.conversationId,
+        input.id,
+        input.activation,
+        input.activationId
+      );
     },
     changeQueuePromptOrder(input: {
       conversationId: string;
       ids: string[];
-    }): Result<void, AcpChangeQueuePromptOrderError> {
-      return runtime.changeQueuePromptOrder(input.conversationId, input.ids);
+      activation: StartSessionInput;
+      activationId?: string;
+    }): Promise<Result<void, AcpChangeQueuePromptOrderError>> {
+      return runtime.changeQueuePromptOrder(
+        input.conversationId,
+        input.ids,
+        input.activation,
+        input.activationId
+      );
     },
     cancelTurn(input: { conversationId: string }): Promise<Result<void, AcpCancelTurnError>> {
       return runtime.cancelTurn(input.conversationId);
-    },
-    setPromptDraft(input: {
-      conversationId: string;
-      draft: PromptDraftUpdate;
-    }): Result<void, AcpSetPromptDraftError> {
-      return runtime.setPromptDraft(input.conversationId, input.draft);
     },
     setModelOption(input: {
       conversationId: string;
       dimension: 'model' | 'effort';
       value: string;
+      activation: StartSessionInput;
+      activationId?: string;
     }): Promise<Result<void, AcpSetModelOptionError>> {
-      return runtime.setModelOption(input.conversationId, input.dimension, input.value);
+      return runtime.setModelOption(
+        input.conversationId,
+        input.dimension,
+        input.value,
+        input.activation,
+        input.activationId
+      );
     },
     setModeOption(input: {
       conversationId: string;
       value: string;
+      activation: StartSessionInput;
+      activationId?: string;
     }): Promise<Result<void, AcpSetModeOptionError>> {
-      return runtime.setModeOption(input.conversationId, input.value);
+      return runtime.setModeOption(
+        input.conversationId,
+        input.value,
+        input.activation,
+        input.activationId
+      );
     },
     resolvePermission(input: {
       conversationId: string;
       requestId: string;
       optionId: string;
-    }): Result<void, AcpResolvePermissionError> {
-      return runtime.resolvePermission(input.conversationId, input.requestId, input.optionId);
+      activation: StartSessionInput;
+      activationId?: string;
+    }): Promise<Result<void, AcpResolvePermissionError>> {
+      return runtime.resolvePermission(
+        input.conversationId,
+        input.requestId,
+        input.optionId,
+        input.activation,
+        input.activationId
+      );
     },
     exportAcpTranscript(input: {
       conversationId: string;
-    }): Result<{ transcript: string }, AcpExportTranscriptError> {
-      const result = runtime.exportParsedTranscript(input.conversationId);
-      return result.success ? ok({ transcript: result.data }) : result;
+      activation: StartSessionInput;
+      activationId?: string;
+    }): Promise<Result<{ transcript: string }, AcpExportTranscriptError>> {
+      return runtime
+        .exportParsedTranscript(input.conversationId, input.activation, input.activationId)
+        .then((result) => (result.success ? ok({ transcript: result.data }) : result));
     },
     exportRawAcpLog(input: {
       conversationId: string;
-    }): Result<{ log: string }, AcpExportRawLogError> {
-      const result = runtime.exportRawAcpLog(input.conversationId);
-      return result.success ? ok({ log: result.data }) : result;
+      activation: StartSessionInput;
+      activationId?: string;
+    }): Promise<Result<{ log: string }, AcpExportRawLogError>> {
+      return runtime
+        .exportRawAcpLog(input.conversationId, input.activation, input.activationId)
+        .then((result) => (result.success ? ok({ log: result.data }) : result));
     },
     async uploadAttachment(
       input: {
@@ -154,8 +207,16 @@ export function createAcpProcedures(runtime: AcpRuntime) {
       conversationId: string;
       before?: number;
       limit: number;
-    }): Result<HistoryPage, AcpGetHistoryError> {
-      return runtime.getHistory(input.conversationId, input.before, input.limit);
+      activation: StartSessionInput;
+      activationId?: string;
+    }): Promise<Result<HistoryPage, AcpGetHistoryError>> {
+      return runtime.getHistory(
+        input.conversationId,
+        input.before,
+        input.limit,
+        input.activation,
+        input.activationId
+      );
     },
   };
 }

--- a/packages/core/src/runtimes/acp/node/connection/source.test.ts
+++ b/packages/core/src/runtimes/acp/node/connection/source.test.ts
@@ -106,7 +106,7 @@ describe('createAcpConnectionSource', () => {
     await acquireResourceAsResult(source, key, isAcpConnectionError);
     host.lastHandle.emitExit(7);
 
-    await vi.waitFor(() => expect(onClosed).toHaveBeenCalledWith(routeKey, 7));
+    await vi.waitFor(() => expect(onClosed).toHaveBeenCalledWith(routeKey, 1, 7));
     await source.invalidate(key);
     await waitForTeardown();
     expect(source.peek(key)).toBeUndefined();

--- a/packages/core/src/runtimes/acp/node/connection/source.ts
+++ b/packages/core/src/runtimes/acp/node/connection/source.ts
@@ -20,6 +20,7 @@ type AcpConnectionProcessHost = Pick<AcpProcessHost, 'spawn' | 'spawnTerminal'>;
 
 export interface AcpConnectionContext {
   key: string;
+  generation: number;
   providerId: string;
   cwd: string;
   normalize: AcpSessionUpdateNormalizer;
@@ -40,7 +41,7 @@ export interface CreateAcpConnectionSourceDeps {
   clock?: Clock;
   idleTtlMs?: number;
   buildClient: (agent: AcpAgentApi, context: AcpConnectionContext) => Client;
-  onClosed: (key: string, exitCode: number | null) => void;
+  onClosed: (key: string, generation: number, exitCode: number | null) => void;
 }
 
 export interface AcpConnectionKey {
@@ -54,11 +55,12 @@ export type AcpConnectionSource = ResourceCache<AcpConnectionKey, PooledAcpProce
 export function createAcpConnectionSource(
   deps: CreateAcpConnectionSourceDeps
 ): AcpConnectionSource {
+  let nextGeneration = 0;
   const source: AcpConnectionSource = createResourceCache<AcpConnectionKey, PooledAcpProcess>({
     key: acpConnectionCacheKey,
     clock: deps.clock,
     idleTtlMs: deps.idleTtlMs,
-    create: (key, scope) => provisionAcpConnection(deps, key, scope),
+    create: (key, scope) => provisionAcpConnection(deps, key, ++nextGeneration, scope),
     onError: (error, keyId) => {
       deps.logger.warn('AcpConnectionSource: provisioning failed', {
         key: keyId,
@@ -86,6 +88,7 @@ export function isAcpConnectionError(error: unknown): error is AcpConnectionErro
 async function provisionAcpConnection(
   deps: CreateAcpConnectionSourceDeps,
   key: AcpConnectionKey,
+  generation: number,
   scope: Scope
 ): Promise<PooledAcpProcess> {
   const binding = deps.agentHost.resolveAcp(key.providerId);
@@ -118,17 +121,19 @@ async function provisionAcpConnection(
       buildClient: (agent, normalize) =>
         deps.buildClient(agent, {
           key: routeKey,
+          generation,
           providerId: key.providerId,
           cwd: key.cwd,
           normalize,
         }),
-      onClosed: (exitCode) => deps.onClosed(routeKey, exitCode),
+      onClosed: (exitCode) => deps.onClosed(routeKey, generation, exitCode),
     }
   );
   if (isErr(connection)) throw connection.error;
 
   return {
     key: routeKey,
+    generation,
     providerId: key.providerId,
     cwd: key.cwd,
     agent: connection.data.agent,

--- a/packages/core/src/runtimes/acp/node/runtime/runtime.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/runtime.ts
@@ -15,12 +15,10 @@ import type {
   AcpSendPromptError,
   AcpSetModeOptionError,
   AcpSetModelOptionError,
-  AcpSetPromptDraftError,
   AcpStartError,
   AcpKillError,
   AttachmentMimeType,
   AttachmentRef,
-  PromptDraftUpdate,
   PromptInput,
   PromptPlacement,
   ResumeResult,
@@ -67,7 +65,7 @@ export class AcpRuntime {
         if (!manager) throw new Error('AcpRuntime session manager not initialized');
         return buildAgentClient(context, manager, { fs, terminals: terminalPort });
       },
-      onClosed: (key, exitCode) => manager?.onProcessClosed(key, exitCode),
+      onClosed: (key, generation, exitCode) => manager?.onProcessClosed(key, generation, exitCode),
     });
     manager = new SessionManager(deps, this.connections, this.terminals, {
       fs,
@@ -76,7 +74,9 @@ export class AcpRuntime {
     this.manager = manager;
   }
 
-  startSession(input: AcpStartInput): Promise<Result<{ sessionId: string }, AcpStartError>> {
+  startSession(
+    input: AcpStartInput
+  ): Promise<Result<{ sessionId: string; activationId: string }, AcpStartError>> {
     return this.manager.start(input);
   }
 
@@ -86,8 +86,14 @@ export class AcpRuntime {
   ): Promise<Result<ResumeResult, AcpResumeError>> {
     const result = await this.manager.start(input);
     if (!result.success) return result;
-    const page = this.manager.getHistory(input.conversationId, undefined, limit);
-    return ok({ sessionId: result.data.sessionId, ...page });
+    const page = await this.manager.getHistory(input.conversationId, undefined, limit);
+    if (!page.success)
+      return acpErr.invalidState('ACP session history was unavailable after resume');
+    return ok({
+      sessionId: result.data.sessionId,
+      activationId: result.data.activationId,
+      ...page.data,
+    });
   }
 
   /** Runtime-internal graceful stop (persists suspended intent); not exposed on the wire. */
@@ -106,70 +112,88 @@ export class AcpRuntime {
   sendPrompt(
     conversationId: string,
     prompt: PromptInput,
-    placement?: PromptPlacement
+    placement?: PromptPlacement,
+    activation?: AcpStartInput,
+    activationId?: string
   ): Promise<Result<{ queued: boolean }, AcpSendPromptError>> {
-    return this.manager.prompt({ conversationId, prompt, placement });
+    return this.manager.prompt({ conversationId, prompt, placement }, activation, activationId);
   }
 
   editQueuedPrompt(
     conversationId: string,
     id: string,
-    prompt: PromptInput
-  ): Result<void, AcpEditQueuedPromptError> {
-    return this.manager.editQueuedPrompt(conversationId, id, prompt);
+    prompt: PromptInput,
+    activation?: AcpStartInput,
+    activationId?: string
+  ): Promise<Result<void, AcpEditQueuedPromptError>> {
+    return this.manager.editQueuedPrompt(conversationId, id, prompt, activation, activationId);
   }
 
-  deleteQueuedPrompt(conversationId: string, id: string): Result<void, AcpDeleteQueuedPromptError> {
-    return this.manager.removeQueuedPrompt(conversationId, id);
+  deleteQueuedPrompt(
+    conversationId: string,
+    id: string,
+    activation?: AcpStartInput,
+    activationId?: string
+  ): Promise<Result<void, AcpDeleteQueuedPromptError>> {
+    return this.manager.removeQueuedPrompt(conversationId, id, activation, activationId);
   }
 
   changeQueuePromptOrder(
     conversationId: string,
-    ids: readonly string[]
-  ): Result<void, AcpChangeQueuePromptOrderError> {
-    return this.manager.reorderQueue(conversationId, ids);
+    ids: readonly string[],
+    activation?: AcpStartInput,
+    activationId?: string
+  ): Promise<Result<void, AcpChangeQueuePromptOrderError>> {
+    return this.manager.reorderQueue(conversationId, ids, activation, activationId);
   }
 
   cancelTurn(conversationId: string): Promise<Result<void, AcpCancelTurnError>> {
     return this.manager.cancel(conversationId);
   }
 
-  setPromptDraft(
-    conversationId: string,
-    draft: PromptDraftUpdate
-  ): Result<void, AcpSetPromptDraftError> {
-    return this.manager.setPromptDraft(conversationId, draft);
-  }
-
   resolvePermission(
     conversationId: string,
     requestId: string,
-    optionId: string
-  ): Result<void, AcpResolvePermissionError> {
-    return this.manager.resolvePermission(conversationId, requestId, optionId);
+    optionId: string,
+    activation?: AcpStartInput,
+    activationId?: string
+  ): Promise<Result<void, AcpResolvePermissionError>> {
+    return this.manager.resolvePermission(
+      conversationId,
+      requestId,
+      optionId,
+      activation,
+      activationId
+    );
   }
 
   setModeOption(
     conversationId: string,
-    modeId: string
+    modeId: string,
+    activation?: AcpStartInput,
+    activationId?: string
   ): Promise<Result<void, AcpSetModeOptionError>> {
-    return this.manager.setMode(conversationId, modeId);
+    return this.manager.setMode(conversationId, modeId, activation, activationId);
   }
 
   setModelOption(
     conversationId: string,
     dimension: 'model' | 'effort',
-    value: string
+    value: string,
+    activation?: AcpStartInput,
+    activationId?: string
   ): Promise<Result<void, AcpSetModelOptionError>> {
-    return this.manager.setConfigOption(conversationId, dimension, value);
+    return this.manager.setConfigOption(conversationId, dimension, value, activation, activationId);
   }
 
   getHistory(
     conversationId: string,
     before?: number,
-    limit?: number
-  ): Result<HistoryPage, AcpGetHistoryError> {
-    return ok(this.manager.getHistory(conversationId, before, limit));
+    limit?: number,
+    activation?: AcpStartInput,
+    activationId?: string
+  ): Promise<Result<HistoryPage, AcpGetHistoryError>> {
+    return this.manager.getHistory(conversationId, before, limit, activation, activationId);
   }
 
   getChatHistory(conversationId: string): {
@@ -179,12 +203,20 @@ export class AcpRuntime {
     return this.manager.getChatHistory(conversationId);
   }
 
-  exportParsedTranscript(conversationId: string): Result<string, AcpExportTranscriptError> {
-    return this.manager.exportParsedTranscript(conversationId);
+  exportParsedTranscript(
+    conversationId: string,
+    activation?: AcpStartInput,
+    activationId?: string
+  ): Promise<Result<string, AcpExportTranscriptError>> {
+    return this.manager.exportParsedTranscript(conversationId, activation, activationId);
   }
 
-  exportRawAcpLog(conversationId: string): Result<string, AcpExportRawLogError> {
-    return this.manager.exportRawAcpLog(conversationId);
+  exportRawAcpLog(
+    conversationId: string,
+    activation?: AcpStartInput,
+    activationId?: string
+  ): Promise<Result<string, AcpExportRawLogError>> {
+    return this.manager.exportRawAcpLog(conversationId, activation, activationId);
   }
 
   getSessionState(conversationId: string): SessionState {
@@ -266,7 +298,7 @@ export class AcpRuntime {
   }
 
   async dispose(): Promise<void> {
-    this.manager.dispose();
+    await this.manager.dispose();
     this.killAllTerminals();
     await this.connections.dispose();
   }

--- a/packages/core/src/runtimes/acp/node/runtime/session-manager.test.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/session-manager.test.ts
@@ -1,7 +1,7 @@
 import type { SessionUpdate } from '@agentclientprotocol/sdk';
 import { isOk, ok } from '@emdash/shared';
 import { createScope } from '@emdash/shared/concurrency';
-import { createManualClock } from '@emdash/shared/testing';
+import { createManualClock, deferred } from '@emdash/shared/testing';
 import { observe, peek } from '@emdash/wire/state';
 import { describe, expect, it, vi } from 'vitest';
 import {
@@ -24,6 +24,11 @@ async function startHarness(conversationId = 'conv-1') {
   const result = await rt.startSession(makeStartInput({ conversationId }));
   expect(isOk(result)).toBe(true);
   return { h, rt, client: h.client(), sessionId: 'session-1', conversationId };
+}
+
+function liveValue<T>(value: T | undefined): T {
+  if (value === undefined) throw new Error('expected live projection value');
+  return value;
 }
 
 describe('AcpRuntime session manager', () => {
@@ -59,6 +64,30 @@ describe('AcpRuntime session manager', () => {
     });
   });
 
+  it('coalesces concurrent starts into one activation and one provider session', async () => {
+    const pendingSession = deferred<{ sessionId: string }>();
+    const h = makeAcpHarness({ lifecycle: { connectionIdleTtlMs: 0 } });
+    h.agent.newSession.mockImplementationOnce(async () => pendingSession.promise);
+    const rt = new AcpRuntime(h.deps);
+    const input = makeStartInput({ conversationId: 'conv-concurrent' });
+
+    const first = rt.startSession(input);
+    const second = rt.startSession(input);
+    await vi.waitFor(() => expect(h.agent.newSession).toHaveBeenCalledTimes(1));
+    expect(h.children).toHaveLength(1);
+
+    pendingSession.resolve({ sessionId: 'session-shared' });
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(firstResult).toEqual(secondResult);
+    expect(firstResult).toMatchObject({
+      success: true,
+      data: { sessionId: 'session-shared', activationId: expect.any(String) },
+    });
+    await rt.stopSession('conv-concurrent');
+    expectNoSessionResidue('conv-concurrent', leakContainers(rt));
+  });
+
   it('deactivates idle sessions and releases the pooled ACP process after its TTL', async () => {
     const clock = createManualClock(0);
     const h = makeAcpHarness({
@@ -70,13 +99,203 @@ describe('AcpRuntime session manager', () => {
       },
     });
     const rt = new AcpRuntime(h.deps);
-    await rt.startSession(makeStartInput({ conversationId: 'conv-idle' }));
+    const started = await rt.startSession(makeStartInput({ conversationId: 'conv-idle' }));
+    if (!started.success) throw new Error('expected ACP activation');
+    const live = rt.sessionLiveModels('conv-idle');
+    if (!live) throw new Error('expected stable live projection');
+    const scope = createScope({ label: 'test:idle-projection' });
+    const lifecycles: string[] = [];
+    observe(live.states.state, (snapshot) => lifecycles.push(liveValue(snapshot.value).lifecycle), {
+      scope,
+    });
 
     await clock.advanceBy(1_200);
+    await rt.manager.sweepNow();
 
     expect(peek(rt.sessionsLiveHost().get(undefined)!.states.list)).toEqual({});
+    expect(rt.sessionLiveModels('conv-idle')).toBe(live);
+    expect(peek(live.states.activationId)).toBeNull();
+    expect(liveValue(peek(live.states.state)).lifecycle).toBe('closed');
+    expect(lifecycles).toContain('closed');
+    const inactivePrompt = await rt.sendPrompt('conv-idle', { text: 'after eviction' });
+    expect(inactivePrompt).toMatchObject({
+      success: false,
+      error: { type: 'activation_missing' },
+    });
+
     await clock.advanceBy(500);
     expect(h.lastChild.kill).toHaveBeenCalledWith('SIGTERM');
+    await scope.dispose();
+  });
+
+  it('rewrites the same projection when a conversation is rematerialized', async () => {
+    const clock = createManualClock(0);
+    const h = makeAcpHarness({
+      clock,
+      lifecycle: {
+        session: { kind: 'idle-after', outputMs: 1_000 },
+        sweepIntervalMs: 10_000,
+      },
+    });
+    const rt = new AcpRuntime(h.deps);
+    const input = makeStartInput({ conversationId: 'conv-rematerialize' });
+    const first = await rt.startSession(input);
+    if (!first.success) throw new Error('expected first activation');
+    const live = rt.sessionLiveModels(input.conversationId);
+    if (!live) throw new Error('expected stable live projection');
+
+    await clock.advanceBy(1_200);
+    await rt.manager.sweepNow();
+    expect(peek(live.states.activationId)).toBeNull();
+
+    h.agent.newSession.mockResolvedValueOnce({ sessionId: 'session-2' });
+    const second = await rt.startSession(input);
+    if (!second.success) throw new Error('expected replacement activation');
+
+    expect(rt.sessionLiveModels(input.conversationId)).toBe(live);
+    expect(second.data.activationId).not.toBe(first.data.activationId);
+    expect(peek(live.states.activationId)).toBe(second.data.activationId);
+    expect(liveValue(peek(live.states.state)).lifecycle).toBe('ready');
+  });
+
+  it('holds activation teardown until a leased provider operation completes', async () => {
+    const promptDeferred = deferred<{ stopReason: 'end_turn' }>();
+    const h = makeAcpHarness();
+    h.agent.prompt.mockImplementationOnce(async () => promptDeferred.promise);
+    const rt = new AcpRuntime(h.deps);
+    await rt.startSession(makeStartInput({ conversationId: 'conv-leased-prompt' }));
+    const live = rt.sessionLiveModels('conv-leased-prompt');
+    if (!live) throw new Error('expected stable live projection');
+
+    const prompt = rt.sendPrompt('conv-leased-prompt', { text: 'hold activation' });
+    await vi.waitFor(() => expect(h.agent.prompt).toHaveBeenCalledTimes(1));
+    const stop = rt.stopSession('conv-leased-prompt');
+    let stopSettled = false;
+    void stop.then(() => {
+      stopSettled = true;
+    });
+    await Promise.resolve();
+
+    expect(stopSettled).toBe(false);
+    expect(h.agent.closeSession).not.toHaveBeenCalled();
+    expect(peek(live.states.activationId)).not.toBeNull();
+
+    promptDeferred.resolve({ stopReason: 'end_turn' });
+    await prompt;
+    await stop;
+    expect(h.agent.closeSession).toHaveBeenCalledTimes(1);
+    expect(peek(live.states.activationId)).toBeNull();
+    expect(liveValue(peek(live.states.state)).lifecycle).toBe('closed');
+  });
+
+  it('waits for full eviction before starting a replacement activation', async () => {
+    const promptDeferred = deferred<{ stopReason: 'end_turn' }>();
+    const h = makeAcpHarness();
+    h.agent.prompt.mockImplementationOnce(async () => promptDeferred.promise);
+    const rt = new AcpRuntime(h.deps);
+    const input = makeStartInput({ conversationId: 'conv-stop-start' });
+    const first = await rt.startSession(input);
+    if (!first.success) throw new Error('expected first activation');
+
+    const prompt = rt.sendPrompt(input.conversationId, { text: 'hold activation' });
+    await vi.waitFor(() => expect(h.agent.prompt).toHaveBeenCalledTimes(1));
+    const stop = rt.stopSession(input.conversationId);
+    h.agent.newSession.mockResolvedValueOnce({ sessionId: 'session-2' });
+    const restart = rt.startSession(input);
+    let restartSettled = false;
+    void restart.then(() => {
+      restartSettled = true;
+    });
+    await Promise.resolve();
+
+    expect(restartSettled).toBe(false);
+    expect(h.agent.newSession).toHaveBeenCalledTimes(1);
+
+    promptDeferred.resolve({ stopReason: 'end_turn' });
+    await prompt;
+    await stop;
+    const second = await restart;
+    if (!second.success) throw new Error('expected replacement activation');
+    expect(second.data.sessionId).toBe('session-2');
+    expect(second.data.activationId).not.toBe(first.data.activationId);
+  });
+
+  it('ignores a late close callback from an older process generation', async () => {
+    const h = makeAcpHarness({ lifecycle: { connectionIdleTtlMs: 0 } });
+    const rt = new AcpRuntime(h.deps);
+    const input = makeStartInput({ conversationId: 'conv-generation' });
+    const first = await rt.startSession(input);
+    if (!first.success) throw new Error('expected first activation');
+    await rt.stopSession(input.conversationId);
+
+    h.agent.newSession.mockResolvedValueOnce({ sessionId: 'session-2' });
+    const second = await rt.startSession(input);
+    if (!second.success) throw new Error('expected replacement activation');
+    rt.manager.onProcessClosed('claude:/tmp/workspace', 1, 42);
+
+    expect(rt.getSessionState(input.conversationId).lifecycle).toBe('ready');
+    expect(peek(rt.sessionLiveModels(input.conversationId)!.states.activationId)).toBe(
+      second.data.activationId
+    );
+  });
+
+  it('rejects commands fenced to a replaced activation', async () => {
+    const h = makeAcpHarness();
+    const rt = new AcpRuntime(h.deps);
+    const input = makeStartInput({ conversationId: 'conv-stale-command' });
+    const first = await rt.startSession(input);
+    if (!first.success) throw new Error('expected first activation');
+    await rt.stopSession(input.conversationId);
+    h.agent.newSession.mockResolvedValueOnce({ sessionId: 'session-2' });
+    const second = await rt.startSession(input);
+    if (!second.success) throw new Error('expected replacement activation');
+    h.agent.prompt.mockClear();
+
+    const result = await rt.sendPrompt(
+      input.conversationId,
+      { text: 'do not replay' },
+      undefined,
+      input,
+      first.data.activationId
+    );
+
+    expect(result).toMatchObject({ success: false, error: { type: 'stale_activation' } });
+    expect(h.agent.prompt).not.toHaveBeenCalled();
+    expect(peek(rt.sessionLiveModels(input.conversationId)!.states.activationId)).toBe(
+      second.data.activationId
+    );
+  });
+
+  it('rejects fenced operations before materializing an evicted activation', async () => {
+    const h = makeAcpHarness({ lifecycle: { connectionIdleTtlMs: 0 } });
+    const rt = new AcpRuntime(h.deps);
+    const input = makeStartInput({ conversationId: 'conv-evicted-fence' });
+    const started = await rt.startSession(input);
+    if (!started.success) throw new Error('expected activation');
+    await rt.stopSession(input.conversationId);
+    h.agent.newSession.mockClear();
+    const processCount = h.children.length;
+
+    const prompt = await rt.sendPrompt(
+      input.conversationId,
+      { text: 'must not restart' },
+      undefined,
+      input,
+      started.data.activationId
+    );
+    const model = await rt.setModelOption(
+      input.conversationId,
+      'model',
+      'replacement-model',
+      input,
+      started.data.activationId
+    );
+
+    expect(prompt).toMatchObject({ success: false, error: { type: 'activation_missing' } });
+    expect(model).toMatchObject({ success: false, error: { type: 'activation_missing' } });
+    expect(h.agent.newSession).not.toHaveBeenCalled();
+    expect(h.children).toHaveLength(processCount);
+    expect([...managerInternals(rt).activations.keys()]).toEqual([]);
   });
 
   it('reconciles legacy session intents and strips desktop identifiers', async () => {
@@ -303,6 +522,7 @@ describe('AcpRuntime session manager', () => {
     await rt.startSession(makeStartInput({ conversationId: 'conv-idle-intent' }));
 
     await clock.advanceBy(1_200);
+    await rt.manager.sweepNow();
 
     await vi.waitFor(() => {
       expect(intents.snapshot()[0]).toMatchObject({
@@ -342,6 +562,7 @@ describe('AcpRuntime session manager', () => {
     observe(live.states.activeTurn, (snapshot) => updates.push(snapshot.value), { scope });
 
     const prompt = rt.sendPrompt('conv-live', { text: 'hello' });
+    await vi.waitFor(() => expect(resolvePrompt).toBeTypeOf('function'));
     updates.length = 0;
     await client.sessionUpdate({
       sessionId,
@@ -368,6 +589,40 @@ describe('AcpRuntime session manager', () => {
     await scope.dispose();
     resolvePrompt({ stopReason: 'end_turn' });
     await prompt;
+  });
+
+  it('does not republish the sessions list when only transcript content changes', async () => {
+    const clock = createManualClock(100);
+    const h = makeAcpHarness({ clock });
+    const rt = new AcpRuntime(h.deps);
+    await rt.startSession(makeStartInput({ conversationId: 'conv-summary-churn' }));
+    const client = h.client();
+    const list = rt.sessionsListLiveModel().states.list;
+
+    await client.sessionUpdate({
+      sessionId: 'session-1',
+      update: {
+        sessionUpdate: 'agent_message_chunk',
+        sessionId: 'session-1',
+        messageId: 'msg-1',
+        content: { type: 'text', text: 'one' },
+      } as SessionUpdate,
+    });
+    const afterFirstChunk = peek(list);
+    const firstSummary = afterFirstChunk['conv-summary-churn'];
+
+    await client.sessionUpdate({
+      sessionId: 'session-1',
+      update: {
+        sessionUpdate: 'agent_message_chunk',
+        sessionId: 'session-1',
+        messageId: 'msg-1',
+        content: { type: 'text', text: 'two' },
+      } as SessionUpdate,
+    });
+
+    expect(peek(list)).toBe(afterFirstChunk);
+    expect(peek(list)['conv-summary-churn']).toBe(firstSummary);
   });
 
   it('publishes usage updates through live models', async () => {
@@ -435,7 +690,7 @@ describe('AcpRuntime session manager', () => {
       ],
     });
 
-    const history = rt.getHistory('conv-attachment');
+    const history = await rt.getHistory('conv-attachment');
     expect(isOk(history)).toBe(true);
     if (!isOk(history)) return;
     expect(history.data.turns[0].items[0]).toMatchObject({
@@ -467,7 +722,7 @@ describe('AcpRuntime session manager', () => {
       ],
     });
 
-    const history = rt.getHistory('conv-hidden-context');
+    const history = await rt.getHistory('conv-hidden-context');
     expect(isOk(history)).toBe(true);
     if (!isOk(history)) return;
     expect(history.data.turns[0].items[0]).toMatchObject({
@@ -619,11 +874,14 @@ describe('AcpRuntime session manager', () => {
 
   it('removes sessions when the process closes', async () => {
     const { h, rt } = await startHarness('conv-close');
+    const live = rt.sessionLiveModels('conv-close');
+    if (!live) throw new Error('expected live models');
 
     h.lastChild.emitExit(42);
 
     await vi.waitFor(() => expect(rt.getSessionState('conv-close').lifecycle).toBe('closed'));
-    expect(rt.sessionLiveModels('conv-close')).toBeNull();
+    expect(rt.sessionLiveModels('conv-close')).toBe(live);
+    expect(peek(live.states.activationId)).toBeNull();
     expect(peek(rt.sessionsListLiveModel().states.list)).toEqual({});
   });
 
@@ -644,8 +902,8 @@ describe('AcpRuntime session manager', () => {
       expect(rt.getSessionState('conv-a').lifecycle).toBe('closed');
       expect(rt.getSessionState('conv-b').lifecycle).toBe('closed');
     });
-    expect(rt.sessionLiveModels('conv-a')).toBeNull();
-    expect(rt.sessionLiveModels('conv-b')).toBeNull();
+    expect(peek(rt.sessionLiveModels('conv-a')!.states.activationId)).toBeNull();
+    expect(peek(rt.sessionLiveModels('conv-b')!.states.activationId)).toBeNull();
     expect(peek(rt.sessionsListLiveModel().states.list)).toEqual({});
   });
 });
@@ -757,7 +1015,9 @@ describe('AcpRuntime conversation lifecycle reports', () => {
       expect(reports.ended).toEqual(['conv-died']);
     });
     // The cell onClosed eviction and the process-close eviction coalesce.
-    await vi.waitFor(() => expect(rt.sessionLiveModels('conv-died')).toBeNull());
+    await vi.waitFor(() =>
+      expect(peek(rt.sessionLiveModels('conv-died')!.states.activationId)).toBeNull()
+    );
     expect(reports.ended).toEqual(['conv-died']);
     expectNoSessionResidue('conv-died', leakContainers(rt));
   });
@@ -771,7 +1031,9 @@ describe('AcpRuntime conversation lifecycle reports', () => {
 
     h.lastChild.emitExit(42);
 
-    await vi.waitFor(() => expect(rt.sessionLiveModels('conv-crash')).toBeNull());
+    await vi.waitFor(() =>
+      expect(peek(rt.sessionLiveModels('conv-crash')!.states.activationId)).toBeNull()
+    );
     expect(intents.snapshot()[0]).toMatchObject({
       conversationId: 'conv-crash',
       status: 'active',
@@ -811,16 +1073,24 @@ describe('AcpRuntime conversation lifecycle reports', () => {
 });
 
 type ManagerInternals = {
-  cells: Map<string, unknown>;
+  activations: { has(key: string): boolean; keys(): IterableIterator<string> };
+  materializing: Map<string, unknown>;
+  evictions: Map<string, Promise<void>>;
   routes: Map<string, Map<string, string>>;
   loadingConversations: Map<string, Set<string>>;
 };
 
+function managerInternals(rt: AcpRuntime): ManagerInternals {
+  return rt.manager as unknown as ManagerInternals;
+}
+
 /** Reflects over the manager's per-key maps so the shared leak check can see them. */
 function leakContainers(rt: AcpRuntime): LeakCheckContainer[] {
-  const internals = rt.manager as unknown as ManagerInternals;
+  const internals = managerInternals(rt);
   return [
-    mapContainer('cells', internals.cells),
+    { name: 'activations', has: (key) => internals.activations.has(key) },
+    mapContainer('materializing', internals.materializing),
+    mapContainer('evictions', internals.evictions),
     {
       name: 'routes',
       has: (key) =>
@@ -830,7 +1100,6 @@ function leakContainers(rt: AcpRuntime): LeakCheckContainer[] {
       name: 'loadingConversations',
       has: (key) => [...internals.loadingConversations.values()].some((set) => set.has(key)),
     },
-    { name: 'liveModels', has: (key) => rt.sessionLiveModels(key) !== null },
     {
       name: 'sessionsList',
       has: (key) => key in peek(rt.sessionsListLiveModel().states.list),

--- a/packages/core/src/runtimes/acp/node/runtime/session-manager.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/session-manager.ts
@@ -10,38 +10,40 @@ import type {
 } from '@agentclientprotocol/sdk';
 import type { Lease, Result, Serializable } from '@emdash/shared';
 import { ok, toSerializedError } from '@emdash/shared';
-import { acquireResourceAsResult } from '@emdash/shared/concurrency';
+import {
+  acquireResourceAsResult,
+  createLifecycleRegistry,
+  type LifecycleRegistry,
+  type LifecycleRegistryStateChange,
+  type Scope,
+} from '@emdash/shared/concurrency';
 import type { Logger } from '@emdash/shared/logger';
 import { systemClock, type Clock } from '@emdash/shared/scheduling';
+import { produce } from '@emdash/wire/state';
 import type {
   AcpCancelTurnError,
+  AcpActivationError,
   AcpChangeQueuePromptOrderError,
   AcpDeleteQueuedPromptError,
   AcpEditQueuedPromptError,
   AcpExportRawLogError,
   AcpExportTranscriptError,
+  AcpKillError,
   AcpResolvePermissionError,
   AcpSendPromptError,
   AcpSetModeOptionError,
   AcpSetModelOptionError,
-  AcpSetPromptDraftError,
   AcpStartError,
-  AcpKillError,
-  AgentState,
   InvalidStateError,
   NormalizedEvent,
-  PlanState,
-  PromptDraft,
-  PromptDraftUpdate,
-  SessionConfigState,
   SessionMcpServer,
   SessionState,
   SessionSummary,
-  SessionUsage,
+  StaleActivationError,
   TerminalState,
   TranscriptTurn,
 } from '#runtimes/acp/api';
-import { acpErr, acpStartInputSchema } from '#runtimes/acp/api';
+import { acpErr, acpStartInputSchema, initialSessionConfigState } from '#runtimes/acp/api';
 import type { InboundRouter } from '#runtimes/acp/node/agent-ports/agent-client';
 import type { FsPort } from '#runtimes/acp/node/agent-ports/fs-port';
 import type { AgentTerminalManager } from '#runtimes/acp/node/agent-ports/terminal-manager';
@@ -54,16 +56,14 @@ import {
   type AcpConnectionSource,
   type PooledAcpProcess,
 } from '#runtimes/acp/node/connection/source';
-import { projectSessionState } from '#runtimes/acp/node/machine/machine';
 import { SessionCell, type AcpChatHistory } from '#runtimes/acp/node/session/cell';
 import type { SessionCellCallbacks } from '#runtimes/acp/node/session/cell-deps';
 import {
   createAcpSessionLiveHost,
   createAcpSessionsLiveHost,
-  createSessionLiveModels,
   createSessionsListModel,
-  publishLiveModelState,
-  produceCell,
+  inactiveSessionState,
+  type ActivationSnapshot,
   type AcpSessionLiveHost,
   type AcpSessionsLiveHost,
   type SessionLiveModels,
@@ -72,6 +72,7 @@ import {
 import type {
   ActivityFields,
   ConversationSessionLifecycle,
+  EvictOptions,
   SessionSnapshotJudgment,
 } from '#services/session-lifecycle/api';
 import { createSessionLifecycle } from '#services/session-lifecycle/node';
@@ -79,8 +80,11 @@ import { registrationsToAcpMcpServers, summarizeAcpMcpServers } from './mcp-serv
 import type { AcpRuntimeDeps, AcpStartInput, SendPromptInput } from './types';
 
 interface SessionRecord {
+  activationId: string;
+  resumeOutcome: 'loaded' | 'replaced-by-new' | null;
   input: AcpStartInput;
   processKey: string;
+  processGeneration: number;
   connectionLease: Lease<PooledAcpProcess>;
   /**
    * Cleared before evicting a record whose pooled process already died: the pool
@@ -88,19 +92,19 @@ interface SessionRecord {
    */
   releaseLeaseOnEvict: boolean;
   cell: SessionCell;
-  live: SessionLiveModels;
+  projection: SessionLiveModels;
+  mcpServers: SessionMcpServer[];
   machineStateBinding: { dispose(): void };
-  lastSynced: {
-    config?: SessionConfigState;
-    usage?: SessionUsage | null;
-    plan?: PlanState | null;
-    agents?: AgentState[];
-    activeTurn?: TranscriptTurn | null;
-    draft?: PromptDraft | null;
-    terminals?: TerminalState[];
-    mcpServers?: SessionMcpServer[];
-  };
+  disposed: boolean;
 }
+
+type ActivationRegistry = LifecycleRegistry<
+  AcpStartInput,
+  SessionRecord,
+  AcpStartError,
+  void,
+  never
+>;
 
 export interface HistoryPage {
   turns: TranscriptTurn[];
@@ -111,7 +115,9 @@ export class SessionManager implements InboundRouter {
   readonly sessionHost: AcpSessionLiveHost = createAcpSessionLiveHost();
   readonly sessionsHost: AcpSessionsLiveHost = createAcpSessionsLiveHost();
   readonly sessionsList: SessionsListModel = createSessionsListModel(this.sessionsHost);
-  private readonly cells = new Map<string, SessionRecord>();
+  private readonly activations: ActivationRegistry;
+  private readonly materializing = new Map<string, SessionRecord>();
+  private readonly evictions = new Map<string, Promise<void>>();
   private readonly routes = new Map<string, Map<string, string>>();
   private readonly loadingConversations = new Map<string, Set<string>>();
   private readonly clock: Clock;
@@ -124,13 +130,35 @@ export class SessionManager implements InboundRouter {
     private readonly ports: { fs: FsPort; terminals: TerminalPort }
   ) {
     this.clock = deps.clock ?? systemClock;
+    this.activations = createLifecycleRegistry<
+      AcpStartInput,
+      SessionRecord,
+      AcpStartError,
+      void,
+      never
+    >({
+      label: 'acp-session-activations',
+      keyOf: (input) => input.conversationId,
+      start: (input, scope) => this.startActivation(input, scope),
+      stop: async (_key, record) => {
+        await record.cell.closeSession().catch(() => {});
+        return ok();
+      },
+      onStateChanged: (change) => this.onActivationStateChanged(change),
+      onObserverError: ({ key, error }) => {
+        this.deps.logger.warn('SessionManager: activation state observer failed', {
+          conversationId: key,
+          error: String(error),
+        });
+      },
+    });
     this.lifecycle = createSessionLifecycle<AcpStartInput, void>({
       name: 'SessionManager',
       logger: deps.logger,
       clock: this.clock,
       idlePolicy: deps.lifecycle?.session,
       sweepIntervalMs: deps.lifecycle?.sweepIntervalMs,
-      entries: () => this.cells.keys(),
+      entries: () => this.activations.keys(),
       snapshot: (conversationId) => this.lifecycleSnapshot(conversationId),
       syncListEntry: (conversationId, activity) =>
         this.syncSessionActivity(conversationId, activity),
@@ -138,45 +166,14 @@ export class SessionManager implements InboundRouter {
         await this.stop(conversationId, cause);
       },
       evictSteps: [
-        { name: 'cell', run: (key) => this.cells.get(key)?.cell.dispose() },
-        {
-          name: 'machine-state-binding',
-          run: (key) => this.cells.get(key)?.machineStateBinding.dispose(),
-        },
-        {
-          name: 'routes',
-          run: (key) => {
-            const record = this.cells.get(key);
-            if (record) this.unregisterRoutes(record.processKey, key);
-          },
-        },
-        { name: 'live-models', run: (key) => this.cells.get(key)?.live.dispose() },
-        {
-          name: 'connection-lease',
-          run: (key) => {
-            const record = this.cells.get(key);
-            if (record?.releaseLeaseOnEvict) void record.connectionLease.release();
-          },
-        },
-        {
-          name: 'record',
-          run: (key) => {
-            this.cells.delete(key);
-          },
-        },
-        {
-          name: 'conversation-terminals',
-          run: (key) => {
-            this.terminals.disposeConversation(key);
-          },
-        },
+        { name: 'activation', run: (key) => this.activations.stop(key) },
         { name: 'sessions-list-summary', run: (key) => this.deleteSessionSummary(key) },
       ],
       conversation: {
         intents: deps.intents,
         reports: deps.conversationReports,
         activePayload: (conversationId) => {
-          const record = this.cells.get(conversationId);
+          const record = this.activations.get(conversationId);
           if (!record) return null;
           const { initialQueue: _initialQueue, ...persisted } = record.input;
           const sessionId = record.cell.acpSessionId;
@@ -195,13 +192,43 @@ export class SessionManager implements InboundRouter {
     });
   }
 
-  async start(input: AcpStartInput): Promise<Result<{ sessionId: string }, AcpStartError>> {
-    const existing = this.cells.get(input.conversationId);
-    if (existing) {
-      this.lifecycle.saveIntent(input.conversationId);
-      return ok({ sessionId: existing.cell.acpSessionId });
-    }
+  async start(
+    input: AcpStartInput
+  ): Promise<Result<{ sessionId: string; activationId: string }, AcpStartError>> {
+    await this.evictions.get(input.conversationId);
     this.lifecycle.recordInput(input.conversationId);
+    const existing = this.activations.get(input.conversationId);
+
+    const started = await this.activations.start(input);
+    if (!started.success) {
+      await this.evict(input.conversationId, { intent: 'keep' });
+      return started;
+    }
+    if (existing === started.data) this.lifecycle.saveIntent(input.conversationId);
+    return ok({
+      sessionId: started.data.cell.acpSessionId,
+      activationId: started.data.activationId,
+    });
+  }
+
+  private async startActivation(
+    input: AcpStartInput,
+    scope: Scope
+  ): Promise<Result<SessionRecord, AcpStartError>> {
+    const activationId = crypto.randomUUID();
+    const projection = this.sessionHost.models(input.conversationId);
+    scope.add(this.sessionHost.models.retain(input.conversationId));
+    projection.source.set({
+      activationId,
+      state: { ...inactiveSessionState, lifecycle: 'starting' },
+      config: initialSessionConfigState,
+      usage: null,
+      plan: null,
+      agents: [],
+      activeTurn: null,
+      terminals: [],
+      mcpServers: [],
+    });
 
     this.upsertSessionSummary(input, null, {
       lifecycle: 'starting',
@@ -213,9 +240,6 @@ export class SessionManager implements InboundRouter {
 
     const binding = this.deps.agentHost.resolveAcp(input.providerId);
     if (!binding) {
-      // Start-failure teardown: no record exists yet, but the eviction drops the
-      // activity tracker and summary entry (the old failed-start leak).
-      await this.lifecycle.evict(input.conversationId, { intent: 'keep' });
       return acpErr.providerUnsupported(input.providerId);
     }
 
@@ -230,11 +254,14 @@ export class SessionManager implements InboundRouter {
       isAcpConnectionError
     );
     if (!acquire.success) {
-      await this.lifecycle.evict(input.conversationId, { intent: 'keep' });
       return acquire;
     }
 
     const acquired = acquire.data;
+    let recordOwnsLease = false;
+    scope.add(async () => {
+      if (!recordOwnsLease) await acquired.release();
+    });
     const connection = acquired.value;
     const mcpServers = await this.resolveSessionMcpServers(input.providerId, connection);
     const mcpServerSummary = summarizeAcpMcpServers(mcpServers);
@@ -248,9 +275,18 @@ export class SessionManager implements InboundRouter {
 
     try {
       if (input.sessionId && connection.supportsLoadSession && connection.agent.loadSession) {
-        record = this.createRecord(input, connection, acquired, input.sessionId);
-        this.addLoading(connection.key, input.conversationId);
-        this.registerRoute(connection.key, input.sessionId, input.conversationId);
+        record = this.createRecord(
+          input,
+          connection,
+          acquired,
+          input.sessionId,
+          activationId,
+          projection,
+          scope
+        );
+        recordOwnsLease = true;
+        this.addLoading(connectionOwnerId(connection), input.conversationId);
+        this.registerRoute(connectionOwnerId(connection), input.sessionId, input.conversationId);
         record.cell.beginReplay();
 
         let loaded = false;
@@ -284,12 +320,13 @@ export class SessionManager implements InboundRouter {
             conversationId: input.conversationId,
           });
         } finally {
-          this.removeLoading(connection.key, input.conversationId);
+          this.removeLoading(connectionOwnerId(connection), input.conversationId);
         }
 
         if (!loaded) {
-          this.discardReplacedRecord(input.conversationId);
+          this.discardReplacedRecord(record);
           record = null;
+          recordOwnsLease = false;
         }
       }
 
@@ -301,13 +338,18 @@ export class SessionManager implements InboundRouter {
           );
         } catch (e) {
           if (isAuthRequiredError(e)) throw e;
-          // No record exists here (the loadSession fallback already discarded its
-          // record), so the lease is still caller-held and released explicitly.
-          await this.lifecycle.evict(input.conversationId, { intent: 'keep' });
-          await acquired.release();
           return acpErr.newSessionFailed(toSerializedError(e));
         }
-        record = this.createRecord(input, connection, acquired, response.sessionId);
+        record = this.createRecord(
+          input,
+          connection,
+          acquired,
+          response.sessionId,
+          activationId,
+          projection,
+          scope
+        );
+        recordOwnsLease = true;
         record.cell.applySessionMeta({
           modes: response.modes,
           configOptions: response.configOptions,
@@ -328,23 +370,17 @@ export class SessionManager implements InboundRouter {
         record.cell.applySessionReady();
       }
 
-      this.registerRoute(connection.key, record.cell.acpSessionId, input.conversationId);
+      this.registerRoute(
+        connectionOwnerId(connection),
+        record.cell.acpSessionId,
+        input.conversationId
+      );
 
-      this.publishSessionMcpServers(record, mcpServerSummary);
+      record.mcpServers = mcpServerSummary;
       this.syncRecord(record);
-      // `started` reports sessionStarted and persists the active intent.
-      this.lifecycle.started(input.conversationId, {
-        conversationId: input.conversationId,
-        providerSessionId: record.cell.acpSessionId,
-        resumeOutcome,
-      });
-      return ok({ sessionId: record.cell.acpSessionId });
+      record.resumeOutcome = resumeOutcome;
+      return ok(record);
     } catch (e) {
-      // When a record exists it holds the lease, so the evict step releases it;
-      // otherwise the caller-held lease is released explicitly.
-      const recordHeldLease = this.cells.has(input.conversationId);
-      await this.lifecycle.evict(input.conversationId, { intent: 'keep' });
-      if (!recordHeldLease) await acquired.release();
       if (isAuthRequiredError(e)) {
         return acpErr.authRequired(toSerializedError(e));
       }
@@ -352,139 +388,169 @@ export class SessionManager implements InboundRouter {
     }
   }
 
-  async prompt(input: SendPromptInput): Promise<Result<{ queued: boolean }, AcpSendPromptError>> {
-    const record = this.cells.get(input.conversationId);
-    if (!record) return acpErr.conversationNotFound(input.conversationId);
-    this.lifecycle.recordInput(input.conversationId);
-    if (input.placement === 'queue') {
-      const state = record.cell.sessionState;
-      if (state.lifecycle !== 'ready' || state.isGenerating || state.queuedPrompts.length > 0) {
-        const result = record.cell.queuePrompt(input.prompt);
-        if (!result.success) return result;
-        return ok({ queued: true });
+  async prompt(
+    input: SendPromptInput,
+    activation?: AcpStartInput,
+    expectedActivationId?: string
+  ): Promise<Result<{ queued: boolean }, AcpSendPromptError>> {
+    const target = this.resolveActivationTarget(
+      input.conversationId,
+      activation,
+      expectedActivationId
+    );
+    if (!target.success) return target;
+    const acquired = await this.activations.acquire(target.data);
+    if (!acquired.success) return acquired;
+    const lease = acquired.data;
+    try {
+      const fence = this.checkActivationFence(lease.value, expectedActivationId);
+      if (!fence.success) return fence;
+      this.lifecycle.recordInput(input.conversationId);
+      if (input.placement === 'queue') {
+        const state = lease.value.cell.sessionState;
+        if (state.lifecycle !== 'ready' || state.isGenerating || state.queuedPrompts.length > 0) {
+          const result = lease.value.cell.queuePrompt(input.prompt);
+          if (!result.success) return result;
+          return ok({ queued: true });
+        }
       }
+      return lease.value.cell.prompt(input.prompt);
+    } finally {
+      await lease.release();
     }
-    return record.cell.prompt(input.prompt);
   }
 
-  editQueuedPrompt(
+  async editQueuedPrompt(
     conversationId: string,
     id: string,
-    input: SendPromptInput['prompt']
-  ): Result<void, AcpEditQueuedPromptError> {
-    const record = this.cells.get(conversationId);
-    if (!record) return acpErr.conversationNotFound(conversationId);
-    return record.cell.editQueuedPrompt(id, input);
+    input: SendPromptInput['prompt'],
+    activation?: AcpStartInput,
+    expectedActivationId?: string
+  ): Promise<Result<void, AcpEditQueuedPromptError>> {
+    return this.useSerialized(conversationId, activation, expectedActivationId, (record) =>
+      record.cell.editQueuedPrompt(id, input)
+    );
   }
 
-  removeQueuedPrompt(conversationId: string, id: string): Result<void, AcpDeleteQueuedPromptError> {
-    const record = this.cells.get(conversationId);
-    if (!record) return acpErr.conversationNotFound(conversationId);
-    return record.cell.removeQueuedPrompt(id);
-  }
-
-  reorderQueue(
+  async removeQueuedPrompt(
     conversationId: string,
-    ids: readonly string[]
-  ): Result<void, AcpChangeQueuePromptOrderError> {
-    const record = this.cells.get(conversationId);
-    if (!record) return acpErr.conversationNotFound(conversationId);
-    return record.cell.reorderQueue(ids);
+    id: string,
+    activation?: AcpStartInput,
+    expectedActivationId?: string
+  ): Promise<Result<void, AcpDeleteQueuedPromptError>> {
+    return this.useSerialized(conversationId, activation, expectedActivationId, (record) =>
+      record.cell.removeQueuedPrompt(id)
+    );
+  }
+
+  async reorderQueue(
+    conversationId: string,
+    ids: readonly string[],
+    activation?: AcpStartInput,
+    expectedActivationId?: string
+  ): Promise<Result<void, AcpChangeQueuePromptOrderError>> {
+    return this.useSerialized(conversationId, activation, expectedActivationId, (record) =>
+      record.cell.reorderQueue(ids)
+    );
   }
 
   async cancel(conversationId: string): Promise<Result<void, AcpCancelTurnError>> {
-    const record = this.cells.get(conversationId);
+    const record = this.recordFor(conversationId);
     if (!record) return ok();
     return record.cell.cancel();
   }
 
-  setPromptDraft(
-    conversationId: string,
-    draft: PromptDraftUpdate
-  ): Result<void, AcpSetPromptDraftError> {
-    const record = this.cells.get(conversationId);
-    if (!record) return acpErr.conversationNotFound(conversationId);
-    return record.cell.setPromptDraft(draft);
-  }
-
   async stop(conversationId: string, cause = 'user'): Promise<Result<void, AcpKillError>> {
-    this.cells
-      .get(conversationId)
-      ?.cell.closeSession()
-      .catch(() => {});
-    await this.lifecycle.evict(conversationId, { cause, intent: 'suspend' });
+    await this.evict(conversationId, { cause, intent: 'suspend' });
     return ok();
   }
 
   async kill(conversationId: string): Promise<Result<void, AcpKillError>> {
-    this.cells
-      .get(conversationId)
-      ?.cell.closeSession()
-      .catch(() => {});
-    await this.lifecycle.evict(conversationId, { cause: 'user', intent: 'remove' });
+    await this.evict(conversationId, { cause: 'user', intent: 'remove' });
     return ok();
   }
 
-  resolvePermission(
+  async resolvePermission(
     conversationId: string,
     requestId: string,
-    optionId: string
-  ): Result<void, AcpResolvePermissionError> {
-    const record = this.cells.get(conversationId);
-    if (!record) return acpErr.conversationNotFound(conversationId);
-    this.lifecycle.recordInput(conversationId);
-    return record.cell.resolvePermission(requestId, optionId);
+    optionId: string,
+    activation?: AcpStartInput,
+    expectedActivationId?: string
+  ): Promise<Result<void, AcpResolvePermissionError>> {
+    return this.useSerialized(conversationId, activation, expectedActivationId, (record) =>
+      record.cell.resolvePermission(requestId, optionId)
+    );
   }
 
   async setMode(
     conversationId: string,
-    modeId: string
+    modeId: string,
+    activation?: AcpStartInput,
+    expectedActivationId?: string
   ): Promise<Result<void, AcpSetModeOptionError>> {
-    const record = this.cells.get(conversationId);
-    if (!record) return acpErr.conversationNotFound(conversationId);
-    return record.cell.setMode(modeId);
+    return this.useSerialized(conversationId, activation, expectedActivationId, (record) =>
+      record.cell.setMode(modeId)
+    );
   }
 
   async setConfigOption(
     conversationId: string,
     dimension: 'model' | 'effort',
-    value: string
+    value: string,
+    activation?: AcpStartInput,
+    expectedActivationId?: string
   ): Promise<Result<void, AcpSetModelOptionError>> {
-    const record = this.cells.get(conversationId);
-    if (!record) return acpErr.conversationNotFound(conversationId);
-    return record.cell.setConfigOption(dimension, value);
+    return this.useSerialized(conversationId, activation, expectedActivationId, (record) =>
+      record.cell.setConfigOption(dimension, value)
+    );
   }
 
   isRunning(conversationId: string): boolean {
-    return this.cells.has(conversationId);
+    return this.activations.has(conversationId);
   }
 
   getChatHistory(conversationId: string): AcpChatHistory {
-    return this.cells.get(conversationId)?.cell.history() ?? { committed: [], active: null };
+    return this.recordFor(conversationId)?.cell.history() ?? { committed: [], active: null };
   }
 
-  exportParsedTranscript(conversationId: string): Result<string, AcpExportTranscriptError> {
-    const record = this.cells.get(conversationId);
-    if (!record) return acpErr.conversationNotFound(conversationId);
-    return ok(record.cell.exportParsedTranscript());
+  exportParsedTranscript(
+    conversationId: string,
+    activation?: AcpStartInput,
+    expectedActivationId?: string
+  ): Promise<Result<string, AcpExportTranscriptError>> {
+    return this.useSerialized(conversationId, activation, expectedActivationId, (record) =>
+      ok(record.cell.exportParsedTranscript())
+    );
   }
 
-  exportRawAcpLog(conversationId: string): Result<string, AcpExportRawLogError> {
-    const record = this.cells.get(conversationId);
-    if (!record) return acpErr.conversationNotFound(conversationId);
-    return ok(record.cell.exportRawLog());
+  exportRawAcpLog(
+    conversationId: string,
+    activation?: AcpStartInput,
+    expectedActivationId?: string
+  ): Promise<Result<string, AcpExportRawLogError>> {
+    return this.useSerialized(conversationId, activation, expectedActivationId, (record) =>
+      ok(record.cell.exportRawLog())
+    );
   }
 
-  getHistory(conversationId: string, before?: number, limit = 50): HistoryPage {
-    const turns = this.getChatHistory(conversationId).committed;
-    const filtered = before === undefined ? turns : turns.filter((turn) => turn.seq < before);
-    const page = [...filtered].sort((a, b) => b.seq - a.seq).slice(0, limit);
-    const nextCursor = page.length === limit ? page.at(-1)!.seq : null;
-    return { turns: page.reverse(), nextCursor };
+  getHistory(
+    conversationId: string,
+    before?: number,
+    limit = 50,
+    activation?: AcpStartInput,
+    expectedActivationId?: string
+  ): Promise<Result<HistoryPage, AcpExportTranscriptError>> {
+    return this.useSerialized(conversationId, activation, expectedActivationId, (record) => {
+      const turns = record.cell.history().committed;
+      const filtered = before === undefined ? turns : turns.filter((turn) => turn.seq < before);
+      const page = [...filtered].sort((a, b) => b.seq - a.seq).slice(0, limit);
+      const nextCursor = page.length === limit ? page.at(-1)!.seq : null;
+      return ok({ turns: page.reverse(), nextCursor });
+    });
   }
 
   getSessionState(conversationId: string): SessionState {
-    const record = this.cells.get(conversationId);
+    const record = this.recordFor(conversationId);
     if (record) return record.cell.sessionState;
     return {
       lifecycle: 'closed',
@@ -510,15 +576,13 @@ export class SessionManager implements InboundRouter {
   }
 
   getLiveModels(conversationId: string): SessionLiveModels | null {
-    return this.cells.get(conversationId)?.live ?? null;
+    return this.sessionHost.models.peekMember(conversationId) ?? null;
   }
 
   syncTerminals(conversationId: string): void {
-    const record = this.cells.get(conversationId);
+    const record = this.recordFor(conversationId);
     if (!record) return;
-    const terminals = this.getTerminals(conversationId);
-    publishLiveModelState(record.live.states.terminals, terminals, record.lastSynced.terminals);
-    record.lastSynced.terminals = terminals;
+    this.syncRecord(record);
   }
 
   killAllTerminals(): void {
@@ -530,7 +594,10 @@ export class SessionManager implements InboundRouter {
     params: SessionNotification,
     event: NormalizedEvent
   ): void {
-    const conversationId = this.resolveConversationForSession(connection.key, params.sessionId);
+    const conversationId = this.resolveConversationForSession(
+      connectionOwnerId(connection),
+      params.sessionId
+    );
     if (!conversationId) {
       this.deps.logger.warn('SessionManager: sessionUpdate for unknown sessionId', {
         sessionId: params.sessionId,
@@ -538,12 +605,12 @@ export class SessionManager implements InboundRouter {
       return;
     }
 
-    const record = this.cells.get(conversationId);
+    const record = this.recordFor(conversationId);
     if (!record) return;
     this.lifecycle.recordOutput(conversationId);
     if (record.cell.acpSessionId !== params.sessionId) {
       record.cell.setAcpSessionId(params.sessionId);
-      this.registerRoute(connection.key, params.sessionId, conversationId);
+      this.registerRoute(connectionOwnerId(connection), params.sessionId, conversationId);
       this.lifecycle.providerSessionId(conversationId, {
         conversationId,
         providerSessionId: params.sessionId,
@@ -563,8 +630,11 @@ export class SessionManager implements InboundRouter {
     connection: AcpConnectionContext,
     params: RequestPermissionRequest
   ): Promise<RequestPermissionResponse> {
-    const conversationId = this.resolveConversationForSession(connection.key, params.sessionId);
-    const record = conversationId ? this.cells.get(conversationId) : undefined;
+    const conversationId = this.resolveConversationForSession(
+      connectionOwnerId(connection),
+      params.sessionId
+    );
+    const record = conversationId ? this.recordFor(conversationId) : undefined;
     if (!conversationId || !record) return Promise.resolve({ outcome: { outcome: 'cancelled' } });
     this.lifecycle.recordOutput(conversationId);
     const response = record.cell.requestPermission(params);
@@ -576,23 +646,33 @@ export class SessionManager implements InboundRouter {
     connection: AcpConnectionContext,
     params: CreateTerminalRequest
   ): Promise<CreateTerminalResponse> {
-    const conversationId = this.resolveConversationForSession(connection.key, params.sessionId);
+    const conversationId = this.resolveConversationForSession(
+      connectionOwnerId(connection),
+      params.sessionId
+    );
     if (!conversationId) {
       throw new Error(`SessionManager: no conversation for ACP sessionId ${params.sessionId}`);
     }
     return this.ports.terminals.createTerminal(conversationId, connection.cwd, params);
   }
 
-  onProcessClosed(processKey: string, exitCode: number | null): void {
-    for (const record of [...this.cells.values()]) {
-      if (record.processKey !== processKey) continue;
+  onProcessClosed(processKey: string, processGeneration: number, exitCode: number | null): void {
+    const records = new Set([...this.activations.values(), ...this.materializing.values()]);
+    for (const record of records) {
+      if (
+        record.processKey !== processKey ||
+        record.processGeneration !== processGeneration ||
+        record.disposed
+      ) {
+        continue;
+      }
       // The pooled process is gone: invalidation owns the pool entry, so the evict
       // step must not release the dead lease.
       record.releaseLeaseOnEvict = false;
       record.cell.processClosed(exitCode);
       // The active intent is kept so restart reconciliation can restore the
       // conversation; the cell's onClosed eviction (triggered above) coalesces.
-      void this.lifecycle.evict(record.input.conversationId, {
+      void this.evict(record.input.conversationId, {
         cause: 'process-exited',
         intent: 'keep',
       });
@@ -607,21 +687,31 @@ export class SessionManager implements InboundRouter {
     input: AcpStartInput,
     connection: AcpConnectionEntry,
     connectionLease: Lease<PooledAcpProcess>,
-    acpSessionId: string
+    acpSessionId: string,
+    activationId: string,
+    projection: SessionLiveModels,
+    scope: Scope
   ): SessionRecord {
-    const record = {} as SessionRecord;
+    const recordRef: { current?: SessionRecord } = {};
     const callbacks: SessionCellCallbacks = {
-      onSessionStateChanged: () => this.syncRecord(record),
-      onTranscriptChanged: () => this.syncRecord(record),
-      onDraftChanged: () => this.syncRecord(record),
+      onSessionStateChanged: () => {
+        if (recordRef.current) this.syncRecord(recordRef.current);
+      },
+      onTranscriptChanged: () => {
+        if (recordRef.current) this.syncRecord(recordRef.current);
+      },
       // Machine-driven close (usually process death): full teardown; the active
       // intent is kept so restart reconciliation can restore the conversation.
-      onClosed: () =>
-        void this.lifecycle.evict(input.conversationId, {
+      onClosed: () => {
+        if (!recordRef.current || !this.isCurrentRecord(recordRef.current)) return;
+        void this.evict(input.conversationId, {
           cause: 'process-exited',
           intent: 'keep',
-        }),
-      onSendQueuedPrompt: () => this.syncRecord(record),
+        });
+      },
+      onSendQueuedPrompt: () => {
+        if (recordRef.current) this.syncRecord(recordRef.current);
+      },
     };
     const cell = new SessionCell({
       conversationId: input.conversationId,
@@ -632,32 +722,26 @@ export class SessionManager implements InboundRouter {
       logger: this.deps.logger,
       callbacks,
     });
-    const live = createSessionLiveModels(this.sessionHost, input.conversationId, cell.sessionState);
-    const syncMachineState = () =>
-      live.states.state.set(projectSessionState(cell.machine.current()));
-    syncMachineState();
-    const unsubscribeMachine = cell.machine.subscribe(syncMachineState);
-    const machineStateBinding = { dispose: unsubscribeMachine };
-    Object.assign(record, {
+    const machineStateBinding = { dispose: () => {} };
+    const record: SessionRecord = {
+      activationId,
+      resumeOutcome: null,
       input,
       processKey: connection.key,
+      processGeneration: connection.generation,
       connectionLease,
       releaseLeaseOnEvict: true,
       cell,
-      live,
+      projection,
+      mcpServers: [],
       machineStateBinding,
-      lastSynced: {
-        config: cell.config,
-        usage: cell.usage,
-        plan: null,
-        agents: [],
-        activeTurn: null,
-        draft: null,
-        terminals: [],
-        mcpServers: [],
-      },
-    });
-    this.cells.set(input.conversationId, record);
+      disposed: false,
+    };
+    recordRef.current = record;
+    this.materializing.set(input.conversationId, record);
+    this.syncRecord(record);
+    machineStateBinding.dispose = cell.machine.subscribe(() => this.syncRecord(record));
+    scope.add(() => this.teardownRecord(record));
     return record;
   }
 
@@ -670,36 +754,23 @@ export class SessionManager implements InboundRouter {
   }
 
   private syncRecord(record: SessionRecord): void {
-    const state = record.cell.sessionState;
+    if (!this.isCurrentRecord(record)) return;
+    record.projection.source.set(this.buildSnapshot(record));
+    this.upsertSessionSummary(record.input, record.cell, record.cell.sessionState);
+  }
 
-    const config = record.cell.config;
-    publishLiveModelState(record.live.states.config, config, record.lastSynced.config);
-    record.lastSynced.config = config;
-
-    const usage = record.cell.usage;
-    publishLiveModelState(record.live.states.usage, usage, record.lastSynced.usage);
-    record.lastSynced.usage = usage;
-
-    const plan = record.cell.transcript.plan ?? null;
-    publishLiveModelState(record.live.states.plan, plan, record.lastSynced.plan);
-    record.lastSynced.plan = plan;
-
-    const agents = record.cell.transcript.agents;
-    const agentSnapshot = [...agents];
-    publishLiveModelState(record.live.states.agents, agentSnapshot, record.lastSynced.agents);
-    record.lastSynced.agents = agentSnapshot;
-
-    const activeTurn = record.cell.transcript.activeTurn;
-    publishLiveModelState(record.live.states.activeTurn, activeTurn, record.lastSynced.activeTurn);
-    record.lastSynced.activeTurn = activeTurn;
-
-    const draft = record.cell.promptDraft;
-    publishLiveModelState(record.live.states.draft, draft, record.lastSynced.draft);
-    record.lastSynced.draft = draft;
-
-    this.syncTerminals(record.input.conversationId);
-
-    this.upsertSessionSummary(record.input, record.cell, state);
+  private buildSnapshot(record: SessionRecord): ActivationSnapshot {
+    return {
+      activationId: record.activationId,
+      state: record.cell.sessionState,
+      config: record.cell.config,
+      usage: record.cell.usage,
+      plan: record.cell.transcript.plan,
+      agents: record.cell.transcript.agents,
+      activeTurn: record.cell.transcript.activeTurn,
+      terminals: this.getTerminals(record.input.conversationId),
+      mcpServers: record.mcpServers,
+    };
   }
 
   private async resolveSessionMcpServers(providerId: string, connection: AcpConnectionEntry) {
@@ -723,11 +794,6 @@ export class SessionManager implements InboundRouter {
     }
   }
 
-  private publishSessionMcpServers(record: SessionRecord, mcpServers: SessionMcpServer[]): void {
-    publishLiveModelState(record.live.states.mcpServers, mcpServers, record.lastSynced.mcpServers);
-    record.lastSynced.mcpServers = mcpServers;
-  }
-
   private upsertSessionSummary(
     input: AcpStartInput,
     cell: SessionCell | null,
@@ -741,7 +807,7 @@ export class SessionManager implements InboundRouter {
       queuedPromptCount?: number;
     }
   ): void {
-    const summary: SessionSummary = {
+    const summary: Omit<SessionSummary, 'updatedAt'> = {
       conversationId: input.conversationId,
       providerId: input.providerId,
       cwd: input.cwd,
@@ -753,7 +819,6 @@ export class SessionManager implements InboundRouter {
       backgroundAgentCount: state.backgroundAgentCount,
       queuedPromptCount: state.queuedPromptCount ?? state.queuedPrompts?.length ?? 0,
       title: cell?.transcript.title ?? null,
-      updatedAt: this.clock.now(),
     };
     const activity = this.lifecycle.activity(input.conversationId);
     if (activity.lastInputAt !== null) {
@@ -762,36 +827,70 @@ export class SessionManager implements InboundRouter {
     if (activity.lastOutputAt !== null) {
       summary.lastOutputAt = activity.lastOutputAt;
     }
-    produceCell(this.sessionsList.states.list, (draft) => {
-      draft[input.conversationId] = summary;
+    this.sessionsList.states.list.update((previous) => {
+      const current = previous[input.conversationId];
+      if (current && sessionSummaryEquals(current, summary)) return previous;
+      return produce(previous, (draft) => {
+        draft[input.conversationId] = { ...summary, updatedAt: this.clock.now() };
+      });
     });
   }
 
-  dispose(): void {
+  async dispose(): Promise<void> {
     this.lifecycle.dispose();
+    await this.activations.dispose();
+    await Promise.all([this.sessionHost.dispose(), this.sessionsHost.dispose()]);
   }
 
   reconcile(): Promise<void> {
     return this.lifecycle.reconcile();
   }
 
+  /** Deterministic lifecycle sweep seam used by runtime tests. */
+  sweepNow(): Promise<void> {
+    return this.lifecycle.sweepNow();
+  }
+
   private deleteSessionSummary(conversationId: string): void {
-    produceCell(this.sessionsList.states.list, (draft) => {
-      delete draft[conversationId];
+    this.sessionsList.states.list.update((previous) => {
+      if (!(conversationId in previous)) return previous;
+      return produce(previous, (draft) => {
+        delete draft[conversationId];
+      });
     });
   }
 
+  private evict(conversationId: string, options: EvictOptions): Promise<void> {
+    const existing = this.evictions.get(conversationId);
+    if (existing) return existing;
+    const pending = this.lifecycle.evict(conversationId, options).finally(() => {
+      if (this.evictions.get(conversationId) === pending) this.evictions.delete(conversationId);
+    });
+    this.evictions.set(conversationId, pending);
+    return pending;
+  }
+
   private syncSessionActivity(conversationId: string, activity: ActivityFields): void {
-    produceCell(this.sessionsList.states.list, (draft) => {
-      const current = draft[conversationId];
-      if (!current) return;
-      if (activity.lastInputAt !== null) current.lastInputAt = activity.lastInputAt;
-      if (activity.lastOutputAt !== null) current.lastOutputAt = activity.lastOutputAt;
+    this.sessionsList.states.list.update((previous) => {
+      const current = previous[conversationId];
+      if (!current) return previous;
+      const lastInputAt = activity.lastInputAt ?? current.lastInputAt;
+      const lastOutputAt = activity.lastOutputAt ?? current.lastOutputAt;
+      if (current.lastInputAt === lastInputAt && current.lastOutputAt === lastOutputAt) {
+        return previous;
+      }
+      return produce(previous, (draft) => {
+        const next = draft[conversationId];
+        if (!next) return;
+        if (activity.lastInputAt !== null) next.lastInputAt = activity.lastInputAt;
+        if (activity.lastOutputAt !== null) next.lastOutputAt = activity.lastOutputAt;
+        next.updatedAt = this.clock.now();
+      });
     });
   }
 
   private lifecycleSnapshot(conversationId: string): SessionSnapshotJudgment | null {
-    const record = this.cells.get(conversationId);
+    const record = this.activations.get(conversationId);
     if (!record) return null;
     const state = record.cell.sessionState;
     return {
@@ -809,16 +908,115 @@ export class SessionManager implements InboundRouter {
    * newSession retry, so this must NOT release it, and the session did not end
    * (no report, no intent write). Deliberately bypasses the chassis evict.
    */
-  private discardReplacedRecord(conversationId: string): void {
-    const record = this.cells.get(conversationId);
-    if (!record) return;
+  private discardReplacedRecord(record: SessionRecord): void {
+    void this.teardownRecord(record, { releaseLease: false });
+  }
+
+  private recordFor(conversationId: string): SessionRecord | undefined {
+    return this.activations.get(conversationId) ?? this.materializing.get(conversationId);
+  }
+
+  private activationInput(
+    conversationId: string,
+    activation?: AcpStartInput
+  ): Result<AcpStartInput, AcpActivationError> {
+    if (activation) {
+      return activation.conversationId === conversationId
+        ? ok(activation)
+        : acpErr.invalidState('Activation descriptor does not match the conversation');
+    }
+    const current = this.recordFor(conversationId);
+    return current ? ok(current.input) : acpErr.activationMissing(conversationId);
+  }
+
+  private resolveActivationTarget(
+    conversationId: string,
+    activation: AcpStartInput | undefined,
+    expectedActivationId: string | undefined
+  ): Result<AcpStartInput, AcpActivationError | StaleActivationError> {
+    if (!expectedActivationId) return this.activationInput(conversationId, activation);
+    const current = this.recordFor(conversationId);
+    if (!current) return acpErr.activationMissing(conversationId);
+    if (current.activationId !== expectedActivationId) {
+      return acpErr.staleActivation(expectedActivationId);
+    }
+    return ok(current.input);
+  }
+
+  private checkActivationFence(
+    record: SessionRecord,
+    expectedActivationId?: string
+  ): Result<void, StaleActivationError> {
+    if (expectedActivationId && record.activationId !== expectedActivationId) {
+      return acpErr.staleActivation(expectedActivationId);
+    }
+    return ok();
+  }
+
+  private async useSerialized<T, E>(
+    conversationId: string,
+    activation: AcpStartInput | undefined,
+    expectedActivationId: string | undefined,
+    operation: (record: SessionRecord) => Result<T, E> | Promise<Result<T, E>>
+  ): Promise<Result<T, AcpActivationError | StaleActivationError | E>> {
+    const target = this.resolveActivationTarget(conversationId, activation, expectedActivationId);
+    if (!target.success) return target;
+    return this.activations.use<T, StaleActivationError | E>(target.data, async (record) => {
+      const fence = this.checkActivationFence(record, expectedActivationId);
+      if (!fence.success) return fence;
+      this.lifecycle.recordInput(conversationId);
+      return operation(record);
+    });
+  }
+
+  private isCurrentRecord(record: SessionRecord): boolean {
+    return !record.disposed && this.recordFor(record.input.conversationId) === record;
+  }
+
+  private async teardownRecord(
+    record: SessionRecord,
+    options: { releaseLease?: boolean } = {}
+  ): Promise<void> {
+    if (record.disposed) return;
+    record.disposed = true;
     record.cell.dispose();
     record.machineStateBinding.dispose();
-    this.unregisterRoutes(record.processKey, conversationId);
-    this.cells.delete(conversationId);
-    this.terminals.disposeConversation(conversationId);
-    record.live.dispose();
-    this.deleteSessionSummary(conversationId);
+    this.unregisterRoutes(connectionOwnerId(record), record.input.conversationId);
+    if (this.materializing.get(record.input.conversationId) === record) {
+      this.materializing.delete(record.input.conversationId);
+    }
+    this.terminals.disposeConversation(record.input.conversationId);
+    if (options.releaseLease !== false && record.releaseLeaseOnEvict) {
+      await record.connectionLease.release();
+    }
+  }
+
+  private onActivationStateChanged(
+    change: LifecycleRegistryStateChange<SessionRecord, AcpStartError, never>
+  ): void {
+    switch (change.current.kind) {
+      case 'ready':
+        if (this.materializing.get(change.key) === change.current.value) {
+          this.materializing.delete(change.key);
+        }
+        this.lifecycle.started(change.key, {
+          conversationId: change.key,
+          providerSessionId: change.current.value.cell.acpSessionId,
+          resumeOutcome: change.current.value.resumeOutcome,
+        });
+        return;
+      case 'idle':
+      case 'start-failed':
+      case 'disposed': {
+        const projection = this.sessionHost.models.peekMember(change.key);
+        if (projection) projection.source.set(null);
+        return;
+      }
+      case 'starting':
+      case 'stopping':
+      case 'stop-failed':
+        return;
+    }
   }
 
   private resolveConversationForSession(processKey: string, acpSessionId: string): string | null {
@@ -923,9 +1121,36 @@ export class SessionManager implements InboundRouter {
   }
 }
 
+function sessionSummaryEquals(
+  current: SessionSummary,
+  candidate: Omit<SessionSummary, 'updatedAt'>
+): boolean {
+  return (
+    current.conversationId === candidate.conversationId &&
+    current.providerId === candidate.providerId &&
+    current.cwd === candidate.cwd &&
+    current.lifecycle === candidate.lifecycle &&
+    current.isGenerating === candidate.isGenerating &&
+    current.lastStopReason === candidate.lastStopReason &&
+    current.lastTurnErrored === candidate.lastTurnErrored &&
+    current.pendingPermissionCount === candidate.pendingPermissionCount &&
+    current.backgroundAgentCount === candidate.backgroundAgentCount &&
+    current.queuedPromptCount === candidate.queuedPromptCount &&
+    current.title === candidate.title &&
+    current.lastInputAt === candidate.lastInputAt &&
+    current.lastOutputAt === candidate.lastOutputAt
+  );
+}
+
 function isAuthRequiredError(error: unknown): boolean {
   if (typeof error !== 'object' || error === null) return false;
   const value = error as { code?: unknown; cause?: unknown };
   if (value.code === -32000) return true;
   return isAuthRequiredError(value.cause);
+}
+
+function connectionOwnerId(connection: AcpConnectionContext | SessionRecord): string {
+  return 'key' in connection
+    ? `${connection.key}:${connection.generation}`
+    : `${connection.processKey}:${connection.processGeneration}`;
 }

--- a/packages/core/src/runtimes/acp/node/session/cell-deps.ts
+++ b/packages/core/src/runtimes/acp/node/session/cell-deps.ts
@@ -15,7 +15,6 @@ export type ResolvePromptAttachment = (
 export interface SessionCellCallbacks {
   onSessionStateChanged?: () => void;
   onTranscriptChanged?: () => void;
-  onDraftChanged?: () => void;
   onClosed?: (exitCode: number | null) => void;
   onAgentEvent?: (phase: 'start' | 'stop' | 'error') => void;
   onSendQueuedPrompt?: (prompt: QueuedPrompt) => void;

--- a/packages/core/src/runtimes/acp/node/session/cell.test.ts
+++ b/packages/core/src/runtimes/acp/node/session/cell.test.ts
@@ -41,21 +41,6 @@ describe('SessionCell prompts', () => {
     expect(history.committed[0].outcome).toEqual({ kind: 'done', reason: 'end_turn' });
   });
 
-  it('stores prompt drafts by monotonic revision and clears them after submit', async () => {
-    const { cell, agent } = makeCell();
-    agent.prompt = vi.fn().mockResolvedValue({ stopReason: 'end_turn' });
-
-    expect(isOk(cell.setPromptDraft({ rev: 1, input: { text: 'old' } }))).toBe(true);
-    expect(isOk(cell.setPromptDraft({ rev: 1, input: { text: 'stale' } }))).toBe(true);
-    expect(cell.promptDraft).toMatchObject({ text: 'old', rev: 1 });
-
-    expect(isOk(cell.setPromptDraft({ rev: 2, input: { text: 'new' } }))).toBe(true);
-    expect(cell.promptDraft).toMatchObject({ text: 'new', rev: 2 });
-
-    await cell.prompt({ text: 'send' });
-    expect(cell.promptDraft).toBeNull();
-  });
-
   it('queues while working and drains after the active turn settles', async () => {
     const { cell, agent } = makeCell();
     let resolveFirst!: (value: { stopReason: 'end_turn' }) => void;

--- a/packages/core/src/runtimes/acp/node/session/cell.ts
+++ b/packages/core/src/runtimes/acp/node/session/cell.ts
@@ -17,8 +17,6 @@ import type {
   AcpSetModelOptionError,
   InvalidStateError,
   NormalizedEvent,
-  PromptDraft,
-  PromptDraftUpdate,
   PromptInput,
   QueuedPrompt,
   SessionConfigState,
@@ -65,8 +63,6 @@ export class SessionCell {
   private quiesceTimer: ReturnType<typeof setTimeout> | null = null;
   private lastRunningAgentCount = 0;
   private readonly effectDriver: MachineEffectDriver<Effect>;
-  private draft: PromptDraft | null = null;
-  private draftRev = 0;
 
   constructor(private readonly deps: SessionCellDeps) {
     this._acpSessionId = deps.acpSessionId;
@@ -110,10 +106,6 @@ export class SessionCell {
 
   get sessionState(): SessionState {
     return this.machine.sessionState();
-  }
-
-  get promptDraft(): PromptDraft | null {
-    return this.draft ? structuredClone(this.draft) : null;
   }
 
   get config(): SessionConfigState {
@@ -223,7 +215,6 @@ export class SessionCell {
       createdAt: now,
       updatedAt: now,
     });
-    if (result.success) this.clearDraft();
     return result;
   }
 
@@ -242,24 +233,6 @@ export class SessionCell {
       ['invalid_state']
     );
     if (!result.success) return result;
-    this.clearDraft();
-    return ok();
-  }
-
-  setPromptDraft(update: PromptDraftUpdate): Result<void, never> {
-    if (update.rev <= this.draftRev) return ok();
-    this.draftRev = update.rev;
-
-    if (update.input === null) {
-      if (this.draft !== null) {
-        this.draft = null;
-        this.deps.callbacks?.onDraftChanged?.();
-      }
-      return ok();
-    }
-
-    this.draft = { ...update.input, rev: update.rev, updatedAt: Date.now() };
-    this.deps.callbacks?.onDraftChanged?.();
     return ok();
   }
 
@@ -615,13 +588,6 @@ export class SessionCell {
         status,
       });
     }
-  }
-
-  private clearDraft(): void {
-    this.draftRev += 1;
-    if (this.draft === null) return;
-    this.draft = null;
-    this.deps.callbacks?.onDraftChanged?.();
   }
 
   private scheduleQuiesce(): void {

--- a/packages/core/src/runtimes/acp/node/state/live-models.test.ts
+++ b/packages/core/src/runtimes/acp/node/state/live-models.test.ts
@@ -1,16 +1,38 @@
+import { flushStateTurn, peek } from '@emdash/wire/state';
 import { describe, expect, it } from 'vitest';
-import { createAcpSessionsLiveHost, produceCell } from './live-models';
+import { initialSessionConfigState } from '#runtimes/acp/api';
+import { createAcpSessionLiveHost, inactiveSessionState } from './live-models';
 
 describe('ACP live models', () => {
-  it('executes cell producers once', async () => {
-    const host = createAcpSessionsLiveHost();
-    let calls = 0;
+  it('derives every exposed state from one activation snapshot', async () => {
+    const host = createAcpSessionLiveHost();
+    const projection = host.models('conversation-1');
 
-    produceCell(host.model.states.list, () => {
-      calls += 1;
+    expect(peek(projection.states.state)).toBe(inactiveSessionState);
+    const inactiveAgents = peek(projection.states.agents);
+
+    projection.source.set({
+      activationId: 'activation-1',
+      state: { ...inactiveSessionState, lifecycle: 'ready', canSubmit: true },
+      config: initialSessionConfigState,
+      usage: null,
+      plan: null,
+      agents: [],
+      activeTurn: null,
+      terminals: [],
+      mcpServers: [],
     });
+    flushStateTurn();
 
-    expect(calls).toBe(1);
+    expect(peek(projection.states.activationId)).toBe('activation-1');
+    expect(peek(projection.states.state)).toMatchObject({ lifecycle: 'ready', canSubmit: true });
+
+    projection.source.set(null);
+    flushStateTurn();
+
+    expect(peek(projection.states.activationId)).toBeNull();
+    expect(peek(projection.states.state)).toBe(inactiveSessionState);
+    expect(peek(projection.states.agents)).toBe(inactiveAgents);
     await host.dispose();
   });
 });

--- a/packages/core/src/runtimes/acp/node/state/live-models.ts
+++ b/packages/core/src/runtimes/acp/node/state/live-models.ts
@@ -1,11 +1,19 @@
 import { type LeasedLiveModelProvider } from '@emdash/wire/rpc';
-import { cell, expose, peek, type Cell, produce, publishStructural } from '@emdash/wire/state';
+import {
+  cell,
+  derived,
+  expose,
+  family,
+  snapshot,
+  type Cell,
+  type Family,
+  type Readable,
+} from '@emdash/wire/state';
 import {
   acpApiContract,
   initialSessionConfigState,
   type AgentState,
   type PlanState,
-  type PromptDraft,
   type SessionConfigState,
   type SessionMcpServer,
   type SessionState,
@@ -15,26 +23,60 @@ import {
   type TranscriptTurn,
 } from '#runtimes/acp/api';
 
+export const inactiveSessionState: SessionState = {
+  lifecycle: 'closed',
+  activeTurnId: null,
+  pendingPermissions: [],
+  lastStopReason: null,
+  lastTurnErrored: false,
+  queuedPrompts: [],
+  agentTurnActive: false,
+  backgroundAgentCount: 0,
+  isGenerating: false,
+  canSubmit: false,
+  canCancel: false,
+};
+
+const EMPTY_AGENTS: AgentState[] = [];
+const EMPTY_TERMINALS: TerminalState[] = [];
+const EMPTY_MCP_SERVERS: SessionMcpServer[] = [];
+Object.freeze(EMPTY_AGENTS);
+Object.freeze(EMPTY_TERMINALS);
+Object.freeze(EMPTY_MCP_SERVERS);
+
+export type ActivationSnapshot = {
+  activationId: string;
+  state: SessionState;
+  config: SessionConfigState;
+  usage: SessionUsage | null;
+  plan: PlanState | null;
+  agents: readonly AgentState[];
+  activeTurn: TranscriptTurn | null;
+  terminals: readonly TerminalState[];
+  mcpServers: readonly SessionMcpServer[];
+};
+
 export type SessionLiveModels = {
+  source: Cell<ActivationSnapshot | null>;
   states: {
-    state: Cell<SessionState>;
-    config: Cell<SessionConfigState>;
-    usage: Cell<SessionUsage | null>;
-    plan: Cell<PlanState | null>;
-    agents: Cell<AgentState[]>;
-    activeTurn: Cell<TranscriptTurn | null>;
-    draft: Cell<PromptDraft | null>;
-    terminals: Cell<TerminalState[]>;
-    mcpServers: Cell<SessionMcpServer[]>;
+    activationId: Readable<string | null | undefined>;
+    state: Readable<SessionState | undefined>;
+    config: Readable<SessionConfigState | undefined>;
+    usage: Readable<SessionUsage | null | undefined>;
+    plan: Readable<PlanState | null | undefined>;
+    agents: Readable<AgentState[] | undefined>;
+    activeTurn: Readable<TranscriptTurn | null | undefined>;
+    terminals: Readable<TerminalState[] | undefined>;
+    mcpServers: Readable<SessionMcpServer[] | undefined>;
   };
-} & { dispose(): void };
+};
 export type SessionsListModel = {
   states: {
     list: Cell<Record<string, SessionSummary>>;
   };
 };
 export type AcpSessionLiveHost = LeasedLiveModelProvider<typeof acpApiContract.session> & {
-  models: Map<string, SessionLiveModels>;
+  models: Family<string, SessionLiveModels>;
 };
 export type AcpSessionsLiveHost = LeasedLiveModelProvider<typeof acpApiContract.sessions> & {
   model: SessionsListModel;
@@ -42,25 +84,33 @@ export type AcpSessionsLiveHost = LeasedLiveModelProvider<typeof acpApiContract.
 };
 
 export function createAcpSessionLiveHost(): AcpSessionLiveHost {
-  const models = new Map<string, SessionLiveModels>();
-  return Object.assign(
-    expose(
-      acpApiContract.session,
-      {
-        state: (key) => requireSessionModel(models, key.conversationId).states.state,
-        config: (key) => requireSessionModel(models, key.conversationId).states.config,
-        usage: (key) => requireSessionModel(models, key.conversationId).states.usage,
-        plan: (key) => requireSessionModel(models, key.conversationId).states.plan,
-        agents: (key) => requireSessionModel(models, key.conversationId).states.agents,
-        activeTurn: (key) => requireSessionModel(models, key.conversationId).states.activeTurn,
-        draft: (key) => requireSessionModel(models, key.conversationId).states.draft,
-        terminals: (key) => requireSessionModel(models, key.conversationId).states.terminals,
-        mcpServers: (key) => requireSessionModel(models, key.conversationId).states.mcpServers,
-      },
-      { publish: 'diff' }
-    ),
-    { models }
+  const models = family<string, SessionLiveModels>(() => createProjection(), {
+    key: (conversationId) => conversationId,
+    name: 'acp-session-projections',
+  });
+  const provider = expose(
+    acpApiContract.session,
+    {
+      activationId: (key) => models(key.conversationId).states.activationId,
+      state: (key) => models(key.conversationId).states.state,
+      config: (key) => models(key.conversationId).states.config,
+      usage: (key) => models(key.conversationId).states.usage,
+      plan: (key) => models(key.conversationId).states.plan,
+      agents: (key) => models(key.conversationId).states.agents,
+      activeTurn: (key) => models(key.conversationId).states.activeTurn,
+      terminals: (key) => models(key.conversationId).states.terminals,
+      mcpServers: (key) => models(key.conversationId).states.mcpServers,
+    },
+    { publish: 'diff' }
   );
+  return {
+    ...provider,
+    models,
+    async dispose() {
+      await provider.dispose();
+      await models.dispose();
+    },
+  };
 }
 
 export function createAcpSessionsLiveHost(): AcpSessionsLiveHost {
@@ -77,48 +127,13 @@ export function createAcpSessionsLiveHost(): AcpSessionsLiveHost {
   );
 }
 
-export function createSessionLiveModels(
-  host: AcpSessionLiveHost,
-  conversationId: string,
-  initialState: SessionState
-): SessionLiveModels {
-  const model: SessionLiveModels = {
-    states: {
-      state: cell(initialState),
-      config: cell(initialSessionConfigState),
-      usage: cell<SessionUsage | null>(null),
-      plan: cell<PlanState | null>(null),
-      agents: cell<AgentState[]>([]),
-      activeTurn: cell<TranscriptTurn | null>(null),
-      draft: cell<PromptDraft | null>(null),
-      terminals: cell<TerminalState[]>([]),
-      mcpServers: cell<SessionMcpServer[]>([]),
-    },
-    dispose() {
-      host.models.delete(conversationId);
-    },
-  };
-  host.models.set(conversationId, model);
-  return model;
-}
-
 export function createSessionsListModel(host: AcpSessionsLiveHost): SessionsListModel {
   return host.model;
-}
-
-export function publishLiveModelState<T>(model: Cell<T>, next: T, previous: T | undefined): void {
-  if (Object.is(previous, next)) return;
-  publishStructural(model, next);
-}
-
-export function produceCell<T>(target: Cell<T>, mutator: (draft: T) => void): void {
-  target.set(produce(peek(target), mutator));
 }
 
 export type {
   AgentState,
   PlanState,
-  PromptDraft,
   SessionConfigState,
   SessionMcpServer,
   SessionState,
@@ -128,11 +143,41 @@ export type {
   TranscriptTurn,
 };
 
-function requireSessionModel(
-  models: Map<string, SessionLiveModels>,
-  conversationId: string
-): SessionLiveModels {
-  const model = models.get(conversationId);
-  if (!model) throw new Error(`ACP session live model is not registered: ${conversationId}`);
-  return model;
+function createProjection(): SessionLiveModels {
+  const source = cell<ActivationSnapshot | null>(null, { name: 'acp-activation' });
+  const slice = <T>(read: (current: ActivationSnapshot) => T, inactive: T, name: string) =>
+    derived(
+      () => {
+        const current = snapshot(source).value;
+        return current ? read(current) : inactive;
+      },
+      { name }
+    );
+
+  return {
+    source,
+    states: {
+      activationId: slice((current) => current.activationId, null, 'acp-activation-id'),
+      state: slice((current) => current.state, inactiveSessionState, 'acp-session-state'),
+      config: slice((current) => current.config, initialSessionConfigState, 'acp-session-config'),
+      usage: slice((current) => current.usage, null, 'acp-session-usage'),
+      plan: slice((current) => current.plan, null, 'acp-session-plan'),
+      agents: slice((current) => asMutable(current.agents), EMPTY_AGENTS, 'acp-session-agents'),
+      activeTurn: slice((current) => current.activeTurn, null, 'acp-session-active-turn'),
+      terminals: slice(
+        (current) => asMutable(current.terminals),
+        EMPTY_TERMINALS,
+        'acp-session-terminals'
+      ),
+      mcpServers: slice(
+        (current) => asMutable(current.mcpServers),
+        EMPTY_MCP_SERVERS,
+        'acp-session-mcp-servers'
+      ),
+    },
+  };
+}
+
+function asMutable<T>(value: readonly T[]): T[] {
+  return value as T[];
 }

--- a/packages/shared/src/concurrency/lifecycle-registry.test.ts
+++ b/packages/shared/src/concurrency/lifecycle-registry.test.ts
@@ -87,6 +87,69 @@ describe('LifecycleRegistry', () => {
     expect(registry.get('task-1')).toEqual({ id: 'task-1', generation: 2 });
   });
 
+  it('atomically starts and uses one generation for concurrent operations', async () => {
+    const startDeferred = deferred<Result<Resource, TestError>>();
+    const start = vi.fn(async () => startDeferred.promise);
+    const registry = createLifecycleRegistry<{ id: string }, Resource, TestError>({
+      keyOf: (input) => input.id,
+      start,
+      stop: async () => ok(),
+    });
+
+    const first = registry.use({ id: 'task-1' }, async (resource) => ok(resource.generation));
+    const second = registry.use({ id: 'task-1' }, async (resource) => ok(resource.generation));
+    await Promise.resolve();
+    expect(start).toHaveBeenCalledTimes(1);
+
+    startDeferred.resolve(ok({ id: 'task-1', generation: 1 }));
+
+    await expect(first).resolves.toEqual(ok(1));
+    await expect(second).resolves.toEqual(ok(1));
+    expect(start).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for acquired leases before tearing down an activation', async () => {
+    const resource = { id: 'task-1', generation: 1 };
+    const stop = vi.fn(async () => ok<void>());
+    const registry = createLifecycleRegistry<{ id: string }, Resource, TestError>({
+      keyOf: (input) => input.id,
+      start: async () => ok(resource),
+      stop,
+    });
+    const acquired = await registry.acquire({ id: 'task-1' });
+    if (!acquired.success) throw new Error('expected activation lease');
+
+    const stopped = registry.stop('task-1');
+    await Promise.resolve();
+
+    expect(registry.state('task-1')).toEqual({ kind: 'stopping', value: resource });
+    expect(stop).not.toHaveBeenCalled();
+
+    await acquired.data.release();
+    await expect(stopped).resolves.toEqual(ok());
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(registry.has('task-1')).toBe(false);
+  });
+
+  it('starts a new generation when use arrives behind an in-flight stop', async () => {
+    const stopDeferred = deferred<Result<void, TestError>>();
+    let generation = 1;
+    const registry = createLifecycleRegistry<{ id: string }, Resource, TestError>({
+      keyOf: (input) => input.id,
+      start: async (input) => ok({ id: input.id, generation: generation++ }),
+      stop: async () => stopDeferred.promise,
+    });
+    await registry.start({ id: 'task-1' });
+
+    const stopped = registry.stop('task-1');
+    const used = registry.use({ id: 'task-1' }, async (resource) => ok(resource));
+    stopDeferred.resolve(ok());
+
+    await expect(stopped).resolves.toEqual(ok());
+    await expect(used).resolves.toEqual(ok({ id: 'task-1', generation: 2 }));
+    expect(registry.get('task-1')).toEqual({ id: 'task-1', generation: 2 });
+  });
+
   it('disposes partial start scope on failure and clears the error on retry', async () => {
     const cleanup = vi.fn();
     let shouldFail = true;

--- a/packages/shared/src/concurrency/lifecycle-registry.ts
+++ b/packages/shared/src/concurrency/lifecycle-registry.ts
@@ -1,4 +1,4 @@
-import type { Unsubscribe } from '../lifecycle';
+import { once, type Lease, type Unsubscribe } from '../lifecycle';
 import { err, ok, type Result } from '../result';
 import { createScope, type Scope } from './scope';
 
@@ -56,6 +56,8 @@ type RegistryEntry<Value, StartError, StopError> = {
   tail: Promise<unknown> | undefined;
   startPromise: Promise<Result<Value, StartError>> | undefined;
   stopPromise: Promise<Result<void, StopError>> | undefined;
+  leaseCount: number;
+  leaseWaiters: Set<() => void>;
 };
 
 export interface LifecycleRegistry<
@@ -73,6 +75,11 @@ export interface LifecycleRegistry<
   state(key: string): LifecycleRegistryState<Value, StartError, StopError>;
   states(): Map<string, LifecycleRegistryState<Value, StartError, StopError>>;
   start(input: StartInput): Promise<Result<Value, StartError>>;
+  use<T, UseError>(
+    input: StartInput,
+    operation: (value: Value) => MaybePromise<Result<T, UseError>>
+  ): Promise<Result<T, StartError | UseError>>;
+  acquire(input: StartInput): Promise<Result<Lease<Value>, StartError>>;
   register(key: string, value: Value): Promise<Value>;
   stop(key: string, context?: StopContext): Promise<Result<void, StopError>>;
   forceRemove(key: string, reason?: unknown): Promise<void>;
@@ -156,43 +163,48 @@ class LifecycleRegistryImpl<
     const existing = valueFromState(entry.state);
     if (existing !== undefined) return Promise.resolve(ok(existing));
 
-    const promise = this.enqueue(entry, async () => {
-      const current = valueFromState(entry.state);
-      if (current !== undefined) return ok(current);
-
-      const scope = this._scope.child(entry.key);
-      entry.scope = scope;
-      this.transition(entry, { kind: 'starting' });
-
-      try {
-        const result = await scope
-          .run('start', (signal) => this._options.start(input, scope, signal))
-          .value();
-
-        if (result.success) {
-          this.transition(entry, { kind: 'ready', value: result.data });
-          return result;
-        }
-
-        await scope.dispose(result.error);
-        entry.scope = undefined;
-        this.transition(entry, { kind: 'start-failed', error: result.error });
-        return err(result.error);
-      } catch (error) {
-        // Observers must never see a permanent 'starting': surface the thrown
-        // failure before the scope teardown and rethrow.
-        this.transition(entry, { kind: 'start-failed', error: error as StartError });
-        await scope.dispose(error);
-        entry.scope = undefined;
-        throw error;
-      }
-    }).finally(() => {
+    const promise = this.enqueue(entry, () => this.startEntry(entry, input)).finally(() => {
       if (entry.startPromise === promise) entry.startPromise = undefined;
     });
 
     entry.startPromise = promise;
     promise.catch(() => {});
     return promise;
+  }
+
+  use<T, UseError>(
+    input: StartInput,
+    operation: (value: Value) => MaybePromise<Result<T, UseError>>
+  ): Promise<Result<T, StartError | UseError>> {
+    this.assertOpen();
+    const entry = this.ensureEntry(this._options.keyOf(input));
+    if (entry.stopPromise) return entry.stopPromise.then(() => this.use(input, operation));
+    return this.enqueue(entry, async () => {
+      const started = await this.ensureStarted(entry, input);
+      if (!started.success) return err(started.error);
+      return operation(started.data);
+    });
+  }
+
+  acquire(input: StartInput): Promise<Result<Lease<Value>, StartError>> {
+    this.assertOpen();
+    const entry = this.ensureEntry(this._options.keyOf(input));
+    if (entry.stopPromise) return entry.stopPromise.then(() => this.acquire(input));
+    return this.enqueue(entry, async () => {
+      const started = await this.ensureStarted(entry, input);
+      if (!started.success) return started;
+      entry.leaseCount += 1;
+      return ok({
+        value: started.data,
+        release: once(async () => {
+          entry.leaseCount = Math.max(0, entry.leaseCount - 1);
+          if (entry.leaseCount !== 0) return;
+          const waiters = [...entry.leaseWaiters];
+          entry.leaseWaiters.clear();
+          for (const resolve of waiters) resolve();
+        }),
+      });
+    });
   }
 
   register(key: string, value: Value): Promise<Value> {
@@ -221,13 +233,22 @@ class LifecycleRegistryImpl<
     if (entry.stopPromise) return entry.stopPromise;
 
     const promise = this.enqueue(entry, async () => {
-      const value = valueFromState(entry.state);
-      if (value === undefined) return ok<void>();
+      let value = valueFromState(entry.state);
+      if (value === undefined) {
+        await this.removeEntry(entry, 'stop without value');
+        return ok<void>();
+      }
 
       const scope = entry.scope;
       if (!scope) return ok<void>();
 
       this.transition(entry, { kind: 'stopping', value });
+      await this.waitForLeases(entry);
+      value = valueFromState(entry.state);
+      if (value === undefined) {
+        await this.removeEntry(entry, 'stop without value');
+        return ok<void>();
+      }
       const result = await scope
         .run('stop', (signal) => this._options.stop(key, value, context, scope, signal))
         .value();
@@ -294,6 +315,8 @@ class LifecycleRegistryImpl<
         tail: undefined,
         startPromise: undefined,
         stopPromise: undefined,
+        leaseCount: 0,
+        leaseWaiters: new Set(),
       };
       this._entries.set(key, entry);
     }
@@ -320,6 +343,54 @@ class LifecycleRegistryImpl<
       })
       .catch(() => {});
     return promise;
+  }
+
+  private ensureStarted(
+    entry: RegistryEntry<Value, StartError, StopError>,
+    input: StartInput
+  ): Promise<Result<Value, StartError>> {
+    const current = valueFromState(entry.state);
+    return current === undefined ? this.startEntry(entry, input) : Promise.resolve(ok(current));
+  }
+
+  private async startEntry(
+    entry: RegistryEntry<Value, StartError, StopError>,
+    input: StartInput
+  ): Promise<Result<Value, StartError>> {
+    const current = valueFromState(entry.state);
+    if (current !== undefined) return ok(current);
+
+    const scope = this._scope.child(entry.key);
+    entry.scope = scope;
+    this.transition(entry, { kind: 'starting' });
+
+    try {
+      const result = await scope
+        .run('start', (signal) => this._options.start(input, scope, signal))
+        .value();
+
+      if (result.success) {
+        this.transition(entry, { kind: 'ready', value: result.data });
+        return result;
+      }
+
+      await scope.dispose(result.error);
+      entry.scope = undefined;
+      this.transition(entry, { kind: 'start-failed', error: result.error });
+      return err(result.error);
+    } catch (error) {
+      // Observers must never see a permanent 'starting': surface the thrown
+      // failure before the scope teardown and rethrow.
+      this.transition(entry, { kind: 'start-failed', error: error as StartError });
+      await scope.dispose(error);
+      entry.scope = undefined;
+      throw error;
+    }
+  }
+
+  private waitForLeases(entry: RegistryEntry<Value, StartError, StopError>): Promise<void> {
+    if (entry.leaseCount === 0) return Promise.resolve();
+    return new Promise<void>((resolve) => entry.leaseWaiters.add(resolve));
   }
 
   private async removeEntry(


### PR DESCRIPTION
- separates session activation from persisted conversation state
- rematerializes acp sessions with fenced activation and lease-aware lifecycle operations
- restores chat history and preserves prompt delivery across runtime restarts
- aligns conversation cleanup and wire contracts with the new session ownership model