### PR TITLE
fix(modals): prevent task overflow and clarify github identity

### DIFF
--- a/apps/emdash-desktop/src/core/features/github/contributions/browser/identity-strip-state.ts
+++ b/apps/emdash-desktop/src/core/features/github/contributions/browser/identity-strip-state.ts
@@ -3,12 +3,12 @@ import type { GitHubAccountSummary } from '@core/primitives/github/api';
 import type { Provenance, Resolved } from '@core/primitives/project-settings/api';
 
 /**
- * React-free view state for the identity strip (spec: github-git-settings §9,
- * prototype Variant A). The strip shows who an account-relevant modal action
- * (create PR, add remote, create repository) will act as: a per-action
- * override when the user picked one in the popover, otherwise the blessed
- * resolver's effective account. Accountless outcomes map through the §7
- * reporting matrix so every surface renders the same rows.
+ * React-free view state for the identity strip (spec: github-git-settings §9).
+ * The strip shows who an account-relevant modal action (create PR, add remote,
+ * create repository) will act as: a per-action override when the user picked
+ * one in the popover, otherwise the blessed resolver's effective account.
+ * Accountless outcomes map through the §7 reporting matrix so every surface
+ * renders the same rows.
  */
 export type IdentityStripView =
   | {

--- a/apps/emdash-desktop/src/core/features/github/contributions/browser/identity-strip.tsx
+++ b/apps/emdash-desktop/src/core/features/github/contributions/browser/identity-strip.tsx
@@ -9,16 +9,15 @@ import { cn } from '@core/primitives/styling/browser/cn';
 import { identityStripView } from './identity-strip-state';
 
 /**
- * The Variant A identity strip (spec: github-git-settings §9): a slim ambient
- * row in account-relevant modals showing "<action> as @login (host)" with
- * provenance, a popover to change the account for this action, and the
- * fail-closed states inline. The modal owns the override and the blocking of
- * its primary action (via `identityStripBlocksAction`); persistence semantics
- * are declared through `persistence`.
+ * The identity strip (spec: github-git-settings §9): a slim ambient row in
+ * account-relevant modals showing the acting GitHub account with provenance, a
+ * popover to change the account for this action, and the fail-closed states
+ * inline. The surrounding modal already names the action. The modal owns the
+ * override and the blocking of its primary action (via
+ * `identityStripBlocksAction`); persistence semantics are declared through
+ * `persistence`.
  */
 export type GitHubIdentityStripProps = {
-  /** Verb phrase for the surrounding action, e.g. "Creating PR". */
-  action: string;
   /** The resolver's effective account (synthetic for project-less modals). */
   resolved: Resolved<GitHubAccountSummary | null>;
   accounts: GitHubAccountSummary[];
@@ -69,7 +68,6 @@ function provenanceExplanation(
 }
 
 export function GitHubIdentityStrip({
-  action,
   resolved,
   accounts,
   override,
@@ -113,7 +111,7 @@ export function GitHubIdentityStrip({
           <span className="font-medium text-foreground-error">{view.message}</span>
           <span className="text-xs text-foreground-muted">
             {accountRequired
-              ? `${action} is blocked until you pick an account.`
+              ? 'Choose a GitHub account to continue.'
               : 'Pick an account, or continue with system git credentials.'}
           </span>
         </div>
@@ -152,17 +150,11 @@ export function GitHubIdentityStrip({
               )}
               title={provenanceExplanation(resolved, override)}
             />
-            <span className="shrink-0 text-foreground-muted">{action} as</span>
             {account ? (
               <GitHubAccountSelectLabel account={account} />
             ) : (
               <span className="text-foreground-muted">—</span>
             )}
-            {view.kind === 'account' &&
-            !view.isActionOverride &&
-            view.provenance.kind === 'inferred' ? (
-              <span className="shrink-0 text-xs text-foreground-passive">(default)</span>
-            ) : null}
             {view.kind === 'no-match' ? (
               <span className="min-w-0 truncate text-xs text-foreground-passive">
                 No connected account matches this repository.

--- a/apps/emdash-desktop/src/core/features/github/contributions/browser/identity-strip.tsx
+++ b/apps/emdash-desktop/src/core/features/github/contributions/browser/identity-strip.tsx
@@ -150,6 +150,7 @@ export function GitHubIdentityStrip({
               )}
               title={provenanceExplanation(resolved, override)}
             />
+            <span className="shrink-0 text-foreground-muted">Creating as</span>
             {account ? (
               <GitHubAccountSelectLabel account={account} />
             ) : (

--- a/apps/emdash-desktop/src/core/features/projects/browser/components/add-project-modal/content.tsx
+++ b/apps/emdash-desktop/src/core/features/projects/browser/components/add-project-modal/content.tsx
@@ -174,7 +174,6 @@ export function CreateNewPanel({
         </Field.Root>
       </Field.Group>
       <GitHubIdentityStrip
-        action="Creating repository"
         resolved={resolvedAccount}
         accounts={accounts}
         override={overrideAccount}

--- a/apps/emdash-desktop/src/core/features/projects/contributions/browser/github-account-select.tsx
+++ b/apps/emdash-desktop/src/core/features/projects/contributions/browser/github-account-select.tsx
@@ -61,7 +61,9 @@ export function GitHubAccountSelectLabel({ account }: { account: GitHubAccountSu
       ) : (
         <Github className="text-muted-foreground h-4 w-4 shrink-0" />
       )}
-      <span className="min-w-0 truncate">@{account.login}</span>
+      <span className="min-w-0 truncate" title={`@${account.login}`}>
+        @{account.login}
+      </span>
       <span className="text-muted-foreground shrink-0 text-xs">{account.host}</span>
       {account.isDefault ? <GitHubDefaultAccountBadge /> : null}
     </div>

--- a/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/create-pr-modal.tsx
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/create-pr-modal.tsx
@@ -271,7 +271,6 @@ export const CreatePrModal = observer(function CreatePrModal({
         </Field.Group>
         {resolvedAccount && accounts ? (
           <GitHubIdentityStrip
-            action="Creating PR"
             resolved={resolvedAccount}
             accounts={accounts}
             override={accountOverride}

--- a/apps/emdash-desktop/src/core/features/tasks/browser/add-remote-modal.tsx
+++ b/apps/emdash-desktop/src/core/features/tasks/browser/add-remote-modal.tsx
@@ -284,7 +284,6 @@ export const AddRemoteModal = observer(function AddRemoteModal({
 
         {resolvedAccount && accounts ? (
           <GitHubIdentityStrip
-            action={tab === 'create' ? 'Creating repository' : 'Adding remote'}
             resolved={resolvedAccount}
             accounts={accounts}
             override={accountOverride}

--- a/apps/emdash-desktop/src/core/features/tasks/contributions/browser/task-config/workspace-settings-section.browser.test.tsx
+++ b/apps/emdash-desktop/src/core/features/tasks/contributions/browser/task-config/workspace-settings-section.browser.test.tsx
@@ -1,0 +1,101 @@
+import '@emdash/ui/style.css';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { WorkspaceSettingsSection } from './workspace-settings-section';
+
+const taskState = vi.hoisted(() => ({
+  workspaceConfig: {
+    presetId: 'new-worktree',
+    setPresetId: vi.fn(),
+    branchSelection: {
+      createBranchAndWorktree: false,
+      setCreateBranchAndWorktree: vi.fn(),
+    },
+  },
+  projectId: undefined,
+  isUnborn: false,
+  hasRepository: true,
+  hasPR: false,
+}));
+
+vi.mock('@core/features/tasks/browser/task-config/checkout-pr-panel', () => ({
+  CheckoutPrPanel: () => null,
+}));
+vi.mock('@core/features/tasks/browser/task-config/existing-workspace-picker', () => ({
+  useProjectWorkspaces: () => ({ data: [] }),
+}));
+vi.mock('@core/features/tasks/browser/task-config/new-worktree-panel', () => ({
+  NewWorktreePanel: () => null,
+}));
+vi.mock('@core/features/tasks/browser/task-config/pr-new-branch-panel', () => ({
+  PrNewBranchPanel: () => null,
+}));
+vi.mock('@core/features/tasks/browser/task-config/use-existing-panel', () => ({
+  UseExistingPanel: () => null,
+}));
+vi.mock('@core/features/tasks/browser/task-config/workspace-preset-picker', () => ({
+  WorkspacePresetPicker: () => null,
+}));
+vi.mock('@core/features/tasks/browser/task-config/worktree-destination-preview', () => ({
+  WorktreeDestinationPreview: () => null,
+}));
+vi.mock('@core/features/tasks/contributions/browser/task-config/task-state-context', () => ({
+  useTaskState: () => taskState,
+}));
+
+beforeAll(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+describe('WorkspaceSettingsSection layout', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let style: HTMLStyleElement;
+
+  beforeEach(() => {
+    style = document.createElement('style');
+    style.textContent = `
+      @layer utilities {
+        .flex { display: flex; }
+        .grid { display: grid; }
+        .flex-col { flex-direction: column; }
+        .h-9 { height: 2.25rem; }
+        .w-full { width: 100%; }
+        .items-center { align-items: center; }
+        .justify-between { justify-content: space-between; }
+        .gap-2 { gap: 0.5rem; }
+        .ml-auto { margin-left: auto; }
+        [class~='grid-cols-[minmax(0,1fr)_auto]'] {
+          grid-template-columns: minmax(0, 1fr) auto;
+        }
+      }
+    `;
+    document.head.append(style);
+
+    container = document.createElement('div');
+    container.style.width = '480px';
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    style.remove();
+  });
+
+  it('allocates an intrinsic column to the branch tabs without overflowing', () => {
+    act(() => root.render(<WorkspaceSettingsSection defaultOpen={false} />));
+
+    const trigger = container.querySelector<HTMLElement>('[data-slot="collapsible-trigger"]');
+    const header = trigger?.parentElement;
+
+    expect(trigger).not.toBeNull();
+    expect(header).not.toBeNull();
+    expect(getComputedStyle(header!).display).toBe('grid');
+    expect(header!.scrollWidth).toBeLessThanOrEqual(header!.clientWidth);
+  });
+});

--- a/apps/emdash-desktop/src/core/features/tasks/contributions/browser/task-config/workspace-settings-section.tsx
+++ b/apps/emdash-desktop/src/core/features/tasks/contributions/browser/task-config/workspace-settings-section.tsx
@@ -59,7 +59,7 @@ export function WorkspaceSettingsSection({ defaultOpen = true }: WorkspaceSettin
         disabled={!hasSettings}
         className="group flex flex-col gap-1.5"
       >
-        <div className="flex h-9 items-center justify-between">
+        <div className="grid h-9 grid-cols-[minmax(0,1fr)_auto] items-center">
           <Collapsible.Trigger
             hideChevron
             className={cn(
@@ -74,7 +74,6 @@ export function WorkspaceSettingsSection({ defaultOpen = true }: WorkspaceSettin
           </Collapsible.Trigger>
           {presetId === 'new-worktree' && (
             <Tabs.Root
-              className="ml-auto"
               value={createBranchAndWorktree ? 'create' : 'checkout'}
               onValueChange={(v) => setCreateBranchAndWorktree(v === 'create')}
             >

--- a/apps/emdash-desktop/src/renderer/tests/browser/github-identity-strip.test.tsx
+++ b/apps/emdash-desktop/src/renderer/tests/browser/github-identity-strip.test.tsx
@@ -111,7 +111,7 @@ describe('GitHubIdentityStrip', () => {
     expect(buttonByText(strip(), 'Change')).toBeDefined();
   });
 
-  it('prioritizes the account identity over redundant action and provenance copy', async () => {
+  it('uses a concise action-agnostic label while preserving the account identity', async () => {
     host.style.width = '440px';
     await act(async () => {
       root.render(
@@ -134,6 +134,7 @@ describe('GitHubIdentityStrip', () => {
       (element) => element.textContent === '@jschwxrz'
     );
 
+    expect(strip().textContent).toContain('Creating as');
     expect(strip().textContent).not.toContain('Creating repository as');
     expect(strip().textContent?.match(/default/gi)).toHaveLength(1);
     expect(login?.getAttribute('title')).toBe('@jschwxrz');

--- a/apps/emdash-desktop/src/renderer/tests/browser/github-identity-strip.test.tsx
+++ b/apps/emdash-desktop/src/renderer/tests/browser/github-identity-strip.test.tsx
@@ -33,11 +33,31 @@ function resolved(
   return { value, provenance };
 }
 
-describe('GitHubIdentityStrip (Variant A, spec §9)', () => {
+describe('GitHubIdentityStrip', () => {
   let host: HTMLDivElement;
   let root: Root;
+  let style: HTMLStyleElement;
 
   beforeEach(() => {
+    style = document.createElement('style');
+    style.textContent = `
+      @layer utilities {
+        .flex { display: flex; }
+        .flex-1 { flex: 1 1 0%; }
+        .min-w-0 { min-width: 0; }
+        .shrink-0 { flex-shrink: 0; }
+        .items-center { align-items: center; }
+        .gap-2 { gap: 0.5rem; }
+        .h-4 { height: 1rem; }
+        .w-4 { width: 1rem; }
+        .px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+        .py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+        .text-sm { font-size: 0.875rem; }
+        .truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+      }
+    `;
+    document.head.append(style);
+
     host = document.createElement('div');
     document.body.appendChild(host);
     root = createRoot(host);
@@ -46,6 +66,7 @@ describe('GitHubIdentityStrip (Variant A, spec §9)', () => {
   afterEach(async () => {
     await act(async () => root.unmount());
     host.remove();
+    style.remove();
   });
 
   function strip(): HTMLElement {
@@ -69,11 +90,10 @@ describe('GitHubIdentityStrip (Variant A, spec §9)', () => {
     return popup;
   }
 
-  it('ambiently shows the action, account, host, and inference hint', async () => {
+  it('ambiently shows the account, host, and default status', async () => {
     await act(async () => {
       root.render(
         <GitHubIdentityStrip
-          action="Creating PR"
           resolved={resolved(dkonopka, { kind: 'inferred', from: 'default account' })}
           accounts={[dkonopka, workBot]}
           override={null}
@@ -85,11 +105,40 @@ describe('GitHubIdentityStrip (Variant A, spec §9)', () => {
       );
     });
 
-    expect(strip().textContent).toContain('Creating PR as');
     expect(strip().textContent).toContain('@dkonopka');
     expect(strip().textContent).toContain('github.com');
-    expect(strip().textContent).toContain('(default)');
+    expect(strip().textContent?.match(/default/gi)).toHaveLength(1);
     expect(buttonByText(strip(), 'Change')).toBeDefined();
+  });
+
+  it('prioritizes the account identity over redundant action and provenance copy', async () => {
+    host.style.width = '440px';
+    await act(async () => {
+      root.render(
+        <GitHubIdentityStrip
+          resolved={resolved(account('row-3', 'jschwxrz', true), {
+            kind: 'inferred',
+            from: 'default account',
+          })}
+          accounts={[account('row-3', 'jschwxrz', true)]}
+          override={null}
+          persistence="action-only"
+          accountRequired
+          onSelect={vi.fn()}
+          onConnect={vi.fn()}
+        />
+      );
+    });
+
+    const login = [...strip().querySelectorAll('span')].find(
+      (element) => element.textContent === '@jschwxrz'
+    );
+
+    expect(strip().textContent).not.toContain('Creating repository as');
+    expect(strip().textContent?.match(/default/gi)).toHaveLength(1);
+    expect(login?.getAttribute('title')).toBe('@jschwxrz');
+    expect(login!.scrollWidth).toBeLessThanOrEqual(login!.clientWidth);
+    expect(strip().scrollWidth).toBeLessThanOrEqual(strip().clientWidth);
   });
 
   it('selects an account for this action from the popover, without remembering by default', async () => {
@@ -97,7 +146,6 @@ describe('GitHubIdentityStrip (Variant A, spec §9)', () => {
     await act(async () => {
       root.render(
         <GitHubIdentityStrip
-          action="Creating repository"
           resolved={resolved(dkonopka, { kind: 'inferred', from: 'default account' })}
           accounts={[dkonopka, workBot]}
           override={null}
@@ -121,7 +169,6 @@ describe('GitHubIdentityStrip (Variant A, spec §9)', () => {
     await act(async () => {
       root.render(
         <GitHubIdentityStrip
-          action="Creating repository"
           resolved={resolved(dkonopka, { kind: 'inferred', from: 'default account' })}
           accounts={[dkonopka, workBot]}
           override={null}
@@ -147,7 +194,6 @@ describe('GitHubIdentityStrip (Variant A, spec §9)', () => {
     await act(async () => {
       root.render(
         <GitHubIdentityStrip
-          action="Creating PR"
           resolved={resolved(dkonopka, { kind: 'inferred', from: 'default account' })}
           accounts={[dkonopka, workBot]}
           override={null}
@@ -171,7 +217,6 @@ describe('GitHubIdentityStrip (Variant A, spec §9)', () => {
     await act(async () => {
       root.render(
         <GitHubIdentityStrip
-          action="Adding remote"
           resolved={resolved(dkonopka, { kind: 'inferred', from: 'default account' })}
           accounts={[dkonopka, workBot]}
           override={workBot}
@@ -192,7 +237,6 @@ describe('GitHubIdentityStrip (Variant A, spec §9)', () => {
     await act(async () => {
       root.render(
         <GitHubIdentityStrip
-          action="Creating PR"
           resolved={resolved(null, { kind: 'unresolvable' })}
           accounts={[dkonopka, workBot]}
           override={null}
@@ -205,7 +249,7 @@ describe('GitHubIdentityStrip (Variant A, spec §9)', () => {
     });
 
     expect(strip().textContent).toContain('The selected GitHub account is no longer connected.');
-    expect(strip().textContent).toContain('Creating PR is blocked until you pick an account.');
+    expect(strip().textContent).toContain('Choose a GitHub account to continue.');
 
     const popup = await openPopover('Pick account');
     await act(async () => buttonByText(popup, '@dkonopka').click());
@@ -217,7 +261,6 @@ describe('GitHubIdentityStrip (Variant A, spec §9)', () => {
     await act(async () => {
       root.render(
         <GitHubIdentityStrip
-          action="Creating PR"
           resolved={resolved(null, { kind: 'inferred', from: 'no host-matching account' })}
           accounts={[]}
           override={null}
@@ -239,7 +282,6 @@ describe('GitHubIdentityStrip (Variant A, spec §9)', () => {
     await act(async () => {
       root.render(
         <GitHubIdentityStrip
-          action="Adding remote"
           resolved={resolved(null, { kind: 'inferred', from: 'no host-matching account' })}
           accounts={[]}
           override={null}
@@ -259,7 +301,6 @@ describe('GitHubIdentityStrip (Variant A, spec §9)', () => {
     await act(async () => {
       root.render(
         <GitHubIdentityStrip
-          action="Creating PR"
           resolved={resolved(null, { kind: 'set' })}
           accounts={[dkonopka]}
           override={null}


### PR DESCRIPTION
- constrain workspace settings tabs within the create task modal
- simplify GitHubIdentityStrip to show “creating as” across repository pull request and remote flows
- prioritize account identity and remove duplicate default messaging while preserving full usernames on hover