### PR TITLE
feat(conversations): persist acp composer drafts across navigation

### DIFF
--- a/agents/architecture/acp-runtime.md
+++ b/agents/architecture/acp-runtime.md
@@ -95,6 +95,10 @@ terminal management, attachment storage, and session cells stay inside the ACP r
 owns a worker manifest that maps the ACP worker id to the emitted child-process entry path for that
 host's build.
 
+Desktop draft mementos may reference attachment bytes that do not appear in a transcript. Runtime
+attachment cleanup must therefore use explicit attachment deletion or whole-conversation deletion;
+absence from transcript history does not prove that stored bytes are orphaned.
+
 Desktop composes the ACP client and renderer exposure in
 `apps/emdash-desktop/src/main/core/wire-workers/desktop-workers.ts`: the raw
 stable worker client is wrapped there for session-ID persistence, then forwarded

--- a/apps/emdash-desktop/src/core/features/conversations/api/contract.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/api/contract.ts
@@ -123,10 +123,6 @@ const conversationsAcpContract = defineContract({
     acpApiContract.resolvePermission.input,
     acpApiContract.resolvePermission.output
   ),
-  setPromptDraft: runtimeFallibleProcedure(
-    acpApiContract.setPromptDraft.input,
-    acpApiContract.setPromptDraft.output
-  ),
   exportAcpTranscript: runtimeFallibleProcedure(
     acpApiContract.exportAcpTranscript.input,
     acpApiContract.exportAcpTranscript.output

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-panel.tsx
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-panel.tsx
@@ -155,7 +155,7 @@ function readFileAsDataUrl(file: File): Promise<string | undefined> {
 async function uploadImageFile(
   store: AcpChatStore,
   file: File
-): Promise<ComposerAttachment | null> {
+): Promise<AcpPromptAttachment | null> {
   const mimeType = toAttachmentMimeType(file);
   if (!mimeType) {
     log.warn('Dropped image type is not supported for ACP attachments', {
@@ -186,11 +186,18 @@ async function uploadImageFile(
 
   if (!ref) return null;
   return {
-    id: ref.id,
-    name: ref.name,
-    kind: 'image',
+    ref: { type: 'attachment', ...ref },
     previewUrl,
-    mimeType: ref.mimeType,
+  };
+}
+
+function toComposerAttachment(attachment: AcpPromptAttachment): ComposerAttachment {
+  return {
+    id: attachment.ref.id,
+    name: attachment.ref.name ?? 'image',
+    kind: 'image',
+    previewUrl: attachment.previewUrl,
+    mimeType: attachment.ref.mimeType,
   };
 }
 
@@ -237,7 +244,7 @@ const ComposerForStore = observer(function ComposerForStore({
 }) {
   const editorApiRef = useRef<PromptEditorRef | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
+  const attachments = store.draftAttachments.map(toComposerAttachment);
   const { value: promptLibrary } = usePromptLibrary();
   const disabledReason = projectAvailabilityUi.getLiveActionDisabledReason(store.projectId);
 
@@ -251,25 +258,6 @@ const ComposerForStore = observer(function ComposerForStore({
     if (!editor || editor.getText() === store.draftText) return;
     editor.setText(store.draftText);
   }, [store, store.draftText]);
-
-  const buildPromptAttachments = useCallback(
-    (): AcpPromptAttachment[] =>
-      attachments
-        .filter((att) => att.kind === 'image' && toAttachmentMimeTypeValue(att.mimeType ?? ''))
-        .map((att) => {
-          const mimeType = toAttachmentMimeTypeValue(att.mimeType ?? '') ?? 'image/png';
-          return {
-            ref: {
-              type: 'attachment' as const,
-              id: att.id,
-              mimeType,
-              name: att.name,
-            },
-            previewUrl: att.previewUrl,
-          };
-        }),
-    [attachments]
-  );
 
   const buildHiddenIssueContext = useCallback(
     (value: string) =>
@@ -294,14 +282,13 @@ const ComposerForStore = observer(function ComposerForStore({
 
   const handleSubmit = useCallback(
     (value: string) => {
-      const promptAttachments = buildPromptAttachments();
+      const promptAttachments = store.draftAttachments;
       if (!value.trim() && promptAttachments.length === 0) return;
-      setAttachments([]);
-      editorApiRef.current?.clear();
       const hiddenContext = buildHiddenIssueContext(value);
       store.submitPrompt(value, promptAttachments, hiddenContext);
+      editorApiRef.current?.clear();
     },
-    [store, buildPromptAttachments, buildHiddenIssueContext]
+    [store, buildHiddenIssueContext]
   );
 
   const handleStop = useCallback(() => {
@@ -385,9 +372,9 @@ const ComposerForStore = observer(function ComposerForStore({
       }
 
       const next = await Promise.all(supportedFiles.map((file) => uploadImageFile(store, file)));
-      const uploaded = next.filter((att): att is ComposerAttachment => att !== null);
+      const uploaded = next.filter((att): att is AcpPromptAttachment => att !== null);
       if (uploaded.length > 0) {
-        setAttachments((prev) => [...prev, ...uploaded]);
+        store.addDraftAttachments(uploaded);
       }
     },
     [store]
@@ -398,10 +385,9 @@ const ComposerForStore = observer(function ComposerForStore({
       const nextIds = new Set(next.map((attachment) => attachment.id));
       for (const attachment of attachments) {
         if (attachment.kind === 'image' && !nextIds.has(attachment.id)) {
-          void store.deleteAttachment(attachment.id);
+          store.removeDraftAttachment(attachment.id);
         }
       }
-      setAttachments(next);
     },
     [attachments, store]
   );

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-panel.tsx
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-panel.tsx
@@ -61,7 +61,7 @@ import { createTranscriptFileCommands } from './transcript-file-commands';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-const attachmentDataUrlCache = new Map<string, Promise<string | null>>();
+const attachmentDataUrlCache = new Map<string, string>();
 const ISSUE_SEARCH_MIN_LENGTH = 2;
 const ISSUE_SEARCH_LIMIT = 20;
 const SLASH_COMMANDS_SECTION = 'Commands';
@@ -201,22 +201,20 @@ function toComposerAttachment(attachment: AcpPromptAttachment): ComposerAttachme
   };
 }
 
-function resolveAttachmentDataUrl(store: AcpChatStore, id: string): Promise<string | null> {
-  if (!store.session) return Promise.resolve(null);
-  const cached = attachmentDataUrlCache.get(id);
+async function resolveAttachmentDataUrl(store: AcpChatStore, id: string): Promise<string | null> {
+  const cacheKey = `${store.conversationId}:${id}`;
+  const cached = attachmentDataUrlCache.get(cacheKey);
   if (cached) return cached;
-  const promise = store.session
-    .downloadAttachment(id)
-    .then((result) => {
-      if (!result.success) return null;
-      return `data:${result.data.ref.mimeType};base64,${bytesToBase64(result.data.data)}`;
-    })
-    .catch((error: unknown) => {
-      log.warn('Failed to resolve ACP attachment', { id, error });
-      return null;
-    });
-  attachmentDataUrlCache.set(id, promise);
-  return promise;
+  try {
+    const result = await store.downloadAttachment(id);
+    if (!result.success) return null;
+    const dataUrl = `data:${result.data.ref.mimeType};base64,${bytesToBase64(result.data.data)}`;
+    attachmentDataUrlCache.set(cacheKey, dataUrl);
+    return dataUrl;
+  } catch (error) {
+    log.warn('Failed to resolve ACP attachment', { id, error });
+    return null;
+  }
 }
 
 function bytesToBase64(bytes: Uint8Array): string {

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
@@ -25,6 +25,10 @@ import {
 } from '@core/features/conversations/api/browser/chat/advertised-command-provider';
 import { getChatUiRuntime } from '@core/features/conversations/api/browser/chat/chat-ui-runtime';
 import { getSharedChatContext } from '@core/features/conversations/api/browser/chat/shared-chat-context';
+import {
+  getConversationsClient,
+  type ConversationsClient,
+} from '@core/features/conversations/api/browser/client';
 import { conversationRegistry } from '@core/features/conversations/api/browser/stores/conversation-registry';
 import {
   ACP_DRAFT_MAX_LENGTH,
@@ -54,7 +58,7 @@ export interface AgentAffordances {
 
 type StoredPromptAttachment = Extract<PromptAttachment, { type: 'attachment' }>;
 
-const draftAttachmentDataUrlCache = new Map<string, Promise<string | null>>();
+const draftAttachmentDataUrlCache = new Map<string, string>();
 
 export type AcpPromptAttachment = {
   ref: StoredPromptAttachment;
@@ -90,6 +94,7 @@ export class AcpChatStore {
   private readonly _draftSpace: SubjectSpace<'conversation'>;
   private readonly _draftHandle: MementoHandle<AcpDraftState>;
   private readonly _disposeHostReaction: () => void;
+  private _acpClientPromise: Promise<ConversationsClient['acp']> | null = null;
   private _disposed = false;
 
   constructor(
@@ -182,8 +187,7 @@ export class AcpChatStore {
             ref: { type: 'attachment', ...attachment },
           }));
         });
-        const session = this.session;
-        if (session) void this._rehydrateDraftAttachmentPreviews(session);
+        void this._rehydrateDraftAttachmentPreviews();
       },
       (error: unknown) => getMementoClient().reportError(error)
     );
@@ -317,11 +321,17 @@ export class AcpChatStore {
   }): Promise<AttachmentRef | null> {
     if (this.hostAccess?.liveAction.kind === 'disabled') return null;
     try {
-      const result = await this.session?.uploadAttachment(input);
-      if (!result) {
-        this._toastError('Failed to upload attachment', new Error('ACP session is not connected'));
-        return null;
-      }
+      const client = await this._getAcpClient();
+      const result = await client.uploadAttachment(
+        { conversationId: this.conversationId, originalPath: input.originalPath },
+        {
+          name: input.name ?? 'attachment',
+          mimeType: input.mimeType,
+          size: input.size ?? input.data?.byteLength,
+          source:
+            input.source ?? (input.data ? singleChunk(input.data) : singleChunk(new Uint8Array())),
+        }
+      );
       if (!result.success) {
         this._toastError('Failed to upload attachment', result.error);
         return null;
@@ -333,10 +343,30 @@ export class AcpChatStore {
     }
   }
 
+  async downloadAttachment(id: string) {
+    const client = await this._getAcpClient();
+    const result = await client.downloadAttachment({
+      conversationId: this.conversationId,
+      attachmentId: id,
+    });
+    if (!result.success) return result;
+    return {
+      success: true as const,
+      data: {
+        ref: result.data.meta,
+        data: await result.data.bytes(),
+      },
+    };
+  }
+
   async deleteAttachment(id: string): Promise<void> {
     try {
-      const result = await this.session?.deleteAttachment(id);
-      if (result && !result.success) this._toastError('Failed to delete attachment', result.error);
+      const client = await this._getAcpClient();
+      const result = await client.deleteAttachment({
+        conversationId: this.conversationId,
+        attachmentId: id,
+      });
+      if (!result.success) this._toastError('Failed to delete attachment', result.error);
     } catch (error) {
       this._toastError('Failed to delete attachment', error);
     }
@@ -378,9 +408,8 @@ export class AcpChatStore {
     const additions = attachments.filter(({ ref }) => !existingIds.has(ref.id));
     if (additions.length === 0) return;
     this.draftAttachments = [...this.draftAttachments, ...additions];
-    const session = this.session;
-    if (session && additions.some((attachment) => !attachment.previewUrl)) {
-      void this._rehydrateDraftAttachmentPreviews(session);
+    if (additions.some((attachment) => !attachment.previewUrl)) {
+      void this._rehydrateDraftAttachmentPreviews();
     }
   }
 
@@ -515,7 +544,7 @@ export class AcpChatStore {
         this.loadError = null;
         this._syncMessageCount();
       });
-      void this._rehydrateDraftAttachmentPreviews(clientSession);
+      void this._rehydrateDraftAttachmentPreviews();
     } catch (error) {
       log.error('ACP chat bootstrap failed', {
         conversationId: this.conversationId,
@@ -675,27 +704,38 @@ export class AcpChatStore {
     );
   }
 
-  private async _rehydrateDraftAttachmentPreviews(session: AcpLiveSession): Promise<void> {
+  private async _rehydrateDraftAttachmentPreviews(): Promise<void> {
     const pending = this.draftAttachments.filter((attachment) => !attachment.previewUrl);
     await Promise.all(
       pending.map(async (attachment) => {
         const previewUrl = await resolveDraftAttachmentDataUrl(
           this.conversationId,
-          session,
+          this,
           attachment.ref.id
         );
         runInAction(() => {
-          if (this._disposed || this.session !== session) return;
+          if (this._disposed) return;
           const current = this.draftAttachments.find(({ ref }) => ref.id === attachment.ref.id);
           if (!current || current.previewUrl) return;
-          this.draftAttachments = previewUrl
-            ? this.draftAttachments.map((candidate) =>
-                candidate.ref.id === attachment.ref.id ? { ...candidate, previewUrl } : candidate
-              )
-            : this.draftAttachments.filter(({ ref }) => ref.id !== attachment.ref.id);
+          if (previewUrl.kind === 'resolved') {
+            this.draftAttachments = this.draftAttachments.map((candidate) =>
+              candidate.ref.id === attachment.ref.id
+                ? { ...candidate, previewUrl: previewUrl.dataUrl }
+                : candidate
+            );
+          } else if (previewUrl.kind === 'not_found') {
+            this.draftAttachments = this.draftAttachments.filter(
+              ({ ref }) => ref.id !== attachment.ref.id
+            );
+          }
         });
       })
     );
+  }
+
+  private _getAcpClient(): Promise<ConversationsClient['acp']> {
+    this._acpClientPromise ??= getConversationsClient().then((client) => client.acp);
+    return this._acpClientPromise;
   }
 
   private _bindTerminalOutputs(session: AcpLiveSession): () => void {
@@ -738,24 +778,36 @@ function toPendingAttachment(attachment: AcpPromptAttachment): ChatImageAttachme
   };
 }
 
-function resolveDraftAttachmentDataUrl(
+type DraftAttachmentPreviewResult =
+  | { kind: 'resolved'; dataUrl: string }
+  | { kind: 'not_found' }
+  | { kind: 'unavailable' };
+
+async function resolveDraftAttachmentDataUrl(
   conversationId: string,
-  session: AcpLiveSession,
+  store: AcpChatStore,
   attachmentId: string
-): Promise<string | null> {
+): Promise<DraftAttachmentPreviewResult> {
   const cacheKey = `${conversationId}:${attachmentId}`;
   const cached = draftAttachmentDataUrlCache.get(cacheKey);
-  if (cached) return cached;
-  const promise = session
-    .downloadAttachment(attachmentId)
-    .then((result) =>
-      result.success
-        ? `data:${result.data.ref.mimeType};base64,${bytesToBase64(result.data.data)}`
-        : null
-    )
-    .catch(() => null);
-  draftAttachmentDataUrlCache.set(cacheKey, promise);
-  return promise;
+  if (cached) return { kind: 'resolved', dataUrl: cached };
+  try {
+    const result = await store.downloadAttachment(attachmentId);
+    if (!result.success) {
+      return result.error.type === 'attachment_not_found'
+        ? { kind: 'not_found' }
+        : { kind: 'unavailable' };
+    }
+    const dataUrl = `data:${result.data.ref.mimeType};base64,${bytesToBase64(result.data.data)}`;
+    draftAttachmentDataUrlCache.set(cacheKey, dataUrl);
+    return { kind: 'resolved', dataUrl };
+  } catch {
+    return { kind: 'unavailable' };
+  }
+}
+
+async function* singleChunk(data: Uint8Array): AsyncIterable<Uint8Array> {
+  yield data;
 }
 
 function bytesToBase64(bytes: Uint8Array): string {

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
@@ -3,11 +3,11 @@ import type {
   AttachmentMimeType,
   AttachmentRef,
   PromptAttachment,
-  PromptDraft,
   PromptInput,
   QueuedPrompt,
   SessionMcpServer,
 } from '@emdash/core/runtimes/acp/api/client';
+import { createScope, type Scope } from '@emdash/shared/concurrency';
 import type {
   CommandItem,
   ComposerEffortOption,
@@ -26,10 +26,21 @@ import {
 import { getChatUiRuntime } from '@core/features/conversations/api/browser/chat/chat-ui-runtime';
 import { getSharedChatContext } from '@core/features/conversations/api/browser/chat/shared-chat-context';
 import { conversationRegistry } from '@core/features/conversations/api/browser/stores/conversation-registry';
+import {
+  ACP_DRAFT_MAX_LENGTH,
+  acpDraftMemento,
+  type AcpDraftState,
+} from '@core/features/conversations/contributions/mementos';
+import { conversationSubject } from '@core/features/conversations/contributions/subject';
 import type { ProjectHostAccess } from '@core/features/projects/api/browser/stores/project-context';
 import { getProjectSshConnectionId } from '@core/features/projects/api/browser/stores/project-selectors';
 import { getHostClient } from '@core/primitives/desktop-host/browser/host-client';
 import { log } from '@core/primitives/logging/browser/logger';
+import {
+  getMementoClient,
+  type MementoHandle,
+  type SubjectSpace,
+} from '@core/primitives/mementos/browser';
 import { AcpLiveSession, AcpStartError, asValueSource } from './acp-live-session';
 import { bindSessionTerminalOutputs } from './acp-terminal-output-binding';
 
@@ -42,6 +53,8 @@ export interface AgentAffordances {
 }
 
 type StoredPromptAttachment = Extract<PromptAttachment, { type: 'attachment' }>;
+
+const draftAttachmentDataUrlCache = new Map<string, Promise<string | null>>();
 
 export type AcpPromptAttachment = {
   ref: StoredPromptAttachment;
@@ -68,14 +81,16 @@ export class AcpChatStore {
   loadError: AcpLoadError | null = null;
   messageCount = 0;
   draftText = '';
+  draftAttachments: AcpPromptAttachment[] = [];
 
   private _view: ChatView | null = null;
   private _bootstrapped = false;
   private _unsubs: Array<() => void> = [];
-  private _draftRev = 0;
-  private _pendingDraftRev: number | null = null;
-  private _draftTimer: number | null = null;
+  private readonly _scope: Scope;
+  private readonly _draftSpace: SubjectSpace<'conversation'>;
+  private readonly _draftHandle: MementoHandle<AcpDraftState>;
   private readonly _disposeHostReaction: () => void;
+  private _disposed = false;
 
   constructor(
     readonly conversationId: string,
@@ -84,9 +99,12 @@ export class AcpChatStore {
     readonly hostAccess?: ProjectHostAccess
   ) {
     this.chatContext = getSharedChatContext();
+    this._scope = createScope({ label: `acp-chat:${conversationId}` });
     this.chatState = getChatUiRuntime().createChatState(this.chatContext, {
       uri: conversationId,
     });
+    this._draftSpace = getMementoClient().subject(conversationSubject({ conversationId }));
+    this._draftHandle = this._draftSpace.handle(acpDraftMemento);
     registerConversationCommands(conversationId, () =>
       this.commands.map((command) => command.name)
     );
@@ -97,6 +115,7 @@ export class AcpChatStore {
       loadError: observable,
       messageCount: observable,
       draftText: observable,
+      draftAttachments: observable.shallow,
       model: computed,
       modelOptions: computed,
       permissionMode: computed,
@@ -121,6 +140,8 @@ export class AcpChatStore {
       reorderQueuedPrompts: action,
       sendQueuedPromptNow: action,
       setDraftText: action,
+      addDraftAttachments: action,
+      removeDraftAttachment: action,
       exportTranscript: action,
       retry: action,
     });
@@ -138,6 +159,33 @@ export class AcpChatStore {
           void this._runBootstrap();
         }
       }
+    );
+    this._draftHandle.autoPersist(
+      () => ({
+        version: '1' as const,
+        text: this.draftText.slice(0, ACP_DRAFT_MAX_LENGTH),
+        attachments: this.draftAttachments.map(({ ref }) => ({
+          id: ref.id,
+          mimeType: ref.mimeType,
+          name: ref.name,
+        })),
+      }),
+      this._scope
+    );
+    void this._draftSpace.ready.then(
+      () => {
+        runInAction(() => {
+          if (this._disposed || this.draftText !== '' || this.draftAttachments.length > 0) return;
+          const stored = this._draftHandle.value;
+          this.draftText = stored.text;
+          this.draftAttachments = stored.attachments.map((attachment) => ({
+            ref: { type: 'attachment', ...attachment },
+          }));
+        });
+        const session = this.session;
+        if (session) void this._rehydrateDraftAttachmentPreviews(session);
+      },
+      (error: unknown) => getMementoClient().reportError(error)
     );
   }
 
@@ -301,6 +349,8 @@ export class AcpChatStore {
   ): void {
     if (this.hostAccess?.liveAction.kind === 'disabled') return;
     const promptAttachments = attachments.map((attachment) => attachment.ref);
+    this.draftText = '';
+    this.draftAttachments = [];
     if (!this.affordances.isWorking) {
       const optimisticId = `optimistic:user:${Date.now()}`;
       this.chatState.session.setPendingPrompt({
@@ -320,9 +370,24 @@ export class AcpChatStore {
   setDraftText(text: string): void {
     if (text === this.draftText) return;
     this.draftText = text;
-    this._draftRev += 1;
-    this._pendingDraftRev = this._draftRev;
-    this._scheduleDraftWrite(text, this._draftRev);
+  }
+
+  addDraftAttachments(attachments: AcpPromptAttachment[]): void {
+    if (attachments.length === 0) return;
+    const existingIds = new Set(this.draftAttachments.map(({ ref }) => ref.id));
+    const additions = attachments.filter(({ ref }) => !existingIds.has(ref.id));
+    if (additions.length === 0) return;
+    this.draftAttachments = [...this.draftAttachments, ...additions];
+    const session = this.session;
+    if (session && additions.some((attachment) => !attachment.previewUrl)) {
+      void this._rehydrateDraftAttachmentPreviews(session);
+    }
+  }
+
+  removeDraftAttachment(id: string): void {
+    if (!this.draftAttachments.some(({ ref }) => ref.id === id)) return;
+    this.draftAttachments = this.draftAttachments.filter(({ ref }) => ref.id !== id);
+    void this.deleteAttachment(id);
   }
 
   stop(): void {
@@ -410,15 +475,16 @@ export class AcpChatStore {
   }
 
   dispose(): void {
+    this._disposed = true;
     this._disposeHostReaction();
     unregisterConversationCommands(this.conversationId);
-    if (this._draftTimer !== null) {
-      window.clearTimeout(this._draftTimer);
-      this._draftTimer = null;
-    }
     this._unsubs.splice(0).forEach((unsub) => unsub());
     this.session?.dispose();
     this.chatState.dispose();
+    void this._scope
+      .dispose()
+      .then(() => this._draftSpace.release())
+      .catch((error: unknown) => getMementoClient().reportError(error));
   }
 
   private async _runBootstrap(): Promise<void> {
@@ -445,11 +511,11 @@ export class AcpChatStore {
         this.session = clientSession;
         this.chatState.transcript.history.seed(history.data.turns);
         this._subscribeLiveSession(clientSession);
-        this._applyDraftSnapshot(clientSession.draft.current());
         this.historyLoading = false;
         this.loadError = null;
         this._syncMessageCount();
       });
+      void this._rehydrateDraftAttachmentPreviews(clientSession);
     } catch (error) {
       log.error('ACP chat bootstrap failed', {
         conversationId: this.conversationId,
@@ -605,56 +671,31 @@ export class AcpChatStore {
           this._syncMessageCount();
         })
       ),
-      session.activeTurn.onChange(() => runInAction(() => this._syncMessageCount())),
-      session.draft.onChange((draft) =>
-        runInAction(() => {
-          this._applyDraftSnapshot(draft);
-        })
-      )
+      session.activeTurn.onChange(() => runInAction(() => this._syncMessageCount()))
     );
   }
 
-  private _scheduleDraftWrite(text: string, rev: number): void {
-    if (this._draftTimer !== null) window.clearTimeout(this._draftTimer);
-    this._draftTimer = window.setTimeout(() => {
-      this._draftTimer = null;
-      const draft = { rev, input: text.trim().length > 0 ? { text } : null };
-      void this.session
-        ?.setPromptDraft(draft)
-        .then((result) => {
-          if (!result.success) this._toastError('Failed to sync draft', result.error);
-          if (result.success && draft.input === null && this._pendingDraftRev === rev) {
-            runInAction(() => {
-              this._pendingDraftRev = null;
-            });
-          }
-        })
-        .catch((error: unknown) => this._toastError('Failed to sync draft', error));
-    }, 300);
-  }
-
-  private _applyDraftSnapshot(draft: PromptDraft | null | undefined): void {
-    if (draft === undefined) return;
-    if (draft === null) {
-      if (this._pendingDraftRev === null) {
-        this._draftRev += 1;
-        this.draftText = '';
-      }
-      return;
-    }
-
-    if (this._pendingDraftRev !== null) {
-      if (draft.rev >= this._pendingDraftRev) {
-        this._draftRev = Math.max(this._draftRev, draft.rev);
-        this._pendingDraftRev = null;
-      }
-      return;
-    }
-
-    if (draft.rev >= this._draftRev) {
-      this._draftRev = draft.rev;
-      this.draftText = draft.text;
-    }
+  private async _rehydrateDraftAttachmentPreviews(session: AcpLiveSession): Promise<void> {
+    const pending = this.draftAttachments.filter((attachment) => !attachment.previewUrl);
+    await Promise.all(
+      pending.map(async (attachment) => {
+        const previewUrl = await resolveDraftAttachmentDataUrl(
+          this.conversationId,
+          session,
+          attachment.ref.id
+        );
+        runInAction(() => {
+          if (this._disposed || this.session !== session) return;
+          const current = this.draftAttachments.find(({ ref }) => ref.id === attachment.ref.id);
+          if (!current || current.previewUrl) return;
+          this.draftAttachments = previewUrl
+            ? this.draftAttachments.map((candidate) =>
+                candidate.ref.id === attachment.ref.id ? { ...candidate, previewUrl } : candidate
+              )
+            : this.draftAttachments.filter(({ ref }) => ref.id !== attachment.ref.id);
+        });
+      })
+    );
   }
 
   private _bindTerminalOutputs(session: AcpLiveSession): () => void {
@@ -695,6 +736,35 @@ function toPendingAttachment(attachment: AcpPromptAttachment): ChatImageAttachme
     name: attachment.ref.name ?? 'image',
     dataUrl: attachment.previewUrl,
   };
+}
+
+function resolveDraftAttachmentDataUrl(
+  conversationId: string,
+  session: AcpLiveSession,
+  attachmentId: string
+): Promise<string | null> {
+  const cacheKey = `${conversationId}:${attachmentId}`;
+  const cached = draftAttachmentDataUrlCache.get(cacheKey);
+  if (cached) return cached;
+  const promise = session
+    .downloadAttachment(attachmentId)
+    .then((result) =>
+      result.success
+        ? `data:${result.data.ref.mimeType};base64,${bytesToBase64(result.data.data)}`
+        : null
+    )
+    .catch(() => null);
+  draftAttachmentDataUrlCache.set(cacheKey, promise);
+  return promise;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
+  }
+  return btoa(binary);
 }
 
 function resultError(error: unknown): Error {

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
@@ -95,6 +95,7 @@ export class AcpChatStore {
   private readonly _draftHandle: MementoHandle<AcpDraftState>;
   private readonly _disposeHostReaction: () => void;
   private _acpClientPromise: Promise<ConversationsClient['acp']> | null = null;
+  private _submissionSequence = 0;
   private _disposed = false;
 
   constructor(
@@ -379,10 +380,12 @@ export class AcpChatStore {
   ): void {
     if (this.hostAccess?.liveAction.kind === 'disabled') return;
     const promptAttachments = attachments.map((attachment) => attachment.ref);
+    const submissionSequence = ++this._submissionSequence;
+    let optimisticId: string | undefined;
     this.draftText = '';
     this.draftAttachments = [];
     if (!this.affordances.isWorking) {
-      const optimisticId = `optimistic:user:${Date.now()}`;
+      optimisticId = `optimistic:user:${Date.now()}`;
       this.chatState.session.setPendingPrompt({
         id: optimisticId,
         text,
@@ -394,7 +397,19 @@ export class AcpChatStore {
       this.chatState.scroll.set(pinMode);
     }
 
-    void this._submitPrompt(text, promptAttachments, hiddenContext);
+    void this._submitPrompt(text, promptAttachments, hiddenContext).then((accepted) => {
+      if (accepted) return;
+      runInAction(() => {
+        if (this._disposed || submissionSequence !== this._submissionSequence) return;
+        if (optimisticId && this.chatState.session.state.pendingPrompt?.id === optimisticId) {
+          this.chatState.session.setPendingPrompt(null);
+          this._syncMessageCount();
+        }
+        if (this.draftText !== '' || this.draftAttachments.length > 0) return;
+        this.draftText = text;
+        this.draftAttachments = attachments;
+      });
+    });
   }
 
   setDraftText(text: string): void {
@@ -595,12 +610,12 @@ export class AcpChatStore {
     text: string,
     attachments: StoredPromptAttachment[],
     hiddenContext?: string | Promise<string | undefined>
-  ): Promise<void> {
-    if (this.hostAccess?.liveAction.kind === 'disabled') return;
+  ): Promise<boolean> {
+    if (this.hostAccess?.liveAction.kind === 'disabled') return false;
     const session = this.session;
     if (!session) {
       this._toastError('Failed to send message', new Error('ACP session is not connected'));
-      return;
+      return false;
     }
 
     let resolvedHiddenContext: string | undefined;
@@ -619,9 +634,14 @@ export class AcpChatStore {
         ...(resolvedHiddenContext ? { hiddenContext: resolvedHiddenContext } : {}),
         ...(attachments.length > 0 ? { attachments } : {}),
       });
-      if (!result.success) this._toastError('Failed to send message', result.error);
+      if (!result.success) {
+        this._toastError('Failed to send message', result.error);
+        return false;
+      }
+      return true;
     } catch (error) {
       this._toastError('Failed to send message', error);
+      return false;
     }
   }
 

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.ts
@@ -1,6 +1,5 @@
 import {
   planStateSchema,
-  promptDraftSchema,
   sessionUsageSchema,
   sessionConfigStateSchema,
   sessionMcpServerSchema,
@@ -11,7 +10,6 @@ import {
   type AttachmentRef,
   type AcpRuntimeError,
   type HistoryPage,
-  type PromptDraftUpdate,
   type PromptInput,
   type PromptPlacement,
   type SessionState,
@@ -88,7 +86,6 @@ export class AcpLiveSession {
   readonly usage: RemoteValueState<z.infer<typeof sessionUsageSchema> | null>;
   readonly plan: RemoteValueState<z.infer<typeof planStateSchema> | null>;
   readonly activeTurn: RemoteValueState<z.infer<typeof transcriptTurnSchema> | null>;
-  readonly draft: RemoteValueState<z.infer<typeof promptDraftSchema> | null>;
   readonly terminals: RemoteValueState<TerminalState[]>;
   readonly mcpServers: RemoteValueState<Array<z.infer<typeof sessionMcpServerSchema>>>;
   private readonly scope = createScope({ label: 'acp-live-session' });
@@ -117,7 +114,6 @@ export class AcpLiveSession {
       transcriptTurnSchema.nullable(),
       this.scope
     );
-    this.draft = remoteValueState(member.states.draft, promptDraftSchema.nullable(), this.scope);
     this.terminals = remoteValueState(
       member.states.terminals,
       z.array(terminalStateSchema),
@@ -148,7 +144,6 @@ export class AcpLiveSession {
           session.usage.ready,
           session.plan.ready,
           session.activeTurn.ready,
-          session.draft.ready,
           session.terminals.ready,
           session.mcpServers.ready,
         ]),
@@ -263,10 +258,6 @@ export class AcpLiveSession {
 
   cancelTurn(): Promise<Result<void, unknown>> {
     return this.client.cancelTurn({ conversationId: this.conversationId });
-  }
-
-  setPromptDraft(draft: PromptDraftUpdate): Promise<Result<void, unknown>> {
-    return this.client.setPromptDraft({ conversationId: this.conversationId, draft });
   }
 
   setModelOption(dimension: 'model' | 'effort', value: string): Promise<Result<void, unknown>> {

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.ts
@@ -6,8 +6,6 @@ import {
   sessionStateSchema,
   terminalStateSchema,
   transcriptTurnSchema,
-  type AttachmentMimeType,
-  type AttachmentRef,
   type AcpRuntimeError,
   type HistoryPage,
   type PromptInput,
@@ -20,7 +18,6 @@ import { createEmitter, type Result, type Unsubscribe } from '@emdash/shared';
 import { createScope, type Scope } from '@emdash/shared/concurrency';
 import { TimeoutError, runWithTimeout } from '@emdash/shared/scheduling';
 import { ReplicaLog, createLineLogStore } from '@emdash/wire/live';
-import { type BlobSource } from '@emdash/wire/rpc';
 import { observe, remote, whenReady, type Readable } from '@emdash/wire/state';
 import { observable, runInAction } from 'mobx';
 import { z } from 'zod';
@@ -190,50 +187,6 @@ export class AcpLiveSession {
     return { success: true, data: result.data.log };
   }
 
-  uploadAttachment(input: {
-    data?: Uint8Array;
-    source?: BlobSource;
-    size?: number;
-    mimeType: AttachmentMimeType;
-    name?: string;
-    originalPath?: string;
-  }): Promise<Result<AttachmentRef, unknown>> {
-    return this.client.uploadAttachment(
-      { conversationId: this.conversationId, originalPath: input.originalPath },
-      {
-        name: input.name ?? 'attachment',
-        mimeType: input.mimeType,
-        size: input.size ?? input.data?.byteLength,
-        source:
-          input.source ?? (input.data ? singleChunk(input.data) : singleChunk(new Uint8Array())),
-      }
-    );
-  }
-
-  downloadAttachment(
-    id: string
-  ): Promise<Result<{ ref: AttachmentRef; data: Uint8Array }, unknown>> {
-    return this.client
-      .downloadAttachment({ conversationId: this.conversationId, attachmentId: id })
-      .then(async (result) => {
-        if (!result.success) return result;
-        return {
-          success: true,
-          data: {
-            ref: result.data.meta,
-            data: await result.data.bytes(),
-          },
-        };
-      });
-  }
-
-  deleteAttachment(id: string): Promise<Result<void, unknown>> {
-    return this.client.deleteAttachment({
-      conversationId: this.conversationId,
-      attachmentId: id,
-    });
-  }
-
   sendPrompt(
     prompt: PromptInput,
     placement?: PromptPlacement
@@ -304,10 +257,6 @@ export class AcpLiveSession {
     }
     this.terminalLogs.clear();
   }
-}
-
-async function* singleChunk(data: Uint8Array): AsyncIterable<Uint8Array> {
-  yield data;
 }
 
 export function remoteValueState<T>(

--- a/apps/emdash-desktop/src/core/features/conversations/contributions/mementos.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/contributions/mementos.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { ACP_DRAFT_MAX_LENGTH, acpDraftMemento, acpDraftSchema } from './mementos';
+
+describe('ACP draft memento', () => {
+  it('retains up to 5000 conversation drafts for 90 days', () => {
+    expect(acpDraftMemento.retention).toEqual({
+      tier: 'persisted',
+      maxAge: 90 * 24 * 60 * 60 * 1_000,
+      maxEntries: 5_000,
+    });
+  });
+
+  it('stores bounded text and attachment refs without attachment bytes', () => {
+    const value = {
+      version: '1' as const,
+      text: 'a'.repeat(ACP_DRAFT_MAX_LENGTH),
+      attachments: [{ id: 'attachment-1', mimeType: 'image/png' as const, name: 'image.png' }],
+    };
+
+    expect(acpDraftSchema.schema.safeParse(value).success).toBe(true);
+    expect(acpDraftSchema.parseJson(acpDraftSchema.serialize(value))).toEqual(value);
+    expect(
+      acpDraftSchema.schema.safeParse({
+        ...value,
+        text: 'a'.repeat(ACP_DRAFT_MAX_LENGTH + 1),
+      }).success
+    ).toBe(false);
+    expect(
+      acpDraftSchema.schema.safeParse({
+        ...value,
+        attachments: [{ id: 'attachment-1', mimeType: 'text/plain', bytes: [1, 2, 3] }],
+      }).success
+    ).toBe(false);
+  });
+});

--- a/apps/emdash-desktop/src/core/features/conversations/contributions/mementos.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/contributions/mementos.ts
@@ -1,0 +1,34 @@
+import { defineVersionedSchema } from '@emdash/core/primitives/versioned-schema/api';
+import { attachmentMimeTypeSchema } from '@emdash/core/runtimes/acp/api/client';
+import { z } from 'zod';
+import { days, defineMemento } from '@core/primitives/mementos/api';
+import { conversationSubject } from './subject';
+
+export const ACP_DRAFT_MAX_LENGTH = 65_536;
+
+const acpDraftV1Schema = z.object({
+  version: z.literal('1'),
+  text: z.string().max(ACP_DRAFT_MAX_LENGTH),
+  attachments: z.array(
+    z.object({
+      id: z.string(),
+      mimeType: attachmentMimeTypeSchema,
+      name: z.string().optional(),
+    })
+  ),
+});
+
+export const acpDraftSchema = defineVersionedSchema().initial('1', acpDraftV1Schema).build();
+export type AcpDraftState = typeof acpDraftSchema.Type;
+
+export const acpDraftMemento = defineMemento({
+  id: 'conversations.acp-draft',
+  subject: conversationSubject,
+  schema: acpDraftSchema,
+  default: {
+    version: '1' as const,
+    text: '',
+    attachments: [],
+  },
+  retention: { tier: 'persisted', maxAge: days(90), maxEntries: 5_000 },
+});

--- a/apps/emdash-desktop/src/core/features/conversations/contributions/subject.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/contributions/subject.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+import { defineSubject } from '@core/primitives/subjects/api';
+
+export const conversationSubject = defineSubject({
+  kind: 'conversation',
+  key: z.object({ conversationId: z.string().min(1) }),
+  encode: ({ conversationId }) => conversationId,
+});

--- a/apps/emdash-desktop/src/core/features/conversations/node/wire-controller.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/wire-controller.ts
@@ -223,8 +223,6 @@ export function createConversationsWireController(
         run(input.conversationId, (client) =>
           client.acp.resolvePermission(input, callOptions(meta))
         ),
-      setPromptDraft: (input, meta) =>
-        run(input.conversationId, (client) => client.acp.setPromptDraft(input, callOptions(meta))),
       exportAcpTranscript: (input, meta) =>
         run(input.conversationId, (client) =>
           client.acp.exportAcpTranscript(input, callOptions(meta))

--- a/apps/emdash-desktop/src/core/manifests/shared/memento-catalog.test.ts
+++ b/apps/emdash-desktop/src/core/manifests/shared/memento-catalog.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from 'vitest';
+import { acpDraftMemento } from '@core/features/conversations/contributions/mementos';
 import { projectPanelLayoutsMemento } from '@core/features/projects/contributions/mementos';
 import { taskPanelLayoutsMemento } from '@core/features/tasks/contributions/mementos';
 import { mementoCatalog } from './memento-catalog';
 
 describe('mementoCatalog', () => {
+  it('registers the persisted conversation draft memento', () => {
+    expect(acpDraftMemento.subject.kind).toBe('conversation');
+    expect(acpDraftMemento.retention.tier).toBe('persisted');
+    expect(mementoCatalog).toContain(acpDraftMemento);
+  });
+
   it('registers the task- and project-scoped panel-layouts mementos', () => {
     expect(taskPanelLayoutsMemento.id).toBe('tasks.panel-layouts');
     expect(taskPanelLayoutsMemento.subject.kind).toBe('task');

--- a/apps/emdash-desktop/src/core/manifests/shared/memento-catalog.ts
+++ b/apps/emdash-desktop/src/core/manifests/shared/memento-catalog.ts
@@ -1,3 +1,4 @@
+import { acpDraftMemento } from '@core/features/conversations/contributions/mementos';
 import {
   projectPanelLayoutsMemento,
   projectViewMemento,
@@ -24,6 +25,7 @@ import { workbenchHistoryMemento } from '@core/primitives/navigation/api/memento
  * subject-level prefetch.
  */
 export const mementoCatalog: readonly MementoCatalogEntry[] = [
+  acpDraftMemento,
   projectViewMemento,
   projectPanelLayoutsMemento,
   workspaceChromeMemento,

--- a/apps/emdash-desktop/src/main/bootstrap/boot/phases/runtimes.ts
+++ b/apps/emdash-desktop/src/main/bootstrap/boot/phases/runtimes.ts
@@ -1,4 +1,11 @@
 import { sql } from 'drizzle-orm';
+import {
+  conversationRegistryTable as conversations,
+  liveConversations,
+} from '@core/features/conversations/api/node/registry';
+import { conversationSubject } from '@core/features/conversations/contributions/subject';
+import { projectSubject } from '@core/features/projects/contributions/subject';
+import { taskSubject } from '@core/features/tasks/contributions/subject';
 import { projects, tasks } from '@core/services/app-db/node/schema';
 import { desktopRuntimes, type DesktopRuntimes } from '@main/gateway/desktop-runtimes';
 import { startDesktopWorkers, type DesktopWorkersHandle } from '@main/gateway/desktop-workers';
@@ -51,14 +58,26 @@ function runMementosOrphanPruning(
   runInBackground(
     'mementos-orphan-pruning',
     async () => {
-      const [taskRows, projectRows] = await Promise.all([
+      const [conversationRows, taskRows, projectRows] = await Promise.all([
+        database.db.select({ id: conversations.id }).from(conversations).where(liveConversations()),
         database.db.select({ id: tasks.id }).from(tasks),
         database.db.select({ id: projects.id }).from(projects),
       ]);
-      const [taskResult, projectResult] = await Promise.all([
-        mementos.deleteOrphans({ kind: 'task', validKeys: taskRows.map(({ id }) => id) }),
-        mementos.deleteOrphans({ kind: 'project', validKeys: projectRows.map(({ id }) => id) }),
+      const [conversationResult, taskResult, projectResult] = await Promise.all([
+        mementos.deleteOrphans({
+          kind: conversationSubject.kind,
+          validKeys: conversationRows.map(({ id }) => id),
+        }),
+        mementos.deleteOrphans({
+          kind: taskSubject.kind,
+          validKeys: taskRows.map(({ id }) => id),
+        }),
+        mementos.deleteOrphans({
+          kind: projectSubject.kind,
+          validKeys: projectRows.map(({ id }) => id),
+        }),
       ]);
+      if (!conversationResult.success) throw new Error(conversationResult.error.message);
       if (!taskResult.success) throw new Error(taskResult.error.message);
       if (!projectResult.success) throw new Error(projectResult.error.message);
       database.db.run(sql`DELETE FROM kv WHERE key LIKE 'view-state:%'`);

--- a/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
@@ -19,8 +19,18 @@ const mementoTestState = vi.hoisted(() => ({
   reportError: vi.fn(),
 }));
 
+const conversationClientTestState = vi.hoisted(() => ({
+  uploadAttachment: vi.fn(),
+  downloadAttachment: vi.fn(),
+  deleteAttachment: vi.fn(),
+}));
+
 vi.mock('@core/features/conversations/api/browser/chat/shared-chat-context', () => ({
   getSharedChatContext: () => ({}),
+}));
+
+vi.mock('@core/features/conversations/api/browser/client', () => ({
+  getConversationsClient: async () => ({ acp: conversationClientTestState }),
 }));
 
 vi.mock('@core/primitives/mementos/browser', () => ({
@@ -75,6 +85,9 @@ describe('AcpChatStore prompt submission', () => {
     mementoTestState.producer = null;
     mementoTestState.ready = Promise.resolve();
     mementoTestState.reportError.mockClear();
+    conversationClientTestState.uploadAttachment.mockReset();
+    conversationClientTestState.downloadAttachment.mockReset();
+    conversationClientTestState.deleteAttachment.mockReset();
   });
 
   it('stages the optimistic prompt before hidden context finishes resolving', async () => {
@@ -147,8 +160,11 @@ describe('AcpChatStore prompt submission', () => {
   });
 
   it('deletes attachment bytes when a draft attachment is removed', async () => {
-    const deleteAttachment = vi.fn(async () => ({ success: true, data: undefined }));
-    const store = createStore(idleState(), vi.fn(), { deleteAttachment });
+    conversationClientTestState.deleteAttachment.mockResolvedValue({
+      success: true,
+      data: undefined,
+    });
+    const store = createStore(idleState(), vi.fn());
     store.addDraftAttachments([
       promptAttachment('attachment-remove', 'data:image/png;base64,AQ=='),
     ]);
@@ -156,7 +172,33 @@ describe('AcpChatStore prompt submission', () => {
     store.removeDraftAttachment('attachment-remove');
 
     expect(store.draftAttachments).toEqual([]);
-    await vi.waitFor(() => expect(deleteAttachment).toHaveBeenCalledWith('attachment-remove'));
+    await vi.waitFor(() =>
+      expect(conversationClientTestState.deleteAttachment).toHaveBeenCalledWith({
+        conversationId: 'conversation-1',
+        attachmentId: 'attachment-remove',
+      })
+    );
+  });
+
+  it('deletes attachment bytes before the live session connects', async () => {
+    conversationClientTestState.deleteAttachment.mockResolvedValue({
+      success: true,
+      data: undefined,
+    });
+    const store = new AcpChatStore('conversation-1', 'project-1', 'task-1');
+    store.addDraftAttachments([
+      promptAttachment('attachment-pre-bootstrap', 'data:image/png;base64,AQ=='),
+    ]);
+
+    store.removeDraftAttachment('attachment-pre-bootstrap');
+
+    expect(store.session).toBeNull();
+    await vi.waitFor(() =>
+      expect(conversationClientTestState.deleteAttachment).toHaveBeenCalledWith({
+        conversationId: 'conversation-1',
+        attachmentId: 'attachment-pre-bootstrap',
+      })
+    );
   });
 
   it('persists attachment refs without preview bytes', () => {
@@ -200,38 +242,88 @@ describe('AcpChatStore prompt submission', () => {
     expect(store.draftAttachments).toEqual([]);
   });
 
-  it('prunes restored attachment refs when preview download fails', async () => {
+  it('prunes restored attachment refs when attachment bytes are missing', async () => {
     mementoTestState.value = {
       version: '1',
       text: '',
       attachments: [{ id: 'attachment-missing', mimeType: 'image/png', name: 'missing.png' }],
     };
-    const downloadAttachment = vi.fn(async () => ({
+    conversationClientTestState.downloadAttachment.mockResolvedValue({
       success: false as const,
-      error: { type: 'invalid_state' as const },
-    }));
+      error: { type: 'attachment_not_found' as const },
+    });
 
-    const store = createStore(idleState(), vi.fn(), { downloadAttachment });
+    const store = createStore(idleState(), vi.fn());
 
-    await vi.waitFor(() => expect(downloadAttachment).toHaveBeenCalledWith('attachment-missing'));
+    await vi.waitFor(() =>
+      expect(conversationClientTestState.downloadAttachment).toHaveBeenCalledWith({
+        conversationId: 'conversation-1',
+        attachmentId: 'attachment-missing',
+      })
+    );
     await vi.waitFor(() => expect(store.draftAttachments).toEqual([]));
   });
 
-  it('rehydrates restored attachment previews after the session connects', async () => {
+  it('keeps restored refs after transient failures and retries after remount', async () => {
+    mementoTestState.value = {
+      version: '1',
+      text: '',
+      attachments: [
+        {
+          id: 'attachment-transient',
+          mimeType: 'image/png',
+          name: 'attachment-transient.png',
+        },
+      ],
+    };
+    conversationClientTestState.downloadAttachment
+      .mockResolvedValueOnce({
+        success: false as const,
+        error: { type: 'invalid_state' as const, message: 'worker unavailable' },
+      })
+      .mockResolvedValueOnce({
+        success: true as const,
+        data: {
+          meta: {
+            id: 'attachment-transient',
+            mimeType: 'image/png' as const,
+            name: 'attachment-transient.png',
+          },
+          bytes: async () => new Uint8Array([1]),
+        },
+      });
+    const firstStore = createStore(idleState(), vi.fn());
+
+    await vi.waitFor(() =>
+      expect(conversationClientTestState.downloadAttachment).toHaveBeenCalledTimes(1)
+    );
+    expect(firstStore.draftAttachments).toEqual([promptAttachment('attachment-transient')]);
+    firstStore.dispose();
+
+    const secondStore = createStore(idleState(), vi.fn());
+
+    await vi.waitFor(() =>
+      expect(secondStore.draftAttachments).toEqual([
+        promptAttachment('attachment-transient', 'data:image/png;base64,AQ=='),
+      ])
+    );
+  });
+
+  it('rehydrates restored attachment previews without waiting for the live session', async () => {
     mementoTestState.value = {
       version: '1',
       text: '',
       attachments: [{ id: 'attachment-preview', mimeType: 'image/png', name: 'preview.png' }],
     };
-    const downloadAttachment = vi.fn(async () => ({
+    conversationClientTestState.downloadAttachment.mockResolvedValue({
       success: true as const,
       data: {
-        ref: { id: 'attachment-preview', mimeType: 'image/png' as const, name: 'preview.png' },
-        data: new Uint8Array([1]),
+        meta: { id: 'attachment-preview', mimeType: 'image/png' as const, name: 'preview.png' },
+        bytes: async () => new Uint8Array([1]),
       },
-    }));
+    });
 
-    const store = createStore(idleState(), vi.fn(), { downloadAttachment });
+    const store = createStore(idleState(), vi.fn());
 
     await vi.waitFor(() =>
       expect(store.draftAttachments).toEqual([
@@ -250,6 +342,7 @@ function createStore(
   store.session = {
     sessionState: { current: () => state },
     sendPrompt,
+    dispose: vi.fn(),
     ...sessionOverrides,
   } as never;
   return store;

--- a/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
@@ -1,10 +1,47 @@
 import type { SessionState } from '@emdash/core/runtimes/acp/api/client';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { installChatUiRuntime } from '@core/features/conversations/api/browser/chat/chat-ui-runtime';
-import { AcpChatStore } from '@core/features/conversations/browser/acp/acp-chat-store';
+import {
+  AcpChatStore,
+  type AcpPromptAttachment,
+} from '@core/features/conversations/browser/acp/acp-chat-store';
+
+type DraftState = {
+  version: '1';
+  text: string;
+  attachments: Array<{ id: string; mimeType: 'image/png'; name?: string }>;
+};
+
+const mementoTestState = vi.hoisted(() => ({
+  value: { version: '1' as const, text: '', attachments: [] } as DraftState,
+  producer: null as null | (() => DraftState),
+  ready: Promise.resolve() as Promise<void>,
+  reportError: vi.fn(),
+}));
 
 vi.mock('@core/features/conversations/api/browser/chat/shared-chat-context', () => ({
   getSharedChatContext: () => ({}),
+}));
+
+vi.mock('@core/primitives/mementos/browser', () => ({
+  getMementoClient: () => ({
+    reportError: mementoTestState.reportError,
+    subject: () => ({
+      get ready() {
+        return mementoTestState.ready;
+      },
+      release: vi.fn(async () => {}),
+      handle: () => ({
+        get value() {
+          return mementoTestState.value;
+        },
+        autoPersist: vi.fn((producer: () => DraftState) => {
+          mementoTestState.producer = producer;
+          return vi.fn();
+        }),
+      }),
+    }),
+  }),
 }));
 
 const setPendingPrompt = vi.fn();
@@ -34,6 +71,10 @@ describe('AcpChatStore prompt submission', () => {
 
   beforeEach(() => {
     setPendingPrompt.mockClear();
+    mementoTestState.value = { version: '1', text: '', attachments: [] };
+    mementoTestState.producer = null;
+    mementoTestState.ready = Promise.resolve();
+    mementoTestState.reportError.mockClear();
   });
 
   it('stages the optimistic prompt before hidden context finishes resolving', async () => {
@@ -85,15 +126,140 @@ describe('AcpChatStore prompt submission', () => {
     await vi.waitFor(() => expect(changeQueuePromptOrder).toHaveBeenCalledWith(['queued-1']));
     expect(cancelTurn).not.toHaveBeenCalled();
   });
+
+  it('clears draft text and attachments on submit', async () => {
+    const sendPrompt = vi.fn(async () => ({ success: true, data: { queued: false } }));
+    const store = createStore(idleState(), sendPrompt);
+    const attachment = promptAttachment('attachment-submit', 'data:image/png;base64,AQ==');
+    store.setDraftText('hello');
+    store.addDraftAttachments([attachment]);
+
+    store.submitPrompt(store.draftText, store.draftAttachments);
+
+    expect(store.draftText).toBe('');
+    expect(store.draftAttachments).toEqual([]);
+    await vi.waitFor(() =>
+      expect(sendPrompt).toHaveBeenCalledWith({
+        text: 'hello',
+        attachments: [attachment.ref],
+      })
+    );
+  });
+
+  it('deletes attachment bytes when a draft attachment is removed', async () => {
+    const deleteAttachment = vi.fn(async () => ({ success: true, data: undefined }));
+    const store = createStore(idleState(), vi.fn(), { deleteAttachment });
+    store.addDraftAttachments([
+      promptAttachment('attachment-remove', 'data:image/png;base64,AQ=='),
+    ]);
+
+    store.removeDraftAttachment('attachment-remove');
+
+    expect(store.draftAttachments).toEqual([]);
+    await vi.waitFor(() => expect(deleteAttachment).toHaveBeenCalledWith('attachment-remove'));
+  });
+
+  it('persists attachment refs without preview bytes', () => {
+    const store = createStore(idleState(), vi.fn());
+    store.setDraftText('persist me');
+    store.addDraftAttachments([
+      promptAttachment('attachment-persist', 'data:image/png;base64,AQ=='),
+    ]);
+
+    expect(mementoTestState.producer?.()).toEqual({
+      version: '1',
+      text: 'persist me',
+      attachments: [
+        {
+          id: 'attachment-persist',
+          mimeType: 'image/png',
+          name: 'attachment-persist.png',
+        },
+      ],
+    });
+  });
+
+  it('does not overwrite local input when memento hydration finishes late', async () => {
+    let resolveMemento!: () => void;
+    mementoTestState.value = {
+      version: '1',
+      text: 'stored text',
+      attachments: [{ id: 'stored-attachment', mimeType: 'image/png' }],
+    };
+    mementoTestState.ready = new Promise<void>((resolve) => {
+      resolveMemento = resolve;
+    });
+    const store = createStore(idleState(), vi.fn());
+    store.setDraftText('local text');
+
+    resolveMemento();
+    await mementoTestState.ready;
+    await Promise.resolve();
+
+    expect(store.draftText).toBe('local text');
+    expect(store.draftAttachments).toEqual([]);
+  });
+
+  it('prunes restored attachment refs when preview download fails', async () => {
+    mementoTestState.value = {
+      version: '1',
+      text: '',
+      attachments: [{ id: 'attachment-missing', mimeType: 'image/png', name: 'missing.png' }],
+    };
+    const downloadAttachment = vi.fn(async () => ({
+      success: false as const,
+      error: { type: 'invalid_state' as const },
+    }));
+
+    const store = createStore(idleState(), vi.fn(), { downloadAttachment });
+
+    await vi.waitFor(() => expect(downloadAttachment).toHaveBeenCalledWith('attachment-missing'));
+    await vi.waitFor(() => expect(store.draftAttachments).toEqual([]));
+  });
+
+  it('rehydrates restored attachment previews after the session connects', async () => {
+    mementoTestState.value = {
+      version: '1',
+      text: '',
+      attachments: [{ id: 'attachment-preview', mimeType: 'image/png', name: 'preview.png' }],
+    };
+    const downloadAttachment = vi.fn(async () => ({
+      success: true as const,
+      data: {
+        ref: { id: 'attachment-preview', mimeType: 'image/png' as const, name: 'preview.png' },
+        data: new Uint8Array([1]),
+      },
+    }));
+
+    const store = createStore(idleState(), vi.fn(), { downloadAttachment });
+
+    await vi.waitFor(() =>
+      expect(store.draftAttachments).toEqual([
+        expect.objectContaining({ previewUrl: 'data:image/png;base64,AQ==' }),
+      ])
+    );
+  });
 });
 
-function createStore(state: SessionState, sendPrompt: ReturnType<typeof vi.fn>) {
+function createStore(
+  state: SessionState,
+  sendPrompt: ReturnType<typeof vi.fn>,
+  sessionOverrides: Record<string, unknown> = {}
+) {
   const store = new AcpChatStore('conversation-1', 'project-1', 'task-1');
   store.session = {
     sessionState: { current: () => state },
     sendPrompt,
+    ...sessionOverrides,
   } as never;
   return store;
+}
+
+function promptAttachment(id: string, previewUrl?: string): AcpPromptAttachment {
+  return {
+    ref: { type: 'attachment', id, mimeType: 'image/png', name: `${id}.png` },
+    previewUrl,
+  };
 }
 
 function idleState(): SessionState {

--- a/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
@@ -54,7 +54,12 @@ vi.mock('@core/primitives/mementos/browser', () => ({
   }),
 }));
 
-const setPendingPrompt = vi.fn();
+const chatSessionTestState = {
+  pendingPrompt: null as { id: string; text: string } | null,
+};
+const setPendingPrompt = vi.fn((prompt: { id: string; text: string } | null) => {
+  chatSessionTestState.pendingPrompt = prompt;
+});
 
 describe('AcpChatStore prompt submission', () => {
   beforeAll(() => {
@@ -63,7 +68,7 @@ describe('AcpChatStore prompt submission', () => {
       createChatState: () =>
         ({
           session: {
-            state: { pendingPrompt: null },
+            state: chatSessionTestState,
             setPendingPrompt,
           },
           transcript: {
@@ -81,6 +86,7 @@ describe('AcpChatStore prompt submission', () => {
 
   beforeEach(() => {
     setPendingPrompt.mockClear();
+    chatSessionTestState.pendingPrompt = null;
     mementoTestState.value = { version: '1', text: '', attachments: [] };
     mementoTestState.producer = null;
     mementoTestState.ready = Promise.resolve();
@@ -115,10 +121,96 @@ describe('AcpChatStore prompt submission', () => {
   it('still sends the prompt when optional issue context fails to resolve', async () => {
     const sendPrompt = vi.fn(async () => ({ success: true, data: { queued: false } }));
     const store = createStore(idleState(), sendPrompt);
+    store.setDraftText('hello');
 
     store.submitPrompt('hello', [], Promise.reject(new Error('context unavailable')));
 
     await vi.waitFor(() => expect(sendPrompt).toHaveBeenCalledWith({ text: 'hello' }));
+    expect(store.draftText).toBe('');
+  });
+
+  it('restores the persisted draft when the live session is unavailable', async () => {
+    const store = createStore(idleState(), vi.fn());
+    const attachment = promptAttachment('attachment-no-session', 'data:image/png;base64,AQ==');
+    store.session = null;
+    store.setDraftText('retry me');
+    store.addDraftAttachments([attachment]);
+
+    store.submitPrompt(store.draftText, store.draftAttachments);
+
+    await vi.waitFor(() => expect(store.draftText).toBe('retry me'));
+    expect(store.draftAttachments).toEqual([attachment]);
+    expect(setPendingPrompt).toHaveBeenLastCalledWith(null);
+    expect(mementoTestState.producer?.()).toEqual({
+      version: '1',
+      text: 'retry me',
+      attachments: [
+        {
+          id: 'attachment-no-session',
+          mimeType: 'image/png',
+          name: 'attachment-no-session.png',
+        },
+      ],
+    });
+  });
+
+  it('restores the persisted draft when prompt delivery is rejected', async () => {
+    const sendPrompt = vi.fn(async () => ({
+      success: false as const,
+      error: { type: 'invalid_state' as const, message: 'session unavailable' },
+    }));
+    const store = createStore(idleState(), sendPrompt);
+    const attachment = promptAttachment('attachment-rejected', 'data:image/png;base64,AQ==');
+    store.setDraftText('retry me');
+    store.addDraftAttachments([attachment]);
+
+    store.submitPrompt(store.draftText, store.draftAttachments);
+
+    await vi.waitFor(() => expect(sendPrompt).toHaveBeenCalled());
+    await vi.waitFor(() => expect(store.draftText).toBe('retry me'));
+    expect(store.draftAttachments).toEqual([attachment]);
+  });
+
+  it('restores the persisted draft when prompt delivery throws', async () => {
+    const sendPrompt = vi.fn(async () => {
+      throw new Error('connection lost');
+    });
+    const store = createStore(idleState(), sendPrompt);
+    store.setDraftText('retry me');
+
+    store.submitPrompt(store.draftText);
+
+    await vi.waitFor(() => expect(sendPrompt).toHaveBeenCalled());
+    await vi.waitFor(() => expect(store.draftText).toBe('retry me'));
+  });
+
+  it('does not overwrite newer composer input when an earlier delivery is rejected', async () => {
+    let rejectDelivery!: (result: {
+      success: false;
+      error: { type: 'invalid_state'; message: string };
+    }) => void;
+    const sendPrompt = vi.fn(
+      () =>
+        new Promise<{
+          success: false;
+          error: { type: 'invalid_state'; message: string };
+        }>((resolve) => {
+          rejectDelivery = resolve;
+        })
+    );
+    const store = createStore(idleState(), sendPrompt);
+    store.setDraftText('first draft');
+
+    store.submitPrompt(store.draftText);
+    store.setDraftText('newer draft');
+    await vi.waitFor(() => expect(sendPrompt).toHaveBeenCalled());
+    rejectDelivery({
+      success: false,
+      error: { type: 'invalid_state', message: 'session unavailable' },
+    });
+
+    await vi.waitFor(() => expect(setPendingPrompt).toHaveBeenLastCalledWith(null));
+    expect(store.draftText).toBe('newer draft');
   });
 
   it('does not cancel a queued prompt that was started from an idle queue', async () => {

--- a/apps/workspace-server/src/api/controller.test.ts
+++ b/apps/workspace-server/src/api/controller.test.ts
@@ -83,7 +83,6 @@ function createFakeAcpClient(): ContractClient<AcpApiContract> {
     setModelOption: vi.fn(),
     setModeOption: vi.fn(),
     resolvePermission: vi.fn(),
-    setPromptDraft: vi.fn(),
     exportAcpTranscript: vi.fn(),
     exportRawAcpLog: vi.fn(),
     uploadAttachment: vi.fn(),

--- a/packages/core/src/runtimes/acp/api/contract.ts
+++ b/packages/core/src/runtimes/acp/api/contract.ts
@@ -20,7 +20,6 @@ import {
   sessionUsageSchema,
 } from '#runtimes/acp/api/models/config';
 import { planStateSchema } from '#runtimes/acp/api/models/plan';
-import { promptDraftSchema } from '#runtimes/acp/api/models/prompt';
 import { sessionStateSchema, sessionSummarySchema } from '#runtimes/acp/api/models/session';
 import { transcriptTurnSchema } from '#runtimes/acp/api/models/turns';
 import {
@@ -38,7 +37,6 @@ import {
   acpSendPromptErrorSchema,
   acpSetModeOptionErrorSchema,
   acpSetModelOptionErrorSchema,
-  acpSetPromptDraftErrorSchema,
   acpStartErrorSchema,
 } from './errors';
 import {
@@ -62,7 +60,6 @@ import {
   sendPromptResponseSchema,
   setModeOptionCommandSchema,
   setModelOptionCommandSchema,
-  setPromptDraftCommandSchema,
   uploadAttachmentCommandSchema,
   uploadAttachmentResponseSchema,
 } from './schemas';
@@ -124,10 +121,6 @@ export const acpApiContract = defineContract({
     input: resolvePermissionCommandSchema,
     error: acpResolvePermissionErrorSchema,
   }),
-  setPromptDraft: fallible({
-    input: setPromptDraftCommandSchema,
-    error: acpSetPromptDraftErrorSchema,
-  }),
   exportAcpTranscript: fallible({
     input: exportAcpTranscriptCommandSchema,
     data: z.object({ transcript: z.string() }),
@@ -182,7 +175,6 @@ export const acpApiContract = defineContract({
       plan: liveState({ data: planStateSchema.nullable() }),
       agents: liveState({ data: z.array(agentStateSchema) }),
       activeTurn: liveState({ data: transcriptTurnSchema.nullable() }),
-      draft: liveState({ data: promptDraftSchema.nullable() }),
       terminals: liveState({ data: z.array(terminalStateSchema) }),
       mcpServers: liveState({ data: z.array(sessionMcpServerSchema) }),
     },

--- a/packages/core/src/runtimes/acp/api/errors.ts
+++ b/packages/core/src/runtimes/acp/api/errors.ts
@@ -72,7 +72,6 @@ export type AcpEditQueuedPromptError = AcpQueueMutationError;
 export type AcpDeleteQueuedPromptError = AcpQueueMutationError;
 export type AcpChangeQueuePromptOrderError = AcpQueueMutationError;
 export type AcpResolvePermissionError = AcpQueueMutationError;
-export type AcpSetPromptDraftError = ConversationNotFoundError;
 export type AcpCancelTurnError = InvalidStateError | CancelFailedError;
 export type AcpSetModelOptionError =
   | ConversationNotFoundError
@@ -164,7 +163,6 @@ export const acpEditQueuedPromptErrorSchema = acpQueueMutationErrorSchema;
 export const acpDeleteQueuedPromptErrorSchema = acpQueueMutationErrorSchema;
 export const acpChangeQueuePromptOrderErrorSchema = acpQueueMutationErrorSchema;
 export const acpResolvePermissionErrorSchema = acpQueueMutationErrorSchema;
-export const acpSetPromptDraftErrorSchema = conversationNotFoundErrorSchema;
 export const acpCancelTurnErrorSchema = z.discriminatedUnion('type', [
   invalidStateErrorSchema,
   cancelFailedErrorSchema,

--- a/packages/core/src/runtimes/acp/api/errors.ts
+++ b/packages/core/src/runtimes/acp/api/errors.ts
@@ -14,6 +14,9 @@ export type ProviderUnsupportedError = BaseError<'provider_unsupported'>;
 /** No conversation with the given id is tracked in the runtime. */
 export type ConversationNotFoundError = BaseError<'conversation_not_found'>;
 
+/** No stored attachment exists for the conversation-scoped attachment id. */
+export type AttachmentNotFoundError = BaseError<'attachment_not_found'>;
+
 /**
  * A command was issued but the current lifecycle state does not allow it,
  * e.g. Prompt while already working.
@@ -83,7 +86,7 @@ export type AcpSetModeOptionError =
   | SetModeFailedError;
 export type AcpExportTranscriptError = ConversationNotFoundError;
 export type AcpExportRawLogError = ConversationNotFoundError;
-export type AcpAttachmentError = InvalidStateError;
+export type AcpAttachmentError = InvalidStateError | AttachmentNotFoundError;
 export type AcpGetHistoryError = never;
 
 export const acpErr = {
@@ -92,6 +95,9 @@ export const acpErr = {
 
   conversationNotFound: (conversationId: string) =>
     fail('conversation_not_found', { message: conversationId }),
+
+  attachmentNotFound: (attachmentId: string) =>
+    fail('attachment_not_found', { message: `Attachment '${attachmentId}' not found` }),
 
   invalidState: (message: string) => fail('invalid_state', { message }),
 
@@ -130,6 +136,7 @@ const failedErrorSchema = <T extends string>(type: T) =>
 
 export const providerUnsupportedErrorSchema = plainTagErrorSchema('provider_unsupported');
 export const conversationNotFoundErrorSchema = plainTagErrorSchema('conversation_not_found');
+export const attachmentNotFoundErrorSchema = plainTagErrorSchema('attachment_not_found');
 export const invalidStateErrorSchema = plainTagErrorSchema('invalid_state');
 export const spawnFailedErrorSchema = failedErrorSchema('spawn_failed');
 export const initializeFailedErrorSchema = failedErrorSchema('initialize_failed');
@@ -179,7 +186,10 @@ export const acpSetModeOptionErrorSchema = z.discriminatedUnion('type', [
 ]);
 export const acpExportTranscriptErrorSchema = conversationNotFoundErrorSchema;
 export const acpExportRawLogErrorSchema = conversationNotFoundErrorSchema;
-export const acpAttachmentErrorSchema = invalidStateErrorSchema;
+export const acpAttachmentErrorSchema = z.discriminatedUnion('type', [
+  invalidStateErrorSchema,
+  attachmentNotFoundErrorSchema,
+]);
 export const acpGetHistoryErrorSchema = z.never();
 
 export const acpRuntimeErrorSchema = z.discriminatedUnion('type', [

--- a/packages/core/src/runtimes/acp/api/models/prompt.ts
+++ b/packages/core/src/runtimes/acp/api/models/prompt.ts
@@ -9,25 +9,6 @@ export const promptInputSchema = z.object({
 });
 export type PromptInput = z.infer<typeof promptInputSchema>;
 
-export const promptDraftInputSchema = promptInputSchema.extend({
-  /** Monotonic writer revision used by clients to suppress stale draft echoes. */
-  rev: z.number(),
-});
-export type PromptDraftInput = z.infer<typeof promptDraftInputSchema>;
-
-export const promptDraftSchema = promptDraftInputSchema.extend({
-  /** Epoch ms when the runtime last accepted this draft revision. */
-  updatedAt: z.number(),
-});
-export type PromptDraft = z.infer<typeof promptDraftSchema>;
-
-export const promptDraftUpdateSchema = z.object({
-  /** Monotonic writer revision used to ignore stale draft updates, including clears. */
-  rev: z.number(),
-  input: promptInputSchema.nullable(),
-});
-export type PromptDraftUpdate = z.infer<typeof promptDraftUpdateSchema>;
-
 export const queuedPromptSchema = promptInputSchema.extend({
   /** Runtime-generated id used for queue removal and stable UI keys. */
   id: z.string(),

--- a/packages/core/src/runtimes/acp/api/schemas.ts
+++ b/packages/core/src/runtimes/acp/api/schemas.ts
@@ -1,11 +1,7 @@
 import { z } from 'zod';
 import { attachmentRefSchema } from '#runtimes/acp/api/models/attachments';
 import { permissionDecisionSchema } from '#runtimes/acp/api/models/permissions';
-import {
-  promptDraftUpdateSchema,
-  promptInputSchema,
-  queuedPromptSchema,
-} from '#runtimes/acp/api/models/prompt';
+import { promptInputSchema, queuedPromptSchema } from '#runtimes/acp/api/models/prompt';
 import { transcriptTurnSchema } from '#runtimes/acp/api/models/turns';
 
 export const acpStartInputSchema = z.object({
@@ -58,10 +54,6 @@ export const setModeOptionCommandSchema = z.object({
 });
 export const resolvePermissionCommandSchema = permissionDecisionSchema.extend({
   conversationId: z.string(),
-});
-export const setPromptDraftCommandSchema = z.object({
-  conversationId: z.string(),
-  draft: promptDraftUpdateSchema,
 });
 export const exportAcpTranscriptCommandSchema = z.object({ conversationId: z.string() });
 export const exportRawAcpLogCommandSchema = exportAcpTranscriptCommandSchema;

--- a/packages/core/src/runtimes/acp/node/api/contract.test.ts
+++ b/packages/core/src/runtimes/acp/node/api/contract.test.ts
@@ -4,6 +4,7 @@ import { createTestWire } from '@emdash/wire/testing';
 import { describe, expect, it, vi } from 'vitest';
 import {
   acpApiContract,
+  acpAttachmentErrorSchema,
   acpRuntimeErrorSchema,
   sessionConfigStateSchema,
   sessionStateSchema,
@@ -81,6 +82,15 @@ describe('ACP API contract schemas', () => {
       acpRuntimeErrorSchema.parse({
         type: 'auth_required',
         cause: { name: 'RequestError', message: 'Authentication required' },
+      })
+    ).not.toThrow();
+  });
+
+  it('accepts typed attachment-not-found errors', () => {
+    expect(() =>
+      acpAttachmentErrorSchema.parse({
+        type: 'attachment_not_found',
+        message: "Attachment 'missing' not found",
       })
     ).not.toThrow();
   });

--- a/packages/core/src/runtimes/acp/node/api/contract.test.ts
+++ b/packages/core/src/runtimes/acp/node/api/contract.test.ts
@@ -5,7 +5,6 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   acpApiContract,
   acpRuntimeErrorSchema,
-  promptDraftSchema,
   sessionConfigStateSchema,
   sessionStateSchema,
   sessionUsageSchema,
@@ -31,7 +30,6 @@ describe('ACP API contract schemas', () => {
     expect(() => sessionConfigStateSchema.parse(peek(live.states.config))).not.toThrow();
     expect(() => sessionUsageSchema.nullable().parse(peek(live.states.usage))).not.toThrow();
     expect(() => transcriptTurnSchema.nullable().parse(peek(live.states.activeTurn))).not.toThrow();
-    expect(() => promptDraftSchema.nullable().parse(peek(live.states.draft))).not.toThrow();
   });
 
   it('round-trips procedures and live state over a wire transport', async () => {

--- a/packages/core/src/runtimes/acp/node/api/procedures.ts
+++ b/packages/core/src/runtimes/acp/node/api/procedures.ts
@@ -15,13 +15,11 @@ import type {
   AcpSendPromptError,
   AcpSetModeOptionError,
   AcpSetModelOptionError,
-  AcpSetPromptDraftError,
   AcpStartError,
   AcpStartInputWire,
   AttachmentMimeType,
   AttachmentRef,
   HistoryPage,
-  PromptDraftUpdate,
   PromptInput,
   PromptPlacement,
   ResumeResult,
@@ -71,12 +69,6 @@ export function createAcpProcedures(runtime: AcpRuntime) {
     },
     cancelTurn(input: { conversationId: string }): Promise<Result<void, AcpCancelTurnError>> {
       return runtime.cancelTurn(input.conversationId);
-    },
-    setPromptDraft(input: {
-      conversationId: string;
-      draft: PromptDraftUpdate;
-    }): Result<void, AcpSetPromptDraftError> {
-      return runtime.setPromptDraft(input.conversationId, input.draft);
     },
     setModelOption(input: {
       conversationId: string;

--- a/packages/core/src/runtimes/acp/node/runtime/runtime-attachments.test.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/runtime-attachments.test.ts
@@ -39,7 +39,10 @@ describe('AcpRuntime conversation-scoped attachments', () => {
 
     // The same attachment id is invisible from another conversation.
     const crossConversation = await rt.downloadAttachment('conv-2', uploaded.data.id);
-    expect(crossConversation.success).toBe(false);
+    expect(crossConversation).toMatchObject({
+      success: false,
+      error: { type: 'attachment_not_found' },
+    });
   });
 
   it('deletes all of a conversation attachments on conversation deletion cleanup', async () => {
@@ -92,6 +95,16 @@ describe('AcpRuntime conversation-scoped attachments', () => {
     await expect(rt.deleteConversationAttachments('conv-1')).resolves.toEqual({
       success: true,
       data: undefined,
+    });
+  });
+
+  it('distinguishes an unavailable attachment store from missing attachment bytes', async () => {
+    const h = makeAcpHarness();
+    const rt = new AcpRuntime(h.deps);
+
+    await expect(rt.downloadAttachment('conv-1', 'missing')).resolves.toMatchObject({
+      success: false,
+      error: { type: 'invalid_state' },
     });
   });
 });

--- a/packages/core/src/runtimes/acp/node/runtime/runtime.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/runtime.ts
@@ -211,7 +211,7 @@ export class AcpRuntime {
   ): Promise<Result<StoredAttachment, AcpAttachmentError>> {
     if (!this.deps.attachmentStore) return acpErr.invalidState('No attachment store configured');
     const stored = await this.deps.attachmentStore.get(conversationId, attachmentId);
-    if (!stored) return acpErr.invalidState(`Attachment '${attachmentId}' not found`);
+    if (!stored) return acpErr.attachmentNotFound(attachmentId);
     return ok(stored);
   }
 

--- a/packages/core/src/runtimes/acp/node/runtime/runtime.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/runtime.ts
@@ -15,12 +15,10 @@ import type {
   AcpSendPromptError,
   AcpSetModeOptionError,
   AcpSetModelOptionError,
-  AcpSetPromptDraftError,
   AcpStartError,
   AcpKillError,
   AttachmentMimeType,
   AttachmentRef,
-  PromptDraftUpdate,
   PromptInput,
   PromptPlacement,
   ResumeResult,
@@ -132,13 +130,6 @@ export class AcpRuntime {
 
   cancelTurn(conversationId: string): Promise<Result<void, AcpCancelTurnError>> {
     return this.manager.cancel(conversationId);
-  }
-
-  setPromptDraft(
-    conversationId: string,
-    draft: PromptDraftUpdate
-  ): Result<void, AcpSetPromptDraftError> {
-    return this.manager.setPromptDraft(conversationId, draft);
   }
 
   resolvePermission(

--- a/packages/core/src/runtimes/acp/node/runtime/session-manager.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/session-manager.ts
@@ -24,15 +24,12 @@ import type {
   AcpSendPromptError,
   AcpSetModeOptionError,
   AcpSetModelOptionError,
-  AcpSetPromptDraftError,
   AcpStartError,
   AcpKillError,
   AgentState,
   InvalidStateError,
   NormalizedEvent,
   PlanState,
-  PromptDraft,
-  PromptDraftUpdate,
   SessionConfigState,
   SessionMcpServer,
   SessionState,
@@ -96,7 +93,6 @@ interface SessionRecord {
     plan?: PlanState | null;
     agents?: AgentState[];
     activeTurn?: TranscriptTurn | null;
-    draft?: PromptDraft | null;
     terminals?: TerminalState[];
     mcpServers?: SessionMcpServer[];
   };
@@ -398,15 +394,6 @@ export class SessionManager implements InboundRouter {
     return record.cell.cancel();
   }
 
-  setPromptDraft(
-    conversationId: string,
-    draft: PromptDraftUpdate
-  ): Result<void, AcpSetPromptDraftError> {
-    const record = this.cells.get(conversationId);
-    if (!record) return acpErr.conversationNotFound(conversationId);
-    return record.cell.setPromptDraft(draft);
-  }
-
   async stop(conversationId: string, cause = 'user'): Promise<Result<void, AcpKillError>> {
     this.cells
       .get(conversationId)
@@ -613,7 +600,6 @@ export class SessionManager implements InboundRouter {
     const callbacks: SessionCellCallbacks = {
       onSessionStateChanged: () => this.syncRecord(record),
       onTranscriptChanged: () => this.syncRecord(record),
-      onDraftChanged: () => this.syncRecord(record),
       // Machine-driven close (usually process death): full teardown; the active
       // intent is kept so restart reconciliation can restore the conversation.
       onClosed: () =>
@@ -652,7 +638,6 @@ export class SessionManager implements InboundRouter {
         plan: null,
         agents: [],
         activeTurn: null,
-        draft: null,
         terminals: [],
         mcpServers: [],
       },
@@ -692,10 +677,6 @@ export class SessionManager implements InboundRouter {
     const activeTurn = record.cell.transcript.activeTurn;
     publishLiveModelState(record.live.states.activeTurn, activeTurn, record.lastSynced.activeTurn);
     record.lastSynced.activeTurn = activeTurn;
-
-    const draft = record.cell.promptDraft;
-    publishLiveModelState(record.live.states.draft, draft, record.lastSynced.draft);
-    record.lastSynced.draft = draft;
 
     this.syncTerminals(record.input.conversationId);
 

--- a/packages/core/src/runtimes/acp/node/session/cell-deps.ts
+++ b/packages/core/src/runtimes/acp/node/session/cell-deps.ts
@@ -15,7 +15,6 @@ export type ResolvePromptAttachment = (
 export interface SessionCellCallbacks {
   onSessionStateChanged?: () => void;
   onTranscriptChanged?: () => void;
-  onDraftChanged?: () => void;
   onClosed?: (exitCode: number | null) => void;
   onAgentEvent?: (phase: 'start' | 'stop' | 'error') => void;
   onSendQueuedPrompt?: (prompt: QueuedPrompt) => void;

--- a/packages/core/src/runtimes/acp/node/session/cell.test.ts
+++ b/packages/core/src/runtimes/acp/node/session/cell.test.ts
@@ -41,21 +41,6 @@ describe('SessionCell prompts', () => {
     expect(history.committed[0].outcome).toEqual({ kind: 'done', reason: 'end_turn' });
   });
 
-  it('stores prompt drafts by monotonic revision and clears them after submit', async () => {
-    const { cell, agent } = makeCell();
-    agent.prompt = vi.fn().mockResolvedValue({ stopReason: 'end_turn' });
-
-    expect(isOk(cell.setPromptDraft({ rev: 1, input: { text: 'old' } }))).toBe(true);
-    expect(isOk(cell.setPromptDraft({ rev: 1, input: { text: 'stale' } }))).toBe(true);
-    expect(cell.promptDraft).toMatchObject({ text: 'old', rev: 1 });
-
-    expect(isOk(cell.setPromptDraft({ rev: 2, input: { text: 'new' } }))).toBe(true);
-    expect(cell.promptDraft).toMatchObject({ text: 'new', rev: 2 });
-
-    await cell.prompt({ text: 'send' });
-    expect(cell.promptDraft).toBeNull();
-  });
-
   it('queues while working and drains after the active turn settles', async () => {
     const { cell, agent } = makeCell();
     let resolveFirst!: (value: { stopReason: 'end_turn' }) => void;

--- a/packages/core/src/runtimes/acp/node/session/cell.ts
+++ b/packages/core/src/runtimes/acp/node/session/cell.ts
@@ -17,8 +17,6 @@ import type {
   AcpSetModelOptionError,
   InvalidStateError,
   NormalizedEvent,
-  PromptDraft,
-  PromptDraftUpdate,
   PromptInput,
   QueuedPrompt,
   SessionConfigState,
@@ -65,8 +63,6 @@ export class SessionCell {
   private quiesceTimer: ReturnType<typeof setTimeout> | null = null;
   private lastRunningAgentCount = 0;
   private readonly effectDriver: MachineEffectDriver<Effect>;
-  private draft: PromptDraft | null = null;
-  private draftRev = 0;
 
   constructor(private readonly deps: SessionCellDeps) {
     this._acpSessionId = deps.acpSessionId;
@@ -110,10 +106,6 @@ export class SessionCell {
 
   get sessionState(): SessionState {
     return this.machine.sessionState();
-  }
-
-  get promptDraft(): PromptDraft | null {
-    return this.draft ? structuredClone(this.draft) : null;
   }
 
   get config(): SessionConfigState {
@@ -223,7 +215,6 @@ export class SessionCell {
       createdAt: now,
       updatedAt: now,
     });
-    if (result.success) this.clearDraft();
     return result;
   }
 
@@ -242,24 +233,6 @@ export class SessionCell {
       ['invalid_state']
     );
     if (!result.success) return result;
-    this.clearDraft();
-    return ok();
-  }
-
-  setPromptDraft(update: PromptDraftUpdate): Result<void, never> {
-    if (update.rev <= this.draftRev) return ok();
-    this.draftRev = update.rev;
-
-    if (update.input === null) {
-      if (this.draft !== null) {
-        this.draft = null;
-        this.deps.callbacks?.onDraftChanged?.();
-      }
-      return ok();
-    }
-
-    this.draft = { ...update.input, rev: update.rev, updatedAt: Date.now() };
-    this.deps.callbacks?.onDraftChanged?.();
     return ok();
   }
 
@@ -615,13 +588,6 @@ export class SessionCell {
         status,
       });
     }
-  }
-
-  private clearDraft(): void {
-    this.draftRev += 1;
-    if (this.draft === null) return;
-    this.draft = null;
-    this.deps.callbacks?.onDraftChanged?.();
   }
 
   private scheduleQuiesce(): void {

--- a/packages/core/src/runtimes/acp/node/state/live-models.ts
+++ b/packages/core/src/runtimes/acp/node/state/live-models.ts
@@ -5,7 +5,6 @@ import {
   initialSessionConfigState,
   type AgentState,
   type PlanState,
-  type PromptDraft,
   type SessionConfigState,
   type SessionMcpServer,
   type SessionState,
@@ -23,7 +22,6 @@ export type SessionLiveModels = {
     plan: Cell<PlanState | null>;
     agents: Cell<AgentState[]>;
     activeTurn: Cell<TranscriptTurn | null>;
-    draft: Cell<PromptDraft | null>;
     terminals: Cell<TerminalState[]>;
     mcpServers: Cell<SessionMcpServer[]>;
   };
@@ -53,7 +51,6 @@ export function createAcpSessionLiveHost(): AcpSessionLiveHost {
         plan: (key) => requireSessionModel(models, key.conversationId).states.plan,
         agents: (key) => requireSessionModel(models, key.conversationId).states.agents,
         activeTurn: (key) => requireSessionModel(models, key.conversationId).states.activeTurn,
-        draft: (key) => requireSessionModel(models, key.conversationId).states.draft,
         terminals: (key) => requireSessionModel(models, key.conversationId).states.terminals,
         mcpServers: (key) => requireSessionModel(models, key.conversationId).states.mcpServers,
       },
@@ -90,7 +87,6 @@ export function createSessionLiveModels(
       plan: cell<PlanState | null>(null),
       agents: cell<AgentState[]>([]),
       activeTurn: cell<TranscriptTurn | null>(null),
-      draft: cell<PromptDraft | null>(null),
       terminals: cell<TerminalState[]>([]),
       mcpServers: cell<SessionMcpServer[]>([]),
     },
@@ -118,7 +114,6 @@ export function produceCell<T>(target: Cell<T>, mutator: (draft: T) => void): vo
 export type {
   AgentState,
   PlanState,
-  PromptDraft,
   SessionConfigState,
   SessionMcpServer,
   SessionState,


### PR DESCRIPTION
- persist draft text and attachment references in conversation-scoped mementos across navigation and app restarts
- restore drafts without overwriting newer local input and lazily rehydrate attachment previews
- prune missing attachment references and orphaned conversation mementos
- remove prompt draft state and setPromptDraft from the acp runtime wire protocol