### PR TITLE
fix(sessions): resolve task launch settings at spawn time

### DIFF
--- a/agents/architecture/settings.md
+++ b/agents/architecture/settings.md
@@ -20,8 +20,8 @@ committed and shared.
 | `autoRunSetup` | Workspace registry host-local personal config | host-local personal > built-in `true` | `resolveProjectConfig()` | Workspace registry activation gate and lifecycle sequencing |
 | `autoRunRun` | Workspace registry host-local personal config | host-local personal > built-in `false` | `resolveProjectConfig()` | Workspace registry activation gate and lifecycle sequencing |
 | `preservePatterns` | Workspace registry host-local personal config; team `.emdash.json` | host-local personal > that workspace's team file > built-in `[]`; arrays replace | `resolveProjectConfig()` | Worktree create/update copy-artifact steps |
-| `shellSetup` | Team `.emdash.json`; host settings JSON | that workspace's team file > host default > unset | `resolveProjectConfig()` | Workspace lifecycle script launches, task conversations, and terminal hydration |
-| `tmux` | Desktop project-settings DB override; host settings JSON; desktop app setting `project.tmuxByDefault` | stored project override > host default > app default | `resolveTmux()` in `apps/emdash-desktop/src/core/primitives/project-settings/api/effective-settings.ts` | Task conversation assembly, terminal hydration, and project-session teardown |
+| `shellSetup` | Team `.emdash.json`; host settings JSON | that workspace's team file > host default > unset | `resolveProjectConfig()` | Workspace lifecycle script launches and task-session launch context resolution |
+| `tmux` | Desktop project-settings DB override; host settings JSON; desktop app setting `project.tmuxByDefault` | stored project override > host default > app default | `resolveTmux()` in `apps/emdash-desktop/src/core/primitives/project-settings/api/effective-settings.ts` | Task-session launch context resolution and project-session teardown |
 | `worktreeRoot` | Desktop project-settings DB override; host settings JSON; built-in host path | stored project override > host default > `<host-home>/emdash/worktrees` | `resolveWorktreeRoot()` in `apps/emdash-desktop/src/core/primitives/project-settings/api/effective-settings.ts` | `WorkspacePlacementResolver`, task creation, and destination previews |
 | `defaultBranch` | Desktop project-settings DB; live repository facts | valid stored branch > remote HEAD > well-known remote branch > well-known local branch > unavailable | `resolveEffectiveSettings()` / `resolveEffectiveGitSettings()` in `apps/emdash-desktop/src/core/primitives/project-settings/api/effective-settings.ts` | Task and terminal environment, task creation, automation deployment, source-control UI |
 | `baseRemote` | Desktop project-settings DB; live repository facts | valid stored remote > `origin` > sole remote > first remote alphabetically > unavailable | `resolveEffectiveSettings()` / `resolveEffectiveGitSettings()` | Git fetch, task creation, automation deployment, source-control UI |
@@ -40,6 +40,9 @@ committed and shared.
   `null` removes an explicit value and restores inheritance.
 - The workspace registry is the sole resolver for lifecycle and file-handling config. The scripts
   runtime receives already-resolved `command` and `shellSetup` values and does not read config.
+- Task and terminal providers retain stable identity and runtime capabilities, not mutable launch
+  settings. `TaskSessionLaunchContextResolver` reads task, project, host, and workspace-registry
+  state immediately before a process starts; task-bound providers receive its zero-argument source.
 - Git/GitHub and placement previews must use the same portable resolvers as execution.
 
 ## Deferred And Deliberate Legacy Behavior

--- a/apps/emdash-desktop/src/core/features/conversations/node/tui-conversation-provider.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/tui-conversation-provider.test.ts
@@ -109,6 +109,56 @@ describe('TuiConversationProvider', () => {
     expect(start).toHaveBeenCalledWith(expect.objectContaining({ trustWorkspace: true }));
   });
 
