### PR TITLE
fix(source-control): keep pr detection stable across task refreshes

### DIFF
--- a/agents/architecture/renderer.md
+++ b/agents/architecture/renderer.md
@@ -37,6 +37,10 @@ Cross-slice task-view lifecycle and workspace composition live in
 `src/core/features/workbench/browser/task-composition-state.ts`; task, project, and workspace
 stores expose feature-owned children through scoped-store tokens.
 
+Task children have two explicit lifetimes: lightweight persistent stores survive session teardown
+for as long as the task row exists (`task-persistent-stores.ts`), while operational task stores are
+disposed when the task session is torn down (`task-scoped-stores.ts`).
+
 Feature views, modals, and task tabs are exposed through `contributions/` and aggregated by
 `src/core/manifests/browser/browser-contributions.ts` and
 `src/core/manifests/browser/task-tab-contributions.ts`.

--- a/apps/emdash-desktop/src/core/features/projects/browser/components/task-view/task-list-model.test.ts
+++ b/apps/emdash-desktop/src/core/features/projects/browser/components/task-view/task-list-model.test.ts
@@ -1,6 +1,9 @@
 import { observable, runInAction } from 'mobx';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TaskPrAssociationStore } from '@core/features/source-control/api/browser/stores/task-pr-association-store';
+import { getTaskPrAssociationStore } from '@core/features/source-control/api/browser/stores/task-source-control-selectors';
 import type { AgentStatus } from '@core/primitives/agents/api';
+import type { PullRequest } from '@core/services/pull-requests/api';
 import { createTaskListView, type ReadyTask, type TaskListTab } from './task-list-model';
 
 const agentStatuses = new Map<string, AgentStatus>();
