### PR TITLE
fix(ssh): extend BaseAgent so ssh2 accepts the identity-filtered agent

### DIFF
--- a/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.test.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.test.ts
@@ -1,7 +1,7 @@
 import { PassThrough } from 'node:stream';
 import { secret } from '@emdash/shared';
-import type { BaseAgent, ParsedKey, SignCallback } from 'ssh2';
-import { utils } from 'ssh2';
+import type { ParsedKey, SignCallback } from 'ssh2';
+import { BaseAgent, utils } from 'ssh2';
 import { describe, expect, it } from 'vitest';
 import type { SshConfig } from '@core/primitives/ssh/api';
 import type { SshConnectionRow } from '@core/services/app-db/node/schema';
@@ -317,6 +317,35 @@ describe('resolveSshConnectConfig', () => {
         });
       })
     ).resolves.toBeInstanceOf(PassThrough);
+  });
+
+  it('produces an agent ssh2 accepts: IdentityFilteredAgent must pass the instanceof check', async () => {
+    const result = await resolveSshConnectConfig(
+      {
+        kind: 'transient',
+        config: baseConfig({ sshConfigAlias: 'corp-dev', authType: 'agent' }),
+      },
+      deps({
+        readFile: async () =>
+          'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILI4wa2zRZoB26D015dsafYmu3jDCI7rh26bFXZrUiAp test-key',
+        resolveSshConfig: async () => ({
+          hostname: 'dev.internal',
+          user: 'alice',
+          port: 22,
+          identityFile: ['~/.ssh/corp_ed25519'],
+          identityAgent: '/tmp/auth-agent.sock',
+          identityAgentDisabled: false,
+          identitiesOnly: true,
+          proxyCommand: undefined,
+          proxyJump: undefined,
+          forwardAgent: false,
+        }),
+      })
+    );
+
+    // ssh2's client config validation keeps a custom agent only when
+    // isAgent(val) holds, and isAgent is `val instanceof BaseAgent`.
+    expect(result.config.agent).toBeInstanceOf(BaseAgent);
   });
 
   it('does not expose agent getStream when the wrapped agent does not support it', async () => {

--- a/apps/emdash-desktop/src/core/services/ssh/node/connect/ssh-connect-auth.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/connect/ssh-connect-auth.ts
@@ -1,6 +1,6 @@
 // Auth assembly: password, key, and agent selection with IdentitiesOnly filtering.
 import ssh2, {
-  type BaseAgent,
+  BaseAgent,
   type ConnectConfig,
   type IdentityCallback,
   type ParsedKey,
@@ -41,7 +41,10 @@ function comparablePublicKey(key: AgentPublicKey): ParsedKey | Buffer | string {
   return key;
 }
 
-class IdentityFilteredAgent implements BaseAgent {
+// Extends ssh2's BaseAgent so `isAgent()` (an instanceof check in ssh2's client
+// config validation) accepts the wrapper; an `implements`-only class is silently
+// dropped from the connect config and agent auth never runs.
+class IdentityFilteredAgent extends BaseAgent {
   readonly kind = 'identity-filtered-agent';
   declare getStream?: BaseAgent['getStream'];
 
@@ -50,6 +53,7 @@ class IdentityFilteredAgent implements BaseAgent {
     private readonly agent: BaseAgent,
     private readonly allowedKeys: ParsedKey[]
   ) {
+    super();
     if (agent.getStream) {
       this.getStream = agent.getStream.bind(agent);
     }


### PR DESCRIPTION
## Problem

Fixes #2901.

When an SSH connection uses agent auth and the resolved `~/.ssh/config` has `IdentitiesOnly yes` + `IdentityFile`, `buildAuthConfig` wraps the agent in `IdentityFilteredAgent`. That class only `implements` ssh2's `BaseAgent` — a type-level statement with no prototype link. ssh2's client config validation accepts a custom agent object only via `isAgent(val)`, which is literally `val instanceof BaseAgent` (ssh2 `lib/agent.js:1110-1111`; applied in `lib/client.js:221-224`). The check fails, so ssh2 silently sets `config.agent = undefined`, sends the `none` probe, gets `USERAUTH_FAILURE`, and disconnects without ever offering a key — every agent-mode connection against an `IdentitiesOnly` host fails with "All configured authentication methods failed".

The filtering logic itself is correct; only the wrapper's prototype chain is wrong.

## Fix

Make `IdentityFilteredAgent extends BaseAgent` (importing `BaseAgent` as a value, calling `super()`) so the instanceof check passes and ssh2 keeps the wrapper. No behavior of the wrapper changes: `getIdentities`/`sign` are still overridden, and the optional `getStream` is still bound only when the wrapped agent supports it.

## Testing

- New focused test in the existing suite (`resolve-ssh-connect-config.test.ts`) asserts the produced agent passes ssh2's exact validation predicate: `expect(result.config.agent).toBeInstanceOf(BaseAgent)`.
- Red/green verified locally:
  - Without the fix: `Test Files 1 failed (1), Tests 1 failed | 18 passed (19)`
  - With the fix: `pnpm vitest run --project node src/core/services/ssh/node/connect/resolve-ssh-connect-config.test.ts` → `Tests 19 passed (19)`
- `pnpm exec tsgo --noEmit -p tsconfig.node.json` → clean
- `oxfmt --check` + `oxlint` on touched files → clean

Not tested end-to-end against a live SSH host with `IdentitiesOnly yes` (no such environment here); the regression test pins the exact ssh2 acceptance check that previously failed.