+  it('resolves mutable task launch context immediately before each fresh start', async () => {
+    let launchContext = {
+      workspace: {
+        workspaceId: 'workspace-1',
+        projectId: 'project-1',
+        host: { type: 'local', id: 'local' } as const,
+        path: '/workspace',
+      },
+      tmux: false,
+      shellSetup: 'source old-profile',
+      env: { EMDASH_TASK_NAME: 'old-name' },
+    };
+    const resolve = vi.fn(async () => ok(launchContext));
+    const provider = createProvider({ launchContextSource: { resolve } });
+
+    await provider.ensureSession({
+      conversation: conversation({ id: 'conversation-1', providerId: 'claude' }),
+      mode: 'start',
+    });
+
+    launchContext = {
+      ...launchContext,
+      tmux: true,
+      shellSetup: 'source new-profile',
+      env: { EMDASH_TASK_NAME: 'new-name' },
+    };
+    await provider.ensureSession({
+      conversation: conversation({ id: 'conversation-2', providerId: 'claude' }),
+      mode: 'start',
+    });
+
+    expect(resolve).toHaveBeenCalledTimes(2);
+    expect(start).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        providerVars: expect.objectContaining({ EMDASH_TASK_NAME: 'old-name' }),
+        shellSetup: 'source old-profile',
+        tmuxSessionName: undefined,
+      })
+    );
+    expect(start).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        providerVars: expect.objectContaining({ EMDASH_TASK_NAME: 'new-name' }),
+        shellSetup: 'source new-profile',
+        tmuxSessionName: expect.stringMatching(/^emdash-/),
+      })
+    );
+  });
+
   it('backs prompt spill creation, writes, and cleanup with workspace files', async () => {
     const createDirectory = vi.fn().mockResolvedValue(ok(undefined));
     const writeFile = vi.fn().mockResolvedValue(ok(undefined));
@@ -161,6 +211,7 @@ function createProvider(
     host?: TuiConversationProviderOptions['host'];
     autoTrustWorktrees?: boolean;
     getTaskSettings?: () => Promise<{ autoTrustWorktrees: boolean }>;
+    launchContextSource?: TuiConversationProviderOptions['launchContextSource'];
   } = {}
 ): TuiConversationProvider {
   return new TuiConversationProvider(
@@ -174,6 +225,19 @@ function createProvider(
       projectId: 'project-1',
       taskId: 'task-1',
       taskPath: '/workspace',
+      launchContextSource: overrides.launchContextSource ?? {
+        resolve: async () =>
+          ok({
+            workspace: {
+              workspaceId: 'workspace-1',
+              projectId: 'project-1',
+              host: overrides.host ?? { type: 'local', id: 'local' },
+              path: '/workspace',
+            },
+            tmux: false,
+            env: {},
+          }),
+      },
     },
     {
       db: { select: vi.fn() } as never,

--- a/apps/emdash-desktop/src/core/features/conversations/node/tui-conversation-provider.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/tui-conversation-provider.ts
@@ -15,6 +15,7 @@ import {
   type SpillLargePromptDeps,
   type SpillLargePromptResult,
 } from '@core/features/conversations/node/spill-large-prompt';
+import type { TaskSessionLaunchContextSource } from '@core/features/tasks/api/node/task-session-launch-context';
 import type { ProviderCustomConfig } from '@core/primitives/app-settings/api';
 import type { Conversation } from '@core/primitives/conversations/api';
 import { makePtySessionId } from '@core/primitives/pty/api';
@@ -45,9 +46,7 @@ export type TuiConversationProviderOptions = {
   projectId: string;
   taskId: string;
   taskPath: string;
-  tmux?: boolean;
-  shellSetup?: string;
-  taskEnvVars?: Record<string, string>;
+  launchContextSource: TaskSessionLaunchContextSource;
 };
 
 export type TuiConversationProviderDependencies = {
@@ -78,9 +77,7 @@ export class TuiConversationProvider implements ConversationProvider {
   private readonly host: HostRef;
   private readonly files: FilesClientScope;
   private readonly tuiAgents: TuiAgentsRuntimeClient;
-  private readonly tmux: boolean;
-  private readonly shellSetup?: string;
-  private readonly taskEnvVars: Record<string, string>;
+  private readonly launchContextSource: TaskSessionLaunchContextSource;
   private readonly spills = new Map<string, SpillLargePromptResult>();
 
   constructor(
@@ -93,9 +90,7 @@ export class TuiConversationProvider implements ConversationProvider {
     this.host = options.host;
     this.files = options.files;
     this.tuiAgents = options.tuiAgents;
-    this.tmux = options.tmux ?? false;
-    this.shellSetup = options.shellSetup;
-    this.taskEnvVars = options.taskEnvVars ?? {};
+    this.launchContextSource = options.launchContextSource;
   }
 
   async ensureSession({
@@ -147,26 +142,35 @@ export class TuiConversationProvider implements ConversationProvider {
     mode: 'start' | 'resume',
     initialPrompt: string | undefined
   ): Promise<TuiAgentStartInput> {
-    const providerConfig = await this.dependencies.getProviderConfig(conversation.providerId);
-    const trustWorkspace =
-      conversation.autoApprove === true ||
-      (await this.dependencies.getTaskSettings()).autoTrustWorktrees;
     const agentSession = resolveAgentSession(conversation, mode);
     const effectiveInitialPrompt = await this.effectiveInitialPrompt(
       conversation.id,
       !agentSession.isResuming && mode === 'start' ? initialPrompt : undefined
     );
-    const colorEnv = await this.dependencies.getTerminalColorEnv();
+    const [providerConfig, taskSettings, colorEnv, launchContext, gitCredentials] =
+      await Promise.all([
+        this.dependencies.getProviderConfig(conversation.providerId),
+        conversation.autoApprove === true
+          ? Promise.resolve(undefined)
+          : this.dependencies.getTaskSettings(),
+        this.dependencies.getTerminalColorEnv(),
+        this.launchContextSource.resolve(),
+        this.dependencies.resolveSessionGitCredentials({
+          projectId: this.projectId,
+          host: this.host,
+        }),
+      ]);
+    if (!launchContext.success) {
+      throw new Error(`Could not resolve task session launch context: ${launchContext.error.type}`);
+    }
+    const trustWorkspace =
+      conversation.autoApprove === true || taskSettings?.autoTrustWorktrees === true;
     const providerVars = {
       ...(providerConfig?.env ?? {}),
       ...colorEnv,
-      ...this.taskEnvVars,
+      ...launchContext.data.env,
     };
     const sessionId = makePtySessionId(this.projectId, this.taskId, conversation.id);
-    const gitCredentials = await this.dependencies.resolveSessionGitCredentials({
-      projectId: this.projectId,
-      host: this.host,
-    });
 
     return {
       conversationId: conversation.id,
@@ -185,8 +189,8 @@ export class TuiConversationProvider implements ConversationProvider {
       gitCredentials,
       cols: initialSize.cols,
       rows: initialSize.rows,
-      shellSetup: this.shellSetup,
-      tmuxSessionName: this.tmux ? makeTmuxSessionName(sessionId) : undefined,
+      shellSetup: launchContext.data.shellSetup,
+      tmuxSessionName: launchContext.data.tmux ? makeTmuxSessionName(sessionId) : undefined,
     };
   }
 

--- a/apps/emdash-desktop/src/core/features/projects/api/node/project-provider.ts
+++ b/apps/emdash-desktop/src/core/features/projects/api/node/project-provider.ts
@@ -53,7 +53,6 @@ export interface TaskProvider {
   readonly taskId: string;
   readonly taskBranch: string | undefined;
   readonly sourceBranch: GitBranchRef | undefined;
-  readonly taskEnvVars: Record<string, string>;
   readonly conversations: ConversationProvider;
 }
 

--- a/apps/emdash-desktop/src/core/features/tasks/api/node/task-provider-assembly.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/api/node/task-provider-assembly.ts
@@ -3,16 +3,13 @@ import type { RuntimeResolveError } from '@emdash/core/services/runtime-broker/a
 import { ok, type Result } from '@emdash/shared';
 import type { ConversationProvider } from '@core/features/conversations/api/node/types';
 import type { TaskProvider } from '@core/features/projects/api/node/project-provider';
-import type { RepoFactsSource } from '@core/features/projects/api/node/settings/effective-settings';
-import type { ProjectSettingsProvider } from '@core/features/projects/api/node/settings/provider';
 import type { Workspace } from '@core/features/workspaces/api/node/workspace';
 import {
   buildTaskProviders,
-  resolveTaskEnv,
-  type ResolveTaskEnvError,
   type TaskProviderOpts,
 } from '@core/features/workspaces/api/node/workspace-factory';
 import type { Task } from '@core/primitives/tasks/api';
+import type { TaskSessionLaunchContextResolver } from './task-session-launch-context';
 
 export type BuildTaskResult = {
   taskProvider: TaskProvider;
@@ -23,16 +20,11 @@ export async function buildTaskFromWorkspace(
   task: Task,
   workspace: Workspace,
   projectId: string,
-  projectPath: string,
-  settings: ProjectSettingsProvider,
-  repoFacts: RepoFactsSource,
+  launchContexts: Pick<TaskSessionLaunchContextResolver, 'bind'>,
   createConversationProvider: (options: TaskProviderOpts) => ConversationProvider,
   workspaceBranchName?: string,
   workspaceSourceBranch?: GitBranchRef
-): Promise<Result<BuildTaskResult, RuntimeResolveError | ResolveTaskEnvError>> {
-  const taskEnv = await resolveTaskEnv(task, workspace, projectPath, settings, repoFacts);
-  if (!taskEnv.success) return taskEnv;
-  const { taskEnvVars, tmuxEnabled, shellSetup } = taskEnv.data;
+): Promise<Result<BuildTaskResult, RuntimeResolveError>> {
   const providers = await buildTaskProviders(
     {
       host: workspace.host,
@@ -42,9 +34,11 @@ export async function buildTaskFromWorkspace(
       taskId: task.id,
       workspaceId: workspace.id,
       taskPath: workspace.path,
-      tmuxEnabled,
-      shellSetup,
-      taskEnvVars,
+      launchContextSource: launchContexts.bind({
+        projectId,
+        taskId: task.id,
+        workspaceId: workspace.id,
+      }),
     },
     createConversationProvider
   );
@@ -54,7 +48,6 @@ export async function buildTaskFromWorkspace(
     taskId: task.id,
     taskBranch: workspaceBranchName,
     sourceBranch: workspaceSourceBranch,
-    taskEnvVars,
     conversations: conversationProvider,
   };
   return ok({ taskProvider, conversationProvider });

--- a/apps/emdash-desktop/src/core/features/tasks/api/node/task-service.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/api/node/task-service.ts
@@ -15,6 +15,7 @@ import type {
   ProvisionResult as SessionProvisionResult,
 } from '@core/features/projects/api/node/project-provider';
 import { buildTaskFromWorkspace } from '@core/features/tasks/api/node/task-provider-assembly';
+import type { TaskSessionLaunchContextResolver } from '@core/features/tasks/api/node/task-session-launch-context';
 import type { TaskSessionManager } from '@core/features/tasks/api/node/task-session-manager';
 import { mapTaskRowToTask } from '@core/features/tasks/api/node/utils/utils';
 import {
@@ -98,6 +99,7 @@ export class TaskService implements Hookable<TaskLifecycleHooks> {
       workspacePlacement: WorkspacePlacementResolver;
       runtimes: RuntimeBroker;
       lifecycleParticipants: readonly WorkspaceLifecycleParticipant[];
+      sessionLaunchContexts: TaskSessionLaunchContextResolver;
       createConversationProvider(options: TaskProviderOpts): ConversationProvider;
       workspaceIdentity: WorkspaceIdentityService;
       creations: WorkspaceCreations;
@@ -275,9 +277,7 @@ export class TaskService implements Hookable<TaskLifecycleHooks> {
           workspaceRegistry: access.data.client.workspaceRegistry,
         },
         project.projectId,
-        project.repoPath,
-        project.settings,
-        project.repoFacts,
+        this.dependencies.sessionLaunchContexts,
         this.dependencies.createConversationProvider,
         workspaceRow.config ? (deriveBranchName(workspaceRow.config.git) ?? undefined) : undefined
       );

--- a/apps/emdash-desktop/src/core/features/tasks/api/node/task-session-launch-context.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/api/node/task-session-launch-context.ts
@@ -1,0 +1,124 @@
+import type { RuntimeBroker } from '@emdash/core/services/runtime-broker/api';
+import { err, ok, type Result } from '@emdash/shared';
+import { and, eq, isNull } from 'drizzle-orm';
+import type { ProjectAttachmentError } from '@core/features/projects/api';
+import type { ProjectAttachmentManager } from '@core/features/projects/api/node/project-attachment-manager';
+import { resolveProjectEffectiveSettings } from '@core/features/projects/api/node/settings/effective-settings';
+import { getTaskEnvVars } from '@core/features/workspaces/api/node/workspace-env';
+import type {
+  WorkspaceIdentity,
+  WorkspaceIdentityService,
+} from '@core/features/workspaces/api/node/workspace-identity-service';
+import type { AppDb } from '@core/services/app-db/node/db';
+import { tasks } from '@core/services/app-db/node/schema';
+
+export type TaskSessionLaunchContext = Readonly<{
+  workspace: WorkspaceIdentity;
+  tmux: boolean;
+  shellSetup?: string;
+  env: Readonly<Record<string, string>>;
+}>;
+
+export type TaskSessionLaunchContextInput = Readonly<{
+  projectId: string;
+  taskId: string;
+  workspaceId?: string;
+}>;
+
+export type TaskSessionLaunchContextError =
+  | ProjectAttachmentError
+  | { type: 'missing-task'; message: string }
+  | { type: 'missing-workspace'; message: string };
+
+export type TaskSessionLaunchContextSource = Readonly<{
+  resolve(): Promise<Result<TaskSessionLaunchContext, TaskSessionLaunchContextError>>;
+}>;
+
+export class TaskSessionLaunchContextResolver {
+  constructor(
+    private readonly dependencies: Readonly<{
+      db: AppDb;
+      projects: Pick<ProjectAttachmentManager, 'requireAttached'>;
+      runtimes: Pick<RuntimeBroker, 'client'>;
+      workspaceIdentity: Pick<WorkspaceIdentityService, 'resolve'>;
+    }>
+  ) {}
+
+  bind(input: TaskSessionLaunchContextInput): TaskSessionLaunchContextSource {
+    return { resolve: () => this.resolve(input) };
+  }
+
+  async resolve(
+    input: TaskSessionLaunchContextInput
+  ): Promise<Result<TaskSessionLaunchContext, TaskSessionLaunchContextError>> {
+    const [task] = await this.dependencies.db
+      .select()
+      .from(tasks)
+      .where(
+        and(
+          eq(tasks.id, input.taskId),
+          eq(tasks.projectId, input.projectId),
+          isNull(tasks.deletedAt)
+        )
+      )
+      .limit(1);
+    if (!task) {
+      return err({ type: 'missing-task', message: `Task ${input.taskId} not found` });
+    }
+    if (!task.workspaceId) {
+      return err({
+        type: 'missing-workspace',
+        message: `Task ${input.taskId} has no workspace`,
+      });
+    }
+    if (input.workspaceId !== undefined && task.workspaceId !== input.workspaceId) {
+      return err({
+        type: 'missing-workspace',
+        message: `Task ${input.taskId} is not bound to workspace ${input.workspaceId}`,
+      });
+    }
+
+    const project = this.dependencies.projects.requireAttached(input.projectId);
+    if (!project.success) return project;
+
+    const identity = await this.dependencies.workspaceIdentity.resolve(task.workspaceId);
+    if (!identity || identity.projectId !== input.projectId) {
+      return err({
+        type: 'missing-workspace',
+        message: `Workspace ${task.workspaceId} was not found`,
+      });
+    }
+
+    const runtime = await this.dependencies.runtimes.client(identity.host);
+    if (!runtime.success) return runtime;
+
+    const [effective, tmux, projectConfig] = await Promise.all([
+      resolveProjectEffectiveSettings({
+        settings: project.data.settings,
+        repoFacts: project.data.repoFacts,
+      }),
+      project.data.settings.resolveTmux(),
+      runtime.data.workspaceRegistry.getProjectConfig({ workspaceId: identity.workspaceId }),
+    ]);
+    if (!projectConfig.success) {
+      return err({
+        type: 'missing-workspace',
+        message: `Workspace ${identity.workspaceId} has no project configuration`,
+      });
+    }
+
+    return ok({
+      workspace: identity,
+      tmux: tmux.value,
+      shellSetup: projectConfig.data.resolved.shellSetup?.value,
+      env: getTaskEnvVars({
+        taskId: task.id,
+        taskName: task.name,
+        taskPath: identity.path,
+        projectPath: project.data.repoPath,
+        defaultBranch: effective.defaultBranch.value?.branch ?? null,
+        portSeed: identity.path,
+      }),
+    });
+  }
+}

--- a/apps/emdash-desktop/src/core/features/tasks/node/task-session-launch-context.test.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/node/task-session-launch-context.test.ts
@@ -1,0 +1,150 @@
+import { ok } from '@emdash/shared';
+import { describe, expect, it, vi } from 'vitest';
+import { TaskSessionLaunchContextResolver } from '../api/node/task-session-launch-context';
+
+describe('TaskSessionLaunchContextResolver', () => {
+  it('reads mutable launch policy from its authorities on every resolution', async () => {
+    let taskName = 'Old task';
+    let tmux = false;
+    let shellSetup = 'source old-profile';
+    let defaultBranch = 'main';
+    const identity = {
+      workspaceId: 'workspace-1',
+      projectId: 'project-1',
+      host: { type: 'local', id: 'local' } as const,
+      path: '/repo/worktree',
+    };
+    const select = vi.fn(() =>
+      selecting({
+        id: 'task-1',
+        projectId: 'project-1',
+        workspaceId: 'workspace-1',
+        name: taskName,
+      })
+    );
+    const getProjectConfig = vi.fn(async () =>
+      ok({
+        resolved: {
+          shellSetup: { value: shellSetup, from: 'team' as const },
+        },
+      })
+    );
+    const settings = {
+      resolveTmux: vi.fn(async () => ({
+        value: tmux,
+        provenance: { kind: 'set' as const },
+      })),
+      getStoredGitSettings: vi.fn(async () => ({
+        defaultBranch: { remote: null, branch: defaultBranch },
+      })),
+      getPlacementContext: vi.fn(async () => ({
+        hostWorktreeRoot: null,
+        builtInWorktreeRoot: '/tmp/worktrees',
+        homeDirectory: '/tmp',
+        hostTmux: null,
+        appDefaultTmux: false,
+      })),
+    };
+    const repoFacts = {
+      get: vi.fn(async () => ({ remotes: [], localBranches: [defaultBranch] })),
+    };
+    const resolver = new TaskSessionLaunchContextResolver({
+      db: { select } as never,
+      projects: {
+        requireAttached: vi.fn(() =>
+          ok({
+            repoPath: '/repo',
+            settings,
+            repoFacts,
+          } as never)
+        ),
+      },
+      runtimes: {
+        client: vi.fn(async () => ok({ workspaceRegistry: { getProjectConfig } } as never)),
+      },
+      workspaceIdentity: { resolve: vi.fn(async () => identity) },
+    });
+    const source = resolver.bind({
+      projectId: 'project-1',
+      taskId: 'task-1',
+      workspaceId: 'workspace-1',
+    });
+
+    const first = await source.resolve();
+
+    taskName = 'New task';
+    tmux = true;
+    shellSetup = 'source new-profile';
+    defaultBranch = 'trunk';
+    const second = await source.resolve();
+
+    expect(first).toMatchObject({
+      success: true,
+      data: {
+        tmux: false,
+        shellSetup: 'source old-profile',
+        env: {
+          EMDASH_TASK_NAME: 'old-task',
+          EMDASH_DEFAULT_BRANCH: 'main',
+        },
+      },
+    });
+    expect(second).toMatchObject({
+      success: true,
+      data: {
+        tmux: true,
+        shellSetup: 'source new-profile',
+        env: {
+          EMDASH_TASK_NAME: 'new-task',
+          EMDASH_DEFAULT_BRANCH: 'trunk',
+        },
+      },
+    });
+    expect(select).toHaveBeenCalledTimes(2);
+    expect(getProjectConfig).toHaveBeenCalledTimes(2);
+    expect(settings.resolveTmux).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not let a task-bound source silently follow a replacement workspace', async () => {
+    const requireAttached = vi.fn();
+    const resolver = new TaskSessionLaunchContextResolver({
+      db: {
+        select: vi.fn(() =>
+          selecting({
+            id: 'task-1',
+            projectId: 'project-1',
+            workspaceId: 'workspace-2',
+            name: 'Task',
+          })
+        ),
+      } as never,
+      projects: { requireAttached },
+      runtimes: { client: vi.fn() },
+      workspaceIdentity: { resolve: vi.fn() },
+    });
+    const source = resolver.bind({
+      projectId: 'project-1',
+      taskId: 'task-1',
+      workspaceId: 'workspace-1',
+    });
+
+    await expect(source.resolve()).resolves.toEqual({
+      success: false,
+      error: {
+        type: 'missing-workspace',
+        message: 'Task task-1 is not bound to workspace workspace-1',
+      },
+    });
+    expect(requireAttached).not.toHaveBeenCalled();
+  });
+});
+
+function selecting<T>(row: T) {
+  return {
+    from: () => ({
+      where: () => ({
+        limit: async () => [row],
+      }),
+    }),
+  };
+}

--- a/apps/emdash-desktop/src/core/features/terminals/node/wire-controller.test.ts
+++ b/apps/emdash-desktop/src/core/features/terminals/node/wire-controller.test.ts
@@ -23,6 +23,15 @@ const controllerDeps = {
   terminalShell: {
     getColorEnv: vi.fn(async () => ({})),
   } as never,
+  sessionLaunchContexts: {
+    resolve: vi.fn(async () =>
+      ok({
+        workspace: identity,
+        tmux: false,
+        env: {},
+      })
+    ),
+  },
   resolveSessionGitCredentials: vi.fn(async () => undefined),
 };
 
@@ -134,61 +143,25 @@ describe('createTerminalsWireController', () => {
       shellId: 'default',
       ssh: 0,
     };
-    const taskRow = {
-      id: 'task-1',
-      projectId: identity.projectId,
-      workspaceId: identity.workspaceId,
-      name: 'Task one',
-    };
-    const select = vi
-      .fn()
-      .mockReturnValueOnce(selecting(terminalRow))
-      .mockReturnValueOnce(selecting(taskRow));
-    const getProjectConfig = vi.fn(async () =>
+    const select = vi.fn().mockReturnValueOnce(selecting(terminalRow));
+    const resolveLaunchContext = vi.fn(async () =>
       ok({
-        resolved: {
-          preservePatterns: { value: [], from: 'built-in' as const },
-          shellSetup: { value: 'source .workspace-env', from: 'team' as const },
-          autoRunSetup: { value: true, from: 'built-in' as const },
-          autoRunRun: { value: false, from: 'built-in' as const },
-        },
+        workspace: identity,
+        tmux: true,
+        shellSetup: 'source .workspace-env',
+        env: { EMDASH_DEFAULT_BRANCH: 'main' },
       })
     );
-    const resolveTmux = vi.fn(async () => ({
-      value: true,
-      provenance: { kind: 'set' as const },
-    }));
     const start = vi.fn(async () => ok(undefined));
     const runtime = {
-      workspaceRegistry: { getProjectConfig },
       terminals: { start },
     };
-    const requireAttached = vi.fn(() =>
-      ok({
-        projectId: identity.projectId,
-        repoPath: '/repo',
-        settings: {
-          resolveTmux,
-          getStoredGitSettings: vi.fn(async () => ({
-            defaultBranch: { remote: null, branch: 'main' },
-          })),
-          getPlacementContext: vi.fn(async () => ({
-            hostWorktreeRoot: null,
-            builtInWorktreeRoot: '/tmp/worktrees',
-            homeDirectory: '/tmp',
-            hostTmux: null,
-            appDefaultTmux: false,
-          })),
-        },
-        repoFacts: {
-          get: vi.fn(async () => ({ remotes: [], localBranches: ['main'] })),
-        },
-      })
-    );
+    const requireAttached = vi.fn(() => ok({} as never));
     const controller = createTerminalsWireController({
       ...controllerDeps,
       db: { select } as never,
       projects: { requireAttached } as never,
+      sessionLaunchContexts: { resolve: resolveLaunchContext },
       runtimes: {
         client: vi.fn(async () => ok(runtime)),
       } as unknown as TerminalsRuntimeBroker,
@@ -198,14 +171,14 @@ describe('createTerminalsWireController', () => {
     await expect(
       controller.call('hydrate', {
         projectId: identity.projectId,
-        taskId: taskRow.id,
+        taskId: terminalRow.taskId,
         terminalId: terminalRow.id,
       })
     ).resolves.toEqual(
       ok({
         key: {
           workspaceId: identity.workspaceId,
-          terminalId: `${identity.projectId}:${taskRow.id}:${terminalRow.id}`,
+          terminalId: `${identity.projectId}:${terminalRow.taskId}:${terminalRow.id}`,
         },
       })
     );
@@ -218,9 +191,11 @@ describe('createTerminalsWireController', () => {
         }),
       })
     );
-    expect(getProjectConfig).toHaveBeenCalledWith({ workspaceId: identity.workspaceId });
+    expect(resolveLaunchContext).toHaveBeenCalledWith({
+      projectId: identity.projectId,
+      taskId: terminalRow.taskId,
+    });
     expect(requireAttached).toHaveBeenCalledWith(identity.projectId);
-    expect(resolveTmux).toHaveBeenCalledOnce();
   });
 
   it('resolves the output source for the workspace host', async () => {

--- a/apps/emdash-desktop/src/core/features/terminals/node/wire-controller.ts
+++ b/apps/emdash-desktop/src/core/features/terminals/node/wire-controller.ts
@@ -17,7 +17,7 @@ import {
   withAttachedProject,
 } from '@core/features/projects/api/node/attached-project';
 import type { ProjectAttachmentManager } from '@core/features/projects/api/node/project-attachment-manager';
-import { resolveProjectEffectiveSettings } from '@core/features/projects/api/node/settings/effective-settings';
+import type { TaskSessionLaunchContextResolver } from '@core/features/tasks/api/node/task-session-launch-context';
 import {
   terminalsContract,
   type TerminalCreateResult,
@@ -35,7 +35,6 @@ import {
   type TerminalsWorkspaceIdentity as WorkspaceIdentity,
   type TerminalsWorkspaceIdentityResolver,
 } from '@core/features/terminals/api/runtime-adapter';
-import { getTaskEnvVars } from '@core/features/workspaces/api/node/workspace-env';
 import { hostFileRefFromNativePath } from '@core/primitives/desktop-runtime/api';
 import { makePtySessionId, parsePtySessionId } from '@core/primitives/pty/api';
 import type { TelemetryService } from '@core/primitives/telemetry/api/telemetry';
@@ -48,6 +47,7 @@ export type CreateTerminalsWireControllerOptions = Readonly<{
   db: AppDb;
   projects: Pick<ProjectAttachmentManager, 'requireAttached'>;
   runtimes: TerminalsRuntimeBroker;
+  sessionLaunchContexts: Pick<TaskSessionLaunchContextResolver, 'resolve'>;
   settings: Pick<AppSettingsService, 'get'>;
   workspaceIdentity: TerminalsWorkspaceIdentityResolver;
   logger: Logger;
@@ -293,73 +293,28 @@ async function resolveTerminalContext(
   options: CreateTerminalsWireControllerOptions,
   terminal: Terminal
 ): Promise<Result<TerminalContext, TerminalControllerError>> {
-  const [taskRow] = await options.db
-    .select()
-    .from(tasks)
-    .where(
-      and(
-        eq(tasks.id, terminal.taskId),
-        eq(tasks.projectId, terminal.projectId),
-        isNull(tasks.deletedAt)
-      )
-    )
-    .limit(1);
-  if (!taskRow) return err(terminalError('missing-task', `Task ${terminal.taskId} not found`));
-  const workspaceId = taskRow.workspaceId;
-  if (!workspaceId) {
-    return err(terminalError('missing-workspace', `Task ${terminal.taskId} has no workspace`));
-  }
+  const launchContext = await options.sessionLaunchContexts.resolve({
+    projectId: terminal.projectId,
+    taskId: terminal.taskId,
+  });
+  if (!launchContext.success) return launchContext;
 
-  return withAttachedProject(options.projects, terminal.projectId, async (project) => {
-    const identity = await options.workspaceIdentity.resolve(workspaceId);
-    if (!identity) {
-      return err(terminalError('missing-workspace', `Workspace ${workspaceId} was not found`));
-    }
-
-    return withWorkspaceRuntime(options, identity.workspaceId, async (client) => {
-      // Effective default branch through the blessed resolver (spec:
-      // github-git-settings §2); null (unresolvable) omits the env var.
-      const [effective, tmux, projectConfig] = await Promise.all([
-        resolveProjectEffectiveSettings({
-          settings: project.settings,
-          repoFacts: project.repoFacts,
-        }),
-        project.settings.resolveTmux(),
-        client.workspaceRegistry.getProjectConfig({ workspaceId: identity.workspaceId }),
-      ]);
-      const defaultBranch = effective.defaultBranch.value?.branch ?? null;
-      if (!projectConfig.success) {
-        return err(
-          terminalError(
-            'missing-workspace',
-            `Workspace ${identity.workspaceId} has no project configuration`
-          )
-        );
-      }
-      const gitCredentials = await options.resolveSessionGitCredentials({
-        projectId: terminal.projectId,
-        host: identity.host,
-      });
-      return ok({
-        identity,
-        workspace: workspaceRef(identity),
-        key: toTerminalKey(
-          identity,
-          makePtySessionId(terminal.projectId, terminal.taskId, terminal.id)
-        ),
-        tmuxEnabled: tmux.value,
-        shellSetup: projectConfig.data.resolved.shellSetup?.value,
-        taskEnvVars: getTaskEnvVars({
-          taskId: terminal.taskId,
-          taskName: taskRow.name,
-          taskPath: identity.path,
-          projectPath: project.repoPath,
-          defaultBranch,
-          portSeed: identity.path,
-        }),
-        gitCredentials,
-      });
-    });
+  const identity = launchContext.data.workspace;
+  const gitCredentials = await options.resolveSessionGitCredentials({
+    projectId: terminal.projectId,
+    host: identity.host,
+  });
+  return ok({
+    identity,
+    workspace: workspaceRef(identity),
+    key: toTerminalKey(
+      identity,
+      makePtySessionId(terminal.projectId, terminal.taskId, terminal.id)
+    ),
+    tmuxEnabled: launchContext.data.tmux,
+    shellSetup: launchContext.data.shellSetup,
+    taskEnvVars: launchContext.data.env,
+    gitCredentials,
   });
 }
 

--- a/apps/emdash-desktop/src/core/features/workspaces/api/node/workspace-factory.ts
+++ b/apps/emdash-desktop/src/core/features/workspaces/api/node/workspace-factory.ts
@@ -1,15 +1,8 @@
 import type { HostRef } from '@emdash/core/primitives/host/api';
 import type { RuntimeResolveError } from '@emdash/core/services/runtime-broker/api';
-import { err, ok, type Result } from '@emdash/shared';
+import { ok, type Result } from '@emdash/shared';
 import type { ConversationProvider } from '@core/features/conversations/api/node/types';
-import {
-  resolveProjectEffectiveSettings,
-  type RepoFactsSource,
-} from '@core/features/projects/api/node/settings/effective-settings';
-import type { ProjectSettingsProvider } from '@core/features/projects/api/node/settings/provider';
-import type { Workspace } from '@core/features/workspaces/api/node/workspace';
-import { getTaskEnvVars } from '@core/features/workspaces/api/node/workspace-env';
-import type { Task } from '@core/primitives/tasks/api';
+import type { TaskSessionLaunchContextSource } from '@core/features/tasks/api/node/task-session-launch-context';
 import type { TuiAgentsRuntimeClient } from '@core/services/runtime-broker/api/clients';
 import type { FilesClientScope } from '@core/services/runtime-broker/node/files';
 
@@ -23,22 +16,7 @@ export type TaskProviderOpts = {
   taskId: string;
   workspaceId: string;
   taskPath: string;
-  tmuxEnabled: boolean;
-  shellSetup?: string;
-  taskEnvVars: Record<string, string>;
-};
-
-export type ResolveTaskEnvError = {
-  type: 'setup-failed';
-  stepKind: 'resolve-project-config';
-  stepErrorType: string;
-  message: string;
-};
-
-export type ResolvedTaskEnv = {
-  taskEnvVars: Record<string, string>;
-  tmuxEnabled: boolean;
-  shellSetup?: string;
+  launchContextSource: TaskSessionLaunchContextSource;
 };
 
 export async function buildTaskProviders(
@@ -47,42 +25,5 @@ export async function buildTaskProviders(
 ): Promise<Result<{ conversations: ConversationProvider }, RuntimeResolveError>> {
   return ok({
     conversations: createConversationProvider(opts),
-  });
-}
-
-export async function resolveTaskEnv(
-  task: Pick<Task, 'id' | 'name'>,
-  workspace: Pick<Workspace, 'id' | 'path' | 'workspaceRegistry'>,
-  projectPath: string,
-  settings: ProjectSettingsProvider,
-  repoFacts: RepoFactsSource
-): Promise<Result<ResolvedTaskEnv, ResolveTaskEnvError>> {
-  // Effective default branch through the blessed resolver (spec:
-  // github-git-settings §2); null (unresolvable) omits the env var.
-  const [effective, tmux, projectConfig] = await Promise.all([
-    resolveProjectEffectiveSettings({ settings, repoFacts }),
-    settings.resolveTmux(),
-    workspace.workspaceRegistry.getProjectConfig({ workspaceId: workspace.id }),
-  ]);
-  const defaultBranch = effective.defaultBranch.value?.branch ?? null;
-  if (!projectConfig.success) {
-    return err({
-      type: 'setup-failed',
-      stepKind: 'resolve-project-config',
-      stepErrorType: projectConfig.error.type,
-      message: `Could not resolve project config for workspace ${workspace.id} (${projectConfig.error.type})`,
-    });
-  }
-  return ok({
-    taskEnvVars: getTaskEnvVars({
-      taskId: task.id,
-      taskName: task.name,
-      taskPath: workspace.path,
-      projectPath,
-      defaultBranch,
-      portSeed: workspace.path,
-    }),
-    tmuxEnabled: tmux.value,
-    shellSetup: projectConfig.data.resolved.shellSetup?.value,
   });
 }

--- a/apps/emdash-desktop/src/core/features/workspaces/node/workspace-factory.test.ts
+++ b/apps/emdash-desktop/src/core/features/workspaces/node/workspace-factory.test.ts
@@ -1,9 +1,6 @@
-import { err, ok } from '@emdash/shared';
+import { ok } from '@emdash/shared';
 import { describe, expect, it, vi } from 'vitest';
-import {
-  buildTaskProviders,
-  resolveTaskEnv,
-} from '@core/features/workspaces/api/node/workspace-factory';
+import { buildTaskProviders } from '@core/features/workspaces/api/node/workspace-factory';
 
 describe('buildTaskProviders', () => {
   it('constructs providers for a remote host with its injected runtime clients', async () => {
@@ -18,8 +15,19 @@ describe('buildTaskProviders', () => {
       taskId: 'task-1',
       workspaceId: 'workspace-1',
       taskPath: '/remote/worktree',
-      tmuxEnabled: false,
-      taskEnvVars: {},
+      launchContextSource: {
+        resolve: async () =>
+          ok({
+            workspace: {
+              workspaceId: 'workspace-1',
+              projectId: 'project-1',
+              host: { type: 'remote' as const, id: 'ssh-1' },
+              path: '/remote/worktree',
+            },
+            tmux: false,
+            env: {},
+          }),
+      },
     };
     const createConversationProvider = vi.fn(() => conversations as never);
 
@@ -30,111 +38,5 @@ describe('buildTaskProviders', () => {
       data: { conversations },
     });
     expect(createConversationProvider).toHaveBeenCalledWith(options);
-  });
-});
-
-describe('resolveTaskEnv', () => {
-  it('reads shell setup from registry config and tmux from the placement resolver', async () => {
-    const getProjectConfig = vi.fn(async () =>
-      ok({
-        resolved: {
-          preservePatterns: { value: [], from: 'built-in' as const },
-          shellSetup: { value: 'source .workspace-env', from: 'team' as const },
-          autoRunSetup: { value: true, from: 'built-in' as const },
-          autoRunRun: { value: false, from: 'built-in' as const },
-        },
-      })
-    );
-    const resolveTmux = vi.fn(async () => ({
-      value: true,
-      provenance: { kind: 'set' as const },
-    }));
-    const settings = {
-      resolveTmux,
-      getStoredGitSettings: vi.fn(async () => ({
-        defaultBranch: { remote: null, branch: 'main' },
-      })),
-      getPlacementContext: vi.fn(async () => ({
-        hostWorktreeRoot: null,
-        builtInWorktreeRoot: '/tmp/worktrees',
-        homeDirectory: '/tmp',
-        hostTmux: null,
-        appDefaultTmux: false,
-      })),
-    } as never;
-
-    const result = await resolveTaskEnv(
-      { id: 'task-1', name: 'Task one' },
-      {
-        id: 'workspace-1',
-        path: '/repo/worktree',
-        workspaceRegistry: { getProjectConfig, createWorkspace: vi.fn() },
-      } as never,
-      '/repo',
-      settings,
-      {
-        get: vi.fn(async () => ({ remotes: [], localBranches: ['main'] })),
-        dispose: vi.fn(),
-      }
-    );
-
-    expect(result).toMatchObject({
-      success: true,
-      data: {
-        tmuxEnabled: true,
-        shellSetup: 'source .workspace-env',
-        taskEnvVars: { EMDASH_DEFAULT_BRANCH: 'main' },
-      },
-    });
-    expect(getProjectConfig).toHaveBeenCalledWith({ workspaceId: 'workspace-1' });
-    expect(resolveTmux).toHaveBeenCalledOnce();
-  });
-
-  it('treats an unknown Host identity as an invariant failure without registering it', async () => {
-    const getProjectConfig = vi.fn(async () =>
-      err({ type: 'workspace-not-found' as const, workspaceId: 'workspace-1' })
-    );
-    const createWorkspace = vi.fn(async () => ok({} as never));
-    const settings = {
-      resolveTmux: vi.fn(async () => ({
-        value: false,
-        provenance: { kind: 'inferred' as const, from: 'app default' },
-      })),
-      getStoredGitSettings: vi.fn(async () => ({})),
-      getPlacementContext: vi.fn(async () => ({
-        hostWorktreeRoot: null,
-        builtInWorktreeRoot: '/tmp/worktrees',
-        homeDirectory: '/tmp',
-        hostTmux: null,
-        appDefaultTmux: false,
-      })),
-    } as never;
-
-    const result = await resolveTaskEnv(
-      { id: 'task-1', name: 'Task one' },
-      {
-        id: 'workspace-1',
-        path: '/repo/worktree',
-        workspaceRegistry: { getProjectConfig, createWorkspace },
-      } as never,
-      '/repo',
-      settings,
-      {
-        get: vi.fn(async () => ({ remotes: [], localBranches: [] })),
-        dispose: vi.fn(),
-      }
-    );
-
-    expect(result).toEqual({
-      success: false,
-      error: {
-        type: 'setup-failed',
-        stepKind: 'resolve-project-config',
-        stepErrorType: 'workspace-not-found',
-        message: 'Could not resolve project config for workspace workspace-1 (workspace-not-found)',
-      },
-    });
-    expect(createWorkspace).not.toHaveBeenCalled();
-    expect(getProjectConfig).toHaveBeenCalledOnce();
   });
 });

--- a/apps/emdash-desktop/src/core/manifests/node/controllers.ts
+++ b/apps/emdash-desktop/src/core/manifests/node/controllers.ts
@@ -55,6 +55,7 @@ import { createSearchWireController } from '@core/features/search/node/wire-cont
 import { createSkillsWireController } from '@core/features/skills/node/wire-controller';
 import { createSourceControlWireController } from '@core/features/source-control/node/wire-controller';
 import type { TaskService } from '@core/features/tasks/api/node/task-service';
+import type { TaskSessionLaunchContextResolver } from '@core/features/tasks/api/node/task-session-launch-context';
 import type { TaskSessionManager } from '@core/features/tasks/api/node/task-session-manager';
 import { TaskListService } from '@core/features/tasks/node/task-list-service';
 import { createTasksWireController } from '@core/features/tasks/node/wire-controller';
@@ -147,6 +148,7 @@ export type DesktopControllerContext = {
   };
   readonly scope: Scope;
   readonly search: SearchService;
+  readonly sessionLaunchContexts: TaskSessionLaunchContextResolver;
   readonly runtimes: RuntimeBroker;
   readonly ssh: SshServiceHandle;
   readonly settingsRuntime: SettingsRuntimePort;
@@ -269,6 +271,7 @@ export const desktopNodeControllers = {
       logger,
       projects,
       runtimes,
+      sessionLaunchContexts,
       telemetry,
       terminalShell,
       workspaceIdentity,
@@ -277,6 +280,7 @@ export const desktopNodeControllers = {
         db,
         projects,
         runtimes,
+        sessionLaunchContexts,
         settings: appSettings,
         logger,
         telemetry,

--- a/apps/emdash-desktop/src/main/bootstrap/boot/phases/services.ts
+++ b/apps/emdash-desktop/src/main/bootstrap/boot/phases/services.ts
@@ -66,6 +66,7 @@ import { migrateAppWorktreeRootToLocalHostDefault } from '@core/features/project
 import { createSearchService } from '@core/features/search/node/search-service';
 import { TaskService } from '@core/features/tasks/api/node/task-service';
 import type { TaskSessionCleanup } from '@core/features/tasks/api/node/task-session-cleanup';
+import { TaskSessionLaunchContextResolver } from '@core/features/tasks/api/node/task-session-launch-context';
 import { TaskSessionManager } from '@core/features/tasks/api/node/task-session-manager';
 import { installAutomationTelemetry } from '@core/features/telemetry/node/automation-telemetry';
 import { installTaskTelemetry } from '@core/features/telemetry/node/task-telemetry';
@@ -167,6 +168,7 @@ export type ServicesBundle = {
   readonly providerSettings: ReturnType<typeof createProviderOverrideSettings>;
   readonly pullRequestsRegistration: PullRequestsRegistration;
   readonly search: ReturnType<typeof createSearchService>;
+  readonly sessionLaunchContexts: TaskSessionLaunchContextResolver;
   readonly taskService: TaskService;
   readonly taskSessions: TaskSessionManager;
   readonly workspacePlacement: WorkspacePlacementResolver;
@@ -308,6 +310,12 @@ export async function bootServices(
     availability: desktopRuntimes.hostAvailability,
     adapter: projectAttachmentAdapter,
   });
+  const sessionLaunchContexts = new TaskSessionLaunchContextResolver({
+    db,
+    projects: projectManager,
+    runtimes,
+    workspaceIdentity,
+  });
   const previewServerAccess = new PreviewServerAccessService({
     projects: projectManager,
     previewServers: previewServerService,
@@ -331,9 +339,7 @@ export async function bootServices(
         host: options.host,
         files: options.files,
         tuiAgents: options.tuiAgents,
-        tmux: options.tmuxEnabled,
-        shellSetup: options.shellSetup,
-        taskEnvVars: options.taskEnvVars,
+        launchContextSource: options.launchContextSource,
       },
       tuiConversationDependencies
     );
@@ -365,6 +371,7 @@ export async function bootServices(
     workspacePlacement,
     runtimes,
     lifecycleParticipants,
+    sessionLaunchContexts,
     createConversationProvider,
     workspaceIdentity,
     creations: workspaceCreations,
@@ -806,6 +813,7 @@ export async function bootServices(
     providerSettings: providerOverrideSettings,
     pullRequestsRegistration,
     search: searchService,
+    sessionLaunchContexts,
     taskService,
     taskSessions: taskSessionManager,
     workspacePlacement,

--- a/apps/emdash-desktop/src/main/bootstrap/boot/wiring.ts
+++ b/apps/emdash-desktop/src/main/bootstrap/boot/wiring.ts
@@ -121,6 +121,7 @@ export function createDesktopWireOptions(
     providerSettings: services.providerSettings,
     reconcileSweep: services.reconcileSweep,
     search: services.search,
+    sessionLaunchContexts: services.sessionLaunchContexts,
     runtimeClients: {
       getMementosRuntimeClient: async () => runtimes.clients.mementos,
       getPullRequestsRuntimeClient: async () => runtimes.clients.pullRequests,


### PR DESCRIPTION
- add TaskSessionLaunchContextResolver to resolve tmux shell setup and task environment from current authorities
- bind conversation providers to stable task and workspace identities while resolving mutable values immediately before launch
- route terminal and tui conversation creation through the same launch context
- prevent bound providers from silently following replacement workspaces
- document launch-time settings ownership and resolution boundaries