@@ -20,8 +23,11 @@ function task(overrides: {
   lastInteractedAt?: string;
   prs?: PrFixture[];
 }): ReadyTask {
+  const association = new TaskPrAssociationStore();
+  association.setAssociation((overrides.prs ?? []) as PullRequest[], { kind: 'unknown' });
   return {
     state: 'provisioned',
+    get: () => association,
     data: {
       id: overrides.id,
       name: overrides.name ?? overrides.id,
@@ -29,7 +35,6 @@ function task(overrides: {
       createdAt: overrides.createdAt ?? '2026-01-01T00:00:00Z',
       updatedAt: overrides.updatedAt ?? '2026-01-01T00:00:00Z',
       lastInteractedAt: overrides.lastInteractedAt,
-      prs: overrides.prs ?? [],
       type: 'task',
     },
   } as unknown as ReadyTask;
@@ -132,6 +137,20 @@ describe('createTaskListView', () => {
     );
 
     expect(visibleIds(view)).toEqual(['merged', 'open', 'closed', 'draft', 'none']);
+  });
+
+  it('re-sorts when a task-scoped PR association changes', () => {
+    const first = task({ id: 'a' });
+    const second = task({ id: 'b' });
+    const { view } = createView([first, second], { sortBy: 'pr-status' });
+    expect(visibleIds(view)).toEqual(['a', 'b']);
+
+    getTaskPrAssociationStore(second).setAssociation(
+      [{ status: 'merged', isDraft: false, createdAt: '2026-01-01T00:00:00Z' } as PullRequest],
+      { kind: 'unknown' }
+    );
+
+    expect(visibleIds(view)).toEqual(['b', 'a']);
   });
 
   it('puts tasks needing attention first for the unread sort', () => {

--- a/apps/emdash-desktop/src/core/features/projects/browser/components/task-view/task-list-model.ts
+++ b/apps/emdash-desktop/src/core/features/projects/browser/components/task-view/task-list-model.ts
@@ -2,11 +2,12 @@ import type { ExternalSelectionStore } from '@emdash/ui/react/patterns';
 import { createListView, createTextMatcher } from '@emdash/ui/react/patterns';
 import { taskAgentStatus } from '@core/features/conversations/api/browser/conversation-selectors';
 import type { ProjectTaskSortBy } from '@core/features/projects/contributions/mementos';
+import { getTaskPrAssociationStore } from '@core/features/source-control/api/browser/stores/task-source-control-selectors';
 import { type TaskStore } from '@core/features/tasks/api/browser/stores/task-store';
-import { type Task } from '@core/primitives/tasks/api';
+import type { RegisteredTaskData } from '@core/primitives/task-state/browser/task-state';
 import { selectCurrentPr } from '@core/services/pull-requests/api/repository';
 
-export type ReadyTask = TaskStore & { data: Task };
+export type ReadyTask = TaskStore & { data: RegisteredTaskData };
 
 export type TaskListTab = 'active' | 'archived';
 
@@ -15,7 +16,7 @@ function latestInstant(task: ReadyTask) {
 }
 
 function prStatusRank(task: ReadyTask) {
-  const pr = selectCurrentPr(task.data.prs);
+  const pr = selectCurrentPr(getTaskPrAssociationStore(task).pullRequests);
   if (!pr) return 4;
   if (pr.status === 'merged') return 0;
   if (pr.status === 'open' && !pr.isDraft) return 1;

--- a/apps/emdash-desktop/src/core/features/projects/browser/components/task-view/task-row.tsx
+++ b/apps/emdash-desktop/src/core/features/projects/browser/components/task-view/task-row.tsx
@@ -7,7 +7,10 @@ import {
   taskConversationStats,
 } from '@core/features/conversations/api/browser/conversation-selectors';
 import { projectAvailabilityUiContribution as projectAvailabilityUi } from '@core/features/projects/contributions/browser/project-availability-ui';
-import { getTaskGitCheckoutStore } from '@core/features/source-control/api/browser/stores/task-source-control-selectors';
+import {
+  getTaskGitCheckoutStore,
+  getTaskPrAssociationStore,
+} from '@core/features/source-control/api/browser/stores/task-source-control-selectors';
 import {
   getTaskManagerStore,
   taskHostActionAvailability,
@@ -71,7 +74,7 @@ export const TaskRow = observer(function TaskRow({
         projectAvailabilityUi.defaultLiveActionDisabledReason)
       : undefined;
   const agentAttention = taskAgentStatus(task);
-  const currentPr = task.data.prs ? selectCurrentPr(task.data.prs) : undefined;
+  const currentPr = selectCurrentPr(getTaskPrAssociationStore(task).pullRequests);
   const branchName =
     getTaskGitCheckoutStore(task.data.projectId, task.data.id)?.branchName ?? undefined;
 

--- a/apps/emdash-desktop/src/core/features/source-control/api/browser/stores/pr-store.test.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/api/browser/stores/pr-store.test.ts
@@ -2,11 +2,11 @@ import { createManualClock } from '@emdash/shared/testing';
 import { observable } from 'mobx';
 import { describe, expect, it } from 'vitest';
 import type { ProjectHostAccessState } from '@core/features/projects/api/browser/stores/project-context';
-import type { TaskStore } from '@core/features/tasks/api/browser/stores/task-store';
 import type { PullRequest } from '@core/services/pull-requests/api';
 import type { GitCheckoutStore } from '../../../browser/stores/git-checkout-store';
 import type { GitRepositoryStore } from './git-repository-store';
 import { PrStore } from './pr-store';
+import { TaskPrAssociationStore } from './task-pr-association-store';
 
 const pullRequest = {
   url: 'https://github.com/example/repo/pull/1',
@@ -30,17 +30,14 @@ describe('PrStore Host observations', () => {
           : { ...observation, kind: 'stale' as const };
       },
     } as GitRepositoryStore;
-    const task = observable({
-      state: 'provisioned' as const,
-      data: { prs: [pullRequest] },
-    }) as unknown as TaskStore;
+    const association = new TaskPrAssociationStore(createManualClock(1_786_000_000_000));
+    association.setAssociation([pullRequest], { kind: 'unknown' });
     const store = new PrStore(
       'project-1',
       'workspace-1',
       repository,
       {} as GitCheckoutStore,
-      task,
-      createManualClock(1_786_000_000_000)
+      association
     );
 
     expect(store.pullRequestsObservation).toMatchObject({
@@ -55,21 +52,16 @@ describe('PrStore Host observations', () => {
       value: [pullRequest],
     });
 
-    task.state = 'unregistered';
     expect(store.pullRequests).toEqual([pullRequest]);
     expect(store.pullRequestsObservation.kind).toBe('stale');
     store.dispose();
 
-    const neverObservedTask = observable({
-      state: 'unregistered' as const,
-      data: {},
-    }) as unknown as TaskStore;
     const neverObserved = new PrStore(
       'project-1',
       'workspace-2',
       repository,
       {} as GitCheckoutStore,
-      neverObservedTask
+      new TaskPrAssociationStore()
     );
     expect(neverObserved.pullRequestsObservation).toEqual({ kind: 'unavailable' });
     neverObserved.dispose();

--- a/apps/emdash-desktop/src/core/features/source-control/api/browser/stores/pr-store.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/api/browser/stores/pr-store.ts
@@ -1,8 +1,7 @@
 import { normalizeDiffTarget, type GitChange } from '@emdash/core/runtimes/git/api';
 import type { UpdateWorktreeError } from '@emdash/core/runtimes/workspace-registry/api';
 import type { RuntimeResolveError } from '@emdash/core/services/runtime-broker/api';
-import { systemClock, type Clock } from '@emdash/shared/scheduling';
-import { makeAutoObservable, reaction, runInAction } from 'mobx';
+import { makeAutoObservable, reaction } from 'mobx';
 import {
   asAvailableProject,
   getProjectStore,
@@ -13,13 +12,11 @@ import {
   getSourceControlClient,
 } from '@core/features/source-control/api/browser/client';
 import type { GitRepositoryStore } from '@core/features/source-control/api/browser/stores/git-repository-store';
-import type { TaskStore } from '@core/features/tasks/api/browser/stores/task-store';
+import type { TaskPrAssociationStore } from '@core/features/source-control/api/browser/stores/task-pr-association-store';
 import { getWorkspaceRegistryWireClient } from '@core/features/workspaces/api/browser/client';
 import { Resource } from '@core/primitives/async-resource/browser/resource';
 import { commitRef, mergeBaseRange } from '@core/primitives/git/api';
 import { projectHostRef } from '@core/primitives/projects/api';
-import { isRegistered } from '@core/primitives/task-state/browser/task-state';
-import type { Task } from '@core/primitives/tasks/api';
 import { captureTelemetry } from '@core/primitives/telemetry/browser/telemetry-client';
 import { compilePrUpdateInstruction } from '@core/primitives/workspaces/api';
 import {
@@ -41,43 +38,29 @@ export class PrStore {
     string,
     { resource: Resource<GitChange[]>; baseRefOid: string; headRefOid: string }
   >();
-  private _pullRequests: PullRequest[] | null = null;
-  private _pullRequestsObservedAt = 0;
-  private readonly _pullRequestsDisposer: () => void;
 
   constructor(
     private readonly projectId: string,
     private readonly workspaceId: string,
     private readonly gitRepositoryStore: GitRepositoryStore,
     private readonly gitCheckoutStore: GitCheckoutStore,
-    private readonly taskStore: TaskStore,
-    private readonly clock: Clock = systemClock
+    private readonly associationStore: TaskPrAssociationStore
   ) {
     makeAutoObservable(this);
-    this._pullRequestsDisposer = reaction(
-      () => (isRegistered(this.taskStore) ? [...((this.taskStore.data as Task).prs ?? [])] : null),
-      (pullRequests) => {
-        if (pullRequests === null) return;
-        runInAction(() => {
-          this._pullRequests = pullRequests;
-          this._pullRequestsObservedAt = this.clock.now();
-        });
-      },
-      { fireImmediately: true }
-    );
   }
 
-  get pullRequests(): PullRequest[] {
-    return this._pullRequests ?? [];
+  get pullRequests(): readonly PullRequest[] {
+    return this.associationStore.pullRequests;
   }
 
-  get pullRequestsObservation(): ProjectHostObservation<PullRequest[]> {
+  get pullRequestsObservation(): ProjectHostObservation<readonly PullRequest[]> {
+    const association = this.associationStore.state;
     return this.gitRepositoryStore.observeHost(
-      this._pullRequests
+      association.kind !== 'unknown'
         ? {
             kind: 'observed',
-            value: this._pullRequests,
-            observedAt: this._pullRequestsObservedAt,
+            value: this.associationStore.pullRequests,
+            observedAt: association.observedAt,
           }
         : { kind: 'never-observed' }
     );
@@ -92,7 +75,7 @@ export class PrStore {
    * Staleness), derived by the task-PR sync coordinator; unknown until derived.
    */
   get checkoutDrift(): PrCheckoutDrift {
-    return this.taskStore.prCheckoutDrift ?? { kind: 'unknown' };
+    return this.associationStore.checkoutDrift;
   }
 
   /**
@@ -252,7 +235,6 @@ export class PrStore {
   }
 
   dispose(): void {
-    this._pullRequestsDisposer();
     for (const entry of this._prFiles.values()) entry.resource.dispose();
   }
 
@@ -316,14 +298,8 @@ export class PrStore {
       repositoryUrl: pullRequest.repositoryUrl,
       number,
     });
-    if (!result.success || !isRegistered(this.taskStore)) return;
-    runInAction(() => {
-      if (!isRegistered(this.taskStore)) return;
-      const task = this.taskStore.data as Task;
-      const index = task.prs.findIndex((candidate) => candidate.url === result.data.pr.url);
-      if (index >= 0) task.prs.splice(index, 1, result.data.pr);
-      else task.prs.push(result.data.pr);
-    });
+    if (!result.success) return;
+    this.associationStore.updateAssociatedPr(result.data.pr);
   }
 }
 

--- a/apps/emdash-desktop/src/core/features/source-control/api/browser/stores/task-pr-association-store.test.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/api/browser/stores/task-pr-association-store.test.ts
@@ -1,0 +1,47 @@
+import { createManualClock } from '@emdash/shared/testing';
+import { describe, expect, it } from 'vitest';
+import type { PullRequest } from '@core/services/pull-requests/api';
+import { TaskPrAssociationStore } from './task-pr-association-store';
+
+const pullRequest = {
+  url: 'https://github.com/emdash/emdash/pull/42',
+  repositoryUrl: 'https://github.com/emdash/emdash',
+  title: 'Original title',
+} as PullRequest;
+
+describe('TaskPrAssociationStore', () => {
+  it('distinguishes unknown, none, and associated PR state', () => {
+    const store = new TaskPrAssociationStore(createManualClock(1_786_000_000_000));
+
+    expect(store.state).toEqual({ kind: 'unknown' });
+    expect(store.pullRequests).toEqual([]);
+
+    store.setAssociation([pullRequest], { kind: 'in-sync', syncedAt: 1 });
+
+    expect(store.state).toMatchObject({
+      kind: 'associated',
+      pullRequests: [pullRequest],
+      observedAt: 1_786_000_000_000,
+    });
+    expect(store.checkoutDrift).toEqual({ kind: 'in-sync', syncedAt: 1 });
+
+    store.setAssociation([], { kind: 'unknown' });
+
+    expect(store.state).toEqual({ kind: 'none', observedAt: 1_786_000_000_000 });
+    expect(store.pullRequests).toEqual([]);
+    expect(store.checkoutDrift).toEqual({ kind: 'unknown' });
+  });
+
+  it('refreshes details only for an already-associated PR', () => {
+    const store = new TaskPrAssociationStore();
+    const refreshed = { ...pullRequest, title: 'Refreshed title' };
+
+    store.updateAssociatedPr(refreshed);
+    expect(store.state).toEqual({ kind: 'unknown' });
+
+    store.setAssociation([pullRequest], { kind: 'unknown' });
+    store.updateAssociatedPr(refreshed);
+
+    expect(store.pullRequests).toEqual([refreshed]);
+  });
+});

--- a/apps/emdash-desktop/src/core/features/source-control/api/browser/stores/task-pr-association-store.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/api/browser/stores/task-pr-association-store.ts
@@ -1,0 +1,58 @@
+import { systemClock, type Clock } from '@emdash/shared/scheduling';
+import { makeAutoObservable, observable } from 'mobx';
+import type { PrCheckoutDrift, PullRequest } from '@core/services/pull-requests/api';
+
+export type TaskPrAssociationState =
+  | { readonly kind: 'unknown' }
+  | { readonly kind: 'none'; readonly observedAt: number }
+  | {
+      readonly kind: 'associated';
+      readonly pullRequests: readonly PullRequest[];
+      readonly observedAt: number;
+    };
+
+/** Task-lifetime ownership boundary for renderer-derived PR association state. */
+export class TaskPrAssociationStore {
+  private _state: TaskPrAssociationState = { kind: 'unknown' };
+  private _checkoutDrift: PrCheckoutDrift = { kind: 'unknown' };
+
+  constructor(private readonly clock: Clock = systemClock) {
+    makeAutoObservable<TaskPrAssociationStore, '_state' | '_checkoutDrift' | 'clock'>(this, {
+      _state: observable.ref,
+      _checkoutDrift: observable.ref,
+      clock: false,
+    });
+  }
+
+  get state(): TaskPrAssociationState {
+    return this._state;
+  }
+
+  get pullRequests(): readonly PullRequest[] {
+    return this._state.kind === 'associated' ? this._state.pullRequests : [];
+  }
+
+  get checkoutDrift(): PrCheckoutDrift {
+    return this._checkoutDrift;
+  }
+
+  setAssociation(pullRequests: readonly PullRequest[], checkoutDrift: PrCheckoutDrift): void {
+    const observedAt = this.clock.now();
+    this._state =
+      pullRequests.length > 0
+        ? { kind: 'associated', pullRequests: [...pullRequests], observedAt }
+        : { kind: 'none', observedAt };
+    this._checkoutDrift = checkoutDrift;
+  }
+
+  updateAssociatedPr(pullRequest: PullRequest): void {
+    if (this._state.kind !== 'associated') return;
+    const index = this._state.pullRequests.findIndex(
+      (candidate) => candidate.url === pullRequest.url
+    );
+    if (index < 0) return;
+    const pullRequests = [...this._state.pullRequests];
+    pullRequests[index] = pullRequest;
+    this._state = { kind: 'associated', pullRequests, observedAt: this.clock.now() };
+  }
+}

--- a/apps/emdash-desktop/src/core/features/source-control/api/browser/stores/task-source-control-selectors.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/api/browser/stores/task-source-control-selectors.ts
@@ -1,4 +1,7 @@
 import { getGitCheckoutStore } from '@core/features/source-control/api/browser/stores/source-control-selectors';
+import type { TaskPrAssociationStore } from '@core/features/source-control/api/browser/stores/task-pr-association-store';
+import { taskPrAssociationStoreToken } from '@core/features/source-control/contributions/browser/task-stores';
+import type { TaskStore } from '@core/features/tasks/api/browser/stores/task-store';
 import { getTaskStore } from '@core/features/tasks/api/browser/task-state/task-selectors';
 import type { GitCheckoutStore } from '../../../browser/stores/git-checkout-store';
 
@@ -9,4 +12,9 @@ export function getTaskGitCheckoutStore(
 ): GitCheckoutStore | undefined {
   const workspaceId = getTaskStore(projectId, taskId)?.workspaceId;
   return workspaceId ? getGitCheckoutStore(workspaceId) : undefined;
+}
+
+/** Task-lifetime PR association state, available for active and inactive tasks. */
+export function getTaskPrAssociationStore(task: TaskStore): TaskPrAssociationStore {
+  return task.get(taskPrAssociationStoreToken);
 }

--- a/apps/emdash-desktop/src/core/features/source-control/browser/stores/task-pr-sync-coordinator.test.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/stores/task-pr-sync-coordinator.test.ts
@@ -1,0 +1,309 @@
+import { observable, runInAction } from 'mobx';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { GitRepositoryStore } from '@core/features/source-control/api/browser/stores/git-repository-store';
+import { getTaskPrAssociationStore } from '@core/features/source-control/api/browser/stores/task-source-control-selectors';
+import type { TaskManagerStore } from '@core/features/tasks/api/browser/stores/task-manager';
+import { createUnprovisionedTask } from '@core/features/tasks/api/browser/stores/task-store';
+import type { Task } from '@core/primitives/tasks/api';
+import { TaskPrSyncCoordinator } from './task-pr-sync-coordinator';
+
+const mocks = vi.hoisted(() => ({
+  getPullRequestsRuntimeClient: vi.fn(() => new Promise<never>(() => {})),
+}));
+
+vi.mock('@core/manifests/browser/task-persistent-stores', async () => {
+  const { sourceControlPersistentTaskStoreContributions } =
+    await import('@core/features/source-control/contributions/browser/task-stores');
+  return {
+    taskPersistentStoreContributions: sourceControlPersistentTaskStoreContributions.filter(
+      (contribution) => contribution.token.id === 'source-control.task-pr-association'
+    ),
+  };
+});
+
+vi.mock('@core/manifests/browser/task-scoped-stores', () => ({
+  taskStoreContributions: [],
+}));
+
+vi.mock('@core/services/pull-requests/api/client', () => ({
+  getPullRequestsRuntimeClient: mocks.getPullRequestsRuntimeClient,
+}));
+
+const coordinators: TaskPrSyncCoordinator[] = [];
+
+afterEach(() => {
+  for (const coordinator of coordinators) coordinator.dispose();
+  coordinators.length = 0;
+  mocks.getPullRequestsRuntimeClient.mockClear();
+});
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'task-1',
+    projectId: 'project-1',
+    name: 'Task 1',
+    status: 'todo',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    statusChangedAt: '2026-01-01T00:00:00.000Z',
+    isPinned: false,
+    prs: [
+      {
+        url: 'https://github.com/emdash/emdash/pull/42',
+        repositoryUrl: 'https://github.com/emdash/emdash',
+      } as Task['prs'][number],
+    ],
+    conversations: {},
+    workspaceId: 'workspace-1',
+    type: 'task',
+    ...overrides,
+  };
+}
+
+function makeTasks(task: Task): TaskManagerStore {
+  const store = createUnprovisionedTask(task);
+  getTaskPrAssociationStore(store).setAssociation(task.prs, { kind: 'unknown' });
+  return { tasks: observable.map([[task.id, store]]) } as unknown as TaskManagerStore;
+}
+
+function prs(tasks: TaskManagerStore, taskId: string): readonly Task['prs'][number][] | undefined {
+  const store = tasks.tasks.get(taskId);
+  return store ? getTaskPrAssociationStore(store).pullRequests : undefined;
+}
+
+function makeRepository(input: {
+  repositoryUrl: string | null;
+  observation:
+    | { kind: 'unavailable' }
+    | {
+        kind: 'fresh';
+        value:
+          | { success: false; error: { type: 'no_remote' } }
+          | {
+              success: true;
+              data: {
+                provider: 'github';
+                host: string;
+                repositoryUrl: string;
+                nameWithOwner: string;
+                capabilities: { pullRequests: boolean; issues: boolean };
+              };
+            };
+        observedAt: number;
+      };
+}): GitRepositoryStore {
+  return observable({
+    pullRequestRepositoryUrl: input.repositoryUrl,
+    providerRepositoryObservation: input.observation,
+  }) as unknown as GitRepositoryStore;
+}
+
+function start(tasks: TaskManagerStore, repository: GitRepositoryStore): TaskPrSyncCoordinator {
+  const coordinator = new TaskPrSyncCoordinator(tasks, repository);
+  coordinators.push(coordinator);
+  return coordinator;
+}
+
+describe('TaskPrSyncCoordinator association preservation', () => {
+  it('preserves the last-known PR when the base remote is removed', () => {
+    const task = makeTask();
+    const tasks = makeTasks(task);
+    const repository = makeRepository({
+      repositoryUrl: null,
+      observation: {
+        kind: 'fresh',
+        value: { success: false, error: { type: 'no_remote' } },
+        observedAt: 1,
+      },
+    });
+
+    start(tasks, repository);
+
+    expect(prs(tasks, task.id)).toHaveLength(1);
+  });
+
+  it('preserves a stale PR while repository capability is transiently unavailable', () => {
+    const task = makeTask();
+    const tasks = makeTasks(task);
+    const repository = makeRepository({
+      repositoryUrl: null,
+      observation: { kind: 'unavailable' },
+    });
+
+    start(tasks, repository);
+
+    expect(prs(tasks, task.id)).toHaveLength(1);
+  });
+
+  it('preserves the last-known PR when a task no longer has a durable workspace', () => {
+    const task = makeTask({ workspaceId: undefined });
+    const tasks = makeTasks(task);
+    const repositoryUrl = 'https://github.com/emdash/emdash';
+    const repository = makeRepository({
+      repositoryUrl,
+      observation: {
+        kind: 'fresh',
+        value: {
+          success: true,
+          data: {
+            provider: 'github',
+            host: 'github.com',
+            repositoryUrl,
+            nameWithOwner: 'emdash/emdash',
+            capabilities: { pullRequests: true, issues: true },
+          },
+        },
+        observedAt: 1,
+      },
+    });
+
+    start(tasks, repository);
+
+    expect(prs(tasks, task.id)).toHaveLength(1);
+  });
+
+  it('preserves a stale PR during a transient input-less read of an associated workspace', () => {
+    const task = makeTask();
+    const tasks = makeTasks(task);
+    const repositoryUrl = 'https://github.com/emdash/emdash';
+    const repository = makeRepository({
+      repositoryUrl,
+      observation: {
+        kind: 'fresh',
+        value: {
+          success: true,
+          data: {
+            provider: 'github',
+            host: 'github.com',
+            repositoryUrl,
+            nameWithOwner: 'emdash/emdash',
+            capabilities: { pullRequests: true, issues: true },
+          },
+        },
+        observedAt: 1,
+      },
+    });
+
+    start(tasks, repository);
+
+    expect(prs(tasks, task.id)).toHaveLength(1);
+  });
+
+  it('preserves the last-known PR when the associated workspace checkout is missing', () => {
+    const task = makeTask();
+    const tasks = makeTasks(task);
+    runInAction(() => {
+      const store = tasks.tasks.get(task.id);
+      if (store) {
+        store.workspaceObservedStatus = 'missing';
+        store.workspaceObservedPr = {
+          branch: 'feature',
+          prBreadcrumb: 'https://github.com/emdash/emdash/pull/42',
+          upstream: null,
+          headOid: null,
+          ahead: null,
+          behind: null,
+        };
+      }
+    });
+    const repositoryUrl = 'https://github.com/emdash/emdash';
+    const repository = makeRepository({
+      repositoryUrl,
+      observation: {
+        kind: 'fresh',
+        value: {
+          success: true,
+          data: {
+            provider: 'github',
+            host: 'github.com',
+            repositoryUrl,
+            nameWithOwner: 'emdash/emdash',
+            capabilities: { pullRequests: true, issues: true },
+          },
+        },
+        observedAt: 1,
+      },
+    });
+
+    start(tasks, repository);
+
+    expect(prs(tasks, task.id)).toHaveLength(1);
+  });
+
+  it('preserves the last-known PR while a changed repository is being resolved', () => {
+    const task = makeTask({
+      prs: [
+        {
+          url: 'https://github.com/emdash/old-repository/pull/42',
+          repositoryUrl: 'https://github.com/emdash/old-repository',
+        } as Task['prs'][number],
+      ],
+    });
+    const tasks = makeTasks(task);
+    const repositoryUrl = 'https://github.com/emdash/new-repository';
+    const repository = makeRepository({
+      repositoryUrl,
+      observation: {
+        kind: 'fresh',
+        value: {
+          success: true,
+          data: {
+            provider: 'github',
+            host: 'github.com',
+            repositoryUrl,
+            nameWithOwner: 'emdash/new-repository',
+            capabilities: { pullRequests: true, issues: true },
+          },
+        },
+        observedAt: 1,
+      },
+    });
+
+    start(tasks, repository);
+
+    expect(prs(tasks, task.id)).toHaveLength(1);
+  });
+
+  it('preserves the last-known PR when an available remote is removed', () => {
+    const task = makeTask();
+    const tasks = makeTasks(task);
+    const repositoryUrl = 'https://github.com/emdash/emdash';
+    const repository = makeRepository({
+      repositoryUrl,
+      observation: {
+        kind: 'fresh',
+        value: {
+          success: true,
+          data: {
+            provider: 'github',
+            host: 'github.com',
+            repositoryUrl,
+            nameWithOwner: 'emdash/emdash',
+            capabilities: { pullRequests: true, issues: true },
+          },
+        },
+        observedAt: 1,
+      },
+    });
+    start(tasks, repository);
+
+    runInAction(() => {
+      const mutableRepository = repository as unknown as {
+        pullRequestRepositoryUrl: string | null;
+        providerRepositoryObservation: {
+          kind: 'fresh';
+          value: { success: false; error: { type: 'no_remote' } };
+          observedAt: number;
+        };
+      };
+      mutableRepository.pullRequestRepositoryUrl = null;
+      mutableRepository.providerRepositoryObservation = {
+        kind: 'fresh',
+        value: { success: false, error: { type: 'no_remote' } },
+        observedAt: 2,
+      };
+    });
+
+    expect(prs(tasks, task.id)).toHaveLength(1);
+  });
+});

--- a/apps/emdash-desktop/src/core/features/source-control/browser/stores/task-pr-sync-coordinator.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/stores/task-pr-sync-coordinator.ts
@@ -1,8 +1,9 @@
 import { isDeepEqual } from '@emdash/shared';
 import { createScope, type Scope } from '@emdash/shared/concurrency';
 import { observe, remote, type RemoteModel } from '@emdash/wire/state';
-import { reaction, runInAction, toJS } from 'mobx';
+import { reaction, toJS } from 'mobx';
 import type { GitRepositoryStore } from '@core/features/source-control/api/browser/stores/git-repository-store';
+import { getTaskPrAssociationStore } from '@core/features/source-control/api/browser/stores/task-source-control-selectors';
 import { gitCheckoutStoreToken } from '@core/features/source-control/contributions/browser/workspace-store-tokens';
 import type { TaskManagerStore } from '@core/features/tasks/api/browser/stores/task-manager';
 import type { TaskStore } from '@core/features/tasks/api/browser/stores/task-store';
@@ -42,6 +43,8 @@ export class TaskPrSyncCoordinator {
           const observed = store.workspaceObservedPr;
           return [
             store.workspaceId,
+            (store.data as Task).workspaceId ?? '',
+            store.workspaceObservedStatus ?? '',
             git?.branchName ?? '',
             git?.headOid ?? '',
             observed?.branch ?? '',
@@ -93,10 +96,13 @@ export class TaskPrSyncCoordinator {
   private async reloadTask(store: TaskStore): Promise<void> {
     if (!isRegistered(store)) return;
     const repositoryUrl = this.repository.pullRequestRepositoryUrl;
+    // Missing repository context prevents a refresh; it does not prove that the
+    // task's last-known PR stopped existing.
     if (!repositoryUrl) return;
+    const association = getTaskPrAssociationStore(store);
     const inputs = associationInputs(store);
-    // Nothing observed and no checkout yet: leave the association alone rather than
-    // clearing it on a transiently input-less read (startup, store teardown).
+    // With no checkout evidence, there is nothing authoritative that can supersede
+    // the task's last-known association.
     if (inputs.observed === null && inputs.checkoutBranch === null) return;
 
     let prs: Task['prs'];
@@ -119,11 +125,8 @@ export class TaskPrSyncCoordinator {
       pr: selectCurrentPr(prs) ?? null,
       syncedAt: this.lastSyncedAt,
     });
-    runInAction(() => {
-      if (!isRegistered(store)) return;
-      (store.data as Task).prs = prs;
-      store.prCheckoutDrift = drift;
-    });
+    if (!isRegistered(store)) return;
+    association.setAssociation(prs, drift);
   }
 
   private async watchSync(repositoryUrl: string | null): Promise<void> {

--- a/apps/emdash-desktop/src/core/features/source-control/contributions/browser/task-stores.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/contributions/browser/task-stores.ts
@@ -1,4 +1,5 @@
 import { DraftCommentsStore } from '@core/features/source-control/api/browser/diff-view/stores/draft-comments-store';
+import { TaskPrAssociationStore } from '@core/features/source-control/api/browser/stores/task-pr-association-store';
 import type { TaskScopedStoreContext } from '@core/features/tasks/contributions/browser/task-stores';
 import {
   contributeScopedStore,
@@ -9,6 +10,17 @@ import {
 export const draftCommentsStoreToken = scopedStoreToken<DraftCommentsStore>(
   'source-control.draft-comments'
 );
+export const taskPrAssociationStoreToken = scopedStoreToken<TaskPrAssociationStore>(
+  'source-control.task-pr-association'
+);
+
+export const sourceControlPersistentTaskStoreContributions: readonly ScopedStoreContribution<TaskScopedStoreContext>[] =
+  [
+    contributeScopedStore({
+      token: taskPrAssociationStoreToken,
+      create: () => new TaskPrAssociationStore(),
+    }),
+  ];
 
 export const sourceControlTaskStoreContributions: readonly ScopedStoreContribution<TaskScopedStoreContext>[] =
   [

--- a/apps/emdash-desktop/src/core/features/tasks/api/browser/stores/task-manager.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/api/browser/stores/task-manager.ts
@@ -283,7 +283,8 @@ export class TaskManagerStore {
         return store;
       },
       update: (current, row) => {
-        const task = this._taskFromRow(row);
+        const prs = isRegistered(current) ? current.data.prs : [];
+        const task = this._taskFromRow(row, prs);
         current.setWorkspaceProjection(
           task.workspaceId ? this._taskStats.workspaceById?.[task.workspaceId] : undefined
         );
@@ -326,12 +327,12 @@ export class TaskManagerStore {
     await Promise.all(activeTaskReady);
   }
 
-  private _taskFromRow(row: TaskListRow): Task {
+  private _taskFromRow(row: TaskListRow, prs: Task['prs'] = []): Task {
     const { activeWorkspace: _activeWorkspace, ...taskRow } = row;
     const git = row.workspaceId ? this._taskStats.byWorkspaceId[row.workspaceId] : undefined;
     return {
       ...taskRow,
-      prs: [],
+      prs,
       workspaceGit: git,
     };
   }

--- a/apps/emdash-desktop/src/core/features/tasks/api/browser/stores/task-manager.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/api/browser/stores/task-manager.ts
@@ -35,6 +35,7 @@ import {
   isRegistered,
   isUnprovisioned,
   isUnregistered,
+  type RegisteredTaskData,
 } from '@core/primitives/task-state/browser/task-state';
 import type {
   CreateTaskError,
@@ -43,7 +44,6 @@ import type {
   DeleteTaskOptions,
   RenameTaskError,
   RenameTaskSuccess,
-  Task,
   TaskLifecycleStatus,
   TaskListData,
   TaskListRow,
@@ -283,8 +283,7 @@ export class TaskManagerStore {
         return store;
       },
       update: (current, row) => {
-        const prs = isRegistered(current) ? current.data.prs : [];
-        const task = this._taskFromRow(row, prs);
+        const task = this._taskFromRow(row);
         current.setWorkspaceProjection(
           task.workspaceId ? this._taskStats.workspaceById?.[task.workspaceId] : undefined
         );
@@ -327,12 +326,11 @@ export class TaskManagerStore {
     await Promise.all(activeTaskReady);
   }
 
-  private _taskFromRow(row: TaskListRow, prs: Task['prs'] = []): Task {
+  private _taskFromRow(row: TaskListRow): RegisteredTaskData {
     const { activeWorkspace: _activeWorkspace, ...taskRow } = row;
     const git = row.workspaceId ? this._taskStats.byWorkspaceId[row.workspaceId] : undefined;
     return {
       ...taskRow,
-      prs,
       workspaceGit: git,
     };
   }
@@ -475,7 +473,7 @@ export class TaskManagerStore {
     const task = this.tasks.get(taskId);
     if (!task || !isUnprovisioned(task)) return;
 
-    const wsId = (task.data as Task).workspaceId;
+    const wsId = task.data.workspaceId;
     if (!wsId) {
       const message = 'This task does not have a workspace record and cannot be opened.';
       runInAction(() => {
@@ -614,7 +612,7 @@ export class TaskManagerStore {
   }
 
   private async _renameTask(
-    task: Task,
+    task: RegisteredTaskData,
     name: string
   ): Promise<SharedResult<RenameTaskSuccess, RenameTaskError>> {
     const result = await this._runTaskListMutation(
@@ -629,7 +627,10 @@ export class TaskManagerStore {
     return ok(result.data.data);
   }
 
-  private async _updateTaskStatus(task: Task, status: TaskLifecycleStatus): Promise<void> {
+  private async _updateTaskStatus(
+    task: RegisteredTaskData,
+    status: TaskLifecycleStatus
+  ): Promise<void> {
     const changedAt = new Date().toISOString();
     const result = await this._runTaskListMutation(
       (member) => member.mutations.setStatus,
@@ -644,7 +645,7 @@ export class TaskManagerStore {
     throwIfMutationFailed(result);
   }
 
-  private async _setTaskPinned(task: Task, isPinned: boolean): Promise<void> {
+  private async _setTaskPinned(task: RegisteredTaskData, isPinned: boolean): Promise<void> {
     const result = await this._runTaskListMutation(
       (member) => member.mutations.setPinned,
       { taskId: task.id, isPinned },
@@ -656,7 +657,7 @@ export class TaskManagerStore {
     throwIfMutationFailed(result);
   }
 
-  private async _updateLinkedIssue(task: Task, issue?: LinkedIssue): Promise<void> {
+  private async _updateLinkedIssue(task: RegisteredTaskData, issue?: LinkedIssue): Promise<void> {
     const result = await this._runTaskListMutation(
       (member) => member.mutations.setLinkedIssue,
       { taskId: task.id, issue },
@@ -668,7 +669,7 @@ export class TaskManagerStore {
     throwIfMutationFailed(result);
   }
 
-  private async _convertAutomationTask(task: Task): Promise<void> {
+  private async _convertAutomationTask(task: RegisteredTaskData): Promise<void> {
     const result = await this._runTaskListMutation(
       (member) => member.mutations.convertAutomation,
       { taskId: task.id },

--- a/apps/emdash-desktop/src/core/features/tasks/api/browser/stores/task-store.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/api/browser/stores/task-store.ts
@@ -1,6 +1,7 @@
 import { err, type Result } from '@emdash/shared';
 import { makeAutoObservable, observable } from 'mobx';
 import type { TaskScopedStoreContext } from '@core/features/tasks/contributions/browser/task-stores';
+import { taskPersistentStoreContributions } from '@core/manifests/browser/task-persistent-stores';
 import { taskStoreContributions } from '@core/manifests/browser/task-scoped-stores';
 import type { LinkedIssue } from '@core/primitives/linked-issues/api';
 import { log } from '@core/primitives/logging/browser/logger';
@@ -12,6 +13,7 @@ import {
 } from '@core/primitives/scoped-stores/browser';
 import {
   registeredTaskData,
+  type RegisteredTaskData,
   type TaskState,
   type UnprovisionedTaskPhase,
   type UnregisteredTaskData,
@@ -25,19 +27,21 @@ import type {
   WorkspaceLifecycleStepInfo,
   WorkspaceObservedPrFacts,
 } from '@core/primitives/tasks/api';
-import type { PrCheckoutDrift } from '@core/services/pull-requests/api';
 
 export type TaskStoreMutations = {
-  rename(task: Task, name: string): Promise<Result<RenameTaskSuccess, RenameTaskError>>;
-  updateStatus(task: Task, status: TaskLifecycleStatus): Promise<void>;
-  setPinned(task: Task, isPinned: boolean): Promise<void>;
-  updateLinkedIssue(task: Task, issue?: LinkedIssue): Promise<void>;
-  convertAutomationTask(task: Task): Promise<void>;
+  rename(
+    task: RegisteredTaskData,
+    name: string
+  ): Promise<Result<RenameTaskSuccess, RenameTaskError>>;
+  updateStatus(task: RegisteredTaskData, status: TaskLifecycleStatus): Promise<void>;
+  setPinned(task: RegisteredTaskData, isPinned: boolean): Promise<void>;
+  updateLinkedIssue(task: RegisteredTaskData, issue?: LinkedIssue): Promise<void>;
+  convertAutomationTask(task: RegisteredTaskData): Promise<void>;
 };
 
 export class TaskStore implements TaskState {
   state: 'unregistered' | 'unprovisioned' | 'provisioned';
-  data: UnregisteredTaskData | Task;
+  data: UnregisteredTaskData | RegisteredTaskData;
   phase: UnregisteredTaskPhase | UnprovisionedTaskPhase | null;
   errorMessage: string | undefined = undefined;
 
@@ -58,11 +62,7 @@ export class TaskStore implements TaskState {
   workspaceLifecycle: WorkspaceLifecycleStepInfo[] | null = null;
   /** Observed PR-association facts (mirror observedGit v2); null when unobserved. */
   workspaceObservedPr: WorkspaceObservedPrFacts | null = null;
-  /**
-   * Derived checkout drift (observation × PR cache), written runtime-only by the
-   * task-PR sync coordinator alongside `Task.prs`; null reads as unknown.
-   */
-  prCheckoutDrift: PrCheckoutDrift | null = null;
+  private persistentStores: ScopedStoreHost<TaskScopedStoreContext>;
   private stores: ScopedStoreHost<TaskScopedStoreContext>;
 
   get displayName(): string {
@@ -78,7 +78,7 @@ export class TaskStore implements TaskState {
   }
 
   constructor(
-    data: UnregisteredTaskData | Task,
+    data: UnregisteredTaskData | Task | RegisteredTaskData,
     state: TaskStore['state'],
     phase: UnregisteredTaskPhase | UnprovisionedTaskPhase | null = null,
     projectId: string = 'projectId' in data ? data.projectId : '',
@@ -86,9 +86,9 @@ export class TaskStore implements TaskState {
     private readonly mutations: TaskStoreMutations = unavailableMutations
   ) {
     this.state = state;
-    this.data = data;
+    this.data = state === 'unregistered' ? data : withoutPullRequests(data as Task);
     this.phase = phase;
-    makeAutoObservable<TaskStore, 'stores'>(this, {
+    makeAutoObservable<TaskStore, 'persistentStores' | 'stores'>(this, {
       workspaceId: observable,
       workspacePath: observable,
       workspaceSshConnectionId: observable,
@@ -97,15 +97,19 @@ export class TaskStore implements TaskState {
       workspaceCreateOutcome: observable,
       workspaceLifecycle: observable,
       workspaceObservedPr: observable,
-      prCheckoutDrift: observable,
+      persistentStores: false,
       stores: false,
       /** Deep observable so nested fields (e.g. `status`) notify observers (e.g. sidebar). */
       data: observable,
     });
-    this.stores = new ScopedStoreHost(
-      { projectId, taskId: data.id, task: this, projectStores },
-      taskStoreContributions
-    );
+    const context = { projectId, taskId: data.id, task: this, projectStores };
+    this.persistentStores = new ScopedStoreHost(context, taskPersistentStoreContributions);
+    try {
+      this.stores = new ScopedStoreHost(context, taskStoreContributions);
+    } catch (error) {
+      this.persistentStores.dispose();
+      throw error;
+    }
   }
 
   setWorkspaceProjection(projection?: {
@@ -129,6 +133,7 @@ export class TaskStore implements TaskState {
   }
 
   get<Token extends ScopedStoreToken<unknown>>(token: Token): ScopedStoreValue<Token> {
+    if (this.persistentStores.has(token)) return this.persistentStores.get(token);
     return this.stores.get(token);
   }
 
@@ -137,12 +142,12 @@ export class TaskStore implements TaskState {
   }
 
   transitionToProvisioned(
-    data: Task,
+    data: Task | RegisteredTaskData,
     path: string,
     workspaceId: string,
     sshConnectionId?: string
   ): void {
-    this.data = { ...data, workspaceId };
+    this.data = { ...withoutPullRequests(data), workspaceId };
     this.workspaceId = workspaceId;
     this.workspacePath = path;
     this.workspaceSshConnectionId = sshConnectionId;
@@ -152,30 +157,39 @@ export class TaskStore implements TaskState {
   }
 
   refreshWorkspaceBinding(
-    data: Task,
+    data: Task | RegisteredTaskData,
     path: string,
     workspaceId: string,
     sshConnectionId?: string
   ): void {
-    this.data = { ...data, workspaceId };
+    this.data = { ...withoutPullRequests(data), workspaceId };
     this.workspaceId = workspaceId;
     this.workspacePath = path;
     this.workspaceSshConnectionId = sshConnectionId;
   }
 
-  transitionToUnprovisioned(data: Task, phase: UnprovisionedTaskPhase = 'idle'): void {
+  transitionToUnprovisioned(
+    data: Task | RegisteredTaskData,
+    phase: UnprovisionedTaskPhase = 'idle'
+  ): void {
     this.workspaceId = null;
     this.workspacePath = null;
     this.workspaceSshConnectionId = undefined;
-    this.data = data;
+    this.data = withoutPullRequests(data);
     this.state = 'unprovisioned';
     this.phase = phase;
     this.errorMessage = undefined;
   }
 
-  transitionToDryUnprovisioned(data: Task, phase: UnprovisionedTaskPhase = 'idle'): void {
-    this.dispose();
-    this.data = data;
+  transitionToDryUnprovisioned(
+    data: Task | RegisteredTaskData,
+    phase: UnprovisionedTaskPhase = 'idle'
+  ): void {
+    this.stores.dispose();
+    this.workspaceId = null;
+    this.workspacePath = null;
+    this.workspaceSshConnectionId = undefined;
+    this.data = withoutPullRequests(data);
     this.state = 'unprovisioned';
     this.phase = phase;
     this.errorMessage = undefined;
@@ -197,6 +211,7 @@ export class TaskStore implements TaskState {
 
   dispose(): void {
     this.stores.dispose();
+    this.persistentStores.dispose();
     this.workspaceId = null;
     this.workspacePath = null;
     this.workspaceSshConnectionId = undefined;
@@ -271,11 +286,17 @@ export function createUnregisteredTask(
 }
 
 export function createUnprovisionedTask(
-  data: Task,
+  data: Task | RegisteredTaskData,
   projectStores?: ScopedStoreLookup,
   mutations?: TaskStoreMutations
 ): TaskStore {
   return new TaskStore(data, 'unprovisioned', 'idle', data.projectId, projectStores, mutations);
+}
+
+function withoutPullRequests(data: Task | RegisteredTaskData): RegisteredTaskData {
+  if (!('prs' in data)) return data;
+  const { prs: _prs, ...task } = data;
+  return task;
 }
 
 const unavailableProjectStores: ScopedStoreLookup = {

--- a/apps/emdash-desktop/src/core/features/tasks/api/browser/task-state/task-selectors.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/api/browser/task-state/task-selectors.ts
@@ -11,8 +11,8 @@ import {
   isUnprovisioned,
   isUnregistered,
   registeredTaskData,
+  type RegisteredTaskData,
 } from '@core/primitives/task-state/browser/task-state';
-import type { Task } from '@core/primitives/tasks/api';
 
 /** Call only inside `observer` components (or other MobX reactions). */
 export function getTaskManagerStore(projectId: string): TaskManagerStore | undefined {
@@ -25,7 +25,10 @@ export function getTaskStore(projectId: string, taskId: string): TaskStore | und
 }
 
 /** Registered task payload (`Task`) when the row exists and is not unregistered; otherwise undefined. */
-export function getRegisteredTaskData(projectId: string, taskId: string): Task | undefined {
+export function getRegisteredTaskData(
+  projectId: string,
+  taskId: string
+): RegisteredTaskData | undefined {
   const store = getTaskStore(projectId, taskId);
   if (!store) return undefined;
   return registeredTaskData(store);

--- a/apps/emdash-desktop/src/core/features/tasks/browser/stores/task-manager.test.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/browser/stores/task-manager.test.ts
@@ -9,6 +9,7 @@ import type {
   ProjectHostAccessState,
 } from '@core/features/projects/api/browser/stores/project-context';
 import { projectViewDef } from '@core/features/projects/contributions/views';
+import { getTaskPrAssociationStore } from '@core/features/source-control/api/browser/stores/task-source-control-selectors';
 import { tasksWireContract } from '@core/features/tasks/api';
 import { TaskManagerStore } from '@core/features/tasks/api/browser/stores/task-manager';
 import { createUnprovisionedTask } from '@core/features/tasks/api/browser/stores/task-store';
@@ -29,6 +30,16 @@ let taskListState: ReturnType<typeof cell<TaskListData>>;
 let taskStatsState: ReturnType<typeof cell<TaskStatsData>>;
 let wire: ReturnType<typeof createTaskWire> | undefined;
 let hostState: ProjectHostAccessState;
+
+vi.mock('@core/manifests/browser/task-persistent-stores', async () => {
+  const { sourceControlPersistentTaskStoreContributions } =
+    await import('@core/features/source-control/contributions/browser/task-stores');
+  return {
+    taskPersistentStoreContributions: sourceControlPersistentTaskStoreContributions.filter(
+      (contribution) => contribution.token.id === 'source-control.task-pr-association'
+    ),
+  };
+});
 
 vi.mock('@core/manifests/browser/task-scoped-stores', () => ({
   taskStoreContributions: [],
@@ -347,7 +358,28 @@ describe('TaskManagerStore lifecycle', () => {
     manager.dispose();
   });
 
-  it('preserves runtime PR associations across task-list emissions', async () => {
+  it('keeps renderer-derived PR state out of task-list payloads', async () => {
+    const manager = makeTaskManager();
+    const task = makeTask();
+    const { prs: _prs, workspaceGit: _workspaceGit, ...taskRow } = task;
+    taskListState.set({ tasks: [taskRow] });
+    await manager.loadTasks();
+    const store = manager.tasks.get(task.id)!;
+    const association = getTaskPrAssociationStore(store);
+    association.setAssociation(
+      [{ url: 'https://github.com/emdash/emdash/pull/42' } as Task['prs'][number]],
+      { kind: 'unknown' }
+    );
+
+    taskListState.set({ tasks: [{ ...taskRow, name: 'Task 1 renamed elsewhere' }] });
+
+    await vi.waitFor(() => expect(store.data.name).toBe('Task 1 renamed elsewhere'));
+    expect('prs' in store.data).toBe(false);
+    expect(association.pullRequests).toHaveLength(1);
+    manager.dispose();
+  });
+
+  it('removes the durable workspace without introducing PR state into task data', async () => {
     const manager = makeTaskManager();
     const task = makeTask();
     const { prs: _prs, workspaceGit: _workspaceGit, ...taskRow } = task;
@@ -355,16 +387,11 @@ describe('TaskManagerStore lifecycle', () => {
     await manager.loadTasks();
     const store = manager.tasks.get(task.id)!;
 
-    runInAction(() => {
-      (store.data as Task).prs = [
-        { url: 'https://github.com/emdash/emdash/pull/42' } as Task['prs'][number],
-      ];
-    });
+    const { workspaceId: _workspaceId, ...rowWithoutWorkspace } = taskRow;
+    taskListState.set({ tasks: [rowWithoutWorkspace] });
 
-    taskListState.set({ tasks: [{ ...taskRow, name: 'Task 1 renamed elsewhere' }] });
-
-    await vi.waitFor(() => expect(store.data.name).toBe('Task 1 renamed elsewhere'));
-    expect((store.data as Task).prs).toHaveLength(1);
+    await vi.waitFor(() => expect((store.data as Task).workspaceId).toBeUndefined());
+    expect('prs' in store.data).toBe(false);
     manager.dispose();
   });
 

--- a/apps/emdash-desktop/src/core/features/tasks/browser/stores/task-manager.test.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/browser/stores/task-manager.test.ts
@@ -347,6 +347,27 @@ describe('TaskManagerStore lifecycle', () => {
     manager.dispose();
   });
 
+  it('preserves runtime PR associations across task-list emissions', async () => {
+    const manager = makeTaskManager();
+    const task = makeTask();
+    const { prs: _prs, workspaceGit: _workspaceGit, ...taskRow } = task;
+    taskListState.set({ tasks: [taskRow] });
+    await manager.loadTasks();
+    const store = manager.tasks.get(task.id)!;
+
+    runInAction(() => {
+      (store.data as Task).prs = [
+        { url: 'https://github.com/emdash/emdash/pull/42' } as Task['prs'][number],
+      ];
+    });
+
+    taskListState.set({ tasks: [{ ...taskRow, name: 'Task 1 renamed elsewhere' }] });
+
+    await vi.waitFor(() => expect(store.data.name).toBe('Task 1 renamed elsewhere'));
+    expect((store.data as Task).prs).toHaveLength(1);
+    manager.dispose();
+  });
+
   it('reports never-observed Task stats as unavailable', async () => {
     const manager = makeTaskManager();
     taskListState.set({ tasks: [makeTask()] });

--- a/apps/emdash-desktop/src/core/features/tasks/browser/stores/task-store.test.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/browser/stores/task-store.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getTaskPrAssociationStore } from '@core/features/source-control/api/browser/stores/task-source-control-selectors';
 import {
   createUnprovisionedTask,
   createUnregisteredTask,
@@ -81,6 +82,32 @@ describe('TaskStore provision state', () => {
     createUnprovisionedTask(makeTask({ workspaceId: undefined }));
 
     expect(contributionMocks.create).toHaveBeenCalledOnce();
+  });
+
+  it('keeps renderer-derived PR data outside the registered task payload', () => {
+    const store = createUnprovisionedTask(
+      makeTask({
+        prs: [{ url: 'https://github.com/emdash/emdash/pull/42' } as Task['prs'][number]],
+      })
+    );
+
+    expect('prs' in store.data).toBe(false);
+  });
+
+  it('retains persistent PR association state when operational task stores are disposed', () => {
+    const task = makeTask();
+    const store = createUnprovisionedTask(task);
+    const association = getTaskPrAssociationStore(store);
+    association.setAssociation(
+      [{ url: 'https://github.com/emdash/emdash/pull/42' } as Task['prs'][number]],
+      { kind: 'unknown' }
+    );
+
+    store.transitionToDryUnprovisioned(task);
+
+    expect(getTaskPrAssociationStore(store)).toBe(association);
+    expect(association.pullRequests).toHaveLength(1);
+    expect(contributionMocks.dispose).toHaveBeenCalledOnce();
   });
 
   it('keeps task contributions stable when the authoritative workspace identity changes', () => {

--- a/apps/emdash-desktop/src/core/features/tasks/contributions/browser/task-git-diff-stats.test.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/contributions/browser/task-git-diff-stats.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TaskStore } from '@core/features/tasks/api/browser/stores/task-store';
+import { useTaskGitDiffStats } from './task-git-diff-stats';
+
+const mocks = vi.hoisted(() => ({
+  git: undefined as
+    | { totalLinesAdded: number; totalLinesDeleted: number; error: string | undefined }
+    | undefined,
+  taskStatsObservation: { kind: 'unavailable' } as { kind: 'unavailable' } | { kind: 'fresh' },
+}));
+
+vi.mock('@core/features/source-control/api/browser/stores/task-source-control-selectors', () => ({
+  getTaskGitCheckoutStore: () => mocks.git,
+}));
+
+vi.mock('@core/features/tasks/api/browser/task-state/task-selectors', () => ({
+  getTaskManagerStore: () => ({ taskStatsObservation: mocks.taskStatsObservation }),
+}));
+
+describe('useTaskGitDiffStats', () => {
+  beforeEach(() => {
+    mocks.git = undefined;
+    mocks.taskStatsObservation = { kind: 'unavailable' };
+  });
+
+  it('shows live checkout totals before cached task stats have been observed', () => {
+    mocks.git = {
+      totalLinesAdded: 7,
+      totalLinesDeleted: 2,
+      error: undefined,
+    };
+    const task = {
+      state: 'provisioned',
+      data: { id: 'task-1', projectId: 'project-1' },
+    } as TaskStore;
+
+    expect(useTaskGitDiffStats(task)).toMatchObject({
+      linesAdded: 7,
+      linesDeleted: 2,
+      visible: true,
+    });
+  });
+
+  it('still requires a fresh or stale observation for cached totals', () => {
+    const task = {
+      state: 'unprovisioned',
+      data: {
+        id: 'task-1',
+        projectId: 'project-1',
+        workspaceGit: { linesAdded: 7, linesDeleted: 2 },
+      },
+    } as TaskStore;
+
+    expect(useTaskGitDiffStats(task).visible).toBe(false);
+
+    mocks.taskStatsObservation = { kind: 'fresh' };
+    expect(useTaskGitDiffStats(task).visible).toBe(true);
+  });
+});

--- a/apps/emdash-desktop/src/core/features/tasks/contributions/browser/task-git-diff-stats.tsx
+++ b/apps/emdash-desktop/src/core/features/tasks/contributions/browser/task-git-diff-stats.tsx
@@ -18,9 +18,10 @@ export function useTaskGitDiffStats(task: TaskStore): {
   const cachedGit = isRegistered(task) ? task.data.workspaceGit : undefined;
   const linesAdded = git?.totalLinesAdded ?? cachedGit?.linesAdded ?? 0;
   const linesDeleted = git?.totalLinesDeleted ?? cachedGit?.linesDeleted ?? 0;
+  const hasObservedCachedGit =
+    (observation?.kind === 'fresh' || observation?.kind === 'stale') && cachedGit !== undefined;
   const visible =
-    (observation?.kind === 'fresh' || observation?.kind === 'stale') &&
-    (git !== undefined || cachedGit !== undefined) &&
+    (git !== undefined || hasObservedCachedGit) &&
     !git?.error &&
     (linesAdded > 0 || linesDeleted > 0);
   return {

--- a/apps/emdash-desktop/src/core/features/workbench/api/browser/task-composition.ts
+++ b/apps/emdash-desktop/src/core/features/workbench/api/browser/task-composition.ts
@@ -6,6 +6,7 @@ import type { FileTabResource } from '@core/features/editor/api/browser/task-edi
 import { DiffViewStore } from '@core/features/source-control/api/browser/diff-view/stores/diff-view-store';
 import type { GitRepositoryStore } from '@core/features/source-control/api/browser/stores/git-repository-store';
 import { PrStore } from '@core/features/source-control/api/browser/stores/pr-store';
+import { getTaskPrAssociationStore } from '@core/features/source-control/api/browser/stores/task-source-control-selectors';
 import {
   diffTabManagerStoreToken,
   gitCheckoutStoreToken,
@@ -381,7 +382,7 @@ export class TaskComposition {
       workspaceId,
       this._gitRepository,
       gitCheckout,
-      this._taskStore
+      getTaskPrAssociationStore(this._taskStore)
     );
 
     const diffSelectionHandle = sanitizedMemento(this._diffSelectionHandle, {

--- a/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/task-item.tsx
+++ b/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/task-item.tsx
@@ -1,7 +1,10 @@
 import { observer } from 'mobx-react-lite';
 import { projectViewDef } from '@core/features/projects/contributions/views';
 import { useAppSettingsKey } from '@core/features/settings/api/browser/use-app-settings-key';
-import { getTaskGitCheckoutStore } from '@core/features/source-control/api/browser/stores/task-source-control-selectors';
+import {
+  getTaskGitCheckoutStore,
+  getTaskPrAssociationStore,
+} from '@core/features/source-control/api/browser/stores/task-source-control-selectors';
 import { type TaskStore } from '@core/features/tasks/api/browser/stores/task-store';
 import {
   getTaskManagerStore,
@@ -152,8 +155,7 @@ export const SidebarTaskItem = observer(function SidebarTaskItem({
 });
 
 const RenderPrBadge = observer(function RenderPrBadge({ task }: { task: TaskStore }) {
-  if (!('prs' in task.data)) return null;
-  const pr = selectCurrentPr(task.data.prs);
+  const pr = selectCurrentPr(getTaskPrAssociationStore(task).pullRequests);
   return pr ? (
     <span onMouseDown={(e) => e.stopPropagation()} onClick={(e) => e.stopPropagation()}>
       <PrBadge variant="compact" pr={pr} hoverDelay={100} />

--- a/apps/emdash-desktop/src/core/manifests/browser/task-persistent-stores.ts
+++ b/apps/emdash-desktop/src/core/manifests/browser/task-persistent-stores.ts
@@ -1,0 +1,7 @@
+import { sourceControlPersistentTaskStoreContributions } from '@core/features/source-control/contributions/browser/task-stores';
+import type { TaskScopedStoreContext } from '@core/features/tasks/contributions/browser/task-stores';
+import type { ScopedStoreContribution } from '@core/primitives/scoped-stores/browser';
+
+/** Lightweight feature state that survives session teardown for as long as the task row exists. */
+export const taskPersistentStoreContributions: readonly ScopedStoreContribution<TaskScopedStoreContext>[] =
+  [...sourceControlPersistentTaskStoreContributions];

--- a/apps/emdash-desktop/src/core/primitives/task-state/browser/task-state.ts
+++ b/apps/emdash-desktop/src/core/primitives/task-state/browser/task-state.ts
@@ -1,5 +1,8 @@
 import type { Task, TaskLifecycleStatus } from '@core/primitives/tasks/api';
 
+/** Browser task-list state; renderer-derived PR association lives in its feature store. */
+export type RegisteredTaskData = Omit<Task, 'prs'>;
+
 export type UnregisteredTaskPhase = 'creating' | 'create-error';
 
 export type UnprovisionedTaskPhase =
@@ -23,7 +26,7 @@ export type UnregisteredTaskData = {
 
 export interface TaskState {
   readonly state: 'unregistered' | 'unprovisioned' | 'provisioned';
-  readonly data: UnregisteredTaskData | Task;
+  readonly data: UnregisteredTaskData | RegisteredTaskData;
   readonly phase: UnregisteredTaskPhase | UnprovisionedTaskPhase | null;
   readonly errorMessage: string | undefined;
   readonly workspaceId: string | null;
@@ -39,13 +42,13 @@ export type UnregisteredTaskState = TaskState & {
 
 export type UnprovisionedTaskState = TaskState & {
   state: 'unprovisioned';
-  data: Task;
+  data: RegisteredTaskData;
   phase: UnprovisionedTaskPhase;
 };
 
 export type ProvisionedTaskState = TaskState & {
   state: 'provisioned';
-  data: Task;
+  data: RegisteredTaskData;
   workspaceId: string;
 };
 
@@ -67,7 +70,7 @@ export function isProvisioned<T extends TaskState>(task: T): task is T & Provisi
   return task.state === 'provisioned';
 }
 
-export function registeredTaskData(task: TaskState): Task | undefined {
+export function registeredTaskData(task: TaskState): RegisteredTaskData | undefined {
   return isRegistered(task) ? task.data : undefined;
 }
 

--- a/apps/emdash-desktop/src/core/services/pull-requests/api/repository.ts
+++ b/apps/emdash-desktop/src/core/services/pull-requests/api/repository.ts
@@ -26,7 +26,7 @@ export function recognizePullRequestUrl(
   return `${repositoryUrl}/pull/${match[1]}`;
 }
 
-export function selectCurrentPr(pullRequests: PullRequest[]): PullRequest | undefined {
+export function selectCurrentPr(pullRequests: readonly PullRequest[]): PullRequest | undefined {
   const open = pullRequests.find((pullRequest) => pullRequest.status === 'open');
   if (open) return open;
   return pullRequests.reduce<PullRequest | undefined>(


### PR DESCRIPTION
- preserve runtime pr associations during task-list refreshes so task views and sidebar status stay on the detected github pr
- show live working-tree line totals before cached task statistics become available
- retain existing freshness rules for cached and offline line totals