### PR TITLE
fix(source-control): keep pr checkout state aligned with live head

### DIFF
--- a/apps/emdash-desktop/src/core/features/source-control/browser/stores/derive-pr-checkout-drift.test.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/stores/derive-pr-checkout-drift.test.ts
@@ -10,6 +10,17 @@ function observedFacts(overrides: Partial<PrDriftObservedFacts> = {}): PrDriftOb
 }
 
 describe('derivePrCheckoutDrift', () => {
+  it('prefers the live checkout facts when the registry mirror is stale', () => {
+    const drift = derivePrCheckoutDrift({
+      checkout: observedFacts({ headOid: MOVED_HEAD }),
+      observed: observedFacts({ headOid: HEAD }),
+      pr: { headRefOid: MOVED_HEAD },
+      syncedAt: 1_700_000_000_000,
+    });
+
+    expect(drift).toEqual({ kind: 'in-sync', syncedAt: 1_700_000_000_000 });
+  });
+
   it('reads in-sync when the observed head equals the cached PR head, carrying syncedAt', () => {
     const drift = derivePrCheckoutDrift({
       observed: observedFacts(),

--- a/apps/emdash-desktop/src/core/features/source-control/browser/stores/derive-pr-checkout-drift.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/stores/derive-pr-checkout-drift.ts
@@ -1,6 +1,6 @@
 import type { PrCheckoutDrift } from '@core/services/pull-requests/api';
 
-/** Registry-observed git facts the drift join needs (mirror observedGit v2 subset). */
+/** Git facts the drift join needs, from either live checkout state or the registry mirror. */
 export type PrDriftObservedFacts = {
   /** Full OID of the observed HEAD; null on unborn HEAD or probe failure. */
   headOid: string | null;
@@ -11,8 +11,9 @@ export type PrDriftObservedFacts = {
 
 /**
  * Derives the checkout-drift state for a PR-associated workspace by joining the
- * registry observation with the synced PR cache (pr-workspace-model spec,
- * Staleness). Pure over its inputs — no observers, no polling, no sync triggers.
+ * live checkout model (falling back to its registry observation) with the synced
+ * PR cache (pr-workspace-model spec, Staleness). Pure over its inputs — no
+ * observers, no polling, no sync triggers.
  *
  * Detail flags on `drifted` are best-effort against the observed `@{u}` counts
  * (ancestry is not computable desktop-side):
@@ -26,20 +27,23 @@ export type PrDriftObservedFacts = {
  *   an unfetched PR move) and when the counts never resolved.
  */
 export function derivePrCheckoutDrift(input: {
-  /** Mirror observedGit v2 facts; null (old host / v1 payload) reads unknown. */
+  /** Direct checkout live-model facts; preferred whenever that model has emitted. */
+  checkout?: PrDriftObservedFacts | null;
+  /** Mirror observedGit v2 facts; fallback for an unavailable live checkout model. */
   observed: PrDriftObservedFacts | null;
   /** The associated PR's cache row; null when unassociated or uncached. */
   pr: { headRefOid: string } | null;
   /** The PR cache's last-sync stamp (epoch ms), when known. */
   syncedAt: number | null;
 }): PrCheckoutDrift {
-  const headOid = input.observed?.headOid ?? null;
+  const facts = input.checkout ?? input.observed;
+  const headOid = facts?.headOid ?? null;
   const prHeadOid = input.pr?.headRefOid || null;
   if (headOid === null || prHeadOid === null) return { kind: 'unknown' };
   if (headOid === prHeadOid) return { kind: 'in-sync', syncedAt: input.syncedAt };
 
-  const ahead = input.observed?.ahead ?? null;
-  const behind = input.observed?.behind ?? null;
+  const ahead = facts?.ahead ?? null;
+  const behind = facts?.behind ?? null;
   return {
     kind: 'drifted',
     localAhead: ahead === null ? null : ahead > 0,

--- a/apps/emdash-desktop/src/core/features/source-control/browser/stores/git-checkout-store.test.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/stores/git-checkout-store.test.ts
@@ -85,6 +85,11 @@ describe('GitCheckoutStore', () => {
     expect(store.branchName).toBe('main');
     expect(store.aheadCount).toBe(2);
     expect(store.behindCount).toBe(1);
+    expect(store.headTrackingSnapshot).toEqual({
+      headOid: '1234567890123456789012345678901234567890',
+      ahead: 2,
+      behind: 1,
+    });
     expect(store.isPublished).toBe(true);
     expect(mocks.getChangedFiles).toHaveBeenCalledTimes(2);
 
@@ -104,6 +109,11 @@ describe('GitCheckoutStore', () => {
     expect(store.isPublished).toBe(false);
     expect(store.aheadCount).toBe(0);
     expect(store.behindCount).toBe(0);
+    expect(store.headTrackingSnapshot).toEqual({
+      headOid: '1234567890123456789012345678901234567890',
+      ahead: null,
+      behind: null,
+    });
     expect(mocks.getGitRepositoryStore).not.toHaveBeenCalled();
     store.dispose();
   });

--- a/apps/emdash-desktop/src/core/features/source-control/browser/stores/git-checkout-store.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/stores/git-checkout-store.ts
@@ -102,6 +102,7 @@ export class GitCheckoutStore {
       isPublished: computed,
       aheadCount: computed,
       behindCount: computed,
+      headTrackingSnapshot: computed,
       branchName: computed,
       headOid: computed,
       headKind: computed,
@@ -268,6 +269,26 @@ export class GitCheckoutStore {
       head.upstream.tracking.kind === 'resolved'
       ? head.upstream.tracking.behind
       : 0;
+  }
+
+  get headTrackingSnapshot(): {
+    headOid: string | null;
+    ahead: number | null;
+    behind: number | null;
+  } | null {
+    const head = this.head;
+    if (!head) return null;
+    const tracking =
+      head.kind !== 'detached' &&
+      head.upstream.kind !== 'none' &&
+      head.upstream.tracking.kind === 'resolved'
+        ? head.upstream.tracking
+        : null;
+    return {
+      headOid: head.kind === 'unborn' ? null : head.oid,
+      ahead: tracking?.ahead ?? null,
+      behind: tracking?.behind ?? null,
+    };
   }
 
   async stageFiles(paths: string[]) {

--- a/apps/emdash-desktop/src/core/features/source-control/browser/stores/task-pr-sync-coordinator.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/stores/task-pr-sync-coordinator.ts
@@ -15,7 +15,7 @@ import {
   type PullRequestsRuntimeClient,
 } from '@core/services/pull-requests/api/client';
 import { derivePrAssociation } from './derive-pr-association';
-import { derivePrCheckoutDrift } from './derive-pr-checkout-drift';
+import { derivePrCheckoutDrift, type PrDriftObservedFacts } from './derive-pr-checkout-drift';
 
 export class TaskPrSyncCoordinator {
   private readonly scope = createScope({ label: 'task-pr-sync-coordinator' });
@@ -33,20 +33,23 @@ export class TaskPrSyncCoordinator {
     private readonly repository: GitRepositoryStore
   ) {
     // Association and drift inputs: the checkout store's live head plus the mirror's
-    // observed facts (breadcrumb, upstream, branch, head OID, ahead/behind counts) —
+    // association facts (breadcrumb, upstream, branch) and fallback git facts —
     // observation changes must re-derive even when the local checkout never moved
     // (e.g. the host scan delivers a breadcrumb or sees the follow move the head).
     this.disposeGitHeadReaction = reaction(
       () =>
         [...tasks.tasks.values()].filter(isRegistered).map((store) => {
           const git = getTaskGitCheckoutStore(store);
+          const checkout = git?.headTrackingSnapshot;
           const observed = store.workspaceObservedPr;
           return [
             store.workspaceId,
             (store.data as Task).workspaceId ?? '',
             store.workspaceObservedStatus ?? '',
             git?.branchName ?? '',
-            git?.headOid ?? '',
+            checkout?.headOid ?? '',
+            checkout?.ahead ?? '',
+            checkout?.behind ?? '',
             observed?.branch ?? '',
             observed?.prBreadcrumb ?? '',
             observed?.upstream?.mergeRef ?? '',
@@ -90,8 +93,9 @@ export class TaskPrSyncCoordinator {
    * failures keep the current association; the next observation or sync re-derives.
    *
    * The checkout-drift state (spec, Staleness) is derived on the same read: the
-   * observed head OID joined with the associated PR's cached head OID, stamped with
-   * the cache's last-sync time.
+   * live checkout head joined with the associated PR's cached head OID (falling
+   * back to the registry mirror until the live model emits), stamped with the
+   * cache's last-sync time.
    */
   private async reloadTask(store: TaskStore): Promise<void> {
     if (!isRegistered(store)) return;
@@ -124,6 +128,7 @@ export class TaskPrSyncCoordinator {
     if (!isDeepEqual(associationInputs(store), inputs)) return;
     // Drift is derived against the PR the panel renders (selectCurrentPr).
     const drift = derivePrCheckoutDrift({
+      checkout: inputs.checkout,
       observed: inputs.observed,
       pr: selectCurrentPr(prs) ?? null,
       syncedAt: this.lastSyncedAt,
@@ -186,14 +191,17 @@ function isRegistered(store: TaskStore): boolean {
 }
 
 type AssociationInputs = {
+  checkout: PrDriftObservedFacts | null;
   observed: WorkspaceObservedPrFacts | null;
   checkoutBranch: string | null;
 };
 
 function associationInputs(store: TaskStore): AssociationInputs {
+  const git = getTaskGitCheckoutStore(store);
   return {
+    checkout: toJS(git?.headTrackingSnapshot ?? null),
     observed: toJS(store.workspaceObservedPr),
-    checkoutBranch: getTaskGitCheckoutStore(store)?.branchName ?? null,
+    checkoutBranch: git?.branchName ?? null,
   };
 }
 

--- a/packages/core/src/runtimes/workspace-registry/node/api/update-worktree.contract.test.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/api/update-worktree.contract.test.ts
@@ -157,6 +157,24 @@ describe('workspace registry updateWorktree', () => {
     );
   });
 
+  it('allows an already-current dirty checkout because no worktree mutation is needed', async () => {
+    const worktree = await createWorktree('dirty-current');
+    const beforeOid = git(worktree.path, 'rev-parse', 'HEAD');
+    await fs.writeFile(path.join(worktree.path, 'scratch.txt'), 'uncommitted');
+
+    const updated = await wire.client.updateWorktree({
+      workspaceId: worktree.id,
+      remote: 'origin',
+      sourceRef: 'refs/heads/main',
+    });
+
+    expect(updated).toEqual({ success: true, data: undefined });
+    expect(git(worktree.path, 'rev-parse', 'HEAD')).toBe(beforeOid);
+    await expect(fs.readFile(path.join(worktree.path, 'scratch.txt'), 'utf8')).resolves.toBe(
+      'uncommitted'
+    );
+  });
+
   it('refuses when the workspace has live sessions and moves nothing', async () => {
     const worktree = await createWorktree('busy');
     const beforeOid = git(worktree.path, 'rev-parse', 'HEAD');
@@ -182,6 +200,21 @@ describe('workspace registry updateWorktree', () => {
       sourceRef: 'refs/heads/main',
     });
     expect(retried).toEqual({ success: true, data: undefined });
+  });
+
+  it('allows an already-current checkout with live sessions because nothing would move', async () => {
+    const worktree = await createWorktree('busy-current');
+    const beforeOid = git(worktree.path, 'rev-parse', 'HEAD');
+    sessionCount = 1;
+
+    const updated = await wire.client.updateWorktree({
+      workspaceId: worktree.id,
+      remote: 'origin',
+      sourceRef: 'refs/heads/main',
+    });
+
+    expect(updated).toEqual({ success: true, data: undefined });
+    expect(git(worktree.path, 'rev-parse', 'HEAD')).toBe(beforeOid);
   });
 
   it('a diverged branch fails ff-only cleanly ("local commits — resolve manually"); nothing moves', async () => {

--- a/packages/core/src/runtimes/workspace-registry/node/update-worktree.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/update-worktree.ts
@@ -19,7 +19,8 @@ export type UpdateWorktreeExecution = {
   tier?: Extract<GitWorkTier, 'activation' | 'background'>;
   /**
    * True when the workspace must not move (live sessions under the worktree path).
-   * Consulted under the writer lock, immediately before any git work.
+   * Consulted under the writer lock after a checkout-neutral fetch proves a
+   * worktree mutation is needed.
    */
   isActive: () => Promise<boolean> | boolean;
 };
@@ -40,7 +41,7 @@ export type UpdateWorktreeExecutionResult =
  * remote and source ref arrive from the caller; nothing here reads durable records.
  *
  * The per-worktree writer lock is taken synchronously, before the first await, and
- * held across guard checks, fetch, and merge, so probes/scans (which wait on
+ * held across fetch, guard checks, and merge, so probes/scans (which wait on
  * `whenUnlocked`) never observe a torn checkout and the guards cannot go stale
  * against a concurrent mutator.
  *
@@ -61,16 +62,6 @@ export async function executeUpdateWorktree(
     repository: execution.repositoryPath,
   });
   return execution.git.locks.withWriter(execution.worktreePath, async () => {
-    if (await execution.isActive()) {
-      return { status: 'refused', reason: 'active-sessions' };
-    }
-    try {
-      // The observation's notion of dirty: any status entry, untracked included.
-      if (await isDirty(exec)) return { status: 'refused', reason: 'dirty' };
-    } catch (error) {
-      return { status: 'failed', stage: 'inspect', message: toMessage(error) };
-    }
-
     const tempRef = `refs/emdash/update/${crypto.randomUUID()}`;
     try {
       let fetchedOid: string;
@@ -97,6 +88,19 @@ export async function executeUpdateWorktree(
         // after a local push looks like this) — a no-op, never a divergence.
         return { status: 'up-to-date', oid: headOid };
       }
+
+      // These guards protect the working-tree mutation below. A checkout that is
+      // already current is safe even when it is busy or dirty because nothing moves.
+      if (await execution.isActive()) {
+        return { status: 'refused', reason: 'active-sessions' };
+      }
+      try {
+        // The observation's notion of dirty: any status entry, untracked included.
+        if (await isDirty(exec)) return { status: 'refused', reason: 'dirty' };
+      } catch (error) {
+        return { status: 'failed', stage: 'inspect', message: toMessage(error) };
+      }
+
       if (!(await isAncestor(exec, 'HEAD', fetchedOid))) {
         return {
           status: 'diverged',


### PR DESCRIPTION
- prefer live checkout head and tracking facts over stale workspace registry observations when deriving pr drift
- fall back to registry observations until the live checkout model emits state
- treat already-current checkout updates as safe no-ops when the workspace has active sessions or uncommitted changes
- preserve active-session and dirty-worktree guards for updates that move the checkout