### PR TITLE
fix(terminal): isolate user environment from worker runtime

### DIFF
--- a/agents/risky-areas/pty.md
+++ b/agents/risky-areas/pty.md
@@ -21,8 +21,9 @@
 ## Rules
 
 - construct every PTY environment through `packages/core/src/services/pty/api/terminal-env.ts`
-- keep the host/worker `process.env` separate from the captured user-shell environment; pass the
-  latter explicitly into terminal and script runtimes, never as an ambient fallback
+- keep the host/worker `process.env` separate from the captured user-shell environment; only the
+  host process captures it, spawning runtimes receive a parent-owned source and resolve that source
+  exactly once per spawn, never as an ambient fallback or immutable worker config
 - do not weaken quoting or spawn behavior casually
 - validate both direct spawn and shell-wrapped spawn cases when changing PTY startup logic
 - confirm renderer event flow if hook/plugin payload or agent status behavior changes

--- a/agents/risky-areas/pty.md
+++ b/agents/risky-areas/pty.md
@@ -2,8 +2,9 @@
 
 ## Main Files
 
-- `src/main/core/pty/` — `local-pty.ts`, `ssh2-pty.ts`, `pty.ts`, `pty-env.ts`, `pty-session-registry.ts`, `spawn-utils.ts`, `exit-signals.ts`, `controller.ts`
-- `src/main/core/terminals/` — terminal lifecycle, local and SSH terminal providers
+- `packages/core/src/services/pty/` — terminal env construction, shell resolution, spawning, and session registry
+- `packages/core/src/runtimes/terminals/` — interactive terminal lifecycle and Wire component
+- `packages/core/src/runtimes/scripts/` — lifecycle script execution through the shared PTY plane
 - `packages/core/src/runtimes/tui-agents/` — PTY-backed agent sessions, runtime-owned hook server, hook installation, and agent state LiveModels
 - `src/main/core/agent-status/` — desktop projection of runtime agent states into the conversation cache
 - `src/services/notifications/` — desktop notification feed, batching, sound sink, and OS notification sink
@@ -19,7 +20,9 @@
 
 ## Rules
 
-- use the allowlisted env passthrough model in `src/main/core/pty/pty-env.ts`
+- construct every PTY environment through `packages/core/src/services/pty/api/terminal-env.ts`
+- keep the host/worker `process.env` separate from the captured user-shell environment; pass the
+  latter explicitly into terminal and script runtimes, never as an ambient fallback
 - do not weaken quoting or spawn behavior casually
 - validate both direct spawn and shell-wrapped spawn cases when changing PTY startup logic
 - confirm renderer event flow if hook/plugin payload or agent status behavior changes

--- a/apps/emdash-desktop/src/main/bootstrap/boot/index.test.ts
+++ b/apps/emdash-desktop/src/main/bootstrap/boot/index.test.ts
@@ -91,8 +91,8 @@ describe('finishBoot', () => {
       mock.mock.invocationCallOrder[0]!;
     expect(order(mocks.resolveUserEnv)).toBeLessThan(order(mocks.database));
     expect(order(mocks.database)).toBeLessThan(order(mocks.runtimes));
-    // PTY security ordering: workers inherit process.env at spawn, so env
-    // capture must complete before the runtimes phase spawns workers.
+    // PTY security ordering: capture must complete before the runtimes phase
+    // snapshots the user env into worker startup config.
     expect(order(mocks.resolveUserEnv)).toBeLessThan(order(mocks.runtimes));
   });
 

--- a/apps/emdash-desktop/src/main/bootstrap/boot/index.test.ts
+++ b/apps/emdash-desktop/src/main/bootstrap/boot/index.test.ts
@@ -24,7 +24,7 @@ const mocks = vi.hoisted(() => ({
   logError: vi.fn(),
   logInfo: vi.fn(),
   logWarn: vi.fn(),
-  resolveUserEnv: vi.fn(),
+  startUserEnvCapture: vi.fn(),
   runtimes: vi.fn(),
   services: vi.fn(),
 }));
