### PR TITLE
fix(ci): raise macOS release build heap limit

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -176,6 +176,8 @@ jobs:
   release-mac:
     needs: [prepare-release]
     runs-on: macos-latest
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
     permissions:
       contents: write
     environment: release

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -170,6 +170,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     needs: [prepare-release]
     runs-on: macos-latest
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
     permissions:
       contents: write
     environment: release


### PR DESCRIPTION
### Description

Give the macOS jobs in both release workflows a 4 GiB V8 old-space limit.

The canary release at https://github.com/generalaction/emdash/actions/runs/32494481924/job/96809717763 exhausted the default heap at about 2,040 MiB while Electron Vite transformed the renderer. The same build completed on the 16 GiB Linux and Windows runners, while `macos-latest` is a 7 GiB ARM runner. A 4 GiB old-space ceiling leaves headroom for native allocations without preallocating that memory.

This changes release workflow configuration. No release workflow or deployment was triggered.

### Related issues

None.

### Testing

- Parsed both modified workflows with the repository's `yaml` package.
- Ran `git diff --check`.
- Reproduced the renderer OOM locally with `--max-old-space-size=2048`.
- Verified the current 6,327-module renderer build succeeds with `--max-old-space-size=3072` (3.41 GiB peak RSS).
- Confirmed `NODE_OPTIONS=--max-old-space-size=4096` produces a 4,288 MiB total V8 heap limit, including young-generation space.
- The full 4 GiB build could not complete in the local verification container because the container itself is capped near 4 GiB; the kernel terminated it at 3.61 GiB RSS.

### Screenshot/Recording (if applicable)

Not applicable.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed, or confirmed no docs change was needed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit message and PR title

</details>
