### PR TITLE
fix(chat-composer): use MCP icon for server count

### DIFF
--- a/packages/ui/src/react/components/chat-composer/chat-composer.css.ts
+++ b/packages/ui/src/react/components/chat-composer/chat-composer.css.ts
@@ -1,5 +1,6 @@
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
+import { svgContainer } from '@styles/effects/svg-helpers.css';
 import { vars } from '@theme/core/contract/contract.css';
 import { tokenVars } from '@theme/tokens.css';
 
@@ -205,22 +206,25 @@ export const permissionModeTrigger = style({
   paddingRight: '0.1875rem',
 });
 
-export const mcpTrigger = style({
-  display: 'inline-flex',
-  alignItems: 'center',
-  gap: '0.25rem',
-  borderRadius: tokenVars.radiusMd,
-  paddingLeft: '0.1875rem',
-  paddingRight: '0.1875rem',
-  color: vars.foreground,
-  fontSize: tokenVars.textXs,
-  lineHeight: 1,
-  outline: 'none',
-  selectors: {
-    '&:hover': { backgroundColor: vars.surfaceBaseSelected },
-    '&[data-popup-open]': { backgroundColor: vars.surfaceBaseSelected },
+export const mcpTrigger = style([
+  svgContainer,
+  {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '0.25rem',
+    borderRadius: tokenVars.radiusMd,
+    paddingLeft: '0.1875rem',
+    paddingRight: '0.1875rem',
+    color: vars.foreground,
+    fontSize: tokenVars.textXs,
+    lineHeight: 1,
+    outline: 'none',
+    selectors: {
+      '&:hover': { backgroundColor: vars.surfaceBaseSelected },
+      '&[data-popup-open]': { backgroundColor: vars.surfaceBaseSelected },
+    },
   },
-});
+]);
 
 export const mcpPopoverContent = style({
   width: '16rem',

--- a/packages/ui/src/react/components/chat-composer/index.tsx
+++ b/packages/ui/src/react/components/chat-composer/index.tsx
@@ -1,12 +1,13 @@
 import { Button } from '@react/primitives/button';
 import { cx } from '@styles/utilities/cx';
-import { ArrowUp, ChevronRight, CircleAlert, Paperclip, Plug, ShieldCheck, X } from 'lucide-react';
+import { ArrowUp, ChevronRight, CircleAlert, Paperclip, ShieldCheck, X } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 import { Combobox } from '@/react/primitives/combobox/combobox';
 import { DropdownMenu } from '@/react/primitives/dropdown-menu';
 import { Popover } from '@/react/primitives/popover';
 import { Select } from '@/react/primitives/select';
 import { ComboboxPopover } from '../combobox-popover';
+import { McpIcon } from '../mcp-icon/mcp-icon';
 import { PromptEditor } from '../prompt-editor/prompt-editor';
 import type {
   CommandItem,
@@ -1023,7 +1024,7 @@ export function ChatComposer({
             {mcpServers.length > 0 && (
               <Popover.Root>
                 <Popover.Trigger className={styles.mcpTrigger} disabled={disabled}>
-                  <Plug style={{ width: '0.75rem', height: '0.75rem', flexShrink: 0 }} />
+                  <McpIcon size={12} />
                   MCP {mcpServers.length}
                 </Popover.Trigger>
                 <Popover.Content


### PR DESCRIPTION
- replaces the generic plug icon with the shared McpIcon
- aligns the chat input mcp indicator with the app settings tabs