### PR TITLE
fix(sidebar): preserve project expansion state across restarts

### DIFF
--- a/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/sidebar-navigation.test.ts
+++ b/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/sidebar-navigation.test.ts
@@ -1,25 +1,102 @@
-import { describe, expect, it } from 'vitest';
+import { createEmitter } from '@emdash/shared';
+import { describe, expect, it, vi } from 'vitest';
 import { taskViewDef } from '@core/features/tasks/contributions/views';
 import type { NavigationEvent } from '@core/primitives/navigation/browser/navigation-store';
-import { taskProjectRevealTarget } from './sidebar-navigation';
+import { SidebarNavigationController, taskProjectRevealTarget } from './sidebar-navigation';
 
-function taskNavigation(kind: NavigationEvent['kind']): NavigationEvent {
+function taskNavigation(
+  kind: NavigationEvent['kind'],
+  source: NavigationEvent['source']
+): NavigationEvent {
   return {
     from: undefined,
     to: taskViewDef({ projectId: 'project-1', taskId: 'task-1' }),
     kind,
+    source,
   };
 }
 
 describe('taskProjectRevealTarget', () => {
-  it('does not reveal a Project during startup or history restoration', () => {
-    expect(taskProjectRevealTarget(taskNavigation('restoration'))).toBeUndefined();
+  it('does not reveal a Project during startup restoration', () => {
+    expect(taskProjectRevealTarget(taskNavigation('traversal', 'startup'))).toBeUndefined();
   });
 
-  it('reveals a Project after explicit task navigation', () => {
-    expect(taskProjectRevealTarget(taskNavigation('traversal'))).toEqual({
-      projectId: 'project-1',
-      taskId: 'task-1',
-    });
+  it.each(['direct', 'history'] as const)(
+    'reveals a Project after %s task navigation',
+    (source) => {
+      expect(taskProjectRevealTarget(taskNavigation('traversal', source))).toEqual({
+        projectId: 'project-1',
+        taskId: 'task-1',
+      });
+    }
+  );
+
+  it('does not reveal a Project for location refinement', () => {
+    expect(taskProjectRevealTarget(taskNavigation('refinement', 'view'))).toBeUndefined();
+  });
+});
+
+describe('SidebarNavigationController', () => {
+  it('reveals an unpinned task Project while no sidebar view is mounted', () => {
+    const onDidNavigate = createEmitter<NavigationEvent>();
+    const revealProject = vi.fn();
+    const controller = new SidebarNavigationController(
+      { onDidNavigate },
+      { revealProject },
+      () => false
+    );
+    controller.activate();
+
+    onDidNavigate.emit(taskNavigation('traversal', 'direct'));
+
+    expect(revealProject).toHaveBeenCalledWith('project-1');
+  });
+
+  it('preserves collapsed Projects for pinned tasks', () => {
+    const onDidNavigate = createEmitter<NavigationEvent>();
+    const revealProject = vi.fn();
+    const controller = new SidebarNavigationController(
+      { onDidNavigate },
+      { revealProject },
+      () => true
+    );
+    controller.activate();
+
+    onDidNavigate.emit(taskNavigation('traversal', 'direct'));
+
+    expect(revealProject).not.toHaveBeenCalled();
+  });
+
+  it('stops handling navigation after disposal', () => {
+    const onDidNavigate = createEmitter<NavigationEvent>();
+    const revealProject = vi.fn();
+    const controller = new SidebarNavigationController(
+      { onDidNavigate },
+      { revealProject },
+      () => false
+    );
+    controller.activate();
+    controller.dispose();
+
+    onDidNavigate.emit(taskNavigation('traversal', 'history'));
+
+    expect(revealProject).not.toHaveBeenCalled();
+  });
+
+  it('does not subscribe more than once', () => {
+    const onDidNavigate = createEmitter<NavigationEvent>();
+    const revealProject = vi.fn();
+    const controller = new SidebarNavigationController(
+      { onDidNavigate },
+      { revealProject },
+      () => false
+    );
+    controller.activate();
+    controller.activate();
+
+    onDidNavigate.emit(taskNavigation('traversal', 'direct'));
+
+    expect(revealProject).toHaveBeenCalledOnce();
+    expect(revealProject).toHaveBeenCalledWith('project-1');
   });
 });

--- a/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/sidebar-navigation.test.ts
+++ b/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/sidebar-navigation.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { taskViewDef } from '@core/features/tasks/contributions/views';
+import type { NavigationEvent } from '@core/primitives/navigation/browser/navigation-store';
+import { taskProjectRevealTarget } from './sidebar-navigation';
+
+function taskNavigation(kind: NavigationEvent['kind']): NavigationEvent {
+  return {
+    from: undefined,
+    to: taskViewDef({ projectId: 'project-1', taskId: 'task-1' }),
+    kind,
+  };
+}
+
+describe('taskProjectRevealTarget', () => {
+  it('does not reveal a Project during startup or history restoration', () => {
+    expect(taskProjectRevealTarget(taskNavigation('restoration'))).toBeUndefined();
+  });
+
+  it('reveals a Project after explicit task navigation', () => {
+    expect(taskProjectRevealTarget(taskNavigation('traversal'))).toEqual({
+      projectId: 'project-1',
+      taskId: 'task-1',
+    });
+  });
+});

--- a/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/sidebar-navigation.ts
+++ b/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/sidebar-navigation.ts
@@ -1,3 +1,4 @@
+import type { Emitter, Unsubscribe } from '@emdash/shared';
 import { taskViewDef } from '@core/features/tasks/contributions/views';
 import type { NavigationEvent } from '@core/primitives/navigation/browser/navigation-store';
 
@@ -9,10 +10,48 @@ export type TaskProjectRevealTarget = {
 export function taskProjectRevealTarget(
   event: NavigationEvent
 ): TaskProjectRevealTarget | undefined {
-  if (event.kind !== 'traversal' || event.to.viewId !== taskViewDef.id) return undefined;
+  if (
+    event.kind !== 'traversal' ||
+    (event.source !== 'direct' && event.source !== 'history') ||
+    event.to.viewId !== taskViewDef.id
+  ) {
+    return undefined;
+  }
   const { projectId, taskId } = event.to.params as {
     projectId?: string;
     taskId?: string;
   };
   return projectId && taskId ? { projectId, taskId } : undefined;
+}
+
+type NavigationEvents = {
+  readonly onDidNavigate: Pick<Emitter<NavigationEvent>, 'subscribe'>;
+};
+
+type ProjectRevealer = {
+  revealProject(projectId: string): void;
+};
+
+export class SidebarNavigationController {
+  private unsubscribe: Unsubscribe | undefined;
+
+  constructor(
+    private readonly navigation: NavigationEvents,
+    private readonly sidebar: ProjectRevealer,
+    private readonly isTaskPinned: (projectId: string, taskId: string) => boolean
+  ) {}
+
+  activate(): void {
+    if (this.unsubscribe) return;
+    this.unsubscribe = this.navigation.onDidNavigate.subscribe((event) => {
+      const target = taskProjectRevealTarget(event);
+      if (!target || this.isTaskPinned(target.projectId, target.taskId)) return;
+      this.sidebar.revealProject(target.projectId);
+    });
+  }
+
+  dispose(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = undefined;
+  }
 }

--- a/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/sidebar-navigation.ts
+++ b/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/sidebar-navigation.ts
@@ -1,0 +1,18 @@
+import { taskViewDef } from '@core/features/tasks/contributions/views';
+import type { NavigationEvent } from '@core/primitives/navigation/browser/navigation-store';
+
+export type TaskProjectRevealTarget = {
+  projectId: string;
+  taskId: string;
+};
+
+export function taskProjectRevealTarget(
+  event: NavigationEvent
+): TaskProjectRevealTarget | undefined {
+  if (event.kind !== 'traversal' || event.to.viewId !== taskViewDef.id) return undefined;
+  const { projectId, taskId } = event.to.params as {
+    projectId?: string;
+    taskId?: string;
+  };
+  return projectId && taskId ? { projectId, taskId } : undefined;
+}

--- a/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/sidebar-store.test.ts
+++ b/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/sidebar-store.test.ts
@@ -1,3 +1,4 @@
+import { observable, runInAction } from 'mobx';
 import { describe, expect, it, vi } from 'vitest';
 import { taskManagerStoreToken } from '@core/features/tasks/contributions/browser/project-store-tokens';
 import type { WorkbenchSidebarState } from '@core/features/workbench/contributions/mementos';
@@ -92,6 +93,43 @@ function mementoHandle(initial: WorkbenchSidebarState): MementoHandle<WorkbenchS
 }
 
 describe('SidebarStore project ordering', () => {
+  it('keeps a restored collapsed project collapsed during initial task hydration', () => {
+    const tasks = observable.map<string, ReturnType<typeof task>>();
+    const project = observable({
+      id: 'project-1',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      context: null as null | {
+        kind: 'available';
+        context: { get: () => { tasks: typeof tasks } };
+      },
+    });
+    const manager = {
+      projects: observable.map([['project-1', project]]),
+    } as unknown as SidebarProjectManager;
+    const handle = mementoHandle({
+      version: '1',
+      expandedProjectIds: [],
+      projectOrder: [],
+      taskOrderByProject: {},
+      taskSortBy: 'created-at',
+    });
+    const store = new SidebarStore(manager);
+    store.attachMemento(handle);
+
+    runInAction(() => {
+      project.context = {
+        kind: 'available',
+        context: { get: () => ({ tasks }) },
+      };
+    });
+    runInAction(() => {
+      tasks.set('task-1', task('task-1', '2026-01-01T00:00:00.000Z'));
+    });
+
+    expect([...store.expandedProjectIds]).toEqual([]);
+    expect(handle.value.expandedProjectIds).toEqual([]);
+  });
+
   it('reads and writes through an attached memento', () => {
     const store = new SidebarStore(projectManager([]));
     const handle = mementoHandle({
@@ -108,6 +146,26 @@ describe('SidebarStore project ordering', () => {
 
     store.setTaskSortBy('created-at');
     expect(handle.value.taskSortBy).toBe('created-at');
+  });
+
+  it('reveals a project without changing its persisted expansion preference', () => {
+    const store = new SidebarStore(projectManager([{ id: 'project-1', createdAt: '2026-01-01' }]));
+    const handle = mementoHandle({
+      version: '1',
+      expandedProjectIds: [],
+      projectOrder: [],
+      taskOrderByProject: {},
+      taskSortBy: 'created-at',
+    });
+    store.attachMemento(handle);
+
+    store.revealProject('project-1');
+    expect([...store.expandedProjectIds]).toEqual(['project-1']);
+    expect(handle.value.expandedProjectIds).toEqual([]);
+
+    store.toggleProjectExpanded('project-1');
+    expect([...store.expandedProjectIds]).toEqual([]);
+    expect(handle.value.expandedProjectIds).toEqual([]);
   });
 
   it('sorts projects newest first by default', () => {
@@ -152,8 +210,8 @@ describe('SidebarStore project ordering', () => {
     );
 
     store.setProjectOrder(['project-1', 'project-2']);
-    store.ensureProjectExpanded('project-1');
-    store.ensureProjectExpanded('project-2');
+    store.toggleProjectExpanded('project-1');
+    store.toggleProjectExpanded('project-2');
     store.setTaskOrder('project-1', ['task-1a', 'task-1b']);
 
     expect(store.visibleTaskEntries).toEqual([
@@ -179,7 +237,7 @@ describe('SidebarStore project ordering', () => {
     tasks.get('automation-task')!.data.type = 'automation-run';
 
     const store = new SidebarStore(manager);
-    store.ensureProjectExpanded('project-1');
+    store.toggleProjectExpanded('project-1');
 
     expect(store.pinnedSidebarEntries).toEqual([
       { projectId: 'project-1', taskId: 'regular-task' },

--- a/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/sidebar-store.ts
+++ b/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/sidebar-store.ts
@@ -1,4 +1,4 @@
-import { computed, makeAutoObservable, observable, reaction, runInAction } from 'mobx';
+import { computed, makeAutoObservable, observable } from 'mobx';
 import { type ProjectStore } from '@core/features/projects/api/browser/stores/project';
 import type { ProjectManagerStore } from '@core/features/projects/api/browser/stores/project-manager';
 import { asAvailableProject } from '@core/features/projects/api/browser/stores/project-selectors';
@@ -49,45 +49,24 @@ export type SidebarRow =
 export class SidebarStore {
   private _handle: MementoHandle<WorkbenchSidebarState> | undefined;
   private _fallbackState: WorkbenchSidebarState = workbenchSidebarMemento.default;
+  private readonly _revealedProjectIds = observable.set<string>();
 
   constructor(private readonly projectManager: ProjectManagerStore) {
     // `_handle` must stay observable: computeds reading `state` before the
     // memento handle is attached would otherwise capture zero dependencies
     // and freeze at the fallback value forever.
-    makeAutoObservable<SidebarStore, '_fallbackState' | '_handle' | 'projectManager'>(this, {
+    makeAutoObservable<
+      SidebarStore,
+      '_fallbackState' | '_handle' | '_revealedProjectIds' | 'projectManager'
+    >(this, {
       _fallbackState: false,
       _handle: observable.ref,
+      _revealedProjectIds: false,
       projectManager: false,
       expandedProjectIds: computed.struct,
       sidebarRows: computed,
       pinnedSidebarEntries: computed,
     });
-
-    // Auto-expand a project when its task count goes from 0 to >0.
-    const prevTaskCounts = new Map<string, number>();
-    reaction(
-      () => {
-        const counts: [string, number][] = [];
-        for (const [id, project] of this.projectManager.projects) {
-          const context = asAvailableProject(project);
-          if (context) {
-            counts.push([id, context.get(taskManagerStoreToken).tasks.size]);
-          }
-        }
-        return counts;
-      },
-      (counts) => {
-        runInAction(() => {
-          for (const [id, count] of counts) {
-            const prev = prevTaskCounts.get(id) ?? 0;
-            if (prev === 0 && count > 0) {
-              this.ensureProjectExpanded(id);
-            }
-            prevTaskCounts.set(id, count);
-          }
-        });
-      }
-    );
   }
 
   get projectOrder(): string[] {
@@ -99,7 +78,7 @@ export class SidebarStore {
   }
 
   get expandedProjectIds(): ReadonlySet<string> {
-    return new Set(this.state.expandedProjectIds);
+    return new Set([...this.state.expandedProjectIds, ...this._revealedProjectIds]);
   }
 
   get taskSortBy(): SidebarTaskSortBy {
@@ -203,16 +182,21 @@ export class SidebarStore {
   }
 
   toggleProjectExpanded(projectId: string): void {
-    if (this.expandedProjectIds.has(projectId)) {
-      this.updateExpandedProjects((ids) => ids.filter((id) => id !== projectId));
-    } else {
-      this.updateExpandedProjects((ids) => [...ids, projectId]);
+    const isPersisted = this.state.expandedProjectIds.includes(projectId);
+    const isRevealed = this._revealedProjectIds.has(projectId);
+    if (isPersisted || isRevealed) {
+      this._revealedProjectIds.delete(projectId);
+      if (isPersisted) {
+        this.updateExpandedProjects((ids) => ids.filter((id) => id !== projectId));
+      }
+      return;
     }
+    this.updateExpandedProjects((ids) => [...ids, projectId]);
   }
 
-  ensureProjectExpanded(projectId: string): void {
+  revealProject(projectId: string): void {
     if (!this.expandedProjectIds.has(projectId)) {
-      this.updateExpandedProjects((ids) => [...ids, projectId]);
+      this._revealedProjectIds.add(projectId);
     }
   }
 

--- a/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/sidebar-virtual-list.tsx
+++ b/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/sidebar-virtual-list.tsx
@@ -34,9 +34,7 @@ import {
   useViewParams,
   useWorkspaceSlots,
 } from '@core/primitives/navigation/browser/navigation-hooks';
-import { getNavigation } from '@core/primitives/navigation/browser/navigation-selectors';
 import { SidebarProjectItem } from './project-item';
-import { taskProjectRevealTarget } from './sidebar-navigation';
 import { SidebarTaskItem } from './task-item';
 
 const ROW_HEIGHT = 32;
@@ -70,18 +68,6 @@ export const SidebarVirtualList = observer(function SidebarVirtualList() {
     estimateSize: () => ROW_HEIGHT,
     overscan: 8,
   });
-
-  // Explicit task navigation may reveal its parent for this renderer session. Startup and
-  // history restoration preserve the durable expansion preference instead.
-  useEffect(() => {
-    return getNavigation().onDidNavigate.subscribe((event) => {
-      const target = taskProjectRevealTarget(event);
-      if (!target) return;
-      const activeTask = getTaskStore(target.projectId, target.taskId);
-      if (activeTask?.data.isPinned) return;
-      getSidebarStore().revealProject(target.projectId);
-    });
-  }, []);
 
   // Scroll the active project/task into view only when the navigation target itself
   // changes, plus the active task's project expansion state. Re-running on every

--- a/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/sidebar-virtual-list.tsx
+++ b/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/sidebar-virtual-list.tsx
@@ -34,7 +34,9 @@ import {
   useViewParams,
   useWorkspaceSlots,
 } from '@core/primitives/navigation/browser/navigation-hooks';
+import { getNavigation } from '@core/primitives/navigation/browser/navigation-selectors';
 import { SidebarProjectItem } from './project-item';
+import { taskProjectRevealTarget } from './sidebar-navigation';
 import { SidebarTaskItem } from './task-item';
 
 const ROW_HEIGHT = 32;
@@ -69,23 +71,23 @@ export const SidebarVirtualList = observer(function SidebarVirtualList() {
     overscan: 8,
   });
 
-  // Expand the parent project when navigating to a task (not when `rows` changes —
-  // otherwise collapsing while staying on that task would immediately re-expand).
+  // Explicit task navigation may reveal its parent for this renderer session. Startup and
+  // history restoration preserve the durable expansion preference instead.
   useEffect(() => {
-    if (currentView !== 'task') return;
-    const targetProjectId = taskParams.projectId;
-    const targetTaskId = taskParams.taskId;
-    if (!targetProjectId || !targetTaskId) return;
-    const activeTask = getTaskStore(targetProjectId, targetTaskId);
-    if (activeTask?.data.isPinned) return;
-    getSidebarStore().ensureProjectExpanded(targetProjectId);
-  }, [currentView, taskParams.projectId, taskParams.taskId]);
+    return getNavigation().onDidNavigate.subscribe((event) => {
+      const target = taskProjectRevealTarget(event);
+      if (!target) return;
+      const activeTask = getTaskStore(target.projectId, target.taskId);
+      if (activeTask?.data.isPinned) return;
+      getSidebarStore().revealProject(target.projectId);
+    });
+  }, []);
 
   // Scroll the active project/task into view only when the navigation target itself
   // changes, plus the active task's project expansion state. Re-running on every
   // `rows` change would yank the user back to the active row whenever the
   // sidebar mutates (e.g. deleting an unrelated task), but direct navigation to a
-  // task in a collapsed project needs one rerun after `ensureProjectExpanded`.
+  // task in a collapsed project needs one rerun after `revealProject`.
   const rowsRef = useRef(rows);
   rowsRef.current = rows;
   useEffect(() => {

--- a/apps/emdash-desktop/src/core/features/workbench/contributions/browser/app-stores.ts
+++ b/apps/emdash-desktop/src/core/features/workbench/contributions/browser/app-stores.ts
@@ -1,5 +1,9 @@
+import { asAvailableProject } from '@core/features/projects/api/browser/stores/project-selectors';
 import { projectManagerStoreToken } from '@core/features/projects/contributions/app-store-tokens';
+import { taskManagerStoreToken } from '@core/features/tasks/contributions/browser/project-store-tokens';
+import { SidebarNavigationController } from '@core/features/workbench/browser/sidebar/sidebar-navigation';
 import { SidebarStore } from '@core/features/workbench/browser/sidebar/sidebar-store';
+import { navigationStoreToken } from '@core/primitives/navigation/browser/app-stores';
 import {
   contributeScopedStore,
   getAppStores,
@@ -8,6 +12,9 @@ import {
 } from '@core/primitives/scoped-stores/browser';
 
 const sidebarStoreToken = scopedStoreToken<SidebarStore>('workbench.sidebar');
+const sidebarNavigationControllerToken = scopedStoreToken<SidebarNavigationController>(
+  'workbench.sidebar-navigation'
+);
 
 // SidebarStore resolves the projects store at create time, so the projects
 // contribution must be registered before this one in the app-scope manifest.
@@ -15,6 +22,22 @@ export const workbenchAppStoreContributions: readonly AppScopedStoreContribution
   contributeScopedStore({
     token: sidebarStoreToken,
     create: (_context, stores) => new SidebarStore(stores.get(projectManagerStoreToken)),
+  }),
+  contributeScopedStore({
+    token: sidebarNavigationControllerToken,
+    create: (_context, stores) => {
+      const projects = stores.get(projectManagerStoreToken);
+      return new SidebarNavigationController(
+        stores.get(navigationStoreToken),
+        stores.get(sidebarStoreToken),
+        (projectId, taskId) => {
+          const project = asAvailableProject(projects.projects.get(projectId));
+          return project?.get(taskManagerStoreToken).tasks.get(taskId)?.data.isPinned === true;
+        }
+      );
+    },
+    activate: (controller) => controller.activate(),
+    dispose: (controller) => controller.dispose(),
   }),
 ];
 

--- a/apps/emdash-desktop/src/core/features/workbench/contributions/browser/layout-provider.tsx
+++ b/apps/emdash-desktop/src/core/features/workbench/contributions/browser/layout-provider.tsx
@@ -77,10 +77,14 @@ export const WorkspaceLayoutContextProvider = observer(function WorkspaceLayoutC
   useEffect(() => {
     return getNavigation().onDidNavigate.subscribe((event) => {
       // The implicit exit-on-navigation cleanup became this explicit command
-      // at the navigation site. Only user navigation ('traversal' to another
-      // view ref) exits zen; the startup 'restoration' commit does not, so
-      // restarting in zen resumes zen with its persisted restore.
-      if (event.kind === 'traversal' && event.from && event.from.key !== event.to.key) {
+      // at the navigation site. Only direct navigation ('traversal' to another
+      // view ref) exits zen; startup and history navigation preserve chrome state.
+      if (
+        event.source === 'direct' &&
+        event.kind === 'traversal' &&
+        event.from &&
+        event.from.key !== event.to.key
+      ) {
         const fromProjectId = projectIdFromRef(event.from);
         if (fromProjectId) {
           const chrome = hydratedWorkspaceChrome(fromProjectId);

--- a/apps/emdash-desktop/src/core/primitives/navigation/browser/navigation-history-store.ts
+++ b/apps/emdash-desktop/src/core/primitives/navigation/browser/navigation-history-store.ts
@@ -13,7 +13,7 @@ function flatten(entries: HistoryEntry[]): HistoryEntry[] {
 
 /**
  * Tracks chronological view refs and participant locations. Traversals push,
- * refinements annotate, and restorations suppress recording.
+ * refinements annotate, and applying history entries suppresses recording.
  */
 export class NavigationHistoryStore {
   entries: HistoryEntry[] = [];

--- a/apps/emdash-desktop/src/core/primitives/navigation/browser/navigation-store.test.ts
+++ b/apps/emdash-desktop/src/core/primitives/navigation/browser/navigation-store.test.ts
@@ -243,7 +243,7 @@ describe('NavigationStore', () => {
     expect(restoreLocation).not.toHaveBeenCalled();
   });
 
-  it('emits typed traversal and refinement events', () => {
+  it('emits direct traversal and refinement events', () => {
     const store = buildStore();
     const listener = vi.fn();
     store.onDidNavigate.subscribe(listener);
@@ -251,6 +251,48 @@ describe('NavigationStore', () => {
     store.navigate(settingsViewDef({ tab: 'general' }));
     store.navigate(settingsViewDef({ tab: 'browser' }));
 
-    expect(listener.mock.calls.map(([event]) => event.kind)).toEqual(['traversal', 'refinement']);
+    expect(listener.mock.calls.map(([event]) => [event.kind, event.source])).toEqual([
+      ['traversal', 'direct'],
+      ['refinement', 'direct'],
+    ]);
+  });
+
+  it('identifies startup restoration separately from history traversal', () => {
+    const store = buildStore();
+    const listener = vi.fn();
+    store.onDidNavigate.subscribe(listener);
+    store.attachMemento(
+      historyHandle({
+        version: '1',
+        entries: [{ viewId: 'project', params: { projectId: 'p1' } }],
+        index: 0,
+      })
+    );
+
+    expect(listener).toHaveBeenLastCalledWith(
+      expect.objectContaining({ kind: 'traversal', source: 'startup' })
+    );
+
+    store.navigate(taskViewDef({ projectId: 'p1', taskId: 't1' }));
+    history.back((entry) => store.applyEntry(entry));
+
+    expect(listener).toHaveBeenLastCalledWith(
+      expect.objectContaining({ kind: 'traversal', source: 'history' })
+    );
+  });
+
+  it('identifies view-reported location changes', () => {
+    const store = buildStore();
+    const ref = taskViewDef({ projectId: 'p1', taskId: 't1' });
+    const listener = vi.fn();
+    store.onDidNavigate.subscribe(listener);
+    store.navigate(ref);
+    listener.mockClear();
+
+    store.reportLocation(ref, { tabId: 'tab-1' });
+
+    expect(listener).toHaveBeenLastCalledWith(
+      expect.objectContaining({ kind: 'refinement', source: 'view' })
+    );
   });
 });

--- a/apps/emdash-desktop/src/core/primitives/navigation/browser/navigation-store.ts
+++ b/apps/emdash-desktop/src/core/primitives/navigation/browser/navigation-store.ts
@@ -24,12 +24,14 @@ import { getNavigationHost, type NavigationHost } from './navigation-host';
 
 const MAX_REDIRECTS = 10;
 
-export type NavigationEventKind = 'traversal' | 'refinement' | 'restoration';
+export type NavigationEventKind = 'traversal' | 'refinement';
+export type NavigationEventSource = 'direct' | 'history' | 'startup' | 'view';
 
 export interface NavigationEvent {
   readonly from: ViewRef | undefined;
   readonly to: ViewRef;
   readonly kind: NavigationEventKind;
+  readonly source: NavigationEventSource;
 }
 
 type LegacyNavigationHandle = MementoHandle<WorkbenchNavigationState>;
@@ -127,7 +129,7 @@ export class NavigationStore implements NavigationParticipantHost {
           this._history.prune((entry) => entry === current);
           this.navigate(resolved);
         } else {
-          this.commit(resolved, 'restoration');
+          this.commit(resolved, 'traversal', 'startup');
           this.deliverLocation(resolved, current.location);
         }
       }
@@ -154,7 +156,7 @@ export class NavigationStore implements NavigationParticipantHost {
     );
     const kind: NavigationEventKind = previousEntry?.key === entry.key ? 'refinement' : 'traversal';
     this._history.record(entry);
-    this.commit(resolved, kind);
+    this.commit(resolved, kind, this._rehydrating ? 'startup' : 'direct');
   }
 
   lastRefFor(definition: { readonly id: string }): ViewRef | undefined {
@@ -203,7 +205,7 @@ export class NavigationStore implements NavigationParticipantHost {
     if (resolved.key !== ref.key) return false;
 
     if (!this.deliverLocation(resolved, entry.location)) return false;
-    this.commit(resolved, 'restoration');
+    this.commit(resolved, 'traversal', 'history');
     return true;
   }
 
@@ -244,13 +246,13 @@ export class NavigationStore implements NavigationParticipantHost {
 
     if (current.location === undefined) {
       this._history.annotate(entry);
-      this.onDidNavigate.emit({ from: ref, to: ref, kind: 'refinement' });
+      this.onDidNavigate.emit({ from: ref, to: ref, kind: 'refinement', source: 'view' });
       return;
     }
 
     const kind: NavigationEventKind = current.key === entry.key ? 'refinement' : 'traversal';
     this._history.record(entry);
-    this.onDidNavigate.emit({ from: ref, to: ref, kind });
+    this.onDidNavigate.emit({ from: ref, to: ref, kind, source: 'view' });
   }
 
   /** Detaches the history subscription. Called when the app scope is disposed (tests/HMR). */
@@ -281,7 +283,7 @@ export class NavigationStore implements NavigationParticipantHost {
     return this._host.homeRef();
   }
 
-  private commit(ref: ViewRef, kind: NavigationEventKind): void {
+  private commit(ref: ViewRef, kind: NavigationEventKind, source: NavigationEventSource): void {
     const from = this._currentRef;
     const viewChanged = from.viewId !== ref.viewId;
     if (viewChanged) {
@@ -296,7 +298,7 @@ export class NavigationStore implements NavigationParticipantHost {
 
     this._currentRef = ref;
     this._lastRefByViewId.set(ref.viewId, ref);
-    this.onDidNavigate.emit({ from, to: ref, kind });
+    this.onDidNavigate.emit({ from, to: ref, kind, source });
     if (kind !== 'refinement') modalStore.dismissAll('navigation');
   }
 

--- a/apps/emdash-desktop/src/renderer/lib/stores/navigation-telemetry.test.ts
+++ b/apps/emdash-desktop/src/renderer/lib/stores/navigation-telemetry.test.ts
@@ -20,20 +20,26 @@ describe('wireNavigationTelemetry', () => {
     captureTelemetry.mockClear();
   });
 
-  it('observes traversals and restorations only when the view changes', () => {
+  it('observes navigation only when the view changes', () => {
     const onDidNavigate = createEmitter<NavigationEvent>();
     wireNavigationTelemetry({ onDidNavigate } as NavigationStore);
     const home = homeViewDef();
     const firstProject = projectViewDef({ projectId: 'p1' });
     const secondProject = projectViewDef({ projectId: 'p2' });
 
-    onDidNavigate.emit({ from: home, to: firstProject, kind: 'traversal' });
+    onDidNavigate.emit({ from: home, to: firstProject, kind: 'traversal', source: 'direct' });
     onDidNavigate.emit({
       from: firstProject,
       to: secondProject,
-      kind: 'restoration',
+      kind: 'traversal',
+      source: 'history',
     });
-    onDidNavigate.emit({ from: secondProject, to: home, kind: 'restoration' });
+    onDidNavigate.emit({
+      from: secondProject,
+      to: home,
+      kind: 'traversal',
+      source: 'history',
+    });
 
     expect(captureTelemetry).toHaveBeenNthCalledWith(1, 'project_viewed', {
       from_view: 'home',

--- a/apps/emdash-desktop/src/renderer/main.tsx
+++ b/apps/emdash-desktop/src/renderer/main.tsx
@@ -133,6 +133,9 @@ async function bootstrap() {
   const historyHandle = appSpace.handle(workbenchHistoryMemento);
   const legacyNavigationHandle = appSpace.handle(workbenchNavigationMemento);
   const sidebarHandle = appSpace.handle(workbenchSidebarMemento);
+  const projectsLoaded = getProjectManagerStore()
+    .load()
+    .then(() => bootMark('projects-loaded'));
   // Memento reads queue behind the wire until the backend registers its
   // controllers, so navigation restore is a gate condition rather than a
   // render prerequisite. On the timeout path the restore lands after render;
@@ -141,16 +144,13 @@ async function bootstrap() {
     bootMark('memento-handles-ready');
     getNavigation().attachMemento(historyHandle, legacyNavigationHandle);
     getSidebarStore().attachMemento(sidebarHandle);
-    if (!sidebarHandle.hasStoredValue) getSidebarStore().expandAllProjects();
     wireNavigationTelemetry(getNavigation());
   });
+  const sidebarInitialized = Promise.all([navigationRestored, projectsLoaded]).then(() => {
+    if (!sidebarHandle.hasStoredValue) getSidebarStore().expandAllProjects();
+  });
 
-  // The list snapshot resolves load(); Host attachment may continue in the
-  // background. The gate below awaits only desktop context for the Project
-  // required by the restored view.
-  const projectsLoaded = getProjectManagerStore()
-    .load()
-    .then(() => bootMark('projects-loaded'));
+  // The gate below awaits only desktop context for the Project required by the restored view.
   const activeProjectReady = waitForActiveProjectContext({
     navigationRestored,
     projectsLoaded,
@@ -164,7 +164,7 @@ async function bootstrap() {
   });
 
   const gate = raceSplashGate(
-    [navigationRestored, activeProjectReady, appQueriesSettled()],
+    [sidebarInitialized, activeProjectReady, appQueriesSettled()],
     SPLASH_GATE_TIMEOUT_MS
   );
 


### PR DESCRIPTION
- stop initial task hydration from overwriting persisted expansion preferences
- keep task navigation reveals transient and ignore navigation restoration
- apply first-run expansion only after the project list finishes loading