### PR TITLE
fix(source-control): restore optimistic staging

### DIFF
--- a/apps/emdash-desktop/src/core/features/source-control/browser/stores/checkout-changes-state.test.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/stores/checkout-changes-state.test.ts
@@ -1,0 +1,121 @@
+import type { CheckoutStatusState, GitChange, GitStatusCode } from '@emdash/core/runtimes/git/api';
+import { describe, expect, it } from 'vitest';
+import { portablePath } from '@core/primitives/desktop-runtime/api';
+import {
+  projectCheckoutChanges,
+  reduceStageAll,
+  reduceStageFiles,
+  reduceUnstageFiles,
+  type CheckoutChangesState,
+} from './checkout-changes-state';
+
+describe('checkout changes state', () => {
+  it('derives side membership from status and enriches it with side-specific diff metadata', () => {
+    const status = okStatus({
+      'partial.ts': {
+        index: 'added',
+        worktree: 'modified',
+      },
+      'staged.ts': {
+        index: 'deleted',
+        worktree: 'unmodified',
+      },
+    });
+    const metadata: CheckoutChangesState = {
+      staged: [change('partial.ts', 'added', 2), change('staged.ts', 'deleted', 0, 3)],
+      unstaged: [change('partial.ts', 'modified', 1, 1)],
+    };
+
+    expect(projectCheckoutChanges(status, metadata)).toEqual(metadata);
+  });
+
+  it('uses status as the authority for membership', () => {
+    const metadata: CheckoutChangesState = {
+      staged: [change('stale.ts', 'modified', 3)],
+      unstaged: [change('stale.ts', 'modified', 3)],
+    };
+
+    expect(projectCheckoutChanges(okStatus({}), metadata)).toEqual({ staged: [], unstaged: [] });
+  });
+
+  it('projects untracked files missing from git diff as unstaged additions', () => {
+    const projected = projectCheckoutChanges(
+      okStatus({
+        'new.ts': {
+          index: 'untracked',
+          worktree: 'untracked',
+        },
+      }),
+      { staged: [], unstaged: [] }
+    );
+
+    expect(projected).toEqual({
+      staged: [],
+      unstaged: [change('new.ts', 'added', 0, 0)],
+    });
+  });
+
+  it('moves only the selected side of a partially staged file', () => {
+    const changes: CheckoutChangesState = {
+      staged: [change('partial.ts', 'added', 2)],
+      unstaged: [change('partial.ts', 'modified', 1, 1), change('other.ts')],
+    };
+
+    reduceStageFiles(changes, { paths: ['partial.ts'] });
+    expect(changes).toEqual({
+      staged: [change('partial.ts', 'modified', 1, 1)],
+      unstaged: [change('other.ts')],
+    });
+
+    reduceUnstageFiles(changes, { paths: ['partial.ts'] });
+    expect(changes).toEqual({
+      staged: [],
+      unstaged: [change('other.ts'), change('partial.ts', 'modified', 1, 1)],
+    });
+  });
+
+  it('stages all files with one entry per path', () => {
+    const changes: CheckoutChangesState = {
+      staged: [change('partial.ts', 'added', 2)],
+      unstaged: [change('partial.ts', 'modified', 1, 1), change('other.ts')],
+    };
+
+    reduceStageAll(changes);
+
+    expect(changes).toEqual({
+      staged: [change('partial.ts', 'modified', 1, 1), change('other.ts')],
+      unstaged: [],
+    });
+  });
+});
+
+function change(
+  path: string,
+  status: GitChange['status'] = 'modified',
+  additions = 1,
+  deletions = 0
+): GitChange {
+  return { path: portablePath(path), status, additions, deletions };
+}
+
+function okStatus(
+  entries: Record<
+    string,
+    {
+      index: GitStatusCode;
+      worktree: GitStatusCode;
+    }
+  >
+): CheckoutStatusState {
+  const statusEntries: Extract<CheckoutStatusState, { kind: 'ok' }>['entries'] = {};
+  for (const [path, entry] of Object.entries(entries)) {
+    const portable = portablePath(path);
+    statusEntries[portable] = { path: portable, ...entry, isConflicted: false };
+  }
+  return {
+    kind: 'ok',
+    entries: statusEntries,
+    summary: { staged: 0, unstaged: 0, conflicted: 0, untracked: 0 },
+    operation: 'none',
+  };
+}