@@ -37,7 +37,7 @@ vi.mock('@main/lib/logger', () => ({
   },
 }));
 vi.mock('@main/lib/userEnv', () => ({
-  resolveUserEnv: mocks.resolveUserEnv,
+  startUserEnvCapture: mocks.startUserEnvCapture,
 }));
 vi.mock('@main/db/instance', () => ({
   closeAppDb: mocks.closeAppDb,
@@ -84,16 +84,17 @@ describe('finishBoot', () => {
     });
   });
 
-  it('captures the user env before the backend chain', async () => {
+  it('starts user env capture before the backend chain without adding a boot step', async () => {
     await expect(finishBoot({} as never)).resolves.toBeUndefined();
 
     const order = (mock: { mock: { invocationCallOrder: number[] } }) =>
       mock.mock.invocationCallOrder[0]!;
-    expect(order(mocks.resolveUserEnv)).toBeLessThan(order(mocks.database));
+    expect(order(mocks.startUserEnvCapture)).toBeLessThan(order(mocks.database));
     expect(order(mocks.database)).toBeLessThan(order(mocks.runtimes));
-    // PTY security ordering: capture must complete before the runtimes phase
-    // snapshots the user env into worker startup config.
-    expect(order(mocks.resolveUserEnv)).toBeLessThan(order(mocks.runtimes));
+    expect(mocks.logInfo).not.toHaveBeenCalledWith(
+      expect.stringContaining('resolve-user-env'),
+      expect.anything()
+    );
   });
 
   it('rethrows a critical step failure and stops boot', async () => {

--- a/apps/emdash-desktop/src/main/bootstrap/boot/index.ts
+++ b/apps/emdash-desktop/src/main/bootstrap/boot/index.ts
@@ -1,5 +1,5 @@
 import { closeAppDb } from '@main/db/instance';
-import { resolveUserEnv } from '@main/lib/userEnv';
+import { startUserEnvCapture } from '@main/lib/userEnv';
 import { appScope } from '../core/app-scope';
 import type { AppConfig } from '../core/config';
 import { step, stepOptional } from '../core/phase';
@@ -23,10 +23,9 @@ import { bootServices } from './phases/services';
 export async function finishBoot(config: AppConfig): Promise<void> {
   let database: DatabaseBundle | undefined;
   try {
-    // The login-shell env capture must complete before any worker spawns so the
-    // terminal and scripts workers receive the complete, separately owned user
-    // environment in startup config (see agents/risky-areas/pty.md).
-    await step('resolve-user-env', () => resolveUserEnv());
+    // Capture runs alongside boot. Spawn-capable workers resolve through the
+    // parent-owned service, whose first request awaits this in-flight capture.
+    startUserEnvCapture();
     database = await step('database', () => bootDatabase(config));
     const databaseBundle = database;
     const infrastructure = await step('infrastructure', () => bootInfrastructure(databaseBundle));

--- a/apps/emdash-desktop/src/main/bootstrap/boot/index.ts
+++ b/apps/emdash-desktop/src/main/bootstrap/boot/index.ts
@@ -23,11 +23,9 @@ import { bootServices } from './phases/services';
 export async function finishBoot(config: AppConfig): Promise<void> {
   let database: DatabaseBundle | undefined;
   try {
-    // The login-shell env capture must complete before any worker spawns:
-    // workers inherit process.env at spawn, and spawning earlier would leak an
-    // incomplete environment into every PTY for the whole session (PTY
-    // security ordering — see agents/risky-areas/pty.md). startDesktopWorkers
-    // asserts this ordering.
+    // The login-shell env capture must complete before any worker spawns so the
+    // terminal and scripts workers receive the complete, separately owned user
+    // environment in startup config (see agents/risky-areas/pty.md).
     await step('resolve-user-env', () => resolveUserEnv());
     database = await step('database', () => bootDatabase(config));
     const databaseBundle = database;

--- a/apps/emdash-desktop/src/main/gateway/desktop-workers.ts
+++ b/apps/emdash-desktop/src/main/gateway/desktop-workers.ts
@@ -51,6 +51,7 @@ import {
   createHostDependenciesComponent,
   type HostDependenciesContract,
 } from '@emdash/core/services/host-dependencies/node';
+import { createUserShellEnvController } from '@emdash/core/services/shell-env/node';
 import { pluginRegistry } from '@emdash/plugins/agents';
 import type { Unsubscribe } from '@emdash/shared';
 import type { Scope } from '@emdash/shared/concurrency';
@@ -83,7 +84,7 @@ import { desktopKeyValueStore } from '@main/db/kv';
 import { resolveDatabasePath } from '@main/db/path';
 import { log } from '@main/lib/logger';
 import { telemetryService } from '@main/lib/telemetry';
-import { getUserShellEnv, isUserEnvResolved, refreshUserEnv } from '@main/lib/userEnv';
+import { refreshUserEnv, userShellEnvManager } from '@main/lib/userEnv';
 import { desktopWorkerPath } from './worker-paths';
 
 export type AcpRuntimeClient = ContractClient<AcpApiContract>;
@@ -164,19 +165,12 @@ export type StartDesktopWorkersDeps = {
  * failure rejects that worker's queued and future calls (ticket 01's
  * queueing). Worker readiness continues to settle in the background.
  *
- * Security ordering: the login-shell capture must complete before this function
- * snapshots it into the terminal and scripts worker configs (see
- * agents/risky-areas/pty.md).
+ * Spawn-capable workers resolve the current login-shell environment through a
+ * parent-owned dependency (see agents/risky-areas/pty.md).
  */
 export async function startDesktopWorkers(
   deps: StartDesktopWorkersDeps
 ): Promise<DesktopWorkersHandle> {
-  if (!isUserEnvResolved()) {
-    throw new Error(
-      'Desktop workers must not be created before the login-shell environment capture ' +
-        'completes: PTY workers require an owned user-shell snapshot.'
-    );
-  }
   const workerScope = deps.scope.child('wire-workers');
   const vitalsSpawner = createVitalsCollectingSpawner(childProcessSpawner(), {
     onReport: (workerName, vitals) => {
@@ -207,7 +201,7 @@ function startDesktopWorkersWithHost(
   host: ReturnType<typeof createWireWorkerHost>
 ): Omit<DesktopWorkersHandle, 'startVitalsSampling' | 'setSpawnLogging'> {
   const workersStartedAt = Date.now();
-  const userShellEnv = getUserShellEnv();
+  const userShellEnv = createUserShellEnvController(() => userShellEnvManager.current());
   // Logs readiness timing and observes rejection so a background readiness
   // failure never surfaces as an unhandled rejection: the failure reaches
   // callers through the queued clients' per-call rejections.
@@ -260,6 +254,7 @@ function startDesktopWorkersWithHost(
         dependencies: {
           hostDependencies: hostDependencies.client.resolver,
           conversations,
+          userEnv: userShellEnv,
         },
         attachmentsDir: join(app.getPath('userData'), 'acp-attachments'),
         intentsFilePath: sessionIntentFilePaths().acp,
@@ -275,6 +270,7 @@ function startDesktopWorkersWithHost(
       env: process.env,
       dependencies: {
         hostDependencies: hostDependencies.client.resolver,
+        userEnv: userShellEnv,
       },
     })
   );
@@ -371,7 +367,7 @@ function startDesktopWorkersWithHost(
         ...fileSearchWorkerSpec({
           executable: desktopWorkerPath('file-search'),
           env: process.env,
-          dependencies: { watcher },
+          dependencies: { watcher, userEnv: userShellEnv },
           databasePath: resolveFileSearchDatabasePath(),
         })
       );
@@ -388,6 +384,7 @@ function startDesktopWorkersWithHost(
           dependencies: {
             watcher,
             hostDependencies: hostDependencies.client.resolver,
+            userEnv: userShellEnv,
           },
           gitExecutable: getGitExecutable(),
         })
@@ -407,6 +404,7 @@ function startDesktopWorkersWithHost(
           dependencies: {
             hostDependencies: hostDependencies.client.resolver,
             conversations,
+            userEnv: userShellEnv,
           },
           intentsFilePath: sessionIntentFilePaths().tuiAgents,
         })
@@ -435,6 +433,7 @@ function startDesktopWorkersWithHost(
             tuiAgents: tuiAgents.client,
             scripts,
             hostSettings,
+            userEnv: userShellEnv,
           },
           databasePath: join(app.getPath('userData'), 'workspace-registry.db'),
         })

--- a/apps/emdash-desktop/src/main/gateway/desktop-workers.ts
+++ b/apps/emdash-desktop/src/main/gateway/desktop-workers.ts
@@ -83,7 +83,7 @@ import { desktopKeyValueStore } from '@main/db/kv';
 import { resolveDatabasePath } from '@main/db/path';
 import { log } from '@main/lib/logger';
 import { telemetryService } from '@main/lib/telemetry';
-import { isUserEnvResolved, refreshUserEnv } from '@main/lib/userEnv';
+import { getUserShellEnv, isUserEnvResolved, refreshUserEnv } from '@main/lib/userEnv';
 import { desktopWorkerPath } from './worker-paths';
 
 export type AcpRuntimeClient = ContractClient<AcpApiContract>;
@@ -164,9 +164,9 @@ export type StartDesktopWorkersDeps = {
  * failure rejects that worker's queued and future calls (ticket 01's
  * queueing). Worker readiness continues to settle in the background.
  *
- * Security ordering: workers inherit `process.env` at spawn, so the
- * login-shell env capture must have completed before this function runs (see
- * agents/risky-areas/pty.md). This is asserted, not assumed.
+ * Security ordering: the login-shell capture must complete before this function
+ * snapshots it into the terminal and scripts worker configs (see
+ * agents/risky-areas/pty.md).
  */
 export async function startDesktopWorkers(
   deps: StartDesktopWorkersDeps
@@ -174,7 +174,7 @@ export async function startDesktopWorkers(
   if (!isUserEnvResolved()) {
     throw new Error(
       'Desktop workers must not be created before the login-shell environment capture ' +
-        'completes: workers inherit process.env at spawn (PTY security ordering).'
+        'completes: PTY workers require an owned user-shell snapshot.'
     );
   }
   const workerScope = deps.scope.child('wire-workers');
@@ -207,6 +207,7 @@ function startDesktopWorkersWithHost(
   host: ReturnType<typeof createWireWorkerHost>
 ): Omit<DesktopWorkersHandle, 'startVitalsSampling' | 'setSpawnLogging'> {
   const workersStartedAt = Date.now();
+  const userShellEnv = getUserShellEnv();
   // Logs readiness timing and observes rejection so a background readiness
   // failure never surfaces as an unhandled rejection: the failure reaches
   // callers through the queued clients' per-call rejections.
@@ -309,6 +310,7 @@ function startDesktopWorkersWithHost(
     ...terminalsWorkerSpec({
       executable: desktopWorkerPath('terminals'),
       env: process.env,
+      userEnv: userShellEnv,
       lifecycle: {
         terminal: { kind: 'always' },
       },
@@ -332,6 +334,7 @@ function startDesktopWorkersWithHost(
     ...scriptsWorkerSpec({
       executable: desktopWorkerPath('scripts'),
       env: process.env,
+      userEnv: userShellEnv,
     })
   );
   const scriptsReady = timedReady('scripts', scriptsWorker.ready());

--- a/apps/emdash-desktop/src/main/lib/userEnv.test.ts
+++ b/apps/emdash-desktop/src/main/lib/userEnv.test.ts
@@ -13,7 +13,7 @@ const {
   ensureUserBinDirsInPath,
   ensureWindowsNpmGlobalBinInPath,
   getUserShellEnv,
-  resolveUserEnv,
+  refreshUserEnv,
 } = await import('./userEnv');
 
 const originalPath = process.env.PATH;
@@ -69,7 +69,7 @@ describe('ensureWindowsNpmGlobalBinInPath', () => {
   });
 });
 
-describe('resolveUserEnv (runtime env boundary)', () => {
+describe('refreshUserEnv (runtime env boundary)', () => {
   it('keeps Electron controls in the app process but excludes them from the user snapshot', async () => {
     const previousElectronRunAsNode = process.env.ELECTRON_RUN_AS_NODE;
     const previousNodeEnv = process.env.NODE_ENV;
@@ -79,7 +79,7 @@ describe('resolveUserEnv (runtime env boundary)', () => {
     mockShellCapture('PATH=/usr/local/bin:/usr/bin\nUSER_VALUE=kept\n');
 
     try {
-      await resolveUserEnv();
+      await refreshUserEnv();
 
       const probeOptions = spawnSyncMock.mock.calls[0]?.[2] as
         | { env?: NodeJS.ProcessEnv }
@@ -100,7 +100,7 @@ describe('resolveUserEnv (runtime env boundary)', () => {
   });
 });
 
-describe('resolveUserEnv (AppImage env scrub)', () => {
+describe('refreshUserEnv (AppImage env scrub)', () => {
   const SCRUBBED_KEYS = [
     'APPIMAGE',
     'APPDIR',
@@ -142,7 +142,7 @@ describe('resolveUserEnv (AppImage env scrub)', () => {
     process.env.LD_LIBRARY_PATH = '/tmp/.mount_emdashTest/usr/lib:/usr/lib';
     process.env.XDG_DATA_DIRS = '/tmp/.mount_emdashTest/usr/share:/usr/local/share:/usr/share';
 
-    await resolveUserEnv();
+    await refreshUserEnv();
 
     expect(spawnSyncMock).toHaveBeenCalledTimes(1);
     const opts = spawnSyncMock.mock.calls[0]?.[2] as

--- a/apps/emdash-desktop/src/main/lib/userEnv.test.ts
+++ b/apps/emdash-desktop/src/main/lib/userEnv.test.ts
@@ -9,8 +9,12 @@ vi.mock('node:child_process', () => ({
   spawnSync: spawnSyncMock,
 }));
 
-const { ensureUserBinDirsInPath, ensureWindowsNpmGlobalBinInPath, resolveUserEnv } =
-  await import('./userEnv');
+const {
+  ensureUserBinDirsInPath,
+  ensureWindowsNpmGlobalBinInPath,
+  getUserShellEnv,
+  resolveUserEnv,
+} = await import('./userEnv');
 
 const originalPath = process.env.PATH;
 
@@ -62,6 +66,37 @@ describe('ensureWindowsNpmGlobalBinInPath', () => {
 
     expect(added).toBe('C:\\Users\\test\\AppData\\Roaming\\npm');
     expect(env.Path).toBe('C:\\Users\\test\\AppData\\Roaming\\npm;C:\\Windows\\System32');
+  });
+});
+
+describe('resolveUserEnv (runtime env boundary)', () => {
+  it('keeps Electron controls in the app process but excludes them from the user snapshot', async () => {
+    const previousElectronRunAsNode = process.env.ELECTRON_RUN_AS_NODE;
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.ELECTRON_RUN_AS_NODE = '1';
+    process.env.NODE_ENV = 'production';
+    spawnSyncMock.mockReset();
+    mockShellCapture('PATH=/usr/local/bin:/usr/bin\nUSER_VALUE=kept\n');
+
+    try {
+      await resolveUserEnv();
+
+      const probeOptions = spawnSyncMock.mock.calls[0]?.[2] as
+        | { env?: NodeJS.ProcessEnv }
+        | undefined;
+      expect(probeOptions?.env?.ELECTRON_RUN_AS_NODE).toBeUndefined();
+      expect(probeOptions?.env?.NODE_ENV).toBeUndefined();
+      expect(process.env.ELECTRON_RUN_AS_NODE).toBe('1');
+      expect(process.env.NODE_ENV).toBe('production');
+      expect(getUserShellEnv()).toMatchObject({ USER_VALUE: 'kept' });
+      expect(getUserShellEnv().ELECTRON_RUN_AS_NODE).toBeUndefined();
+      expect(getUserShellEnv().NODE_ENV).toBeUndefined();
+    } finally {
+      if (previousElectronRunAsNode === undefined) delete process.env.ELECTRON_RUN_AS_NODE;
+      else process.env.ELECTRON_RUN_AS_NODE = previousElectronRunAsNode;
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
+    }
   });
 });
 

--- a/apps/emdash-desktop/src/main/lib/userEnv.ts
+++ b/apps/emdash-desktop/src/main/lib/userEnv.ts
@@ -39,7 +39,7 @@ export { SHELL_ENV_CAPTURE_GUARD };
 
 const USER_BIN_DIRS = [path.join(os.homedir(), '.local', 'bin')];
 
-const userShellEnvManager = createShellEnvManager({
+export const userShellEnvManager = createShellEnvManager({
   target: process.env,
   baseEnvForProbe: buildExternalToolEnv,
   policy: {
@@ -59,34 +59,23 @@ export function ensureWindowsNpmGlobalBinInPath(
   return ensureCoreWindowsNpmGlobalBinInPath(env);
 }
 
-let userEnvResolved = false;
-
-/**
- * Whether the boot-time login-shell environment capture has completed. Worker
- * spawning asserts this because the terminal and scripts workers receive the
- * captured user-shell snapshot in their immutable startup config.
- */
-export function isUserEnvResolved(): boolean {
-  return userEnvResolved;
-}
-
-/** Returns a copy of the captured user-shell environment for PTYs and scripts. */
+/** Returns a synchronous copy for compatibility consumers that cannot spawn. */
 export function getUserShellEnv(): Record<string, string> {
   return userShellEnvManager.getUserShellEnv();
 }
 
 /**
- * Spawns `$SHELL -ilc 'env'` with a 5 s timeout. On any error (timeout,
- * missing shell, restricted environment) the function logs a warning and
- * returns — the app continues with whatever `process.env` already contains.
+ * Starts `$SHELL -ilc 'env'` with a 5 s timeout and returns immediately. On
+ * any error (timeout, missing shell, restricted environment) the manager logs
+ * a warning and retains a sanitized usable environment.
  *
- * After this call returns, compatibility consumers of `process.env` see the
- * resolved shell values, while PTYs and scripts consume the separately owned
- * snapshot returned by `getUserShellEnv()`.
+ * Spawn-capable runtimes request the separately owned snapshot through the
+ * parent controller; the manager makes their first request await this capture.
  */
-export async function resolveUserEnv(): Promise<void> {
-  await refreshUserEnv();
-  userEnvResolved = true;
+export function startUserEnvCapture(): void {
+  void refreshUserEnv().catch((error: unknown) => {
+    log.warn('[shell-env] Unexpected initial capture failure', { error });
+  });
 }
 
 export async function refreshUserEnv(): Promise<void> {

--- a/apps/emdash-desktop/src/main/lib/userEnv.ts
+++ b/apps/emdash-desktop/src/main/lib/userEnv.ts
@@ -39,7 +39,7 @@ export { SHELL_ENV_CAPTURE_GUARD };
 
 const USER_BIN_DIRS = [path.join(os.homedir(), '.local', 'bin')];
 
-const userShellEnv = createShellEnvManager({
+const userShellEnvManager = createShellEnvManager({
   target: process.env,
   baseEnvForProbe: buildExternalToolEnv,
   policy: {
@@ -63,13 +63,16 @@ let userEnvResolved = false;
 
 /**
  * Whether the boot-time login-shell environment capture has completed. Worker
- * spawning asserts this: workers inherit `process.env` at spawn, and spawning
- * before the capture would leak an incomplete environment into every PTY and
- * child process for the whole session (a security ordering guarantee, not a
- * performance choice — see agents/risky-areas/pty.md).
+ * spawning asserts this because the terminal and scripts workers receive the
+ * captured user-shell snapshot in their immutable startup config.
  */
 export function isUserEnvResolved(): boolean {
   return userEnvResolved;
+}
+
+/** Returns a copy of the captured user-shell environment for PTYs and scripts. */
+export function getUserShellEnv(): Record<string, string> {
+  return userShellEnvManager.getUserShellEnv();
 }
 
 /**
@@ -77,9 +80,9 @@ export function isUserEnvResolved(): boolean {
  * missing shell, restricted environment) the function logs a warning and
  * returns — the app continues with whatever `process.env` already contains.
  *
- * After this call returns, all subsequent consumers that inherit `process.env`
- * (execFile, PTY env builders, dependency prober, etc.) automatically see the
- * full PATH, SSH_AUTH_SOCK, and other variables the user's shell init sets.
+ * After this call returns, compatibility consumers of `process.env` see the
+ * resolved shell values, while PTYs and scripts consume the separately owned
+ * snapshot returned by `getUserShellEnv()`.
  */
 export async function resolveUserEnv(): Promise<void> {
   await refreshUserEnv();
@@ -88,9 +91,9 @@ export async function resolveUserEnv(): Promise<void> {
 
 export async function refreshUserEnv(): Promise<void> {
   if (process.platform === 'win32') {
-    // Windows PATH is managed differently; no login-shell capture needed.
+    // Windows PATH is managed differently; refresh still snapshots the cleaned
+    // environment after adding npm's global bin directory.
     ensureWindowsNpmGlobalBinInPath();
-    return;
   }
 
   // Route through buildExternalToolEnv so AppImage runtime vars (APPIMAGE,
@@ -98,7 +101,7 @@ export async function refreshUserEnv(): Promise<void> {
   // the probe shell. Otherwise login-shell hooks that resolve a binary by
   // name through PATH (mise/starship/oh-my-zsh) can re-enter the AppImage
   // and fork-bomb the app on Linux. See #1679.
-  await userShellEnv.refresh();
+  await userShellEnvManager.refresh();
 }
 
 /**

--- a/apps/workspace-server/src/api/controller.test.ts
+++ b/apps/workspace-server/src/api/controller.test.ts
@@ -126,7 +126,7 @@ describe('runtime domain forwarding', () => {
     };
     const terminalsRuntime = new TerminalsRuntime({
       spawner,
-      userEnv: {},
+      userEnv: async () => ({}),
       shellResolver,
     });
     const terminals = createTestWire(

--- a/apps/workspace-server/src/api/controller.test.ts
+++ b/apps/workspace-server/src/api/controller.test.ts
@@ -124,7 +124,11 @@ describe('runtime domain forwarding', () => {
       },
       getAvailability: async () => availability,
     };
-    const terminalsRuntime = new TerminalsRuntime({ spawner, shellResolver });
+    const terminalsRuntime = new TerminalsRuntime({
+      spawner,
+      userEnv: {},
+      shellResolver,
+    });
     const terminals = createTestWire(
       terminalsContract,
       createTerminalsController(terminalsRuntime)

--- a/apps/workspace-server/src/gateway/workspace-workers.ts
+++ b/apps/workspace-server/src/gateway/workspace-workers.ts
@@ -35,6 +35,10 @@ import {
   createHostDependenciesComponent,
   type HostDependenciesContract,
 } from '@emdash/core/services/host-dependencies/node';
+import {
+  createUserShellEnvController,
+  type ShellEnvManager,
+} from '@emdash/core/services/shell-env/node';
 import { pluginRegistry } from '@emdash/plugins/agents';
 import { ok } from '@emdash/shared';
 import type { Scope } from '@emdash/shared/concurrency';
@@ -69,9 +73,7 @@ export type WorkspaceServerRuntimeHost = {
 export type CreateWorkspaceServerRuntimeHostOptions = {
   scope: Scope;
   socketPath?: string;
-  env?: NodeJS.ProcessEnv;
-  userShellEnv: Record<string, string>;
-  refreshShellEnv?: () => Promise<void>;
+  shellEnv: ShellEnvManager;
   logger?: Logger;
 };
 
@@ -80,7 +82,8 @@ const DETACHED_TERMINAL_GRACE_MS = 5 * 60_000;
 export async function createWorkspaceServerRuntimeHost(
   options: CreateWorkspaceServerRuntimeHostOptions
 ): Promise<WorkspaceServerRuntimeHost> {
-  const env = options.env ?? process.env;
+  const env = options.shellEnv.env;
+  const userShellEnv = createUserShellEnvController(() => options.shellEnv.current());
   const paths = workspaceServerRuntimePaths(options.socketPath);
   await Promise.all([
     mkdir(paths.stateDirectory, { recursive: true }),
@@ -93,7 +96,7 @@ export async function createWorkspaceServerRuntimeHost(
   });
   const hostDependencies = createHostDependenciesComponent({
     store: createJsonFileKeyValueStore({ path: paths.hostDependenciesStore }),
-    exec: new NodeExecutionContext({ env, refreshShellEnv: options.refreshShellEnv }),
+    exec: new NodeExecutionContext({ env, refreshShellEnv: () => options.shellEnv.refresh() }),
     logger: options.logger,
   }).create({
     scope: options.scope.child('host-dependencies'),
@@ -121,7 +124,7 @@ export async function createWorkspaceServerRuntimeHost(
     ...terminalsWorkerSpec({
       executable: workspaceWorkerPath('terminals'),
       env,
-      userEnv: options.userShellEnv,
+      userEnv: userShellEnv,
       lifecycle: {
         terminal: { kind: 'while-attached', graceMs: DETACHED_TERMINAL_GRACE_MS },
       },
@@ -144,7 +147,7 @@ export async function createWorkspaceServerRuntimeHost(
     ...scriptsWorkerSpec({
       executable: workspaceWorkerPath('scripts'),
       env,
-      userEnv: options.userShellEnv,
+      userEnv: userShellEnv,
     })
   );
   const acpPromise = conversationsPromise.then((conversations) =>
@@ -156,6 +159,7 @@ export async function createWorkspaceServerRuntimeHost(
         dependencies: {
           hostDependencies: hostDependencies.client.resolver,
           conversations,
+          userEnv: userShellEnv,
         },
         attachmentsDir: paths.attachmentsDirectory,
         intentsFilePath: paths.acpIntentsFile,
@@ -169,6 +173,7 @@ export async function createWorkspaceServerRuntimeHost(
       env,
       dependencies: {
         hostDependencies: hostDependencies.client.resolver,
+        userEnv: userShellEnv,
       },
     })
   );
@@ -181,6 +186,7 @@ export async function createWorkspaceServerRuntimeHost(
         dependencies: {
           hostDependencies: hostDependencies.client.resolver,
           conversations,
+          userEnv: userShellEnv,
         },
         intentsFilePath: paths.tuiAgentsIntentsFile,
       })
@@ -228,7 +234,7 @@ export async function createWorkspaceServerRuntimeHost(
     ...fileSearchWorkerSpec({
       executable: workspaceWorkerPath('file-search'),
       env,
-      dependencies: { watcher },
+      dependencies: { watcher, userEnv: userShellEnv },
       databasePath: paths.fileSearchDatabase,
       ripgrepPath: env['EMDASH_WS_RIPGREP_PATH'],
     })
@@ -240,6 +246,7 @@ export async function createWorkspaceServerRuntimeHost(
       dependencies: {
         watcher,
         hostDependencies: hostDependencies.client.resolver,
+        userEnv: userShellEnv,
       },
     })
   );
@@ -247,7 +254,15 @@ export async function createWorkspaceServerRuntimeHost(
     ...workspaceRegistryWorkerSpec({
       executable: workspaceWorkerPath('workspace-registry'),
       env,
-      dependencies: { watcher, acp, terminals, tuiAgents, scripts, hostSettings },
+      dependencies: {
+        watcher,
+        acp,
+        terminals,
+        tuiAgents,
+        scripts,
+        hostSettings,
+        userEnv: userShellEnv,
+      },
       databasePath: paths.workspaceRegistryDatabase,
     })
   );

--- a/apps/workspace-server/src/gateway/workspace-workers.ts
+++ b/apps/workspace-server/src/gateway/workspace-workers.ts
@@ -70,6 +70,7 @@ export type CreateWorkspaceServerRuntimeHostOptions = {
   scope: Scope;
   socketPath?: string;
   env?: NodeJS.ProcessEnv;
+  userShellEnv: Record<string, string>;
   refreshShellEnv?: () => Promise<void>;
   logger?: Logger;
 };
@@ -120,6 +121,7 @@ export async function createWorkspaceServerRuntimeHost(
     ...terminalsWorkerSpec({
       executable: workspaceWorkerPath('terminals'),
       env,
+      userEnv: options.userShellEnv,
       lifecycle: {
         terminal: { kind: 'while-attached', graceMs: DETACHED_TERMINAL_GRACE_MS },
       },
@@ -142,6 +144,7 @@ export async function createWorkspaceServerRuntimeHost(
     ...scriptsWorkerSpec({
       executable: workspaceWorkerPath('scripts'),
       env,
+      userEnv: options.userShellEnv,
     })
   );
   const acpPromise = conversationsPromise.then((conversations) =>

--- a/apps/workspace-server/src/index.ts
+++ b/apps/workspace-server/src/index.ts
@@ -57,6 +57,7 @@ async function serve(config: WorkspaceServerConfig, logger: Logger): Promise<Dis
       scope,
       socketPath: config.serve.kind === 'socket' ? config.serve.path : undefined,
       env: shellEnv.env,
+      userShellEnv: shellEnv.getUserShellEnv(),
       refreshShellEnv: () => shellEnv.refresh(),
       logger,
     });

--- a/apps/workspace-server/src/index.ts
+++ b/apps/workspace-server/src/index.ts
@@ -52,13 +52,13 @@ async function serve(config: WorkspaceServerConfig, logger: Logger): Promise<Dis
   });
   try {
     const shellEnv = createShellEnvManager({ target: process.env, logger });
-    await shellEnv.refresh();
+    void shellEnv.refresh().catch((error: unknown) => {
+      logger.warn('[shell-env] Unexpected initial capture failure', { error });
+    });
     const runtimeHost = await createWorkspaceServerRuntimeHost({
       scope,
       socketPath: config.serve.kind === 'socket' ? config.serve.path : undefined,
-      env: shellEnv.env,
-      userShellEnv: shellEnv.getUserShellEnv(),
-      refreshShellEnv: () => shellEnv.refresh(),
+      shellEnv,
       logger,
     });
     const controller = createWorkspaceWireController({

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -125,6 +125,11 @@
       "types": "./dist/services-exec-api.d.mts",
       "default": "./dist/services-exec-api.mjs"
     },
+    "./services/shell-env/api": {
+      "development": "./src/services/shell-env/api/index.ts",
+      "types": "./dist/services-shell-env-api.d.mts",
+      "default": "./dist/services-shell-env-api.mjs"
+    },
     "./services/shell-env/node": {
       "development": "./src/services/shell-env/node/index.ts",
       "types": "./dist/services-shell-env-node.d.mts",

--- a/packages/core/src/primitives/exec/api/execution-context.ts
+++ b/packages/core/src/primitives/exec/api/execution-context.ts
@@ -12,6 +12,9 @@ export type ExecStreamingResult = {
   exitCode: number | null;
 };
 
+/** Resolves the environment to use for one subprocess spawn. */
+export type EnvSource = () => Promise<Record<string, string | undefined>>;
+
 /**
  * An execution context represents a host + optional working directory where
  * commands run. Implementations abstract the transport (local spawn vs SSH exec)

--- a/packages/core/src/primitives/exec/api/index.ts
+++ b/packages/core/src/primitives/exec/api/index.ts
@@ -1,5 +1,6 @@
 export { formatCommandLine, quoteArg, type Command, type ShellFamily } from './command';
 export type {
+  EnvSource,
   ExecContextOptions,
   ExecStreamingResult,
   IExecutionContext,

--- a/packages/core/src/runtimes/acp/node/acp-test-support.ts
+++ b/packages/core/src/runtimes/acp/node/acp-test-support.ts
@@ -307,7 +307,7 @@ export function testPluginHost(
     exec: fakeExec(),
     dependencies: fakeDependencies(providerId),
     fs: fakePluginFs(),
-    env: { PATH: '/bin', HOME: '/home/test' },
+    env: async () => ({ PATH: '/bin', HOME: '/home/test' }),
     homeDir: '/home/test',
   });
 }

--- a/packages/core/src/runtimes/acp/node/component.ts
+++ b/packages/core/src/runtimes/acp/node/component.ts
@@ -24,6 +24,7 @@ import {
   createNoopSessionIntentStore,
 } from '#services/session-intents/node';
 import { idlePolicyConfigSchema } from '#services/session-lifecycle/api';
+import { userShellEnvContract } from '#services/shell-env/api';
 
 export const acpComponentConfigSchema = z.object({
   attachmentsDir: z.string().min(1),
@@ -39,7 +40,6 @@ export const acpComponentConfigSchema = z.object({
 
 export type CreateAcpComponentOptions = {
   pluginRegistry: PluginRegistry<CLIAgentPluginProvider>;
-  env?: NodeJS.ProcessEnv;
   logger?: Logger;
 };
 
@@ -50,10 +50,11 @@ export function createAcpComponent(options: CreateAcpComponentOptions) {
     requirements: {
       hostDependencies: requireContract(hostDependencyResolverContract),
       conversations: requireContract(conversationReportsContract),
+      userEnv: requireContract(userShellEnvContract),
     },
     configSchema: acpComponentConfigSchema,
     create: ({ config, dependencies, instance, logger, scope }) => {
-      const env = options.env ?? process.env;
+      const env = () => dependencies.userEnv.get();
       const runtimeLogger = options.logger ?? logger;
       const childHost = new ChildAcpProcessHost();
       const attachmentStore = new LocalAttachmentStore(config.attachmentsDir);

--- a/packages/core/src/runtimes/acp/node/worker-spec.test.ts
+++ b/packages/core/src/runtimes/acp/node/worker-spec.test.ts
@@ -18,6 +18,7 @@ describe('acpWorkerSpec', () => {
     expect(component.id).toBe('acp');
     expect(options.name).toBe('acp');
     expect(options.env).toBe(env);
+    expect(component.requirements).toHaveProperty('userEnv');
     expect(options.supervision).toBeUndefined();
     expect(component.configSchema.parse(options.config)).toEqual({
       attachmentsDir: '/data/attachments',

--- a/packages/core/src/runtimes/acp/node/worker-spec.ts
+++ b/packages/core/src/runtimes/acp/node/worker-spec.ts
@@ -41,7 +41,6 @@ export function acpWorkerSpec(
   return [
     createAcpComponent({
       pluginRegistry: input.pluginRegistry,
-      env: input.env,
       logger: input.logger,
     }),
     {

--- a/packages/core/src/runtimes/agent-config/node/component.ts
+++ b/packages/core/src/runtimes/agent-config/node/component.ts
@@ -14,12 +14,12 @@ import {
   hostDependencyResolverContract,
 } from '#services/host-dependencies/node';
 import { NodePtySpawner } from '#services/pty/node';
+import { userShellEnvContract } from '#services/shell-env/api';
 
 export const agentConfigComponentConfigSchema = z.object({});
 
 export type CreateAgentConfigComponentOptions = {
   pluginRegistry: PluginRegistry<CLIAgentPluginProvider>;
-  env?: NodeJS.ProcessEnv;
   logger?: Logger;
 };
 
@@ -29,10 +29,11 @@ export function createAgentConfigComponent(options: CreateAgentConfigComponentOp
     contract: agentConfigContract,
     requirements: {
       hostDependencies: requireContract(hostDependencyResolverContract),
+      userEnv: requireContract(userShellEnvContract),
     },
     configSchema: agentConfigComponentConfigSchema,
     create: ({ dependencies, instance, logger, scope }) => {
-      const env = options.env ?? process.env;
+      const env = () => dependencies.userEnv.get();
       const runtimeLogger = options.logger ?? logger;
       const homeDir = os.homedir();
       const spawner = new NodePtySpawner();

--- a/packages/core/src/runtimes/agent-config/node/runtime/runtime.test.ts
+++ b/packages/core/src/runtimes/agent-config/node/runtime/runtime.test.ts
@@ -389,14 +389,14 @@ function makeRuntime(
       }),
     },
     fs,
-    env: {
+    env: async () => ({
       PATH: '/bin',
       HOME: '/home/ada',
       USER: 'ada',
       SHELL: '/bin/zsh',
       ANTHROPIC_API_KEY: 'secret',
       UNSAFE_ENV: 'nope',
-    },
+    }),
     homeDir: '/home/ada',
   });
 

--- a/packages/core/src/runtimes/agent-config/node/worker-spec.test.ts
+++ b/packages/core/src/runtimes/agent-config/node/worker-spec.test.ts
@@ -15,6 +15,7 @@ describe('agentConfigWorkerSpec', () => {
     expect(component.id).toBe('agent-config');
     expect(options.name).toBe('agent-config');
     expect(options.env).toBe(env);
+    expect(component.requirements).toHaveProperty('userEnv');
     expect(options.supervision).toBeUndefined();
     expect(options.shutdownGraceMs).toBeUndefined();
     expect(component.configSchema.parse(options.config)).toEqual({});

--- a/packages/core/src/runtimes/agent-config/node/worker-spec.ts
+++ b/packages/core/src/runtimes/agent-config/node/worker-spec.ts
@@ -30,7 +30,6 @@ export function agentConfigWorkerSpec(
   return [
     createAgentConfigComponent({
       pluginRegistry: input.pluginRegistry,
-      env: input.env,
       logger: input.logger,
     }),
     {

--- a/packages/core/src/runtimes/file-search/node/component.ts
+++ b/packages/core/src/runtimes/file-search/node/component.ts
@@ -6,6 +6,7 @@ import { createFileSearchController } from '#runtimes/file-search/node/api/contr
 import { FileSearchRuntime } from '#runtimes/file-search/node/file-search-runtime';
 import { fsWatchContract } from '#services/fs-watch/api';
 import { createProcessWatchServiceFromDependency } from '#services/fs-watch/node/process-watch-service';
+import { userShellEnvContract } from '#services/shell-env/api';
 import { fileSearchStore } from './storage/store';
 
 export const fileSearchComponentConfigSchema = z.object({
@@ -27,6 +28,7 @@ export const fileSearchComponent = defineWireComponent({
   contract: fileSearchContract,
   requirements: {
     watcher: requireContract(fsWatchContract),
+    userEnv: requireContract(userShellEnvContract),
   },
   configSchema: fileSearchComponentConfigSchema,
   create: ({ config, dependencies, instance, logger, scope }) => {
@@ -41,6 +43,7 @@ export const fileSearchComponent = defineWireComponent({
     const runtime = new FileSearchRuntime({
       handle,
       watcher,
+      env: () => dependencies.userEnv.get(),
       ripgrepPath: config.ripgrepPath,
       maxConcurrentScans: config.maxConcurrentScans,
       maxConcurrentContentSearches: config.maxConcurrentContentSearches,

--- a/packages/core/src/runtimes/file-search/node/content/ripgrep/ripgrep-content-searcher.test.ts
+++ b/packages/core/src/runtimes/file-search/node/content/ripgrep/ripgrep-content-searcher.test.ts
@@ -323,7 +323,7 @@ describe('RipgrepContentSearcher', () => {
     await writeFile(path.join(rootPath, '.hidden.ts'), 'VALUE\n');
 
     const result = await createSearcher({
-      env: { ...process.env, RIPGREP_CONFIG_PATH: configPath },
+      env: async () => ({ ...process.env, RIPGREP_CONFIG_PATH: configPath }),
     }).search(
       { root: absolute(rootPath), rootPath, searchPath: rootPath, query: 'VALUE', limit: 1_000 },
       { signal: new AbortController().signal, onProgress: () => {} }

--- a/packages/core/src/runtimes/file-search/node/content/ripgrep/ripgrep-content-searcher.ts
+++ b/packages/core/src/runtimes/file-search/node/content/ripgrep/ripgrep-content-searcher.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { err, ok, type Result } from '@emdash/shared';
 import { abortReason } from '@emdash/shared/scheduling';
+import type { EnvSource } from '#primitives/exec/api';
 import { parsePortableRelativePath, type PortableRelativePath } from '#primitives/path/api';
 import {
   CONTENT_SEARCH_MAX_PREVIEW_LENGTH,
@@ -26,7 +27,7 @@ const DEFAULT_MAX_JSON_RECORD_BYTES = 32 * 1024 * 1024;
 
 type RipgrepContentSearcherOptions = Readonly<{
   executable?: string;
-  env?: NodeJS.ProcessEnv;
+  env?: EnvSource;
   exclusions: FileSearchExclusions;
   maxRecordBytes?: number;
 }>;
@@ -39,13 +40,13 @@ type RipgrepRunState =
 
 export class RipgrepContentSearcher implements FileContentSearcher {
   private readonly executable: string;
-  private readonly env: NodeJS.ProcessEnv | undefined;
+  private readonly env: EnvSource;
   private readonly exclusions: FileSearchExclusions;
   private readonly maxRecordBytes: number;
 
   constructor(options: RipgrepContentSearcherOptions) {
     this.executable = options.executable ?? 'rg';
-    this.env = options.env;
+    this.env = options.env ?? (async () => process.env);
     this.exclusions = options.exclusions;
     this.maxRecordBytes = positiveSafeInteger(
       options.maxRecordBytes ?? DEFAULT_MAX_JSON_RECORD_BYTES,
@@ -53,7 +54,7 @@ export class RipgrepContentSearcher implements FileContentSearcher {
     );
   }
 
-  search(
+  async search(
     input: ResolvedContentSearchInput,
     context: ContentSearchContext
   ): Promise<Result<ContentSearchResult, ContentSearchExecutionError>> {

--- a/packages/core/src/runtimes/file-search/node/content/ripgrep/ripgrep-content-searcher.ts
+++ b/packages/core/src/runtimes/file-search/node/content/ripgrep/ripgrep-content-searcher.ts
@@ -69,18 +69,18 @@ export class RipgrepContentSearcher implements FileContentSearcher {
   }
 }
 
-function runRipgrep(
+async function runRipgrep(
   executable: BoundExec,
   input: ResolvedContentSearchInput,
   context: ContentSearchContext,
   exclusions: FileSearchExclusions,
   maxRecordBytes: number
 ): Promise<Result<ContentSearchResult, ContentSearchExecutionError>> {
+  const args = createRipgrepContentSearchArgs(input, exclusions);
+  const child = await executable.spawn(args, { signal: context.signal });
   return new Promise((resolve, reject) => {
     const accumulator = new ContentSearchAccumulator(context);
     const limit = input.limit;
-    const args = createRipgrepContentSearchArgs(input, exclusions);
-    const child = executable.spawn(args, { signal: context.signal });
     const framer = new RipgrepJsonFramer({ maxRecordBytes });
     let stderr = '';
     let state: RipgrepRunState = { kind: 'running' };

--- a/packages/core/src/runtimes/file-search/node/file-search-runtime.ts
+++ b/packages/core/src/runtimes/file-search/node/file-search-runtime.ts
@@ -7,6 +7,7 @@ import {
 } from '@emdash/shared/concurrency';
 import type Database from 'better-sqlite3';
 import { DEFAULT_SEARCH_EXCLUDE } from '#primitives/exclusion-policy/api';
+import type { EnvSource } from '#primitives/exec/api';
 import type { StoreHandle } from '#primitives/sqlite-store/api';
 import type {
   ContentSearchError,
@@ -39,7 +40,7 @@ export type FileSearchRuntimeOptions = Readonly<{
   handle: StoreHandle<FileSearchDb, Database.Database>;
   watcher: IWatchService;
   ripgrepPath?: string;
-  env?: NodeJS.ProcessEnv;
+  env?: EnvSource;
   maxConcurrentScans?: number;
   maxConcurrentContentSearches?: number;
   onError?: (context: string, error: unknown) => void;
@@ -73,7 +74,7 @@ export class FileSearchRuntime {
       );
       this.contentSearcher = new RipgrepContentSearcher({
         executable: options.ripgrepPath,
-        env: options.env,
+        env: options.env ?? (async () => process.env),
         exclusions: defaultContentExclusions,
       });
       this.roots = new FileSearchRootRegistry({

--- a/packages/core/src/runtimes/file-search/node/worker-spec.test.ts
+++ b/packages/core/src/runtimes/file-search/node/worker-spec.test.ts
@@ -16,6 +16,7 @@ describe('fileSearchWorkerSpec', () => {
     expect(component.id).toBe('file-search');
     expect(options.name).toBe('file-search');
     expect(options.env).toBe(env);
+    expect(component.requirements).toHaveProperty('userEnv');
     expect(component.configSchema.parse(options.config)).toEqual({
       databasePath: '/data/file-search.db',
       ripgrepPath: '/opt/bin/rg',

--- a/packages/core/src/runtimes/git/node/component.ts
+++ b/packages/core/src/runtimes/git/node/component.ts
@@ -3,13 +3,14 @@ import { z } from 'zod';
 import { gitContract } from '#runtimes/git/api';
 import { createGitController } from '#runtimes/git/node/api/controller';
 import { GitRuntime } from '#runtimes/git/node/git-runtime';
+import { gitRuntimeEnv } from '#runtimes/git/node/non-interactive-env';
 import { fsWatchContract } from '#services/fs-watch/api';
 import { createProcessWatchServiceFromDependency } from '#services/fs-watch/node/process-watch-service';
 import { hostDependencyResolverContract } from '#services/host-dependencies/api';
+import { userShellEnvContract } from '#services/shell-env/api';
 
 export const gitComponentConfigSchema = z.object({
   executable: z.string().min(1).optional(),
-  env: z.record(z.string(), z.string().optional()).optional(),
   idleTtlMs: z.number().nonnegative().optional(),
   aliasTtlMs: z.number().nonnegative().optional(),
   maxFileContentStates: z.number().nonnegative().optional(),
@@ -21,6 +22,7 @@ export const gitComponent = defineWireComponent({
   requirements: {
     watcher: requireContract(fsWatchContract),
     hostDependencies: requireContract(hostDependencyResolverContract),
+    userEnv: requireContract(userShellEnvContract),
   },
   configSchema: gitComponentConfigSchema,
   create: ({ config, dependencies, instance, logger, scope }) => {
@@ -32,7 +34,7 @@ export const gitComponent = defineWireComponent({
     const runtime = new GitRuntime({
       watcher,
       executable: config.executable,
-      env: config.env as NodeJS.ProcessEnv | undefined,
+      env: async () => gitRuntimeEnv(await dependencies.userEnv.get()),
       idleTtlMs: config.idleTtlMs,
       aliasTtlMs: config.aliasTtlMs,
       maxFileContentStates: config.maxFileContentStates,

--- a/packages/core/src/runtimes/git/node/exec/git-exec.test.ts
+++ b/packages/core/src/runtimes/git/node/exec/git-exec.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { BoundExec } from '#services/exec/api';
-import { bindGitDir, gitEnv } from './git-exec';
+import { bindGitDir, createGitExec, gitEnv } from './git-exec';
 
 describe('gitEnv', () => {
   it('pins git output locale for stable parsing and error classification', () => {
@@ -17,6 +17,22 @@ describe('gitEnv', () => {
     expect(gitEnv({ GIT_SSH_COMMAND: 'ssh -F custom-config' }).GIT_SSH_COMMAND).toBe(
       'ssh -F custom-config'
     );
+  });
+
+  it('loads the current environment for every git subprocess', async () => {
+    let env = { EMDASH_ENV_REVISION: 'before-refresh' };
+    const exec = createGitExec({
+      cwd: process.cwd(),
+      executable: process.execPath,
+      env: async () => env,
+    });
+
+    const before = await exec.exec(['-p', 'process.env.EMDASH_ENV_REVISION']);
+    env = { EMDASH_ENV_REVISION: 'after-refresh' };
+    const after = await exec.exec(['-p', 'process.env.EMDASH_ENV_REVISION']);
+
+    expect(before.stdout.trim()).toBe('before-refresh');
+    expect(after.stdout.trim()).toBe('after-refresh');
   });
 });
 

--- a/packages/core/src/runtimes/git/node/exec/git-exec.test.ts
+++ b/packages/core/src/runtimes/git/node/exec/git-exec.test.ts
@@ -48,7 +48,7 @@ describe('bindGitDir', () => {
     await exec.exec(['status']);
     await exec.execStreaming(['fetch'], () => {});
     await exec.execBuffer(['cat-file', 'blob', 'HEAD:file']);
-    exec.spawn(['cat-file', '--batch']);
+    await exec.spawn(['cat-file', '--batch']);
     const moved = exec.withCwd('/other');
     await moved.exec(['branch']);
 

--- a/packages/core/src/runtimes/git/node/exec/git-exec.ts
+++ b/packages/core/src/runtimes/git/node/exec/git-exec.ts
@@ -1,3 +1,4 @@
+import type { EnvSource } from '#primitives/exec/api';
 import {
   createBoundExec,
   type BoundExec,
@@ -6,11 +7,12 @@ import {
   type ExecResult,
   type ExecSpawnOptions,
 } from '#services/exec/api';
+import { gitRuntimeEnv } from '../non-interactive-env';
 
 export type CreateGitExecOptions = {
   cwd: string;
   executable?: string;
-  env?: NodeJS.ProcessEnv;
+  env: NodeJS.ProcessEnv | EnvSource;
 };
 
 /**
@@ -18,11 +20,8 @@ export type CreateGitExecOptions = {
  * SSH_AUTH_SOCK, credential helpers), so it is composed in deliberately — exec itself
  * never merges `process.env`.
  */
-export function gitEnv(extra?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  const env = {
-    ...process.env,
-    ...extra,
-  };
+export function gitEnv(base: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env = gitRuntimeEnv(base);
   return {
     ...env,
     LC_ALL: 'C',
@@ -37,10 +36,12 @@ export function gitEnv(extra?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
 }
 
 export function createGitExec(options: CreateGitExecOptions): BoundExec {
+  const source = options.env;
+  const env = typeof source === 'function' ? async () => gitEnv(await source()) : gitEnv(source);
   return createBoundExec({
     file: options.executable ?? 'git',
     cwd: options.cwd,
-    env: gitEnv(options.env),
+    env,
   });
 }
 

--- a/packages/core/src/runtimes/git/node/git-runtime.ts
+++ b/packages/core/src/runtimes/git/node/git-runtime.ts
@@ -1,4 +1,5 @@
 import { KeyedMutex } from '@emdash/shared/concurrency';
+import type { EnvSource } from '#primitives/exec/api';
 import { GitAllocationGraph } from '#runtimes/git/node/allocation/allocation-graph';
 import { GitCheckoutRuntime } from '#runtimes/git/node/checkout/checkout-runtime';
 import { createGitExec } from '#runtimes/git/node/exec/git-exec';
@@ -11,7 +12,7 @@ import { createNativeWatchService } from '#services/fs-watch/node';
 export type GitRuntimeOptions = Readonly<{
   watcher?: IWatchService;
   executable?: string;
-  env?: NodeJS.ProcessEnv;
+  env?: EnvSource;
   exec?: BoundExec;
   idleTtlMs?: number;
   aliasTtlMs?: number;
@@ -36,7 +37,11 @@ export class GitRuntime {
     this.watcher = options.watcher ?? createNativeWatchService({ onError });
     const exec =
       options.exec ??
-      createGitExec({ cwd: process.cwd(), executable: options.executable, env: options.env });
+      createGitExec({
+        cwd: process.cwd(),
+        executable: options.executable,
+        env: options.env ?? (async () => process.env),
+      });
     this.provisioning = new GitRepositoryProvisioner(exec);
     this.allocations = new GitAllocationGraph({
       exec,

--- a/packages/core/src/runtimes/git/node/worker-spec.test.ts
+++ b/packages/core/src/runtimes/git/node/worker-spec.test.ts
@@ -18,7 +18,7 @@ describe('gitRuntimeEnv', () => {
 });
 
 describe('gitWorkerSpec', () => {
-  it('gives the worker and its git subprocesses the same composed env', () => {
+  it('keeps the user snapshot out of worker config', () => {
     const [component, options] = gitWorkerSpec({
       executable: '/w/git.mjs',
       env,
@@ -28,10 +28,9 @@ describe('gitWorkerSpec', () => {
     expect(component.id).toBe('git');
     expect(options.name).toBe('git');
     expect(options.env).toEqual(gitRuntimeEnv(env));
-    expect(options.config.env).toBe(options.env);
+    expect(component.requirements).toHaveProperty('userEnv');
     expect(component.configSchema.parse(options.config)).toEqual({
       executable: '/usr/local/bin/git',
-      env: gitRuntimeEnv(env),
     });
   });
 

--- a/packages/core/src/runtimes/git/node/worker-spec.ts
+++ b/packages/core/src/runtimes/git/node/worker-spec.ts
@@ -19,9 +19,9 @@ export type GitWorkerSpecInput = {
 };
 
 /**
- * Spawn spec for the git runtime worker. The worker process and the git
- * subprocesses it spawns both run under `gitRuntimeEnv`: non-interactive
- * credentials and a stable C locale.
+ * Spawn spec for the git runtime worker. Its own process receives the
+ * non-interactive environment; each git subprocess resolves a fresh user
+ * environment through the component dependency.
  */
 export function gitWorkerSpec(
   input: GitWorkerSpecInput
@@ -36,7 +36,6 @@ export function gitWorkerSpec(
       dependencies: input.dependencies,
       config: {
         ...(input.gitExecutable ? { executable: input.gitExecutable } : {}),
-        env,
       },
     },
   ];

--- a/packages/core/src/runtimes/scripts/node/api/contract.test.ts
+++ b/packages/core/src/runtimes/scripts/node/api/contract.test.ts
@@ -19,6 +19,7 @@ describe('scripts runtime contract', () => {
     spawner = new FakePtySpawner();
     runtime = new ScriptsRuntime({
       spawner,
+      userEnv: { HOME: '/home/test', PATH: '/usr/bin', SHELL: '/bin/sh', USER_VALUE: 'kept' },
       portProbe: async () => true,
     });
     wire = createTestWire(scriptsContract, createScriptsController(runtime));
@@ -85,8 +86,9 @@ describe('scripts runtime contract', () => {
       EMDASH_TASK_NAME: 'feature-x',
       EMDASH_ROOT_PATH: '/repos/app',
     });
-    // CI is never injected: it is whatever the worker's own environment carries.
-    expect(spec.env?.CI).toBe(process.env.CI);
+    expect(spec.env?.USER_VALUE).toBe('kept');
+    expect(spec.env?.ELECTRON_RUN_AS_NODE).toBeUndefined();
+    expect(spec.env?.NODE_ENV).toBeUndefined();
 
     spawner.processes[0]!.emitData('installing...\n');
     spawner.processes[0]!.emitExit({ exitCode: 0, signal: null });

--- a/packages/core/src/runtimes/scripts/node/api/contract.test.ts
+++ b/packages/core/src/runtimes/scripts/node/api/contract.test.ts
@@ -19,7 +19,12 @@ describe('scripts runtime contract', () => {
     spawner = new FakePtySpawner();
     runtime = new ScriptsRuntime({
       spawner,
-      userEnv: { HOME: '/home/test', PATH: '/usr/bin', SHELL: '/bin/sh', USER_VALUE: 'kept' },
+      userEnv: async () => ({
+        HOME: '/home/test',
+        PATH: '/usr/bin',
+        SHELL: '/bin/sh',
+        USER_VALUE: 'kept',
+      }),
       portProbe: async () => true,
     });
     wire = createTestWire(scriptsContract, createScriptsController(runtime));
@@ -104,6 +109,47 @@ describe('scripts runtime contract', () => {
     // The tail and the run record survive the exit in the live model.
     const runs = await runsFor(WORKSPACE);
     expect(runs.setup).toMatchObject({ status: 'succeeded', outputTail: 'installing...\n' });
+  });
+
+  it('loads the current user env for each newly started script', async () => {
+    let userEnv = { PATH: '/tools/old', USER_VALUE: 'before-refresh' };
+    const refreshedSpawner = new FakePtySpawner();
+    const refreshedRuntime = new ScriptsRuntime({
+      spawner: refreshedSpawner,
+      userEnv: async () => userEnv,
+    });
+
+    try {
+      await refreshedRuntime.start({
+        workspacePath: WORKSPACE,
+        script: 'setup',
+        provenance: 'manual',
+        facts: FACTS,
+        command: 'tool-before-refresh',
+        shellSetup: '',
+      });
+
+      userEnv = { PATH: '/tools/new', USER_VALUE: 'after-refresh' };
+      await refreshedRuntime.start({
+        workspacePath: WORKSPACE,
+        script: 'prepare',
+        provenance: 'manual',
+        facts: FACTS,
+        command: 'tool-after-refresh',
+        shellSetup: '',
+      });
+
+      expect(refreshedSpawner.specs[0]!.env).toMatchObject({
+        PATH: '/tools/old',
+        USER_VALUE: 'before-refresh',
+      });
+      expect(refreshedSpawner.specs[1]!.env).toMatchObject({
+        PATH: '/tools/new',
+        USER_VALUE: 'after-refresh',
+      });
+    } finally {
+      refreshedRuntime.dispose();
+    }
   });
 
   it('rejects a second start of a running script; different scripts run concurrently', async () => {

--- a/packages/core/src/runtimes/scripts/node/component.ts
+++ b/packages/core/src/runtimes/scripts/node/component.ts
@@ -6,14 +6,19 @@ import { createScriptsController } from './api/controller';
 import { ScriptsRuntime } from './runtime';
 
 /** The scripts worker: a strict execution plane for already-resolved inputs. */
+export const scriptsComponentConfigSchema = z.object({
+  userEnv: z.record(z.string(), z.string()),
+});
+
 export const scriptsComponent = defineWireComponent({
   id: 'scripts',
   contract: scriptsContract,
   requirements: {},
-  configSchema: z.object({}),
-  create: ({ instance, logger, scope }) => {
+  configSchema: scriptsComponentConfigSchema,
+  create: ({ config, instance, logger, scope }) => {
     const runtime = new ScriptsRuntime({
       spawner: new NodePtySpawner(),
+      userEnv: config.userEnv,
       logger,
     });
     scope.add(() => runtime.dispose());

--- a/packages/core/src/runtimes/scripts/node/component.ts
+++ b/packages/core/src/runtimes/scripts/node/component.ts
@@ -1,24 +1,25 @@
-import { defineWireComponent } from '@emdash/wire/worker';
+import { defineWireComponent, requireContract } from '@emdash/wire/worker';
 import { z } from 'zod';
 import { NodePtySpawner } from '#services/pty/node';
+import { userShellEnvContract } from '#services/shell-env/api';
 import { scriptsContract } from '../api/contract';
 import { createScriptsController } from './api/controller';
 import { ScriptsRuntime } from './runtime';
 
 /** The scripts worker: a strict execution plane for already-resolved inputs. */
-export const scriptsComponentConfigSchema = z.object({
-  userEnv: z.record(z.string(), z.string()),
-});
+export const scriptsComponentConfigSchema = z.object({});
 
 export const scriptsComponent = defineWireComponent({
   id: 'scripts',
   contract: scriptsContract,
-  requirements: {},
+  requirements: {
+    userEnv: requireContract(userShellEnvContract),
+  },
   configSchema: scriptsComponentConfigSchema,
-  create: ({ config, instance, logger, scope }) => {
+  create: ({ dependencies, instance, logger, scope }) => {
     const runtime = new ScriptsRuntime({
       spawner: new NodePtySpawner(),
-      userEnv: config.userEnv,
+      userEnv: () => dependencies.userEnv.get(),
       logger,
     });
     scope.add(() => runtime.dispose());

--- a/packages/core/src/runtimes/scripts/node/index.ts
+++ b/packages/core/src/runtimes/scripts/node/index.ts
@@ -1,4 +1,4 @@
-export { scriptsComponent } from './component';
+export { scriptsComponent, scriptsComponentConfigSchema } from './component';
 export { buildScriptEnv } from './env';
 export { ScriptsRuntime, type ScriptsRuntimeOptions } from './runtime';
 export { scriptsWorkerSpec, type ScriptsWorkerSpecInput } from './worker-spec';

--- a/packages/core/src/runtimes/scripts/node/runtime.ts
+++ b/packages/core/src/runtimes/scripts/node/runtime.ts
@@ -10,6 +10,7 @@ import {
   type TerminalPortProbe,
 } from '#services/preview-detection/node';
 import { buildTerminalEnv, PtyRegistry, type PtySpawner } from '#services/pty/api';
+import type { UserShellEnv } from '#services/shell-env/api';
 import { scriptsContract } from '../api/contract';
 import type { ScriptRunNotFoundError, StartScriptRunError } from '../api/errors';
 import type {
@@ -33,7 +34,7 @@ const OUTPUT_TAIL_CAP = 16 * 1024;
 
 export type ScriptsRuntimeOptions = {
   spawner: PtySpawner;
-  userEnv: Readonly<Record<string, string>>;
+  userEnv: () => Promise<UserShellEnv>;
   /** Test seam for the dev-server URL detector's port liveness probe. */
   portProbe?: TerminalPortProbe;
   now?: () => number;
@@ -86,7 +87,7 @@ export class ScriptsRuntime {
   );
 
   private readonly registry: PtyRegistry;
-  private readonly userEnv: Record<string, string>;
+  private readonly loadUserEnv: () => Promise<UserShellEnv>;
   private readonly portProbe: TerminalPortProbe | undefined;
   private readonly now: () => number;
   private readonly logger: Logger;
@@ -97,7 +98,7 @@ export class ScriptsRuntime {
 
   constructor(options: ScriptsRuntimeOptions) {
     this.registry = new PtyRegistry(options.spawner);
-    this.userEnv = { ...options.userEnv };
+    this.loadUserEnv = options.userEnv;
     this.portProbe = options.portProbe;
     this.now = options.now ?? Date.now;
     this.logger = options.logger ?? noopLogger;
@@ -112,12 +113,6 @@ export class ScriptsRuntime {
       });
     }
 
-    // User-shell env + the host-derived EMDASH_* vars; deliberately no CI=1
-    // injection (spec: env parity — a documented breaking change).
-    const env = buildTerminalEnv({
-      baseEnv: this.userEnv,
-      overrides: buildScriptEnv(input.workspacePath, input.facts),
-    });
     const log = this.logFor(input);
     log.reseed();
 
@@ -130,6 +125,12 @@ export class ScriptsRuntime {
 
     let session;
     try {
+      // User-shell env + the host-derived EMDASH_* vars; deliberately no CI=1
+      // injection (spec: env parity — a documented breaking change).
+      const env = buildTerminalEnv({
+        baseEnv: await this.loadUserEnv(),
+        overrides: buildScriptEnv(input.workspacePath, input.facts),
+      });
       session = await this.registry.create(
         runKey,
         spawnSpec({

--- a/packages/core/src/runtimes/scripts/node/runtime.ts
+++ b/packages/core/src/runtimes/scripts/node/runtime.ts
@@ -33,6 +33,7 @@ const OUTPUT_TAIL_CAP = 16 * 1024;
 
 export type ScriptsRuntimeOptions = {
   spawner: PtySpawner;
+  userEnv: Readonly<Record<string, string>>;
   /** Test seam for the dev-server URL detector's port liveness probe. */
   portProbe?: TerminalPortProbe;
   now?: () => number;
@@ -85,6 +86,7 @@ export class ScriptsRuntime {
   );
 
   private readonly registry: PtyRegistry;
+  private readonly userEnv: Record<string, string>;
   private readonly portProbe: TerminalPortProbe | undefined;
   private readonly now: () => number;
   private readonly logger: Logger;
@@ -95,6 +97,7 @@ export class ScriptsRuntime {
 
   constructor(options: ScriptsRuntimeOptions) {
     this.registry = new PtyRegistry(options.spawner);
+    this.userEnv = { ...options.userEnv };
     this.portProbe = options.portProbe;
     this.now = options.now ?? Date.now;
     this.logger = options.logger ?? noopLogger;
@@ -109,9 +112,12 @@ export class ScriptsRuntime {
       });
     }
 
-    // Worker env verbatim + the host-derived EMDASH_* vars; deliberately no
-    // CI=1 injection (spec: env parity — a documented breaking change).
-    const env = buildTerminalEnv({ overrides: buildScriptEnv(input.workspacePath, input.facts) });
+    // User-shell env + the host-derived EMDASH_* vars; deliberately no CI=1
+    // injection (spec: env parity — a documented breaking change).
+    const env = buildTerminalEnv({
+      baseEnv: this.userEnv,
+      overrides: buildScriptEnv(input.workspacePath, input.facts),
+    });
     const log = this.logFor(input);
     log.reseed();
 
@@ -424,7 +430,7 @@ function spawnSpec(input: {
   const command = input.shellSetup ? `${input.shellSetup}\n${input.command}` : input.command;
   if (process.platform === 'win32') {
     return {
-      command: process.env.ComSpec ?? 'cmd.exe',
+      command: input.env.ComSpec ?? 'cmd.exe',
       args: ['/d', '/s', '/c', command],
       cwd: input.cwd,
       env: input.env,
@@ -433,7 +439,7 @@ function spawnSpec(input: {
     };
   }
   return {
-    command: process.env.SHELL ?? '/bin/sh',
+    command: input.env.SHELL ?? '/bin/sh',
     args: ['-lc', command],
     cwd: input.cwd,
     env: input.env,

--- a/packages/core/src/runtimes/scripts/node/worker-spec.test.ts
+++ b/packages/core/src/runtimes/scripts/node/worker-spec.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { scriptsWorkerSpec } from './worker-spec';
+
+describe('scriptsWorkerSpec', () => {
+  it('keeps the worker process env separate from the user shell env', () => {
+    const env = { ELECTRON_RUN_AS_NODE: '1', NODE_ENV: 'production' };
+    const userEnv = { PATH: '/user/bin', USER_VALUE: 'kept' };
+
+    const [component, options] = scriptsWorkerSpec({
+      executable: '/w/scripts.mjs',
+      env,
+      userEnv,
+    });
+
+    expect(component.id).toBe('scripts');
+    expect(options.env).toBe(env);
+    expect(component.configSchema.parse(options.config)).toEqual({ userEnv });
+  });
+});

--- a/packages/core/src/runtimes/scripts/node/worker-spec.test.ts
+++ b/packages/core/src/runtimes/scripts/node/worker-spec.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from 'vitest';
+import { createUserShellEnvController } from '#services/shell-env/node';
 import { scriptsWorkerSpec } from './worker-spec';
 
 describe('scriptsWorkerSpec', () => {
   it('keeps the worker process env separate from the user shell env', () => {
     const env = { ELECTRON_RUN_AS_NODE: '1', NODE_ENV: 'production' };
-    const userEnv = { PATH: '/user/bin', USER_VALUE: 'kept' };
+    const userEnv = createUserShellEnvController(async () => ({
+      PATH: '/user/bin',
+      USER_VALUE: 'kept',
+    }));
 
     const [component, options] = scriptsWorkerSpec({
       executable: '/w/scripts.mjs',
@@ -14,6 +18,7 @@ describe('scriptsWorkerSpec', () => {
 
     expect(component.id).toBe('scripts');
     expect(options.env).toBe(env);
-    expect(component.configSchema.parse(options.config)).toEqual({ userEnv });
+    expect(options.dependencies.userEnv).toBe(userEnv);
+    expect(component.configSchema.parse(options.config)).toEqual({});
   });
 });

--- a/packages/core/src/runtimes/scripts/node/worker-spec.ts
+++ b/packages/core/src/runtimes/scripts/node/worker-spec.ts
@@ -1,14 +1,16 @@
 import type { WireComponentWorkerCreateOptions } from '@emdash/wire/worker';
-import { scriptsComponent } from './component';
+import type { z } from 'zod';
+import { scriptsComponent, type scriptsComponentConfigSchema } from './component';
 
 type ScriptsWorkerOptions = WireComponentWorkerCreateOptions<
   (typeof scriptsComponent)['requirements'],
-  Record<string, never>
+  z.infer<typeof scriptsComponentConfigSchema>
 >;
 
 export type ScriptsWorkerSpecInput = {
   executable: string;
   env: NodeJS.ProcessEnv;
+  userEnv: Record<string, string>;
 };
 
 /** Spawn spec for the scripts worker. */
@@ -22,7 +24,7 @@ export function scriptsWorkerSpec(
       executable: input.executable,
       env: input.env,
       dependencies: {},
-      config: {},
+      config: { userEnv: input.userEnv },
     },
   ];
 }

--- a/packages/core/src/runtimes/scripts/node/worker-spec.ts
+++ b/packages/core/src/runtimes/scripts/node/worker-spec.ts
@@ -1,4 +1,7 @@
-import type { WireComponentWorkerCreateOptions } from '@emdash/wire/worker';
+import type {
+  ProvidedWireComponentRequirements,
+  WireComponentWorkerCreateOptions,
+} from '@emdash/wire/worker';
 import type { z } from 'zod';
 import { scriptsComponent, type scriptsComponentConfigSchema } from './component';
 
@@ -10,7 +13,7 @@ type ScriptsWorkerOptions = WireComponentWorkerCreateOptions<
 export type ScriptsWorkerSpecInput = {
   executable: string;
   env: NodeJS.ProcessEnv;
-  userEnv: Record<string, string>;
+  userEnv: ProvidedWireComponentRequirements<(typeof scriptsComponent)['requirements']>['userEnv'];
 };
 
 /** Spawn spec for the scripts worker. */
@@ -23,8 +26,8 @@ export function scriptsWorkerSpec(
       name: 'scripts',
       executable: input.executable,
       env: input.env,
-      dependencies: {},
-      config: { userEnv: input.userEnv },
+      dependencies: { userEnv: input.userEnv },
+      config: {},
     },
   ];
 }

--- a/packages/core/src/runtimes/terminals/node/component.ts
+++ b/packages/core/src/runtimes/terminals/node/component.ts
@@ -1,14 +1,14 @@
-import { defineWireComponent } from '@emdash/wire/worker';
+import { defineWireComponent, requireContract } from '@emdash/wire/worker';
 import { z } from 'zod';
 import { terminalsContract } from '#runtimes/terminals/api';
 import { NodeExecutionContext } from '#services/exec/api';
 import { createNodeTerminalShellResolver, NodePtySpawner } from '#services/pty/node';
 import { idlePolicyConfigSchema } from '#services/session-lifecycle/api';
+import { userShellEnvContract } from '#services/shell-env/api';
 import { createTerminalsController } from './api/controller';
 import { TerminalsRuntime } from './runtime/runtime';
 
 export const terminalsComponentConfigSchema = z.object({
-  userEnv: z.record(z.string(), z.string()),
   lifecycle: z
     .object({
       terminal: idlePolicyConfigSchema.optional(),
@@ -20,17 +20,18 @@ export const terminalsComponentConfigSchema = z.object({
 export const terminalsComponent = defineWireComponent({
   id: 'terminals',
   contract: terminalsContract,
-  requirements: {},
+  requirements: {
+    userEnv: requireContract(userShellEnvContract),
+  },
   configSchema: terminalsComponentConfigSchema,
-  create: ({ config, instance, logger, scope }) => {
-    const exec = new NodeExecutionContext({ env: config.userEnv });
+  create: ({ config, dependencies, instance, logger, scope }) => {
     const runtime = new TerminalsRuntime({
       spawner: new NodePtySpawner(),
-      userEnv: config.userEnv,
-      exec,
+      userEnv: () => dependencies.userEnv.get(),
+      createExecutionContext: (env) => new NodeExecutionContext({ env }),
       scope,
       lifecycle: config.lifecycle,
-      shellResolver: createNodeTerminalShellResolver({ env: config.userEnv }),
+      createShellResolver: (env) => createNodeTerminalShellResolver({ env }),
       logger,
     });
     scope.add(() => runtime.dispose());

--- a/packages/core/src/runtimes/terminals/node/component.ts
+++ b/packages/core/src/runtimes/terminals/node/component.ts
@@ -8,6 +8,7 @@ import { createTerminalsController } from './api/controller';
 import { TerminalsRuntime } from './runtime/runtime';
 
 export const terminalsComponentConfigSchema = z.object({
+  userEnv: z.record(z.string(), z.string()),
   lifecycle: z
     .object({
       terminal: idlePolicyConfigSchema.optional(),
@@ -22,13 +23,14 @@ export const terminalsComponent = defineWireComponent({
   requirements: {},
   configSchema: terminalsComponentConfigSchema,
   create: ({ config, instance, logger, scope }) => {
-    const exec = new NodeExecutionContext({ env: process.env });
+    const exec = new NodeExecutionContext({ env: config.userEnv });
     const runtime = new TerminalsRuntime({
       spawner: new NodePtySpawner(),
+      userEnv: config.userEnv,
       exec,
       scope,
       lifecycle: config.lifecycle,
-      shellResolver: createNodeTerminalShellResolver(),
+      shellResolver: createNodeTerminalShellResolver({ env: config.userEnv }),
       logger,
     });
     scope.add(() => runtime.dispose());

--- a/packages/core/src/runtimes/terminals/node/runtime/runtime.test.ts
+++ b/packages/core/src/runtimes/terminals/node/runtime/runtime.test.ts
@@ -68,11 +68,48 @@ class FakeShellResolver implements TerminalShellResolver {
 }
 
 describe('TerminalsRuntime', () => {
+  it('builds PTY env from the injected user env, not the worker process env', async () => {
+    const previousElectronRunAsNode = process.env.ELECTRON_RUN_AS_NODE;
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.ELECTRON_RUN_AS_NODE = '1';
+    process.env.NODE_ENV = 'production';
+
+    const spawner = new FakePtySpawner();
+    const scope = createScope({ label: 'test-terminals-env-boundary' });
+    const runtime = new TerminalsRuntime({
+      spawner,
+      scope,
+      userEnv: { HOME: '/home/test', PATH: '/usr/bin', SHELL: '/bin/sh', USER_VALUE: 'kept' },
+    });
+
+    try {
+      await runtime.start({
+        key: { workspace: testWorkspace(), id: 'terminal-1' },
+        spec: { cwd: '/repo', env: { EMDASH_TASK_ID: 'task-1' } },
+      });
+
+      expect(spawner.specs[0]!.env).toMatchObject({
+        USER_VALUE: 'kept',
+        EMDASH_TASK_ID: 'task-1',
+      });
+      expect(spawner.specs[0]!.env?.ELECTRON_RUN_AS_NODE).toBeUndefined();
+      expect(spawner.specs[0]!.env?.NODE_ENV).toBeUndefined();
+    } finally {
+      runtime.dispose();
+      await scope.dispose();
+      if (previousElectronRunAsNode === undefined) delete process.env.ELECTRON_RUN_AS_NODE;
+      else process.env.ELECTRON_RUN_AS_NODE = previousElectronRunAsNode;
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
+    }
+  });
+
   it('publishes detected dev servers and prunes them when the session exits', async () => {
     const spawner = new FakePtySpawner();
     const scope = createScope({ label: 'test-terminals' });
     const runtime = new TerminalsRuntime({
       spawner,
+      userEnv: testUserEnv(),
       scope,
       clock: createManualClock(1000),
       portProbe: async () => true,
@@ -106,7 +143,7 @@ describe('TerminalsRuntime', () => {
   it('retains exited terminals with scrollback instead of evicting them', async () => {
     const spawner = new FakePtySpawner();
     const scope = createScope({ label: 'test-terminals' });
-    const runtime = new TerminalsRuntime({ spawner, scope });
+    const runtime = new TerminalsRuntime({ spawner, userEnv: testUserEnv(), scope });
     const workspace = testWorkspace();
     const key = { workspace, id: 'terminal-1' };
     const sessionKey = `${workspaceKey(workspace)}:terminal-1`;
@@ -125,7 +162,7 @@ describe('TerminalsRuntime', () => {
   it('kill evicts the session: list entry removed and no per-key map holds the key', async () => {
     const spawner = new FakePtySpawner();
     const scope = createScope({ label: 'test-terminals' });
-    const runtime = new TerminalsRuntime({ spawner, scope });
+    const runtime = new TerminalsRuntime({ spawner, userEnv: testUserEnv(), scope });
     const workspace = testWorkspace();
     const key = { workspace, id: 'terminal-1' };
     const sessionKey = `${workspaceKey(workspace)}:terminal-1`;
@@ -144,7 +181,7 @@ describe('TerminalsRuntime', () => {
   it('kill also evicts a retained exited terminal', async () => {
     const spawner = new FakePtySpawner();
     const scope = createScope({ label: 'test-terminals' });
-    const runtime = new TerminalsRuntime({ spawner, scope });
+    const runtime = new TerminalsRuntime({ spawner, userEnv: testUserEnv(), scope });
     const workspace = testWorkspace();
     const key = { workspace, id: 'terminal-1' };
     const sessionKey = `${workspaceKey(workspace)}:terminal-1`;
@@ -163,7 +200,7 @@ describe('TerminalsRuntime', () => {
   it('kill on an unknown terminal returns not-found', async () => {
     const spawner = new FakePtySpawner();
     const scope = createScope({ label: 'test-terminals' });
-    const runtime = new TerminalsRuntime({ spawner, scope });
+    const runtime = new TerminalsRuntime({ spawner, userEnv: testUserEnv(), scope });
 
     const result = await runtime.kill({ workspace: testWorkspace(), id: 'missing' });
 
@@ -174,7 +211,7 @@ describe('TerminalsRuntime', () => {
   it('restarting an exited terminal evicts the old entry, then creates a fresh one', async () => {
     const spawner = new FakePtySpawner();
     const scope = createScope({ label: 'test-terminals' });
-    const runtime = new TerminalsRuntime({ spawner, scope });
+    const runtime = new TerminalsRuntime({ spawner, userEnv: testUserEnv(), scope });
     const workspace = testWorkspace();
     const key = { workspace, id: 'terminal-1' };
     const sessionKey = `${workspaceKey(workspace)}:terminal-1`;
@@ -198,7 +235,7 @@ describe('TerminalsRuntime', () => {
   it('workspace deactivation (kill per session) evicts every terminal under the workspace', async () => {
     const spawner = new FakePtySpawner();
     const scope = createScope({ label: 'test-terminals' });
-    const runtime = new TerminalsRuntime({ spawner, scope });
+    const runtime = new TerminalsRuntime({ spawner, userEnv: testUserEnv(), scope });
     const workspace = testWorkspace();
     const keys = [
       { workspace, id: 'terminal-1' },
@@ -226,6 +263,7 @@ describe('TerminalsRuntime', () => {
     const scope = createScope({ label: 'test-terminals' });
     const runtime = new TerminalsRuntime({
       spawner,
+      userEnv: testUserEnv(),
       scope,
       clock,
       lifecycle: {
@@ -253,7 +291,7 @@ describe('TerminalsRuntime', () => {
     const exec = fakeExec();
     const spawner = new FakePtySpawner();
     const scope = createScope({ label: 'test-terminals' });
-    const runtime = new TerminalsRuntime({ spawner, exec, scope });
+    const runtime = new TerminalsRuntime({ spawner, userEnv: testUserEnv(), exec, scope });
 
     const result = await runtime.killTmuxSessions({
       sessionNames: ['emdash-session1', 'emdash-session2'],
@@ -271,7 +309,7 @@ describe('TerminalsRuntime', () => {
     exec.exec.mockRejectedValue(new Error('no session'));
     const spawner = new FakePtySpawner();
     const scope = createScope({ label: 'test-terminals' });
-    const runtime = new TerminalsRuntime({ spawner, exec, scope });
+    const runtime = new TerminalsRuntime({ spawner, userEnv: testUserEnv(), exec, scope });
 
     const result = await runtime.killTmuxSessions({
       sessionNames: ['emdash-missing'],
@@ -284,7 +322,7 @@ describe('TerminalsRuntime', () => {
   it('killTmuxSessions returns ok without calling exec when no exec is injected', async () => {
     const spawner = new FakePtySpawner();
     const scope = createScope({ label: 'test-terminals' });
-    const runtime = new TerminalsRuntime({ spawner, scope });
+    const runtime = new TerminalsRuntime({ spawner, userEnv: testUserEnv(), scope });
 
     const result = await runtime.killTmuxSessions({
       sessionNames: ['emdash-session1'],
@@ -300,7 +338,12 @@ describe('TerminalsRuntime', () => {
     const shellResolver = new FakeShellResolver({
       profile: posixShellProfile({ executable: '/opt/homebrew/bin/zsh' }),
     });
-    const runtime = new TerminalsRuntime({ spawner, scope, shellResolver });
+    const runtime = new TerminalsRuntime({
+      spawner,
+      userEnv: testUserEnv(),
+      scope,
+      shellResolver,
+    });
     const workspace = testWorkspace();
 
     await runtime.start({
@@ -318,7 +361,12 @@ describe('TerminalsRuntime', () => {
     const spawner = new FakePtySpawner();
     const scope = createScope({ label: 'test-terminals' });
     const shellResolver = new FakeShellResolver();
-    const runtime = new TerminalsRuntime({ spawner, scope, shellResolver });
+    const runtime = new TerminalsRuntime({
+      spawner,
+      userEnv: testUserEnv(),
+      scope,
+      shellResolver,
+    });
     const workspace = testWorkspace();
 
     await runtime.start({
@@ -340,6 +388,7 @@ describe('TerminalsRuntime', () => {
     });
     const runtime = new TerminalsRuntime({
       spawner,
+      userEnv: testUserEnv(),
       scope,
       shellResolver,
       logger: { ...noopLogger, warn },
@@ -367,6 +416,7 @@ describe('TerminalsRuntime', () => {
     ];
     const runtime = new TerminalsRuntime({
       spawner,
+      userEnv: testUserEnv(),
       scope,
       shellResolver: new FakeShellResolver({ availability }),
     });
@@ -381,7 +431,7 @@ describe('TerminalsRuntime', () => {
   it('fails shell availability when no resolver is configured', async () => {
     const spawner = new FakePtySpawner();
     const scope = createScope({ label: 'test-terminals' });
-    const runtime = new TerminalsRuntime({ spawner, scope });
+    const runtime = new TerminalsRuntime({ spawner, userEnv: testUserEnv(), scope });
 
     await expect(runtime.getShellAvailability()).resolves.toMatchObject({
       success: false,
@@ -399,6 +449,12 @@ function parseAbsoluteWorkspace(path: string) {
   const parsed = parseAbsolute(path, { profile: { style: 'posix' } });
   if (!parsed.success) throw new Error(parsed.error.message);
   return parsed.data;
+}
+
+function testUserEnv(): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined)
+  );
 }
 
 function fakeExec(): IExecutionContext & { exec: ReturnType<typeof vi.fn> } {

--- a/packages/core/src/runtimes/terminals/node/runtime/runtime.test.ts
+++ b/packages/core/src/runtimes/terminals/node/runtime/runtime.test.ts
@@ -79,7 +79,12 @@ describe('TerminalsRuntime', () => {
     const runtime = new TerminalsRuntime({
       spawner,
       scope,
-      userEnv: { HOME: '/home/test', PATH: '/usr/bin', SHELL: '/bin/sh', USER_VALUE: 'kept' },
+      userEnv: async () => ({
+        HOME: '/home/test',
+        PATH: '/usr/bin',
+        SHELL: '/bin/sh',
+        USER_VALUE: 'kept',
+      }),
     });
 
     try {
@@ -104,12 +109,48 @@ describe('TerminalsRuntime', () => {
     }
   });
 
+  it('loads the current user env for each newly started terminal', async () => {
+    let userEnv = { PATH: '/tools/old', USER_VALUE: 'before-refresh' };
+    const spawner = new FakePtySpawner();
+    const scope = createScope({ label: 'test-terminals-env-refresh' });
+    const runtime = new TerminalsRuntime({
+      spawner,
+      scope,
+      userEnv: async () => userEnv,
+    });
+
+    try {
+      await runtime.start({
+        key: { workspace: testWorkspace(), id: 'terminal-before-refresh' },
+        spec: { cwd: '/repo', env: {} },
+      });
+
+      userEnv = { PATH: '/tools/new', USER_VALUE: 'after-refresh' };
+      await runtime.start({
+        key: { workspace: testWorkspace(), id: 'terminal-after-refresh' },
+        spec: { cwd: '/repo', env: {} },
+      });
+
+      expect(spawner.specs[0]!.env).toMatchObject({
+        PATH: '/tools/old',
+        USER_VALUE: 'before-refresh',
+      });
+      expect(spawner.specs[1]!.env).toMatchObject({
+        PATH: '/tools/new',
+        USER_VALUE: 'after-refresh',
+      });
+    } finally {
+      runtime.dispose();
+      await scope.dispose();
+    }
+  });
+
   it('publishes detected dev servers and prunes them when the session exits', async () => {
     const spawner = new FakePtySpawner();
     const scope = createScope({ label: 'test-terminals' });
     const runtime = new TerminalsRuntime({
       spawner,
-      userEnv: testUserEnv(),
+      userEnv: async () => testUserEnv(),
       scope,
       clock: createManualClock(1000),
       portProbe: async () => true,
@@ -143,7 +184,7 @@ describe('TerminalsRuntime', () => {
   it('retains exited terminals with scrollback instead of evicting them', async () => {
     const spawner = new FakePtySpawner();
     const scope = createScope({ label: 'test-terminals' });
-    const runtime = new TerminalsRuntime({ spawner, userEnv: testUserEnv(), scope });
+    const runtime = new TerminalsRuntime({ spawner, userEnv: async () => testUserEnv(), scope });
     const workspace = testWorkspace();
     const key = { workspace, id: 'terminal-1' };
     const sessionKey = `${workspaceKey(workspace)}:terminal-1`;
@@ -162,7 +203,7 @@ describe('TerminalsRuntime', () => {
   it('kill evicts the session: list entry removed and no per-key map holds the key', async () => {
     const spawner = new FakePtySpawner();
     const scope = createScope({ label: 'test-terminals' });
-    const runtime = new TerminalsRuntime({ spawner, userEnv: testUserEnv(), scope });
+    const runtime = new TerminalsRuntime({ spawner, userEnv: async () => testUserEnv(), scope });
     const workspace = testWorkspace();
     const key = { workspace, id: 'terminal-1' };
     const sessionKey = `${workspaceKey(workspace)}:terminal-1`;
@@ -181,7 +222,7 @@ describe('TerminalsRuntime', () => {
   it('kill also evicts a retained exited terminal', async () => {
     const spawner = new FakePtySpawner();
     const scope = createScope({ label: 'test-terminals' });
-    const runtime = new TerminalsRuntime({ spawner, userEnv: testUserEnv(), scope });
+    const runtime = new TerminalsRuntime({ spawner, userEnv: async () => testUserEnv(), scope });
     const workspace = testWorkspace();
     const key = { workspace, id: 'terminal-1' };
     const sessionKey = `${workspaceKey(workspace)}:terminal-1`;
@@ -200,7 +241,7 @@ describe('TerminalsRuntime', () => {
   it('kill on an unknown terminal returns not-found', async () => {
     const spawner = new FakePtySpawner();
     const scope = createScope({ label: 'test-terminals' });
-    const runtime = new TerminalsRuntime({ spawner, userEnv: testUserEnv(), scope });
+    const runtime = new TerminalsRuntime({ spawner, userEnv: async () => testUserEnv(), scope });
 
     const result = await runtime.kill({ workspace: testWorkspace(), id: 'missing' });
 
@@ -211,7 +252,7 @@ describe('TerminalsRuntime', () => {
   it('restarting an exited terminal evicts the old entry, then creates a fresh one', async () => {
     const spawner = new FakePtySpawner();
     const scope = createScope({ label: 'test-terminals' });
-    const runtime = new TerminalsRuntime({ spawner, userEnv: testUserEnv(), scope });
+    const runtime = new TerminalsRuntime({ spawner, userEnv: async () => testUserEnv(), scope });
     const workspace = testWorkspace();
     const key = { workspace, id: 'terminal-1' };
     const sessionKey = `${workspaceKey(workspace)}:terminal-1`;
@@ -235,7 +276,7 @@ describe('TerminalsRuntime', () => {
   it('workspace deactivation (kill per session) evicts every terminal under the workspace', async () => {
     const spawner = new FakePtySpawner();
     const scope = createScope({ label: 'test-terminals' });
-    const runtime = new TerminalsRuntime({ spawner, userEnv: testUserEnv(), scope });
+    const runtime = new TerminalsRuntime({ spawner, userEnv: async () => testUserEnv(), scope });
     const workspace = testWorkspace();
     const keys = [
       { workspace, id: 'terminal-1' },
@@ -263,7 +304,7 @@ describe('TerminalsRuntime', () => {
     const scope = createScope({ label: 'test-terminals' });
     const runtime = new TerminalsRuntime({
       spawner,
-      userEnv: testUserEnv(),
+      userEnv: async () => testUserEnv(),
       scope,
       clock,
       lifecycle: {
@@ -291,7 +332,12 @@ describe('TerminalsRuntime', () => {
     const exec = fakeExec();
     const spawner = new FakePtySpawner();
     const scope = createScope({ label: 'test-terminals' });
-    const runtime = new TerminalsRuntime({ spawner, userEnv: testUserEnv(), exec, scope });
+    const runtime = new TerminalsRuntime({
+      spawner,
+      userEnv: async () => testUserEnv(),
+      exec,
+      scope,
+    });
 
     const result = await runtime.killTmuxSessions({
       sessionNames: ['emdash-session1', 'emdash-session2'],
@@ -309,7 +355,12 @@ describe('TerminalsRuntime', () => {
     exec.exec.mockRejectedValue(new Error('no session'));
     const spawner = new FakePtySpawner();
     const scope = createScope({ label: 'test-terminals' });
-    const runtime = new TerminalsRuntime({ spawner, userEnv: testUserEnv(), exec, scope });
+    const runtime = new TerminalsRuntime({
+      spawner,
+      userEnv: async () => testUserEnv(),
+      exec,
+      scope,
+    });
 
     const result = await runtime.killTmuxSessions({
       sessionNames: ['emdash-missing'],
@@ -322,7 +373,7 @@ describe('TerminalsRuntime', () => {
   it('killTmuxSessions returns ok without calling exec when no exec is injected', async () => {
     const spawner = new FakePtySpawner();
     const scope = createScope({ label: 'test-terminals' });
-    const runtime = new TerminalsRuntime({ spawner, userEnv: testUserEnv(), scope });
+    const runtime = new TerminalsRuntime({ spawner, userEnv: async () => testUserEnv(), scope });
 
     const result = await runtime.killTmuxSessions({
       sessionNames: ['emdash-session1'],
@@ -340,7 +391,7 @@ describe('TerminalsRuntime', () => {
     });
     const runtime = new TerminalsRuntime({
       spawner,
-      userEnv: testUserEnv(),
+      userEnv: async () => testUserEnv(),
       scope,
       shellResolver,
     });
@@ -363,7 +414,7 @@ describe('TerminalsRuntime', () => {
     const shellResolver = new FakeShellResolver();
     const runtime = new TerminalsRuntime({
       spawner,
-      userEnv: testUserEnv(),
+      userEnv: async () => testUserEnv(),
       scope,
       shellResolver,
     });
@@ -388,7 +439,7 @@ describe('TerminalsRuntime', () => {
     });
     const runtime = new TerminalsRuntime({
       spawner,
-      userEnv: testUserEnv(),
+      userEnv: async () => testUserEnv(),
       scope,
       shellResolver,
       logger: { ...noopLogger, warn },
@@ -416,7 +467,7 @@ describe('TerminalsRuntime', () => {
     ];
     const runtime = new TerminalsRuntime({
       spawner,
-      userEnv: testUserEnv(),
+      userEnv: async () => testUserEnv(),
       scope,
       shellResolver: new FakeShellResolver({ availability }),
     });
@@ -431,7 +482,7 @@ describe('TerminalsRuntime', () => {
   it('fails shell availability when no resolver is configured', async () => {
     const spawner = new FakePtySpawner();
     const scope = createScope({ label: 'test-terminals' });
-    const runtime = new TerminalsRuntime({ spawner, userEnv: testUserEnv(), scope });
+    const runtime = new TerminalsRuntime({ spawner, userEnv: async () => testUserEnv(), scope });
 
     await expect(runtime.getShellAvailability()).resolves.toMatchObject({
       success: false,

--- a/packages/core/src/runtimes/terminals/node/runtime/runtime.ts
+++ b/packages/core/src/runtimes/terminals/node/runtime/runtime.ts
@@ -48,6 +48,7 @@ import type {
   SessionSnapshotJudgment,
 } from '#services/session-lifecycle/api';
 import { createSessionLifecycle } from '#services/session-lifecycle/node';
+import type { UserShellEnv } from '#services/shell-env/api';
 
 const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
@@ -68,13 +69,15 @@ type PreviewOutputSource = {
 
 export type TerminalsRuntimeOptions = {
   spawner: PtySpawner;
-  userEnv: Readonly<Record<string, string>>;
+  userEnv: () => Promise<UserShellEnv>;
   exec?: IExecutionContext;
+  createExecutionContext?: (env: UserShellEnv) => IExecutionContext;
   scope?: Scope;
   clock?: Clock;
   portProbe?: TerminalPortProbe;
   lifecycle?: TerminalsRuntimeLifecycleOptions;
   shellResolver?: TerminalShellResolver;
+  createShellResolver?: (env: UserShellEnv) => TerminalShellResolver;
   logger?: Logger;
 };
 
@@ -98,12 +101,14 @@ export class TerminalsRuntime {
   );
 
   private readonly registry: PtyRegistry;
-  private readonly userEnv: Record<string, string>;
+  private readonly loadUserEnv: () => Promise<UserShellEnv>;
   private readonly exec: IExecutionContext | undefined;
+  private readonly createExecutionContext: ((env: UserShellEnv) => IExecutionContext) | undefined;
   private readonly scope: Scope;
   private readonly clock: Clock;
   private readonly portProbe: TerminalPortProbe | undefined;
   private readonly shellResolver: TerminalShellResolver | undefined;
+  private readonly createShellResolver: ((env: UserShellEnv) => TerminalShellResolver) | undefined;
   private readonly logger: Logger;
   private readonly lifecycle: SessionLifecycle;
   private readonly logs = new Map<string, LiveLogSource>();
@@ -116,12 +121,14 @@ export class TerminalsRuntime {
     this.registry = new PtyRegistry(options.spawner, {
       onSessionChanged: (key, session) => this.syncSession(key, session),
     });
-    this.userEnv = { ...options.userEnv };
+    this.loadUserEnv = options.userEnv;
     this.exec = options.exec;
+    this.createExecutionContext = options.createExecutionContext;
     this.scope = options.scope ?? createScope({ label: 'terminals-runtime' });
     this.clock = options.clock ?? systemClock;
     this.portProbe = options.portProbe;
     this.shellResolver = options.shellResolver;
+    this.createShellResolver = options.createShellResolver;
     this.logger = options.logger ?? noopLogger;
     this.lifecycle = createSessionLifecycle({
       name: 'TerminalsRuntime',
@@ -205,14 +212,15 @@ export class TerminalsRuntime {
   async getShellAvailability(): Promise<
     Result<TerminalShellAvailability[], ShellAvailabilityFailedError>
   > {
-    if (!this.shellResolver) {
-      return err({
-        type: 'shell-availability-failed',
-        message: 'No shell resolver is configured for this terminals runtime',
-      });
-    }
     try {
-      return ok(await this.shellResolver.getAvailability());
+      const shellResolver = await this.shellResolverFor();
+      if (!shellResolver) {
+        return err({
+          type: 'shell-availability-failed',
+          message: 'No shell resolver is configured for this terminals runtime',
+        });
+      }
+      return ok(await shellResolver.getAvailability());
     } catch (error) {
       return err({
         type: 'shell-availability-failed',
@@ -274,10 +282,10 @@ export class TerminalsRuntime {
   async killTmuxSessions(
     input: KillTmuxSessionsInput
   ): Promise<Result<void, TerminalRuntimeError>> {
-    if (process.platform === 'win32' || !this.exec) return ok(undefined);
-    for (const name of input.sessionNames) {
-      await killTmuxSession(this.exec, name);
-    }
+    if (process.platform === 'win32') return ok(undefined);
+    await this.withExecutionContext(async (exec) => {
+      for (const name of input.sessionNames) await killTmuxSession(exec, name);
+    });
     return ok(undefined);
   }
 
@@ -312,9 +320,10 @@ export class TerminalsRuntime {
     this.startCounts.set(sessionKey, startCount);
     this.sessionKeys.set(sessionKey, key);
 
-    const shellProfile = await this.resolveShellProfile(key, spec.shellIntent);
+    const userEnv = await this.loadUserEnv();
+    const shellProfile = await this.resolveShellProfile(key, spec.shellIntent, userEnv);
     const env = buildTerminalEnv({
-      baseEnv: this.userEnv,
+      baseEnv: userEnv,
       shellProfile,
       overrides: spec.env,
       gitCredentials: spec.gitCredentials,
@@ -358,10 +367,12 @@ export class TerminalsRuntime {
 
   private async resolveShellProfile(
     key: TerminalKey,
-    intent: TerminalShellId | undefined
+    intent: TerminalShellId | undefined,
+    userEnv: UserShellEnv
   ): Promise<ResolvedShellProfile | undefined> {
-    if (!intent || !this.shellResolver) return undefined;
-    return await this.shellResolver.resolveWithSystemFallback({
+    const shellResolver = await this.shellResolverFor(userEnv);
+    if (!intent || !shellResolver) return undefined;
+    return await shellResolver.resolveWithSystemFallback({
       intent,
       onFallback: (event) =>
         this.logger.warn('terminals: falling back to system shell', {
@@ -374,8 +385,36 @@ export class TerminalsRuntime {
 
   private async killTmuxForSession(sessionKey: string): Promise<void> {
     const config = this.interactiveConfigs.get(sessionKey);
-    if (!config?.spec.tmux || process.platform === 'win32' || !this.exec) return;
-    await killTmuxSession(this.exec, makeTmuxSessionName(sessionKey));
+    if (!config?.spec.tmux || process.platform === 'win32') return;
+    await this.withExecutionContext((exec) =>
+      killTmuxSession(exec, makeTmuxSessionName(sessionKey))
+    );
+  }
+
+  private async shellResolverFor(
+    userEnv?: UserShellEnv
+  ): Promise<TerminalShellResolver | undefined> {
+    if (this.createShellResolver) {
+      return this.createShellResolver(userEnv ?? (await this.loadUserEnv()));
+    }
+    return this.shellResolver;
+  }
+
+  private async withExecutionContext(
+    operation: (exec: IExecutionContext) => Promise<void>
+  ): Promise<void> {
+    if (this.exec) {
+      await operation(this.exec);
+      return;
+    }
+    if (!this.createExecutionContext) return;
+
+    const exec = this.createExecutionContext(await this.loadUserEnv());
+    try {
+      await operation(exec);
+    } finally {
+      exec.dispose();
+    }
   }
 
   private logFor(key: TerminalKey): LiveLogSource {

--- a/packages/core/src/runtimes/terminals/node/runtime/runtime.ts
+++ b/packages/core/src/runtimes/terminals/node/runtime/runtime.ts
@@ -68,6 +68,7 @@ type PreviewOutputSource = {
 
 export type TerminalsRuntimeOptions = {
   spawner: PtySpawner;
+  userEnv: Readonly<Record<string, string>>;
   exec?: IExecutionContext;
   scope?: Scope;
   clock?: Clock;
@@ -97,6 +98,7 @@ export class TerminalsRuntime {
   );
 
   private readonly registry: PtyRegistry;
+  private readonly userEnv: Record<string, string>;
   private readonly exec: IExecutionContext | undefined;
   private readonly scope: Scope;
   private readonly clock: Clock;
@@ -114,6 +116,7 @@ export class TerminalsRuntime {
     this.registry = new PtyRegistry(options.spawner, {
       onSessionChanged: (key, session) => this.syncSession(key, session),
     });
+    this.userEnv = { ...options.userEnv };
     this.exec = options.exec;
     this.scope = options.scope ?? createScope({ label: 'terminals-runtime' });
     this.clock = options.clock ?? systemClock;
@@ -311,6 +314,7 @@ export class TerminalsRuntime {
 
     const shellProfile = await this.resolveShellProfile(key, spec.shellIntent);
     const env = buildTerminalEnv({
+      baseEnv: this.userEnv,
       shellProfile,
       overrides: spec.env,
       gitCredentials: spec.gitCredentials,

--- a/packages/core/src/runtimes/terminals/node/worker-spec.test.ts
+++ b/packages/core/src/runtimes/terminals/node/worker-spec.test.ts
@@ -4,18 +4,20 @@ import { terminalsWorkerSpec } from './worker-spec';
 describe('terminalsWorkerSpec', () => {
   it('takes the lifecycle policy as a per-app parameter', () => {
     const env = { PATH: '/usr/bin' };
+    const userEnv = { PATH: '/user/bin', USER_VALUE: 'kept' };
     const lifecycle = {
       terminal: { kind: 'while-attached', graceMs: 5 * 60_000 },
     } as const;
     const [component, options] = terminalsWorkerSpec({
       executable: '/w/terminals.mjs',
       env,
+      userEnv,
       lifecycle,
     });
     expect(component.id).toBe('terminals');
     expect(options.name).toBe('terminals');
     expect(options.env).toBe(env);
     expect(options.supervision).toBeUndefined();
-    expect(component.configSchema.parse(options.config)).toEqual({ lifecycle });
+    expect(component.configSchema.parse(options.config)).toEqual({ userEnv, lifecycle });
   });
 });

--- a/packages/core/src/runtimes/terminals/node/worker-spec.test.ts
+++ b/packages/core/src/runtimes/terminals/node/worker-spec.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from 'vitest';
+import { createUserShellEnvController } from '#services/shell-env/node';
 import { terminalsWorkerSpec } from './worker-spec';
 
 describe('terminalsWorkerSpec', () => {
   it('takes the lifecycle policy as a per-app parameter', () => {
     const env = { PATH: '/usr/bin' };
-    const userEnv = { PATH: '/user/bin', USER_VALUE: 'kept' };
+    const userEnv = createUserShellEnvController(async () => ({
+      PATH: '/user/bin',
+      USER_VALUE: 'kept',
+    }));
     const lifecycle = {
       terminal: { kind: 'while-attached', graceMs: 5 * 60_000 },
     } as const;
@@ -18,6 +22,7 @@ describe('terminalsWorkerSpec', () => {
     expect(options.name).toBe('terminals');
     expect(options.env).toBe(env);
     expect(options.supervision).toBeUndefined();
-    expect(component.configSchema.parse(options.config)).toEqual({ userEnv, lifecycle });
+    expect(options.dependencies.userEnv).toBe(userEnv);
+    expect(component.configSchema.parse(options.config)).toEqual({ lifecycle });
   });
 });

--- a/packages/core/src/runtimes/terminals/node/worker-spec.ts
+++ b/packages/core/src/runtimes/terminals/node/worker-spec.ts
@@ -11,6 +11,7 @@ type TerminalsWorkerOptions = WireComponentWorkerCreateOptions<
 export type TerminalsWorkerSpecInput = {
   executable: string;
   env: NodeJS.ProcessEnv;
+  userEnv: Record<string, string>;
   /**
    * Genuinely per-app policy: the desktop keeps terminals alive for the app's
    * lifetime, while a detachable server reaps terminals nobody is attached to.
@@ -29,7 +30,7 @@ export function terminalsWorkerSpec(
       executable: input.executable,
       env: input.env,
       dependencies: {},
-      config: { lifecycle: input.lifecycle },
+      config: { userEnv: input.userEnv, lifecycle: input.lifecycle },
     },
   ];
 }

--- a/packages/core/src/runtimes/terminals/node/worker-spec.ts
+++ b/packages/core/src/runtimes/terminals/node/worker-spec.ts
@@ -1,4 +1,7 @@
-import type { WireComponentWorkerCreateOptions } from '@emdash/wire/worker';
+import type {
+  ProvidedWireComponentRequirements,
+  WireComponentWorkerCreateOptions,
+} from '@emdash/wire/worker';
 import type { z } from 'zod';
 import { terminalsComponent, type terminalsComponentConfigSchema } from './component';
 
@@ -11,7 +14,9 @@ type TerminalsWorkerOptions = WireComponentWorkerCreateOptions<
 export type TerminalsWorkerSpecInput = {
   executable: string;
   env: NodeJS.ProcessEnv;
-  userEnv: Record<string, string>;
+  userEnv: ProvidedWireComponentRequirements<
+    (typeof terminalsComponent)['requirements']
+  >['userEnv'];
   /**
    * Genuinely per-app policy: the desktop keeps terminals alive for the app's
    * lifetime, while a detachable server reaps terminals nobody is attached to.
@@ -29,8 +34,8 @@ export function terminalsWorkerSpec(
       name: 'terminals',
       executable: input.executable,
       env: input.env,
-      dependencies: {},
-      config: { userEnv: input.userEnv, lifecycle: input.lifecycle },
+      dependencies: { userEnv: input.userEnv },
+      config: { lifecycle: input.lifecycle },
     },
   ];
 }

--- a/packages/core/src/runtimes/tui-agents/node/component.ts
+++ b/packages/core/src/runtimes/tui-agents/node/component.ts
@@ -21,6 +21,7 @@ import {
   createNoopSessionIntentStore,
 } from '#services/session-intents/node';
 import { idlePolicyConfigSchema } from '#services/session-lifecycle/api';
+import { userShellEnvContract } from '#services/shell-env/api';
 
 export const tuiAgentsComponentConfigSchema = z.object({
   intentsFilePath: z.string().min(1).optional(),
@@ -34,7 +35,6 @@ export const tuiAgentsComponentConfigSchema = z.object({
 
 export type CreateTuiAgentsComponentOptions = {
   pluginRegistry: PluginRegistry<CLIAgentPluginProvider>;
-  env?: NodeJS.ProcessEnv;
   logger?: Logger;
 };
 
@@ -45,10 +45,11 @@ export function createTuiAgentsComponent(options: CreateTuiAgentsComponentOption
     requirements: {
       hostDependencies: requireContract(hostDependencyResolverContract),
       conversations: requireContract(conversationReportsContract),
+      userEnv: requireContract(userShellEnvContract),
     },
     configSchema: tuiAgentsComponentConfigSchema,
     create: ({ config, dependencies, instance, logger, scope }) => {
-      const env = options.env ?? process.env;
+      const env = () => dependencies.userEnv.get();
       const runtimeLogger = options.logger ?? logger;
       const homeDir = os.homedir();
       const exec = new NodeExecutionContext({ env });

--- a/packages/core/src/runtimes/tui-agents/node/worker-spec.test.ts
+++ b/packages/core/src/runtimes/tui-agents/node/worker-spec.test.ts
@@ -17,6 +17,7 @@ describe('tuiAgentsWorkerSpec', () => {
     expect(component.id).toBe('tui-agents');
     expect(options.name).toBe('tui-agents');
     expect(options.env).toBe(env);
+    expect(component.requirements).toHaveProperty('userEnv');
     expect(options.supervision).toBeUndefined();
     expect(component.configSchema.parse(options.config)).toEqual({
       intentsFilePath: '/data/tui-intents.json',

--- a/packages/core/src/runtimes/tui-agents/node/worker-spec.ts
+++ b/packages/core/src/runtimes/tui-agents/node/worker-spec.ts
@@ -33,7 +33,6 @@ export function tuiAgentsWorkerSpec(
   return [
     createTuiAgentsComponent({
       pluginRegistry: input.pluginRegistry,
-      env: input.env,
       logger: input.logger,
     }),
     {

--- a/packages/core/src/runtimes/workspace-registry/node/api/activation.contract.test.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/api/activation.contract.test.ts
@@ -79,7 +79,7 @@ describe('workspace registry activation lifecycle', () => {
     killedPaths = [];
     scriptsRuntime = new ScriptsRuntime({
       spawner: new ChildProcessPtySpawner(),
-      userEnv: TEST_USER_ENV,
+      userEnv: async () => TEST_USER_ENV,
     });
     scriptsWire = createTestWire(scriptsContract, createScriptsController(scriptsRuntime));
     runtime = createRegistryRuntime();

--- a/packages/core/src/runtimes/workspace-registry/node/api/activation.contract.test.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/api/activation.contract.test.ts
@@ -25,6 +25,9 @@ import { WorkspaceRegistryRuntime } from '#runtimes/workspace-registry/node/runt
 import { createWorkspaceRegistryController } from './controller';
 
 const execFileAsync = promisify(execFile);
+const TEST_USER_ENV = Object.fromEntries(
+  Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined)
+);
 
 // Contract-seam tests for the activation lifecycle (ADR 0005): activate returns at the
 // session-gating point (prepare); setup and run continue in the background and are
@@ -76,6 +79,7 @@ describe('workspace registry activation lifecycle', () => {
     killedPaths = [];
     scriptsRuntime = new ScriptsRuntime({
       spawner: new ChildProcessPtySpawner(),
+      userEnv: TEST_USER_ENV,
     });
     scriptsWire = createTestWire(scriptsContract, createScriptsController(scriptsRuntime));
     runtime = createRegistryRuntime();

--- a/packages/core/src/runtimes/workspace-registry/node/api/config-model.contract.test.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/api/config-model.contract.test.ts
@@ -88,7 +88,7 @@ describe('workspace registry config live model', () => {
     clock = new ManualClock(10_000);
     scriptsRuntime = new ScriptsRuntime({
       spawner: new ChildProcessPtySpawner(),
-      userEnv: TEST_USER_ENV,
+      userEnv: async () => TEST_USER_ENV,
     });
     scriptsWire = createTestWire(scriptsContract, createScriptsController(scriptsRuntime));
     runtime = new WorkspaceRegistryRuntime({ handle, clock, scripts: scriptsWire.client });

--- a/packages/core/src/runtimes/workspace-registry/node/api/config-model.contract.test.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/api/config-model.contract.test.ts
@@ -23,6 +23,10 @@ import {
 import { WorkspaceRegistryRuntime } from '#runtimes/workspace-registry/node/runtime';
 import { createWorkspaceRegistryController } from './controller';
 
+const TEST_USER_ENV = Object.fromEntries(
+  Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined)
+);
+
 // Contract-seam tests for the `.emdash.json` config live model (spec:
 // workspace-lifecycle-v2). The model is internal — behavior is asserted through the
 // registry verbs and records, never by inspecting the cache: activation gates which
@@ -84,6 +88,7 @@ describe('workspace registry config live model', () => {
     clock = new ManualClock(10_000);
     scriptsRuntime = new ScriptsRuntime({
       spawner: new ChildProcessPtySpawner(),
+      userEnv: TEST_USER_ENV,
     });
     scriptsWire = createTestWire(scriptsContract, createScriptsController(scriptsRuntime));
     runtime = new WorkspaceRegistryRuntime({ handle, clock, scripts: scriptsWire.client });

--- a/packages/core/src/runtimes/workspace-registry/node/api/delete-worktree.contract.test.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/api/delete-worktree.contract.test.ts
@@ -73,7 +73,7 @@ describe('workspace registry deleteWorktree', () => {
     killedPaths = [];
     scriptsRuntime = new ScriptsRuntime({
       spawner: new ChildProcessPtySpawner(),
-      userEnv: TEST_USER_ENV,
+      userEnv: async () => TEST_USER_ENV,
     });
     scriptsWire = createTestWire(scriptsContract, createScriptsController(scriptsRuntime));
     runtime = new WorkspaceRegistryRuntime({

--- a/packages/core/src/runtimes/workspace-registry/node/api/delete-worktree.contract.test.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/api/delete-worktree.contract.test.ts
@@ -23,6 +23,10 @@ import {
 import { WorkspaceRegistryRuntime } from '#runtimes/workspace-registry/node/runtime';
 import { createWorkspaceRegistryController } from './controller';
 
+const TEST_USER_ENV = Object.fromEntries(
+  Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined)
+);
+
 // Contract-seam tests for deleteWorktree (ADR 0005): one call that deactivates
 // (sessions + teardown), force-removes the artifact, optionally deletes the branch, and
 // unregisters — with no host-side dirty/unpushed refusals, and idempotent on absent ids.
@@ -69,6 +73,7 @@ describe('workspace registry deleteWorktree', () => {
     killedPaths = [];
     scriptsRuntime = new ScriptsRuntime({
       spawner: new ChildProcessPtySpawner(),
+      userEnv: TEST_USER_ENV,
     });
     scriptsWire = createTestWire(scriptsContract, createScriptsController(scriptsRuntime));
     runtime = new WorkspaceRegistryRuntime({

--- a/packages/core/src/runtimes/workspace-registry/node/component.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/component.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { fsWatchContract } from '#services/fs-watch/api';
 import { createProcessWatchServiceFromDependency } from '#services/fs-watch/node/process-watch-service';
 import { hostRuntimesDefinitions } from '#services/runtime-broker/api';
+import { userShellEnvContract } from '#services/shell-env/api';
 import { workspaceRegistryContract } from '../api';
 import { createWorkspaceRegistryController } from './api/controller';
 import { workspaceRegistryStore } from './persistence/store';
@@ -41,6 +42,7 @@ export const workspaceRegistryComponent = defineWireComponent({
     // registry observes its run state to write durable script lifecycle steps.
     scripts: requireContract(hostRuntimesDefinitions.scripts),
     hostSettings: requireContract(hostRuntimesDefinitions.hostSettings),
+    userEnv: requireContract(userShellEnvContract),
   },
   configSchema: workspaceRegistryComponentConfigSchema,
   create: ({ config, dependencies, instance, logger, scope }) => {
@@ -59,6 +61,7 @@ export const workspaceRegistryComponent = defineWireComponent({
       killSessions,
       countSessions: createSessionCounter(sessionClients),
       scripts: dependencies.scripts,
+      env: () => dependencies.userEnv.get(),
       getHostSettings: async () => {
         const result = await dependencies.hostSettings.get();
         return result.success ? result.data.settings : {};

--- a/packages/core/src/runtimes/workspace-registry/node/copy-artifacts.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/copy-artifacts.ts
@@ -157,7 +157,7 @@ async function filterIgnored(
   const ignored = await git.schedule.run(
     { tier: 'background', repository: repositoryPath },
     async () => {
-      const child = git.exec(repositoryPath).spawn(['check-ignore', '--stdin', '-z']);
+      const child = await git.exec(repositoryPath).spawn(['check-ignore', '--stdin', '-z']);
       const stdoutChunks: Buffer[] = [];
       child.stdout.on('data', (chunk: Buffer) => stdoutChunks.push(chunk));
       child.stderr.resume();

--- a/packages/core/src/runtimes/workspace-registry/node/git-context-env.test.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/git-context-env.test.ts
@@ -1,0 +1,34 @@
+import { chmod, mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createRegistryGitContext } from './git-context';
+
+let temporaryDirectory: string | undefined;
+
+afterEach(async () => {
+  if (temporaryDirectory) await rm(temporaryDirectory, { recursive: true, force: true });
+  temporaryDirectory = undefined;
+});
+
+describe('createRegistryGitContext environment', () => {
+  it('loads the current environment and composes non-interactive overrides per spawn', async () => {
+    temporaryDirectory = await mkdtemp(path.join(os.tmpdir(), 'emdash-registry-git-env-'));
+    const binDirectory = path.join(temporaryDirectory, 'bin');
+    await mkdir(binDirectory);
+    await writeFile(
+      path.join(binDirectory, 'git'),
+      '#!/bin/sh\nprintf "%s|%s|%s" "$EMDASH_ENV_REVISION" "$LC_ALL" "$GIT_TERMINAL_PROMPT"\n'
+    );
+    await chmod(path.join(binDirectory, 'git'), 0o755);
+    let env = { PATH: binDirectory, EMDASH_ENV_REVISION: 'before-refresh' };
+    const git = createRegistryGitContext({ env: async () => env });
+
+    const before = await git.exec(temporaryDirectory).exec(['version']);
+    env = { PATH: binDirectory, EMDASH_ENV_REVISION: 'after-refresh' };
+    const after = await git.exec(temporaryDirectory).exec(['version']);
+
+    expect(before.stdout).toBe('before-refresh|C|0');
+    expect(after.stdout).toBe('after-refresh|C|0');
+  });
+});

--- a/packages/core/src/runtimes/workspace-registry/node/git-context.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/git-context.ts
@@ -1,3 +1,4 @@
+import type { EnvSource } from '#primitives/exec/api';
 import { createBoundExec, type BoundExec, type ExecOptions } from '#services/exec/api';
 import {
   GitSchedule,
@@ -6,26 +7,15 @@ import {
   type GitWorkTier,
 } from './git-schedule';
 
-const GIT_ENV = {
-  ...process.env,
-  LC_ALL: 'C',
-  LANG: 'C',
-  LANGUAGE: 'C',
-  GIT_TERMINAL_PROMPT: '0',
-  GIT_ASKPASS: '',
-};
-
-/**
- * Probes never take git's optional locks (`GIT_OPTIONAL_LOCKS=0`): a `status` probe
- * must not contend with a real mutator over the index lock (spec: git hygiene).
- */
-const PROBE_GIT_ENV = { ...GIT_ENV, GIT_OPTIONAL_LOCKS: '0' };
-
 export type RegistryGitExecOptions = {
   /** Budget priority class; defaults to 'probe' (the safe floor for read paths). */
   tier?: GitWorkTier;
   /** Repository key for idle gating; only meaningful for tiers above 'probe'. */
   repository?: string;
+};
+
+export type CreateRegistryGitContextOptions = GitScheduleOptions & {
+  env?: EnvSource;
 };
 
 /**
@@ -42,23 +32,27 @@ export type RegistryGitContext = {
 };
 
 /** Builds a real context; `GitScheduleOptions` is the composition-test lever. */
-export function createRegistryGitContext(options: GitScheduleOptions = {}): RegistryGitContext {
+export function createRegistryGitContext(
+  options: CreateRegistryGitContextOptions = {}
+): RegistryGitContext {
   const schedule = new GitSchedule(options);
+  const env = options.env ?? (async () => process.env);
   return {
     schedule,
     locks: new WorktreeWriteLocks(),
-    exec: (cwd, execOptions) => createRegistryGitExec(schedule, cwd, execOptions),
+    exec: (cwd, execOptions) => createRegistryGitExec(schedule, env, cwd, execOptions),
   };
 }
 
 /**
  * Every registry git subprocess flows through the context's budget (spec: git
  * concurrency model) — buffered exec calls acquire a slot for the subprocess's
- * lifetime at the caller's tier. `spawn` stays direct (its synchronous contract
- * cannot await a slot); spawn-based callers gate through `schedule.run` themselves.
+ * lifetime at the caller's tier. Spawn-based callers gate through `schedule.run`
+ * themselves because they retain the child process after creation.
  */
 function createRegistryGitExec(
   schedule: GitSchedule,
+  env: EnvSource,
   cwd: string,
   options: RegistryGitExecOptions = {}
 ): BoundExec {
@@ -67,7 +61,7 @@ function createRegistryGitExec(
   const inner = createBoundExec({
     file: 'git',
     cwd,
-    env: tier === 'probe' ? PROBE_GIT_ENV : GIT_ENV,
+    env: async () => registryGitEnv(await env(), tier === 'probe'),
   });
   return {
     get file() {
@@ -86,6 +80,18 @@ function createRegistryGitExec(
     execBuffer: (args, execOptions) =>
       schedule.run(work, () => inner.execBuffer(args, execOptions)),
     spawn: (args, spawnOptions) => inner.spawn(args, spawnOptions),
-    withCwd: (nextCwd: string) => createRegistryGitExec(schedule, nextCwd, options),
+    withCwd: (nextCwd: string) => createRegistryGitExec(schedule, env, nextCwd, options),
+  };
+}
+
+function registryGitEnv(base: NodeJS.ProcessEnv, probe: boolean): NodeJS.ProcessEnv {
+  return {
+    ...base,
+    LC_ALL: 'C',
+    LANG: 'C',
+    LANGUAGE: 'C',
+    GIT_TERMINAL_PROMPT: '0',
+    GIT_ASKPASS: '',
+    ...(probe ? { GIT_OPTIONAL_LOCKS: '0' } : {}),
   };
 }

--- a/packages/core/src/runtimes/workspace-registry/node/inspect-path.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/inspect-path.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import type { EnvSource } from '#primitives/exec/api';
 import { createBoundExec, ExecError } from '#services/exec/api';
 
 /** What the host found at a canonical directory path (kind is host-detected, ADR 0005). */
@@ -25,27 +26,21 @@ export async function canonicalizeWorkspacePath(inputPath: string): Promise<stri
   }
 }
 
-const NON_INTERACTIVE_ENV = {
-  ...process.env,
-  LC_ALL: 'C',
-  LANG: 'C',
-  LANGUAGE: 'C',
-  GIT_TERMINAL_PROMPT: '0',
-  GIT_ASKPASS: '',
-};
-
 /**
  * Detects what a directory is: the toplevel of a repository, the toplevel of a linked
  * worktree (with its admin name and owning repository path), or a plain directory —
  * including directories inside a repository that are not its toplevel.
  */
-export async function inspectWorkspacePath(canonicalPath: string): Promise<PathInspection> {
+export async function inspectWorkspacePath(
+  canonicalPath: string,
+  env: EnvSource = async () => process.env
+): Promise<PathInspection> {
   let stdout: string;
   try {
     ({ stdout } = await createBoundExec({
       file: 'git',
       cwd: canonicalPath,
-      env: NON_INTERACTIVE_ENV,
+      env: async () => nonInteractiveEnv(await env()),
     }).exec(['rev-parse', '--show-toplevel', '--git-dir', '--git-common-dir'], {
       timeoutMs: 10_000,
     }));
@@ -79,6 +74,17 @@ export async function inspectWorkspacePath(canonicalPath: string): Promise<PathI
   // working directory is the parent of the common .git dir.
   const repositoryPath = await realpathSafe(path.dirname(commonDir));
   return { kind: 'worktree', repositoryPath, gitAdminName: path.basename(gitDir) };
+}
+
+function nonInteractiveEnv(base: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return {
+    ...base,
+    LC_ALL: 'C',
+    LANG: 'C',
+    LANGUAGE: 'C',
+    GIT_TERMINAL_PROMPT: '0',
+    GIT_ASKPASS: '',
+  };
 }
 
 async function realpathSafe(target: string): Promise<string> {

--- a/packages/core/src/runtimes/workspace-registry/node/runtime.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/runtime.ts
@@ -17,6 +17,7 @@ import {
   type Family,
   type Query,
 } from '@emdash/wire/state';
+import type { EnvSource } from '#primitives/exec/api';
 import type { StoreHandle } from '#primitives/sqlite-store/api';
 // oxlint-disable-next-line emdash/core-module-boundaries -- the registry sequences lifecycle scripts through the scripts runtime (activation-scripts-via-terminals spec); the contract has no services-level home yet
 import type { ScriptWorkspaceFacts } from '#runtimes/scripts/api';
@@ -108,6 +109,7 @@ import { executeUpdateWorktree, type UpdateWorktreeExecutionResult } from './upd
 
 export type WorkspaceRegistryRuntimeOptions = {
   handle: StoreHandle<WorkspaceRegistryDb>;
+  env?: EnvSource;
   clock?: Clock;
   logger?: Logger;
   /** Test seam for hosts without git; production always inspects the real filesystem. */
@@ -214,10 +216,11 @@ export class WorkspaceRegistryRuntime {
   readonly scanner: RegistryScanner;
 
   constructor(options: WorkspaceRegistryRuntimeOptions) {
+    const env = options.env ?? (async () => process.env);
     this.clock = options.clock ?? systemClock;
     this.logger = options.logger ?? noopLogger;
-    this.inspector = options.inspector ?? inspectWorkspacePath;
-    this.gitContext = options.gitContext ?? createRegistryGitContext();
+    this.inspector = options.inspector ?? ((path) => inspectWorkspacePath(path, env));
+    this.gitContext = options.gitContext ?? createRegistryGitContext({ env });
     this.onRecordsChanged = options.onRecordsChanged;
     this.store = new WorkspaceRecordStore(options.handle);
     this.killSessions = options.killSessions ?? (async () => undefined);

--- a/packages/core/src/runtimes/workspace-registry/node/worker-spec.test.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/worker-spec.test.ts
@@ -13,6 +13,7 @@ describe('workspaceRegistryWorkerSpec', () => {
     expect(component.id).toBe('workspace-registry');
     expect(options.name).toBe('workspace-registry');
     expect(options.env).toBe(env);
+    expect(component.requirements).toHaveProperty('userEnv');
     expect(options.supervision).toBeUndefined();
     expect(options.shutdownGraceMs).toBe(3_000);
     expect(component.configSchema.parse(options.config)).toEqual({

--- a/packages/core/src/services/agent-plugins/api/plugins/plugin-host.test.ts
+++ b/packages/core/src/services/agent-plugins/api/plugins/plugin-host.test.ts
@@ -1,6 +1,6 @@
 import { createScope } from '@emdash/shared/concurrency';
 import { describe, expect, it, vi } from 'vitest';
-import type { IExecutionContext } from '#primitives/exec/api';
+import type { EnvSource, IExecutionContext } from '#primitives/exec/api';
 import type { HostDependencyResolver } from '#primitives/host-dependencies/api';
 import type { IAcpBehavior } from '#services/agent-plugins/api/plugins/capabilities/acp';
 import type { IAgentAuthBehavior } from '#services/agent-plugins/api/plugins/capabilities/auth';
@@ -230,9 +230,24 @@ describe('AgentPluginHost', () => {
     await expect(host.readMcpServers('test')).resolves.toEqual({ success: true, data: servers });
     expect(readServers).toHaveBeenCalledWith(expect.any(Object));
   });
+
+  it('loads the current user environment for each agent spawn context', async () => {
+    let env = { HOME: '/home/test', PATH: '/tools/old' };
+    const host = createHost([plugin()], async () => env);
+
+    const before = await host.resolveSpawnContext('test');
+    env = { HOME: '/home/test', PATH: '/tools/new' };
+    const after = await host.resolveSpawnContext('test');
+
+    expect(before).toMatchObject({ success: true, data: { agentEnv: { PATH: '/tools/old' } } });
+    expect(after).toMatchObject({ success: true, data: { agentEnv: { PATH: '/tools/new' } } });
+  });
 });
 
-function createHost(plugins: CLIAgentPluginProvider[]): AgentPluginHost {
+function createHost(
+  plugins: CLIAgentPluginProvider[],
+  env: EnvSource = async () => ({ HOME: '/home/test', PATH: '/bin', UNSAFE_ENV: 'nope' })
+): AgentPluginHost {
   const registry = createPluginRegistry<CLIAgentPluginProvider>();
   for (const item of plugins) registry.register(item);
   return new AgentPluginHost({
@@ -241,7 +256,7 @@ function createHost(plugins: CLIAgentPluginProvider[]): AgentPluginHost {
     exec: fakeExec(),
     dependencies: fakeDependencies(),
     fs: memoryFs(),
-    env: { HOME: '/home/test', PATH: '/bin', UNSAFE_ENV: 'nope' },
+    env,
     homeDir: '/home/test',
   });
 }

--- a/packages/core/src/services/agent-plugins/api/plugins/plugin-host.ts
+++ b/packages/core/src/services/agent-plugins/api/plugins/plugin-host.ts
@@ -3,7 +3,7 @@ import type { Scope } from '@emdash/shared/concurrency';
 import type { PluginRegistry } from '@emdash/shared/plugins';
 import { compose, deduplicate } from '@emdash/shared/requests';
 import { buildAllowlistedAgentEnv } from '#primitives/agent-env/api';
-import type { IExecutionContext } from '#primitives/exec/api';
+import type { EnvSource, IExecutionContext } from '#primitives/exec/api';
 import type { HostDependencyResolver, Platform } from '#primitives/host-dependencies/api';
 import type { PluginFs } from '#primitives/plugin-fs/api';
 import type {
@@ -56,7 +56,7 @@ export type AgentHostDeps = {
   exec: IExecutionContext;
   dependencies: HostDependencyResolver;
   fs: PluginFs;
-  env: Record<string, string | undefined>;
+  env: EnvSource;
   homeDir: string;
   platform?: Platform;
 };
@@ -116,9 +116,9 @@ export class AgentPluginHost {
     return this.deps.homeDir;
   }
 
-  configRootContext(): ConfigRootContext {
+  async configRootContext(): Promise<ConfigRootContext> {
     return {
-      env: buildAllowlistedAgentEnv(this.deps.env, {
+      env: buildAllowlistedAgentEnv(await this.deps.env(), {
         homeDir: this.deps.homeDir,
         includeShellVar: true,
       }),

--- a/packages/core/src/services/agent-plugins/api/spawn-context.ts
+++ b/packages/core/src/services/agent-plugins/api/spawn-context.ts
@@ -1,5 +1,6 @@
 import { err, ok, type Result } from '@emdash/shared';
 import { buildAllowlistedAgentEnv } from '#primitives/agent-env/api';
+import type { EnvSource } from '#primitives/exec/api';
 
 export type SpawnContext = {
   cli: string;
@@ -17,7 +18,7 @@ export interface SpawnContextResolver {
 
 export type CreateSpawnContextResolverOptions = {
   resolveCli: (providerId: string) => Promise<string>;
-  env: Record<string, string | undefined>;
+  env: EnvSource;
   homeDir: string;
   includeShellVar?: boolean;
   hasProvider?: (providerId: string) => boolean;
@@ -32,7 +33,7 @@ export function createSpawnContextResolver(
     }
 
     try {
-      return ok({ cli: await options.resolveCli(providerId), agentEnv: buildAgentEnv() });
+      return ok({ cli: await options.resolveCli(providerId), agentEnv: await buildAgentEnv() });
     } catch (error: unknown) {
       return err({
         type: 'cli-not-found',
@@ -46,8 +47,8 @@ export function createSpawnContextResolver(
 
   return { resolve, invalidate };
 
-  function buildAgentEnv(): Record<string, string> {
-    return buildAllowlistedAgentEnv(options.env, {
+  async function buildAgentEnv(): Promise<Record<string, string>> {
+    return buildAllowlistedAgentEnv(await options.env(), {
       homeDir: options.homeDir,
       includeShellVar: options.includeShellVar,
     });

--- a/packages/core/src/services/agent-plugins/node/hook-installer.test.ts
+++ b/packages/core/src/services/agent-plugins/node/hook-installer.test.ts
@@ -175,7 +175,7 @@ function createInstaller(
       exists: async () => false,
       list: async () => [],
     },
-    env: { HOME: homeDir, PATH: '/bin', ...env },
+    env: async () => ({ HOME: homeDir, PATH: '/bin', ...env }),
     homeDir,
     platform: 'linux',
   });

--- a/packages/core/src/services/agent-plugins/node/hook-installer.ts
+++ b/packages/core/src/services/agent-plugins/node/hook-installer.ts
@@ -87,7 +87,7 @@ export class AgentHookInstaller {
     const descriptor = plugin?.capabilities.hooks;
     if (!plugin || !descriptor || descriptor.kind === 'none') return null;
 
-    const configContext = this.options.agentHost.configRootContext();
+    const configContext = await this.options.agentHost.configRootContext();
     if (descriptor.kind === 'config' && plugin.behavior.hooks) {
       const behavior = plugin.behavior.hooks;
       const roots =

--- a/packages/core/src/services/exec/api/bound-exec.test.ts
+++ b/packages/core/src/services/exec/api/bound-exec.test.ts
@@ -34,7 +34,7 @@ describe('BoundExec', () => {
 
   it('opens a piped child with the bound cwd and environment', async () => {
     const cwd = await mkdtemp(path.join(tmpdir(), 'emdash-shared-exec-spawn-'));
-    const child = createBoundExec({
+    const child = await createBoundExec({
       file: process.execPath,
       cwd,
       env: { ...process.env, EMDASH_EXEC_TEST: 'configured' },

--- a/packages/core/src/services/exec/api/bound-exec.ts
+++ b/packages/core/src/services/exec/api/bound-exec.ts
@@ -1,6 +1,7 @@
 import { spawn as spawnProcess } from 'node:child_process';
 import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from 'node:child_process';
 import { classifySpawnPurpose, recordSpawn } from '@emdash/shared/perf';
+import type { EnvSource } from '#primitives/exec/api';
 import {
   ExecError,
   type BoundExec,
@@ -16,7 +17,7 @@ const TIMEOUT_KILL_GRACE_MS = 1_000;
 export type CreateBoundExecOptions = {
   file: string;
   cwd: string;
-  env?: NodeJS.ProcessEnv;
+  env?: NodeJS.ProcessEnv | EnvSource;
 };
 
 export function createBoundExec(options: CreateBoundExecOptions): BoundExec {
@@ -32,7 +33,7 @@ class ProcessBoundExec implements BoundExec {
   constructor(
     readonly file: string,
     readonly cwd: string,
-    readonly env?: NodeJS.ProcessEnv
+    readonly env?: NodeJS.ProcessEnv | EnvSource
   ) {}
 
   async exec(args: string[], options: ExecOptions = {}): Promise<ExecResult> {
@@ -55,11 +56,15 @@ class ProcessBoundExec implements BoundExec {
     return { stdout: Buffer.concat(chunks), stderr };
   }
 
-  spawn(args: string[], options: ExecSpawnOptions = {}): ChildProcessWithoutNullStreams {
+  async spawn(
+    args: string[],
+    options: ExecSpawnOptions = {}
+  ): Promise<ChildProcessWithoutNullStreams> {
+    const env = await resolveEnv(this.env);
     recordSpawn(classifySpawnPurpose(this.file, args), this.file);
     return spawnProcess(this.file, args, {
       cwd: options.cwd ?? this.cwd,
-      env: composeEnv(this.env, options.env),
+      env: composeEnv(env, options.env),
       signal: options.signal,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
@@ -69,11 +74,16 @@ class ProcessBoundExec implements BoundExec {
     return new ProcessBoundExec(this.file, cwd, this.env);
   }
 
-  private run(args: string[], options: ExecOptions, sink: StdoutSink): Promise<{ stderr: string }> {
+  private async run(
+    args: string[],
+    options: ExecOptions,
+    sink: StdoutSink
+  ): Promise<{ stderr: string }> {
+    const env = await resolveEnv(this.env);
     return new Promise((resolve, reject) => {
       const spawnOptions: SpawnOptionsWithoutStdio = {
         cwd: options.cwd ?? this.cwd,
-        env: composeEnv(this.env, options.env),
+        env: composeEnv(env, options.env),
         detached: process.platform !== 'win32',
       };
       recordSpawn(classifySpawnPurpose(this.file, args), this.file);
@@ -196,6 +206,12 @@ class ProcessBoundExec implements BoundExec {
       });
     });
   }
+}
+
+async function resolveEnv(
+  env: NodeJS.ProcessEnv | EnvSource | undefined
+): Promise<NodeJS.ProcessEnv | undefined> {
+  return typeof env === 'function' ? await env() : env;
 }
 
 function composeEnv(

--- a/packages/core/src/services/exec/api/node-execution-context.test.ts
+++ b/packages/core/src/services/exec/api/node-execution-context.test.ts
@@ -34,4 +34,16 @@ describe('NodeExecutionContext', () => {
 
     expect(result).toEqual({ exitCode: 0 });
   });
+
+  it('resolves the current environment for every command spawn', async () => {
+    let env = { EMDASH_ENV_REVISION: 'before-refresh' };
+    const context = new NodeExecutionContext({ env: async () => env });
+
+    const before = await context.exec(process.execPath, ['-p', 'process.env.EMDASH_ENV_REVISION']);
+    env = { EMDASH_ENV_REVISION: 'after-refresh' };
+    const after = await context.exec(process.execPath, ['-p', 'process.env.EMDASH_ENV_REVISION']);
+
+    expect(before.stdout.trim()).toBe('before-refresh');
+    expect(after.stdout.trim()).toBe('after-refresh');
+  });
 });

--- a/packages/core/src/services/exec/api/node-execution-context.ts
+++ b/packages/core/src/services/exec/api/node-execution-context.ts
@@ -1,6 +1,7 @@
 import { execFile, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 import { classifySpawnPurpose, recordSpawn } from '@emdash/shared/perf';
+import type { EnvSource } from '#primitives/exec/api';
 import type {
   ExecContextOptions,
   ExecStreamingResult,
@@ -12,7 +13,7 @@ const execFileAsync = promisify(execFile);
 
 export type NodeExecutionContextOptions = {
   root?: string;
-  env?: NodeJS.ProcessEnv;
+  env?: NodeJS.ProcessEnv | EnvSource;
   refreshShellEnv?: () => Promise<void>;
 };
 
@@ -29,25 +30,31 @@ export class NodeExecutionContext implements IExecutionContext {
     this.refreshShellEnvDelegate = options.refreshShellEnv;
   }
 
-  private readonly env: NodeJS.ProcessEnv | undefined;
+  private readonly env: NodeJS.ProcessEnv | EnvSource | undefined;
 
-  exec(command: string, args: string[] = [], opts: ExecContextOptions = {}): Promise<ExecResult> {
+  async exec(
+    command: string,
+    args: string[] = [],
+    opts: ExecContextOptions = {}
+  ): Promise<ExecResult> {
+    const env = await this.resolveEnv();
     recordSpawn(classifySpawnPurpose(command, args), command);
-    return execFileAsync(command, args, {
+    return (await execFileAsync(command, args, {
       cwd: this.root || undefined,
-      env: this.env,
+      env,
       timeout: opts.timeout,
       maxBuffer: opts.maxBuffer,
       signal: this.signal(opts.signal),
-    }) as Promise<ExecResult>;
+    })) as ExecResult;
   }
 
-  execStreaming(
+  async execStreaming(
     command: string,
     args: string[],
     onChunk: (chunk: string) => boolean,
     opts: { signal?: AbortSignal } = {}
   ): Promise<ExecStreamingResult> {
+    const env = await this.resolveEnv();
     return new Promise((resolve, reject) => {
       const signal = this.signal(opts.signal);
       if (signal.aborted) {
@@ -58,7 +65,7 @@ export class NodeExecutionContext implements IExecutionContext {
       recordSpawn(classifySpawnPurpose(command, args), command);
       const child = spawn(command, args, {
         cwd: this.root || undefined,
-        env: this.env,
+        env,
       });
       let settled = false;
 
@@ -106,5 +113,9 @@ export class NodeExecutionContext implements IExecutionContext {
     return callerSignal
       ? AbortSignal.any([this.lifetime.signal, callerSignal])
       : this.lifetime.signal;
+  }
+
+  private async resolveEnv(): Promise<NodeJS.ProcessEnv | undefined> {
+    return typeof this.env === 'function' ? await this.env() : this.env;
   }
 }

--- a/packages/core/src/services/exec/api/types.ts
+++ b/packages/core/src/services/exec/api/types.ts
@@ -1,4 +1,5 @@
 import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import type { EnvSource } from '#primitives/exec/api';
 
 export type ExecOptions = {
   cwd?: string;
@@ -37,7 +38,7 @@ export class ExecError extends Error {
 export type BoundExec = {
   readonly file: string;
   readonly cwd: string;
-  readonly env?: NodeJS.ProcessEnv;
+  readonly env?: NodeJS.ProcessEnv | EnvSource;
   exec(args: string[], options?: ExecOptions): Promise<ExecResult>;
   execStreaming(
     args: string[],
@@ -45,6 +46,9 @@ export type BoundExec = {
     options?: ExecOptions
   ): Promise<void>;
   execBuffer(args: string[], options?: ExecOptions): Promise<ExecBufferResult>;
-  spawn(args: string[], options?: ExecSpawnOptions): ChildProcessWithoutNullStreams;
+  spawn(
+    args: string[],
+    options?: ExecSpawnOptions
+  ): ChildProcessWithoutNullStreams | Promise<ChildProcessWithoutNullStreams>;
   withCwd(cwd: string): BoundExec;
 };

--- a/packages/core/src/services/host-dependencies/node/runtime.test.ts
+++ b/packages/core/src/services/host-dependencies/node/runtime.test.ts
@@ -84,6 +84,9 @@ describe('HostDependenciesRuntime.runInstallCommand', () => {
       { signal: expect.any(AbortSignal) }
     );
     expect(exec.refreshShellEnv).toHaveBeenCalledOnce();
+    expect(vi.mocked(exec.execStreaming).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(exec.refreshShellEnv!).mock.invocationCallOrder[0]!
+    );
     expect(progress).toHaveBeenCalledWith({ phase: 'resolving' });
     expect(progress).toHaveBeenCalledWith({ phase: 'running' });
     expect(progress).toHaveBeenCalledWith({ phase: 'refreshing' });

--- a/packages/core/src/services/pty/api/terminal-env.ts
+++ b/packages/core/src/services/pty/api/terminal-env.ts
@@ -5,20 +5,18 @@ import {
 } from '#primitives/git-credentials/api';
 import type { ResolvedPtyShellProfile } from './local-spawn';
 
-export function buildTerminalEnv(
-  options: {
-    shellProfile?: ResolvedPtyShellProfile;
-    baseEnv?: NodeJS.ProcessEnv | Record<string, string | undefined>;
-    overrides?: Record<string, string | undefined>;
-    /**
-     * Per-session git credential behavior (spec: github-git-settings §4).
-     * Applied last so scrubbing ("none") wins over base env and overrides;
-     * absent means native/system behavior.
-     */
-    gitCredentials?: GitCredentialsSessionSpec;
-  } = {}
-): Record<string, string> {
-  const source = options.baseEnv ?? process.env;
+export function buildTerminalEnv(options: {
+  shellProfile?: ResolvedPtyShellProfile;
+  baseEnv: NodeJS.ProcessEnv | Record<string, string | undefined>;
+  overrides?: Record<string, string | undefined>;
+  /**
+   * Per-session git credential behavior (spec: github-git-settings §4).
+   * Applied last so scrubbing ("none") wins over base env and overrides;
+   * absent means native/system behavior.
+   */
+  gitCredentials?: GitCredentialsSessionSpec;
+}): Record<string, string> {
+  const source = options.baseEnv;
   const env: Record<string, string> = {};
   for (const [key, val] of Object.entries(source)) {
     if (val !== undefined) env[key] = val;

--- a/packages/core/src/services/shell-env/api/contract.ts
+++ b/packages/core/src/services/shell-env/api/contract.ts
@@ -1,0 +1,15 @@
+import { defineContract, procedure } from '@emdash/wire/rpc';
+import { z } from 'zod';
+
+export const userShellEnvSchema = z.record(z.string(), z.string());
+
+/** Parent-owned source of the latest captured user-shell environment. */
+export const userShellEnvContract = defineContract({
+  get: procedure({
+    input: z.void().optional(),
+    output: userShellEnvSchema,
+  }),
+});
+
+export type UserShellEnv = z.output<typeof userShellEnvSchema>;
+export type UserShellEnvContract = typeof userShellEnvContract;

--- a/packages/core/src/services/shell-env/api/index.ts
+++ b/packages/core/src/services/shell-env/api/index.ts
@@ -1,0 +1,6 @@
+export {
+  userShellEnvContract,
+  userShellEnvSchema,
+  type UserShellEnv,
+  type UserShellEnvContract,
+} from './contract';

--- a/packages/core/src/services/shell-env/node/capture.test.ts
+++ b/packages/core/src/services/shell-env/node/capture.test.ts
@@ -46,7 +46,9 @@ describe('captureShellEnv', () => {
       error: undefined,
       status: 0,
       stderr: '',
-      stdout: 'PATH=/usr/local/bin:/usr/bin\nFOO=bar\n',
+      stdout:
+        'PATH=/usr/local/bin:/usr/bin\nFOO=bar\nDISABLE_AUTO_UPDATE=true\n' +
+        'ZSH_TMUX_AUTOSTART=false\nZSH_TMUX_AUTOSTARTED=true\n',
     });
 
     const result = await captureShellEnv({

--- a/packages/core/src/services/shell-env/node/capture.ts
+++ b/packages/core/src/services/shell-env/node/capture.ts
@@ -33,7 +33,7 @@ export async function captureShellEnv(
 
   if (process.platform === 'win32') {
     return ok({
-      env: stringEnv(baseEnv),
+      env: withoutCaptureGuard(stringEnv(baseEnv)),
       source: 'windows',
       capturedAt: now(),
     });
@@ -71,10 +71,17 @@ export async function captureShellEnv(
   }
 
   return ok({
-    env: parseEnvOutput(result.stdout),
+    env: withoutCaptureGuard(parseEnvOutput(result.stdout)),
     source: 'login-shell',
     capturedAt: now(),
   });
+}
+
+function withoutCaptureGuard(env: Record<string, string>): Record<string, string> {
+  for (const key of Object.keys(SHELL_ENV_CAPTURE_GUARD)) {
+    delete env[key];
+  }
+  return env;
 }
 
 export function resolveLoginShell(env: NodeJS.ProcessEnv = process.env): string {

--- a/packages/core/src/services/shell-env/node/controller.test.ts
+++ b/packages/core/src/services/shell-env/node/controller.test.ts
@@ -1,0 +1,50 @@
+import { createTestWire } from '@emdash/wire/testing';
+import { describe, expect, it } from 'vitest';
+import { userShellEnvContract } from '#services/shell-env/api';
+import { createUserShellEnvController } from './controller';
+
+describe('createUserShellEnvController', () => {
+  it('reads the current parent-owned snapshot on every request', async () => {
+    let userEnv = { PATH: '/tools/old', USER_VALUE: 'before-refresh' };
+    const wire = createTestWire(
+      userShellEnvContract,
+      createUserShellEnvController(async () => userEnv)
+    );
+
+    try {
+      await expect(wire.client.get()).resolves.toEqual(userEnv);
+
+      userEnv = { PATH: '/tools/new', USER_VALUE: 'after-refresh' };
+
+      await expect(wire.client.get()).resolves.toEqual(userEnv);
+    } finally {
+      wire.dispose();
+    }
+  });
+
+  it('waits for an in-flight refresh before responding', async () => {
+    let release!: () => void;
+    const refresh = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const wire = createTestWire(
+      userShellEnvContract,
+      createUserShellEnvController(async () => {
+        await refresh;
+        return { PATH: '/tools/new', USER_VALUE: 'after-refresh' };
+      })
+    );
+
+    try {
+      const request = wire.client.get();
+      release();
+
+      await expect(request).resolves.toEqual({
+        PATH: '/tools/new',
+        USER_VALUE: 'after-refresh',
+      });
+    } finally {
+      wire.dispose();
+    }
+  });
+});

--- a/packages/core/src/services/shell-env/node/controller.ts
+++ b/packages/core/src/services/shell-env/node/controller.ts
@@ -1,0 +1,10 @@
+import { createController, type Controller } from '@emdash/wire/rpc';
+import { userShellEnvContract, type UserShellEnv } from '#services/shell-env/api';
+
+export function createUserShellEnvController(
+  getUserShellEnv: () => Promise<UserShellEnv>
+): Controller {
+  return createController(userShellEnvContract, {
+    get: () => getUserShellEnv(),
+  });
+}

--- a/packages/core/src/services/shell-env/node/index.ts
+++ b/packages/core/src/services/shell-env/node/index.ts
@@ -12,6 +12,7 @@ export {
   resolveLoginShell,
   type CaptureShellEnvOptions,
 } from './capture';
+export { createUserShellEnvController } from './controller';
 export { createShellEnvManager, type CreateShellEnvManagerOptions } from './manager';
 export { buildUserShellEnvSeed } from './user-env';
 export {

--- a/packages/core/src/services/shell-env/node/index.ts
+++ b/packages/core/src/services/shell-env/node/index.ts
@@ -13,6 +13,7 @@ export {
   type CaptureShellEnvOptions,
 } from './capture';
 export { createShellEnvManager, type CreateShellEnvManagerOptions } from './manager';
+export { buildUserShellEnvSeed } from './user-env';
 export {
   DEFAULT_SHELL_ENV_PRESERVE_KEYS,
   SHELL_ENV_CAPTURE_GUARD,

--- a/packages/core/src/services/shell-env/node/manager.test.ts
+++ b/packages/core/src/services/shell-env/node/manager.test.ts
@@ -31,6 +31,25 @@ beforeEach(() => {
 });
 
 describe('createShellEnvManager', () => {
+  it('starts and awaits the initial capture from current()', async () => {
+    spawnSyncMock.mockReturnValue({
+      error: undefined,
+      status: 0,
+      stderr: '',
+      stdout: 'PATH=/shell/bin\nFOO=initial\n',
+    });
+    const manager = createShellEnvManager({
+      target: { PATH: '/worker/bin' },
+      baseEnvForProbe: () => ({ SHELL: '/bin/bash', PATH: '/worker/bin' }),
+    });
+
+    await expect(manager.current()).resolves.toMatchObject({
+      FOO: 'initial',
+      PATH: '/shell/bin:/worker/bin',
+    });
+    expect(spawnSyncMock).toHaveBeenCalledOnce();
+  });
+
   it('coalesces concurrent refreshes', async () => {
     spawnSyncMock.mockReturnValue({
       error: undefined,
@@ -95,6 +114,38 @@ describe('createShellEnvManager', () => {
     expect(manager.getUserShellEnv().NODE_ENV).toBe('development');
   });
 
+  it('retains the last snapshot until an in-flight refresh publishes atomically', async () => {
+    spawnSyncMock.mockReturnValue({
+      error: undefined,
+      status: 0,
+      stderr: '',
+      stdout: 'PATH=/tools/old\nUSER_VALUE=before-refresh\n',
+    });
+    const manager = createShellEnvManager({
+      target: { PATH: '/worker/bin' },
+      baseEnvForProbe: () => ({ SHELL: '/bin/bash', PATH: '/worker/bin' }),
+    });
+    await manager.refresh();
+
+    spawnSyncMock.mockReturnValue({
+      error: undefined,
+      status: 0,
+      stderr: '',
+      stdout: 'PATH=/tools/new\nUSER_VALUE=after-refresh\n',
+    });
+    const refresh = manager.refresh();
+
+    expect(manager.getUserShellEnv()).toMatchObject({
+      PATH: '/tools/old:/worker/bin',
+      USER_VALUE: 'before-refresh',
+    });
+    await expect(manager.current()).resolves.toMatchObject({
+      PATH: '/tools/new:/worker/bin',
+      USER_VALUE: 'after-refresh',
+    });
+    await refresh;
+  });
+
   it('logs and keeps the existing env when capture fails', async () => {
     const warn = vi.fn();
     spawnSyncMock.mockReturnValue({
@@ -117,5 +168,36 @@ describe('createShellEnvManager', () => {
       expect.objectContaining({ shell: '/bin/bash', error: 'spawn failed' })
     );
     expect(target).toEqual({ PATH: '/usr/bin' });
+    await expect(manager.current()).resolves.toEqual({
+      PATH: '/probe/bin',
+      SHELL: '/bin/bash',
+    });
+  });
+
+  it('retains the last known-good snapshot when a later refresh fails', async () => {
+    spawnSyncMock.mockReturnValue({
+      error: undefined,
+      status: 0,
+      stderr: '',
+      stdout: 'PATH=/tools/good\nUSER_VALUE=known-good\n',
+    });
+    const manager = createShellEnvManager({
+      target: { PATH: '/worker/bin' },
+      baseEnvForProbe: () => ({ SHELL: '/bin/bash', PATH: '/worker/bin' }),
+    });
+    await manager.refresh();
+
+    spawnSyncMock.mockReturnValue({
+      error: new Error('refresh failed'),
+      status: null,
+      stderr: '',
+      stdout: '',
+    });
+    await manager.refresh();
+
+    await expect(manager.current()).resolves.toMatchObject({
+      PATH: '/tools/good:/worker/bin',
+      USER_VALUE: 'known-good',
+    });
   });
 });

--- a/packages/core/src/services/shell-env/node/manager.test.ts
+++ b/packages/core/src/services/shell-env/node/manager.test.ts
@@ -49,6 +49,50 @@ describe('createShellEnvManager', () => {
     expect(spawnSyncMock).toHaveBeenCalledTimes(1);
     expect(target.FOO).toBe('bar');
     expect(target.PATH).toBe('/usr/local/bin:/usr/bin');
+    expect(manager.getUserShellEnv()).toMatchObject({
+      FOO: 'bar',
+      PATH: '/usr/local/bin:/usr/bin',
+    });
+  });
+
+  it('keeps runtime controls in the host env but excludes them from the user snapshot', async () => {
+    spawnSyncMock.mockReturnValue({
+      error: undefined,
+      status: 0,
+      stderr: '',
+      stdout: 'PATH=/shell/bin\nUSER_VALUE=kept\n',
+    });
+    const target: NodeJS.ProcessEnv = {
+      PATH: '/worker/bin',
+      NODE_ENV: 'production',
+      ELECTRON_RUN_AS_NODE: '1',
+    };
+    const manager = createShellEnvManager({ target });
+
+    await manager.refresh();
+
+    expect(target.NODE_ENV).toBe('production');
+    expect(target.ELECTRON_RUN_AS_NODE).toBe('1');
+    expect(manager.getUserShellEnv()).toEqual({
+      PATH: '/shell/bin:/worker/bin',
+      USER_VALUE: 'kept',
+    });
+  });
+
+  it('preserves a runtime-named variable when the login shell explicitly exports it', async () => {
+    spawnSyncMock.mockReturnValue({
+      error: undefined,
+      status: 0,
+      stderr: '',
+      stdout: 'PATH=/shell/bin\nNODE_ENV=development\n',
+    });
+    const target: NodeJS.ProcessEnv = { PATH: '/worker/bin', NODE_ENV: 'production' };
+    const manager = createShellEnvManager({ target });
+
+    await manager.refresh();
+
+    expect(target.NODE_ENV).toBe('production');
+    expect(manager.getUserShellEnv().NODE_ENV).toBe('development');
   });
 
   it('logs and keeps the existing env when capture fails', async () => {

--- a/packages/core/src/services/shell-env/node/manager.ts
+++ b/packages/core/src/services/shell-env/node/manager.ts
@@ -15,26 +15,40 @@ export function createShellEnvManager(options: CreateShellEnvManagerOptions = {}
   const target = options.target ?? process.env;
   const userEnv = stringEnv(buildUserShellEnvSeed(options.baseEnvForProbe?.() ?? target));
   let inFlight: Promise<void> | undefined;
+  let captureStarted = false;
+  let hasGoodSnapshot = false;
+
+  const refresh = (): Promise<void> => {
+    captureStarted = true;
+    inFlight ??= refreshShellEnv(target, userEnv, hasGoodSnapshot, options)
+      .then((succeeded) => {
+        if (succeeded) hasGoodSnapshot = true;
+      })
+      .finally(() => {
+        inFlight = undefined;
+      });
+    return inFlight;
+  };
 
   return {
     env: target,
-    getUserShellEnv: () => ({ ...userEnv }),
-    refresh() {
-      inFlight ??= refreshShellEnv(target, userEnv, options).finally(() => {
-        inFlight = undefined;
-      });
-      return inFlight;
+    async current() {
+      if (!captureStarted) await refresh();
+      else await inFlight;
+      return { ...userEnv };
     },
+    getUserShellEnv: () => ({ ...userEnv }),
+    refresh,
   };
 }
 
 async function refreshShellEnv(
   target: NodeJS.ProcessEnv,
   userEnv: Record<string, string>,
+  hasGoodSnapshot: boolean,
   options: CreateShellEnvManagerOptions
-): Promise<void> {
+): Promise<boolean> {
   const baseEnv = buildUserShellEnvSeed(options.baseEnvForProbe?.() ?? target);
-  replaceEnv(userEnv, stringEnv(baseEnv));
   const capture = await captureShellEnv({
     baseEnv,
     timeoutMs: options.timeoutMs,
@@ -45,21 +59,25 @@ async function refreshShellEnv(
       shell: capture.error.shell,
       error: capture.error.message,
     });
-    return;
+    if (!hasGoodSnapshot) replaceEnv(userEnv, stringEnv(baseEnv));
+    return false;
   }
 
   applyShellEnvCapture(target, capture.data, options.policy, { mergeBaseEnv: baseEnv });
+  const nextUserEnv = stringEnv(baseEnv);
   applyShellEnvCapture(
-    userEnv,
+    nextUserEnv,
     capture.data,
     { ...options.policy, preserveKeys: new Set() },
     { mergeBaseEnv: baseEnv }
   );
+  replaceEnv(userEnv, nextUserEnv);
 
   options.logger?.info?.('[shell-env] Resolved shell env', {
     source: capture.data.source,
     pathEntries: target.PATH?.split(process.platform === 'win32' ? ';' : ':').length ?? 0,
   });
+  return true;
 }
 
 function stringEnv(env: NodeJS.ProcessEnv): Record<string, string> {

--- a/packages/core/src/services/shell-env/node/manager.ts
+++ b/packages/core/src/services/shell-env/node/manager.ts
@@ -1,6 +1,7 @@
 import { applyShellEnvCapture } from './apply';
 import { captureShellEnv } from './capture';
 import { type ShellEnvLogger, type ShellEnvManager, type ShellEnvPolicy } from './types';
+import { buildUserShellEnvSeed } from './user-env';
 
 export type CreateShellEnvManagerOptions = {
   readonly target?: NodeJS.ProcessEnv;
@@ -12,12 +13,14 @@ export type CreateShellEnvManagerOptions = {
 
 export function createShellEnvManager(options: CreateShellEnvManagerOptions = {}): ShellEnvManager {
   const target = options.target ?? process.env;
+  const userEnv = stringEnv(buildUserShellEnvSeed(options.baseEnvForProbe?.() ?? target));
   let inFlight: Promise<void> | undefined;
 
   return {
     env: target,
+    getUserShellEnv: () => ({ ...userEnv }),
     refresh() {
-      inFlight ??= refreshShellEnv(target, options).finally(() => {
+      inFlight ??= refreshShellEnv(target, userEnv, options).finally(() => {
         inFlight = undefined;
       });
       return inFlight;
@@ -27,9 +30,11 @@ export function createShellEnvManager(options: CreateShellEnvManagerOptions = {}
 
 async function refreshShellEnv(
   target: NodeJS.ProcessEnv,
+  userEnv: Record<string, string>,
   options: CreateShellEnvManagerOptions
 ): Promise<void> {
-  const baseEnv = options.baseEnvForProbe?.() ?? target;
+  const baseEnv = buildUserShellEnvSeed(options.baseEnvForProbe?.() ?? target);
+  replaceEnv(userEnv, stringEnv(baseEnv));
   const capture = await captureShellEnv({
     baseEnv,
     timeoutMs: options.timeoutMs,
@@ -44,9 +49,28 @@ async function refreshShellEnv(
   }
 
   applyShellEnvCapture(target, capture.data, options.policy, { mergeBaseEnv: baseEnv });
+  applyShellEnvCapture(
+    userEnv,
+    capture.data,
+    { ...options.policy, preserveKeys: new Set() },
+    { mergeBaseEnv: baseEnv }
+  );
 
   options.logger?.info?.('[shell-env] Resolved shell env', {
     source: capture.data.source,
     pathEntries: target.PATH?.split(process.platform === 'win32' ? ';' : ':').length ?? 0,
   });
+}
+
+function stringEnv(env: NodeJS.ProcessEnv): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (value !== undefined) result[key] = value;
+  }
+  return result;
+}
+
+function replaceEnv(target: Record<string, string>, source: Record<string, string>): void {
+  for (const key of Object.keys(target)) delete target[key];
+  Object.assign(target, source);
 }

--- a/packages/core/src/services/shell-env/node/types.ts
+++ b/packages/core/src/services/shell-env/node/types.ts
@@ -28,6 +28,8 @@ export type ShellEnvLogger = {
 export type ShellEnvManager = {
   /** The operational host process environment updated for compatibility consumers. */
   readonly env: NodeJS.ProcessEnv;
+  /** Awaits any initial or in-flight capture and returns an owned user-shell snapshot. */
+  current(): Promise<Record<string, string>>;
   /** Returns an owned user-shell snapshot with host runtime controls excluded. */
   getUserShellEnv(): Record<string, string>;
   refresh(): Promise<void>;

--- a/packages/core/src/services/shell-env/node/types.ts
+++ b/packages/core/src/services/shell-env/node/types.ts
@@ -26,7 +26,10 @@ export type ShellEnvLogger = {
 };
 
 export type ShellEnvManager = {
+  /** The operational host process environment updated for compatibility consumers. */
   readonly env: NodeJS.ProcessEnv;
+  /** Returns an owned user-shell snapshot with host runtime controls excluded. */
+  getUserShellEnv(): Record<string, string>;
   refresh(): Promise<void>;
 };
 

--- a/packages/core/src/services/shell-env/node/user-env.test.ts
+++ b/packages/core/src/services/shell-env/node/user-env.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { buildUserShellEnvSeed } from './user-env';
+
+describe('buildUserShellEnvSeed', () => {
+  it('keeps user/session values and removes host runtime controls', () => {
+    expect(
+      buildUserShellEnvSeed({
+        HOME: '/home/test',
+        PATH: '/usr/bin',
+        SSH_AUTH_SOCK: '/tmp/agent.sock',
+        CUSTOM_USER_VALUE: 'kept',
+        NODE_ENV: 'production',
+        NODE_ENV_ELECTRON_VITE: 'development',
+        ELECTRON_RUN_AS_NODE: '1',
+        ELECTRON_EXEC_PATH: '/app/node_modules/electron',
+        EMDASH_DB_FILE: '/tmp/app.db',
+        EMDASH_LOG_FILE: '/tmp/app.log',
+        npm_lifecycle_event: 'dev',
+        npm_package_name: '@emdash/emdash-desktop',
+        NX_TASK_TARGET_TARGET: 'dev',
+        NX_NO_CLOUD: 'true',
+        PNPM_HOME: '/home/test/.local/share/pnpm',
+        PNPM_PACKAGE_NAME: '@emdash/emdash-desktop',
+        DISABLE_AUTO_UPDATE: 'true',
+      })
+    ).toEqual({
+      HOME: '/home/test',
+      PATH: '/usr/bin',
+      SSH_AUTH_SOCK: '/tmp/agent.sock',
+      CUSTOM_USER_VALUE: 'kept',
+      NX_NO_CLOUD: 'true',
+      PNPM_HOME: '/home/test/.local/share/pnpm',
+    });
+  });
+});

--- a/packages/core/src/services/shell-env/node/user-env.ts
+++ b/packages/core/src/services/shell-env/node/user-env.ts
@@ -1,0 +1,61 @@
+import { SHELL_ENV_CAPTURE_GUARD } from './types';
+
+const RUNTIME_ONLY_KEYS = new Set([
+  'INIT_CWD',
+  'LOG_LEVEL',
+  'NODE',
+  'NODE_ENV',
+  'NODE_ENV_ELECTRON_VITE',
+  'NO_SANDBOX',
+  'NX_STREAM_OUTPUT',
+  'NX_WORKSPACE_ROOT',
+  'PNPM_PACKAGE_NAME',
+  'PNPM_SCRIPT_SRC_DIR',
+  'REMOTE_DEBUGGING_PORT',
+  'TELEMETRY_ENABLED',
+  'V8_INSPECTOR_BRK_PORT',
+  'V8_INSPECTOR_PORT',
+  'VITE_DEBUG_FILTER',
+  'VITE_LOG_LEVEL',
+  'VITE_POSTHOG_HOST',
+  'VITE_POSTHOG_KEY',
+  ...Object.keys(SHELL_ENV_CAPTURE_GUARD),
+]);
+
+const RUNTIME_ONLY_PREFIXES = [
+  'ELECTRON_',
+  'EMDASH_',
+  'MAIN_VITE_',
+  'NX_TASK_',
+  'NX_TERMINAL_',
+  'PRELOAD_VITE_',
+  'RENDERER_VITE_',
+  'VITE_',
+  'npm_',
+] as const;
+
+/**
+ * Builds the inherited seed for resolving a user's login-shell environment.
+ *
+ * A host process environment is an implementation detail of the process that
+ * happens to run Emdash. Electron, electron-vite, pnpm/Nx, and Emdash itself
+ * all add control variables to it. Those variables are not part of a user's
+ * terminal environment, so they must not be present in the seed inherited by
+ * the login-shell probe. A shell startup file can still deliberately export
+ * any of these names; that value appears in the capture and is preserved.
+ */
+export function buildUserShellEnvSeed(
+  processEnv: NodeJS.ProcessEnv = process.env
+): NodeJS.ProcessEnv {
+  const seed: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(processEnv)) {
+    if (value === undefined || isRuntimeOnlyKey(key)) continue;
+    seed[key] = value;
+  }
+  return seed;
+}
+
+function isRuntimeOnlyKey(key: string): boolean {
+  if (RUNTIME_ONLY_KEYS.has(key)) return true;
+  return RUNTIME_ONLY_PREFIXES.some((prefix) => key.startsWith(prefix));
+}

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     'primitives-sqlite-store-codegen': 'src/primitives/sqlite-store/codegen/index.ts',
     'primitives-sqlite-store-node': 'src/primitives/sqlite-store/node/index.ts',
     'services-exec-api': 'src/services/exec/api/index.ts',
+    'services-shell-env-api': 'src/services/shell-env/api/index.ts',
     'services-shell-env-node': 'src/services/shell-env/node/index.ts',
     'services-pty-api': 'src/services/pty/api/index.ts',
     'services-host-dependencies-api': 'src/services/host-dependencies/api/index.ts',


### PR DESCRIPTION
- separates the operational worker environment from the captured user shell environment
- prevents electron vite emdash nx and package manager runtime variables from leaking into terminals and lifecycle scripts
- preserves variables explicitly exported by user shell startup files
- removes the ambient process.env fallback and requires explicit terminal environment ownership
- applies the same environment model to desktop and workspace server runtimes