### PR TITLE
fix(source-control): prevent branch commits flicker

### DIFF
--- a/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/commits-list.tsx
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/commits-list.tsx
@@ -40,7 +40,7 @@ const EMPTY_EXPANDED_HASHES: ReadonlySet<string> = new Set();
 
 function commitRangeIdentity(range: CommitRange | undefined): string {
   if (!range) return 'none';
-  return `${range.source}:${range.baseRefOid}:${range.headRefOid}:${range.revision ?? 0}`;
+  return `${range.source}:${range.baseRefOid}:${range.headRefOid}`;
 }
 
 export const CommitRangeCommitsList = observer(function CommitRangeCommitsList({

--- a/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/use-commits.test.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/use-commits.test.ts
@@ -1,0 +1,90 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { JSDOM } from 'jsdom';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { commitsQueryKey, useCommits } from './use-commits';
+
+const mocks = vi.hoisted(() => ({
+  getLog: vi.fn(),
+}));
+
+vi.mock('@core/features/source-control/api/browser/client', () => ({
+  checkoutSelector: (workspaceId: string) => ({ workspaceId }),
+  getSourceControlClient: async () => ({ checkout: { getLog: mocks.getLog } }),
+}));
+
+describe('useCommits', () => {
+  let dom: JSDOM;
+  let root: Root;
+  let host: HTMLDivElement;
+  let queryClient: QueryClient;
+  let resolveReplacement: (() => void) | undefined;
+
+  beforeEach(() => {
+    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>');
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    host = dom.window.document.getElementById('root') as HTMLDivElement;
+    root = createRoot(host);
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    mocks.getLog
+      .mockResolvedValueOnce({ success: true, data: { commits: [], totalCount: 2 } })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveReplacement = () =>
+              resolve({ success: true, data: { commits: [], totalCount: 3 } });
+          })
+      );
+  });
+
+  afterEach(async () => {
+    await queryClient.cancelQueries();
+    await act(async () => root.unmount());
+    queryClient.clear();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    dom.window.close();
+  });
+
+  it('keys commit data only by its immutable OID range', () => {
+    const key = commitsQueryKey('project-1', 'workspace-1', 'branch', 'base', 'head');
+
+    expect(key).toEqual(['project-1', 'workspace-1', 'commits', 'branch', 'base', 'head']);
+  });
+
+  it('retains the branch commit presentation while a changed OID range loads', async () => {
+    function Probe({ headRefOid }: { headRefOid: string }) {
+      const result = useCommits('project-1', 'workspace-1', {
+        source: 'branch',
+        baseRefOid: 'base',
+        headRefOid,
+      });
+      const aheadCount = result.data?.pages[0]?.aheadCount;
+      const label = aheadCount !== undefined && aheadCount > 0 ? 'Branch Commits' : 'Pull Requests';
+      return React.createElement('span', null, `${label}:${aheadCount ?? 0}`);
+    }
+
+    const render = (headRefOid: string) =>
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(Probe, { headRefOid })
+        )
+      );
+
+    await act(async () => render('head-1'));
+    await vi.waitFor(() => expect(host.textContent).toBe('Branch Commits:2'));
+
+    await act(async () => render('head-2'));
+    expect(host.textContent).toBe('Branch Commits:2');
+
+    await act(async () => resolveReplacement?.());
+    await vi.waitFor(() => expect(host.textContent).toBe('Branch Commits:3'));
+  });
+});

--- a/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/use-commits.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/use-commits.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { keepPreviousData, useInfiniteQuery } from '@tanstack/react-query';
 import {
   checkoutSelector,
   getSourceControlClient,
@@ -14,7 +14,6 @@ export type CommitRange = {
   source: CommitRangeSource;
   baseRefOid: string;
   headRefOid: string;
-  revision?: number;
 };
 
 export function commitRangeForPullRequest(pr: PullRequest): CommitRange {
@@ -30,18 +29,16 @@ export const commitsQueryKey = (
   workspaceId: string,
   source: CommitRangeSource,
   baseRefOid: string,
-  headRefOid: string,
-  revision: number
-) => [projectId, workspaceId, 'commits', source, baseRefOid, headRefOid, revision] as const;
+  headRefOid: string
+) => [projectId, workspaceId, 'commits', source, baseRefOid, headRefOid] as const;
 
 export function useCommits(projectId: string, workspaceId: string, range: CommitRange | undefined) {
   const source = range?.source ?? 'branch';
   const baseRefOid = range?.baseRefOid ?? '';
   const headRefOid = range?.headRefOid ?? '';
-  const revision = range?.revision ?? 0;
 
   return useInfiniteQuery({
-    queryKey: commitsQueryKey(projectId, workspaceId, source, baseRefOid, headRefOid, revision),
+    queryKey: commitsQueryKey(projectId, workspaceId, source, baseRefOid, headRefOid),
     queryFn: async ({ pageParam }: { pageParam: number }) => {
       if (!range) return { commits: [], aheadCount: 0 };
 
@@ -62,6 +59,7 @@ export function useCommits(projectId: string, workspaceId: string, range: Commit
     getNextPageParam: (lastPage, _all, lastPageParam) =>
       lastPage.commits.length === PAGE_SIZE ? lastPageParam + PAGE_SIZE : undefined,
     enabled: !!range,
+    placeholderData: keepPreviousData,
     staleTime: 5 * 60_000,
   });
 }

--- a/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/pr-section.tsx
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/pr-section.tsx
@@ -64,7 +64,6 @@ function usePullRequestsSectionModel() {
           source: 'branch',
           baseRefOid: defaultBranch.oid,
           headRefOid: headOid,
-          revision: gitCheckout.statusRevision,
         }
       : undefined;
   const branchCommits = useCommits(projectId, workspaceId, branchCommitRange);


### PR DESCRIPTION
- key commit queries by immutable base and head oids instead of volatile worktree status revisions
- preserve the previous branch commit result while a changed oid range loads to prevent pull request state flicker
- align commit list identity with the oid-based query cache and cover the stable presentation with regression tests