--- a/apps/emdash-desktop/src/core/features/source-control/browser/stores/checkout-changes-state.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/stores/checkout-changes-state.ts
@@ -1,0 +1,99 @@
+import type {
+  CheckoutStatusState,
+  FileGitStatus,
+  GitChange,
+  GitChangeStatus,
+} from '@emdash/core/runtimes/git/api';
+
+export interface CheckoutChangesState {
+  staged: GitChange[];
+  unstaged: GitChange[];
+}
+
+export function emptyCheckoutChangesState(): CheckoutChangesState {
+  return { staged: [], unstaged: [] };
+}
+
+/**
+ * Projects visible membership from status and uses diff reads only to enrich
+ * entries which status says belong to that side.
+ */
+export function projectCheckoutChanges(
+  status: CheckoutStatusState | undefined,
+  metadata: CheckoutChangesState
+): CheckoutChangesState {
+  if (!status || status.kind !== 'ok') return emptyCheckoutChangesState();
+
+  const stagedMetadata = new Map(metadata.staged.map((change) => [change.path, change]));
+  const unstagedMetadata = new Map(metadata.unstaged.map((change) => [change.path, change]));
+  const staged: GitChange[] = [];
+  const unstaged: GitChange[] = [];
+
+  for (const entry of Object.values(status.entries)) {
+    if (isChangedOnSide(entry, 'staged')) {
+      staged.push(stagedMetadata.get(entry.path) ?? changeFromStatus(entry, 'staged'));
+    }
+    if (isChangedOnSide(entry, 'unstaged')) {
+      unstaged.push(unstagedMetadata.get(entry.path) ?? changeFromStatus(entry, 'unstaged'));
+    }
+  }
+
+  return { staged, unstaged };
+}
+
+export function reduceStageFiles(
+  changes: CheckoutChangesState,
+  input: { paths: readonly string[] }
+): void {
+  movePaths(changes, input.paths, 'unstaged', 'staged');
+}
+
+export function reduceStageAll(changes: CheckoutChangesState): void {
+  changes.staged = mergeByPath([...changes.staged, ...changes.unstaged]);
+  changes.unstaged = [];
+}
+
+export function reduceUnstageFiles(
+  changes: CheckoutChangesState,
+  input: { paths: readonly string[] }
+): void {
+  movePaths(changes, input.paths, 'staged', 'unstaged');
+}
+
+export function reduceUnstageAll(changes: CheckoutChangesState): void {
+  changes.unstaged = mergeByPath([...changes.unstaged, ...changes.staged]);
+  changes.staged = [];
+}
+
+function isChangedOnSide(entry: FileGitStatus, side: 'staged' | 'unstaged'): boolean {
+  return side === 'staged'
+    ? entry.index !== 'unmodified' && entry.index !== 'untracked' && entry.index !== 'ignored'
+    : entry.worktree !== 'unmodified' && entry.worktree !== 'ignored';
+}
+
+function changeFromStatus(entry: FileGitStatus, side: 'staged' | 'unstaged'): GitChange {
+  const code = side === 'staged' ? entry.index : entry.worktree;
+  let status: GitChangeStatus = 'modified';
+  if (entry.isConflicted || code === 'unmerged') status = 'conflicted';
+  else if (code === 'added' || code === 'copied' || code === 'untracked') status = 'added';
+  else if (code === 'deleted') status = 'deleted';
+  else if (code === 'renamed') status = 'renamed';
+  return { path: entry.path, status, additions: 0, deletions: 0 };
+}
+
+function movePaths(
+  changes: CheckoutChangesState,
+  paths: readonly string[],
+  from: keyof CheckoutChangesState,
+  to: keyof CheckoutChangesState
+): void {
+  const requested = new Set(paths);
+  const moving = changes[from].filter((change) => requested.has(change.path));
+  const movingPaths = new Set(moving.map((change) => change.path));
+  changes[from] = changes[from].filter((change) => !requested.has(change.path));
+  changes[to] = [...changes[to].filter((change) => !movingPaths.has(change.path)), ...moving];
+}
+
+function mergeByPath(changes: GitChange[]): GitChange[] {
+  return [...new Map(changes.map((change) => [change.path, change])).values()];
+}

--- a/apps/emdash-desktop/src/core/features/source-control/browser/stores/git-checkout-store.test.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/stores/git-checkout-store.test.ts
@@ -1,9 +1,10 @@
 import type { CheckoutHeadState, CheckoutStatusState } from '@emdash/core/runtimes/git/api';
-import { ok } from '@emdash/shared';
+import { err, ok } from '@emdash/shared';
 import { cell, expose, flushStateTurn } from '@emdash/wire/state';
 import { createTestWire } from '@emdash/wire/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type * as SourceControlClientModule from '@core/features/source-control/api/browser/client';
+import { portablePath } from '@core/primitives/desktop-runtime/api';
 import { sourceControlContract } from '../../api';
 import { GitCheckoutStore } from './git-checkout-store';
 
@@ -16,6 +17,11 @@ const mocks = vi.hoisted(() => ({
 let statusState: ReturnType<typeof cell<CheckoutStatusState>>;
 let headState: ReturnType<typeof cell<CheckoutHeadState>>;
 let wire: ReturnType<typeof createSourceControlWire> | undefined;
+let stageStarted: Deferred<void>;
+let releaseStage: Deferred<void>;
+let failStage: boolean;
+let unstageStarted: Deferred<void>;
+let releaseUnstage: Deferred<void>;
 
 vi.mock('@core/features/source-control/api/browser/client', async (importOriginal) => {
   const actual = await importOriginal<typeof SourceControlClientModule>();
@@ -41,6 +47,11 @@ describe('GitCheckoutStore', () => {
   beforeEach(() => {
     statusState = cell(status());
     headState = cell(head('main'));
+    stageStarted = deferred<void>();
+    releaseStage = deferred<void>();
+    failStage = false;
+    unstageStarted = deferred<void>();
+    releaseUnstage = deferred<void>();
     mocks.getChangedFiles.mockResolvedValue(ok({ files: [] }));
     mocks.getGitRepositoryStore.mockReturnValue({
       isBranchOnRemote: () => true,
@@ -87,6 +98,83 @@ describe('GitCheckoutStore', () => {
     expect(store.headDisplay).toBe('feature');
     store.dispose();
   });
+
+  it('projects staged membership before the mutation settles', async () => {
+    statusState.set(status('src/index.ts'));
+    const store = new GitCheckoutStore('project-1', 'workspace-1', '/repo');
+    store.start();
+    await waitFor(() => hasPath(store.unstagedFileChanges, 'src/index.ts'));
+
+    const staging = store.stageFiles(['src/index.ts']);
+    await stageStarted.promise;
+    try {
+      expect(hasPath(store.unstagedFileChanges, 'src/index.ts')).toBe(false);
+      expect(hasPath(store.stagedFileChanges, 'src/index.ts')).toBe(true);
+    } finally {
+      releaseStage.resolve();
+      await staging;
+      store.dispose();
+    }
+  });
+
+  it('keeps staged membership while diff metadata catches up', async () => {
+    statusState.set(status('src/index.ts'));
+    const store = new GitCheckoutStore('project-1', 'workspace-1', '/repo');
+    store.start();
+    await waitFor(() => hasPath(store.unstagedFileChanges, 'src/index.ts'));
+    const changedFiles = deferred<ReturnType<typeof emptyChangesResult>>();
+    mocks.getChangedFiles.mockReturnValue(changedFiles.promise);
+
+    const staging = store.stageFiles(['src/index.ts']);
+    await stageStarted.promise;
+    releaseStage.resolve();
+    await staging;
+
+    expect(hasPath(store.unstagedFileChanges, 'src/index.ts')).toBe(false);
+    expect(hasPath(store.stagedFileChanges, 'src/index.ts')).toBe(true);
+
+    changedFiles.resolve(emptyChangesResult());
+    await waitFor(() => hasPath(store.stagedFileChanges, 'src/index.ts'));
+    expect(hasPath(store.unstagedFileChanges, 'src/index.ts')).toBe(false);
+    store.dispose();
+  });
+
+  it('rolls optimistic staged membership back when the mutation fails', async () => {
+    failStage = true;
+    statusState.set(status('src/index.ts'));
+    const store = new GitCheckoutStore('project-1', 'workspace-1', '/repo');
+    store.start();
+    await waitFor(() => hasPath(store.unstagedFileChanges, 'src/index.ts'));
+
+    const staging = store.stageFiles(['src/index.ts']);
+    await stageStarted.promise;
+    expect(hasPath(store.unstagedFileChanges, 'src/index.ts')).toBe(false);
+    expect(hasPath(store.stagedFileChanges, 'src/index.ts')).toBe(true);
+
+    releaseStage.resolve();
+    await expect(staging).resolves.toEqual(err({ type: 'git_error', message: 'stage failed' }));
+    await waitFor(() => hasPath(store.unstagedFileChanges, 'src/index.ts'));
+    expect(hasPath(store.stagedFileChanges, 'src/index.ts')).toBe(false);
+    store.dispose();
+  });
+
+  it('projects unstaged membership before the mutation settles', async () => {
+    statusState.set(stagedStatus('src/index.ts'));
+    const store = new GitCheckoutStore('project-1', 'workspace-1', '/repo');
+    store.start();
+    await waitFor(() => hasPath(store.stagedFileChanges, 'src/index.ts'));
+
+    const unstaging = store.unstageFiles(['src/index.ts']);
+    await unstageStarted.promise;
+    try {
+      expect(hasPath(store.stagedFileChanges, 'src/index.ts')).toBe(false);
+      expect(hasPath(store.unstagedFileChanges, 'src/index.ts')).toBe(true);
+    } finally {
+      releaseUnstage.resolve();
+      await unstaging;
+      store.dispose();
+    }
+  });
 });
 
 function createSourceControlWire() {
@@ -94,10 +182,55 @@ function createSourceControlWire() {
     refs: cell({ branches: [], tags: [] }),
     remotes: cell({ remotes: [] }),
   });
-  const checkoutProvider = expose(sourceControlContract.checkout.model, {
-    status: statusState,
-    head: headState,
-  });
+  const checkoutProvider = expose(
+    sourceControlContract.checkout.model,
+    {
+      status: statusState,
+      head: headState,
+    },
+    {
+      mutations: {
+        async stage(context) {
+          stageStarted.resolve();
+          await releaseStage.promise;
+          if (failStage) return err({ type: 'git_error', message: 'stage failed' });
+          const path = context.input.paths[0];
+          if (!path) return ok<void>();
+          const revision = statusState.set(stagedStatus(path), {
+            mutationIds: [context.mutationId],
+          });
+          await context.observed('status', revision);
+          return ok<void>();
+        },
+        async unstage(context) {
+          unstageStarted.resolve();
+          await releaseUnstage.promise;
+          const path = context.input.paths[0];
+          if (!path) return ok<void>();
+          const revision = statusState.set(status(path), {
+            mutationIds: [context.mutationId],
+          });
+          await context.observed('status', revision);
+          return ok<void>();
+        },
+        async stageAll() {
+          return ok<void>();
+        },
+        async unstageAll() {
+          return ok<void>();
+        },
+        async revert() {
+          return ok<void>();
+        },
+        async revertAll() {
+          return ok<void>();
+        },
+        async commit() {
+          return ok({ hash: 'abc123' });
+        },
+      },
+    }
+  );
 
   return createTestWire(sourceControlContract, {
     repository: {
@@ -153,6 +286,44 @@ function status(changedPath?: string): CheckoutStatusState {
     },
     operation: 'none',
   };
+}
+
+function stagedStatus(changedPath: string): CheckoutStatusState {
+  const path = portablePath(changedPath);
+  return {
+    kind: 'ok',
+    entries: {
+      [path]: {
+        path,
+        index: 'modified',
+        worktree: 'unmodified',
+        isConflicted: false,
+      },
+    },
+    summary: { staged: 1, unstaged: 0, conflicted: 0, untracked: 0 },
+    operation: 'none',
+  };
+}
+
+function emptyChangesResult() {
+  return ok({ files: [] });
+}
+
+function hasPath(changes: readonly { path: string }[], path: string): boolean {
+  return changes.some((change) => change.path === path);
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
 }
 
 async function waitFor(predicate: () => boolean): Promise<void> {

--- a/apps/emdash-desktop/src/core/features/source-control/browser/stores/git-checkout-store.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/stores/git-checkout-store.ts
@@ -2,14 +2,23 @@ import { encodeResourceUri } from '@emdash/core/primitives/path/api';
 import {
   type CheckoutHeadState,
   type CheckoutStatusState,
-  type FileGitStatus,
   type GitChange,
-  type GitChangeStatus,
 } from '@emdash/core/runtimes/git/api';
 import { err, ok } from '@emdash/shared';
 import { createScope, type Scope } from '@emdash/shared/concurrency';
 import { runWithTimeout, TimeoutError } from '@emdash/shared/scheduling';
-import { observe, pin, remote, type RemoteModel } from '@emdash/wire/state';
+import {
+  cell,
+  derived,
+  observe,
+  optimistic,
+  pin,
+  remote,
+  snapshot,
+  type Cell,
+  type OptimisticView,
+  type RemoteModel,
+} from '@emdash/wire/state';
 import { computed, makeObservable, observable, runInAction } from 'mobx';
 import { getFilesClient } from '@core/features/files/api/browser/client';
 import {
@@ -22,6 +31,15 @@ import { resolveWorkspacePath } from '@core/features/workspaces/api/browser/work
 import { hostFileRefFromNativePath } from '@core/primitives/desktop-runtime/api';
 import { runDesktopLiveJob } from '@core/primitives/wire/browser/run-live-job';
 import { sourceControlContract } from '../../api';
+import {
+  type CheckoutChangesState,
+  emptyCheckoutChangesState,
+  projectCheckoutChanges,
+  reduceStageAll,
+  reduceStageFiles,
+  reduceUnstageAll,
+  reduceUnstageFiles,
+} from './checkout-changes-state';
 
 const TOO_MANY_FILES_MSG = 'Too many files changed to display';
 // A healthy checkout model emits status and head within a few seconds; a wait
@@ -42,6 +60,8 @@ export class GitCheckoutStore {
   private syncError: string | null = null;
   private statusData: CheckoutStatusState | null = null;
   private headData: CheckoutHeadState | null = null;
+  private changesMetadata: Cell<CheckoutChangesState> | null = null;
+  private changesView: OptimisticView<CheckoutChangesState> | null = null;
   private changesRequest = 0;
   private stagedChanges: GitChange[] = [];
   private unstagedChanges: GitChange[] = [];
@@ -100,7 +120,7 @@ export class GitCheckoutStore {
     const model = this.model;
     if (!model) return;
     await Promise.all([model.states.status.refresh(), model.states.head.refresh()]);
-    await this.refreshChanges();
+    await this.refreshDiffMetadata();
   }
 
   async retry(): Promise<void> {
@@ -115,6 +135,8 @@ export class GitCheckoutStore {
       this.syncError = null;
       this.statusData = null;
       this.headData = null;
+      this.changesMetadata = null;
+      this.changesView = null;
       this.stagedChanges = [];
       this.unstagedChanges = [];
     });
@@ -136,6 +158,8 @@ export class GitCheckoutStore {
     this.model = null;
     this.statusData = null;
     this.headData = null;
+    this.changesMetadata = null;
+    this.changesView = null;
     void (async () => {
       try {
         await remote?.dispose();
@@ -235,23 +259,23 @@ export class GitCheckoutStore {
   }
 
   async stageFiles(paths: string[]) {
-    const model = await this.requireModel();
-    return settleMutation(model.mutations.stage({ paths: paths.map(gitFilePath) }));
+    const { model, view } = await this.requireChangesMutation();
+    return view.run(model.mutations.stage, { paths: paths.map(gitFilePath) }, reduceStageFiles);
   }
 
   async stageAllFiles() {
-    const model = await this.requireModel();
-    return settleMutation(model.mutations.stageAll({}));
+    const { model, view } = await this.requireChangesMutation();
+    return view.run(model.mutations.stageAll, {}, reduceStageAll);
   }
 
   async unstageFiles(paths: string[]) {
-    const model = await this.requireModel();
-    return settleMutation(model.mutations.unstage({ paths: paths.map(gitFilePath) }));
+    const { model, view } = await this.requireChangesMutation();
+    return view.run(model.mutations.unstage, { paths: paths.map(gitFilePath) }, reduceUnstageFiles);
   }
 
   async unstageAllFiles() {
-    const model = await this.requireModel();
-    return settleMutation(model.mutations.unstageAll({}));
+    const { model, view } = await this.requireChangesMutation();
+    return view.run(model.mutations.unstageAll, {}, reduceUnstageAll);
   }
 
   async discardFiles(paths: string[]) {
@@ -309,6 +333,16 @@ export class GitCheckoutStore {
     return this.model;
   }
 
+  private async requireChangesMutation(): Promise<{
+    model: CheckoutRemoteMember;
+    view: OptimisticView<CheckoutChangesState>;
+  }> {
+    const model = await this.requireModel();
+    const view = this.changesView;
+    if (!view) throw new Error(this.syncError ?? 'Git checkout changes are unavailable');
+    return { model, view };
+  }
+
   private async bindRuntime(): Promise<void> {
     const scope = createScope({ label: `git-checkout-store:${this.workspaceId}` });
     let checkoutRemote: CheckoutRemote | null = null;
@@ -319,6 +353,21 @@ export class GitCheckoutStore {
         lingerMs: 15_000,
       });
       const model = checkoutRemote(checkoutSelector(this.workspaceId));
+      const changesMetadata = cell(emptyCheckoutChangesState());
+      const baseChanges = derived(() =>
+        projectCheckoutChanges(snapshot(model.states.status).value, snapshot(changesMetadata).value)
+      );
+      const changesView = optimistic(baseChanges);
+      observe(
+        changesView,
+        (current) => {
+          runInAction(() => {
+            this.stagedChanges = current.value?.staged ?? [];
+            this.unstagedChanges = current.value?.unstaged ?? [];
+          });
+        },
+        { scope }
+      );
       pin(scope, Object.values(model.states));
       await runWithTimeout(
         () =>
@@ -326,7 +375,7 @@ export class GitCheckoutStore {
             setStatus: (status) => {
               this.statusData = status;
               this.revision += 1;
-              void this.refreshChanges();
+              void this.refreshDiffMetadata(changesMetadata);
             },
             setHead: (head) => {
               this.headData = head;
@@ -344,6 +393,8 @@ export class GitCheckoutStore {
         this.remote = checkoutRemote;
         this.remoteScope = scope;
         this.model = model;
+        this.changesMetadata = changesMetadata;
+        this.changesView = changesView;
         this.syncError = null;
       });
     } catch (error) {
@@ -360,13 +411,13 @@ export class GitCheckoutStore {
     }
   }
 
-  private async refreshChanges(): Promise<void> {
+  private async refreshDiffMetadata(
+    metadata: Cell<CheckoutChangesState> | null = this.changesMetadata
+  ): Promise<void> {
+    if (!metadata) return;
     const status = this.status;
     if (!status || status.kind !== 'ok') {
-      runInAction(() => {
-        this.stagedChanges = [];
-        this.unstagedChanges = [];
-      });
+      metadata.set(emptyCheckoutChangesState());
       return;
     }
     const request = ++this.changesRequest;
@@ -384,13 +435,14 @@ export class GitCheckoutStore {
       return;
     }
 
-    const staged = completeChanges(stagedResult.data.files, status.entries, 'staged');
-    const unstaged = completeChanges(unstagedResult.data.files, status.entries, 'unstaged');
-    await addUntrackedLineCounts(unstaged, this.workspacePath, this.sshConnectionId);
+    const enriched = projectCheckoutChanges(status, {
+      staged: stagedResult.data.files,
+      unstaged: unstagedResult.data.files,
+    });
+    await addUntrackedLineCounts(enriched.unstaged, this.workspacePath, this.sshConnectionId);
     if (request !== this.changesRequest || !this.started) return;
+    metadata.set(enriched);
     runInAction(() => {
-      this.stagedChanges = staged;
-      this.unstagedChanges = unstaged;
       this.syncError = null;
     });
   }
@@ -402,28 +454,6 @@ async function settleMutation<
   const invocation = await invocationPromise;
   if (invocation.result.success) await invocation.settled;
   return invocation.result;
-}
-
-function completeChanges(
-  changes: GitChange[],
-  entries: Record<string, FileGitStatus>,
-  side: 'staged' | 'unstaged'
-): GitChange[] {
-  const byPath = new Map(changes.map((change) => [change.path, change]));
-  for (const entry of Object.values(entries)) {
-    const changed =
-      side === 'staged'
-        ? entry.index !== 'unmodified' && entry.index !== 'untracked' && entry.index !== 'ignored'
-        : entry.worktree !== 'unmodified' && entry.worktree !== 'ignored';
-    if (!changed || byPath.has(entry.path)) continue;
-    byPath.set(entry.path, {
-      path: entry.path,
-      status: changeStatus(entry),
-      additions: 0,
-      deletions: 0,
-    });
-  }
-  return [...byPath.values()];
 }
 
 function waitForCheckoutModel(
@@ -477,17 +507,6 @@ function waitForCheckoutModel(
       { scope }
     );
   });
-}
-
-function changeStatus(entry: FileGitStatus): GitChangeStatus {
-  if (entry.isConflicted || entry.index === 'unmerged' || entry.worktree === 'unmerged') {
-    return 'conflicted';
-  }
-  const code = entry.worktree !== 'unmodified' ? entry.worktree : entry.index;
-  if (code === 'added' || code === 'copied' || code === 'untracked') return 'added';
-  if (code === 'deleted') return 'deleted';
-  if (code === 'renamed') return 'renamed';
-  return 'modified';
 }
 
 async function addUntrackedLineCounts(


### PR DESCRIPTION
- derives staged and unstaged membership from model.states.status
- applies stage and unstage mutations optimistically with automatic failure rollback
- uses getChangedFiles only to enrich diff metadata without blocking sidebar updates
- prevents stale diff metadata from keeping files in the wrong section