### PR TITLE
fix(workspaces): run teardown when deleting never-activated workspaces

### DIFF
--- a/packages/core/src/runtimes/workspace-registry/node/activation.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/activation.ts
@@ -100,7 +100,7 @@ export class WorkspaceActivationManager {
   private readonly logger: Logger;
   private readonly teardownTimeoutMs: number;
   private readonly active = new Map<string, ActiveState>();
-  /** Workspaces whose no-activation teardown already ran (at most once per run). */
+  /** Workspaces whose removal teardown already settled (at most once per id). */
   private readonly removalTeardowns = new Set<string>();
 
   constructor(options: WorkspaceActivationManagerOptions) {
@@ -230,7 +230,13 @@ export class WorkspaceActivationManager {
     id: string,
     workspacePath: string
   ): Promise<WorkspaceDeactivationResult> {
-    if (this.active.has(id)) return await this.deactivate(id);
+    if (this.active.has(id)) {
+      const result = await this.deactivate(id);
+      // The activation's one teardown settled (success or not): consume the id so a
+      // failed-teardown retry proceeds past it instead of re-running the orphan path.
+      this.removalTeardowns.add(id);
+      return result;
+    }
     if (this.removalTeardowns.has(id)) return { teardownFailure: null };
     if (!(await isDirectory(workspacePath))) return { teardownFailure: null };
 

--- a/packages/core/src/runtimes/workspace-registry/node/activation.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/activation.ts
@@ -1,3 +1,4 @@
+import { promises as fs } from 'node:fs';
 import { noopLogger, type Logger } from '@emdash/shared/logger';
 import { systemClock, type Clock } from '@emdash/shared/scheduling';
 import { type EmdashScriptsConfig } from '#primitives/emdash-config/api';
@@ -99,6 +100,8 @@ export class WorkspaceActivationManager {
   private readonly logger: Logger;
   private readonly teardownTimeoutMs: number;
   private readonly active = new Map<string, ActiveState>();
+  /** Workspaces whose no-activation teardown already ran (at most once per run). */
+  private readonly removalTeardowns = new Set<string>();
 
   constructor(options: WorkspaceActivationManagerOptions) {
     this.options = options;
@@ -216,6 +219,42 @@ export class WorkspaceActivationManager {
     return { teardownFailure };
   }
 
+  /**
+   * The removal verbs' deactivation: the plain activation teardown when an activation
+   * exists, otherwise a one-time orphan teardown so deleting a workspace that was never
+   * activated in this run (archived task, never opened, daemon restart) still settles
+   * its `.emdash.json` teardown before its artifacts are destroyed (#2886). A missing
+   * workspace path has nothing left to settle.
+   */
+  async deactivateForRemoval(
+    id: string,
+    workspacePath: string
+  ): Promise<WorkspaceDeactivationResult> {
+    if (this.active.has(id)) return await this.deactivate(id);
+    if (this.removalTeardowns.has(id)) return { teardownFailure: null };
+    if (!(await isDirectory(workspacePath))) return { teardownFailure: null };
+
+    const policy = await this.resolveLifecycleConfig(id, workspacePath);
+    const teardown = policy.scripts.teardown;
+    if (!teardown) return { teardownFailure: null };
+
+    const outcome = await this.runner.run({
+      id: 'teardown',
+      command: teardown,
+      shellSetup: policy.shellSetup,
+      cwd: workspacePath,
+      timeoutMs: this.teardownTimeoutMs,
+    });
+    // Consumed even on failure: like a spent activation, the retry proceeds past it.
+    this.removalTeardowns.add(id);
+    if (outcome.status === 'succeeded') {
+      this.options.clearNotice(id, 'teardown');
+      return { teardownFailure: null };
+    }
+    this.options.setNotice(id, 'teardown', outcome.message);
+    return { teardownFailure: { message: outcome.message } };
+  }
+
   /** Abandons all activations without teardown; used on runtime disposal only. */
   dispose(): void {
     for (const state of this.active.values()) {
@@ -315,4 +354,12 @@ async function readWorkspaceScripts(
 ): Promise<EmdashScriptsConfig> {
   // Lenient by design: an unparseable .emdash.json must never block activation.
   return (await readWorkspaceConfig(workspacePath)).config.scripts ?? {};
+}
+
+async function isDirectory(path: string): Promise<boolean> {
+  try {
+    return (await fs.stat(path)).isDirectory();
+  } catch {
+    return false;
+  }
 }

--- a/packages/core/src/runtimes/workspace-registry/node/api/delete-worktree.contract.test.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/api/delete-worktree.contract.test.ts
@@ -340,6 +340,40 @@ describe('workspace registry deleteWorktree', () => {
     expect((await listRecords())['wt-unactivated']).toBeUndefined();
   });
 
+  it('deleting an orphaned worktree still settles its own .emdash.json teardown', async () => {
+    const repoPath = await makeRepo(root, 'repo');
+    await wire.client.createWorkspace({ workspaceId: 'ws-repo', path: repoPath });
+    const worktree = await createWorktree('ws-repo', 'orphan');
+    await fs.writeFile(
+      path.join(worktree.path, '.emdash.json'),
+      JSON.stringify({ scripts: { teardown: 'exit 9' } })
+    );
+    await wire.client.refresh({ workspaceId: 'wt-orphan' });
+
+    // The parent repository record goes away while the worktree stays on disk.
+    expect((await wire.client.deleteWorkspace({ workspaceId: 'ws-repo' })).success).toBe(true);
+
+    // Removal still resolves the repository from disk, so the worktree's own config
+    // must govern its teardown even though layered resolution has no project root.
+    const deleted = await wire.client.deleteWorktree({
+      workspaceId: 'wt-orphan',
+      deleteBranch: false,
+    });
+    expect(deleted).toMatchObject({
+      success: false,
+      error: { type: 'remove-failed', stage: 'teardown', class: 'transient' },
+    });
+    await expect(fs.stat(worktree.path)).resolves.toBeDefined();
+
+    // Settled once: the retry converges.
+    const retried = await wire.client.deleteWorktree({
+      workspaceId: 'wt-orphan',
+      deleteBranch: false,
+    });
+    expect(retried).toEqual({ success: true, data: undefined });
+    await expect(fs.stat(worktree.path)).rejects.toThrow();
+  });
+
   it('deleteWorkspace records a failing teardown as a removal attempt and stays retryable', async () => {
     const repoPath = await makeRepo(root, 'repo');
     await wire.client.createWorkspace({ workspaceId: 'ws-repo', path: repoPath });

--- a/packages/core/src/runtimes/workspace-registry/node/api/delete-worktree.contract.test.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/api/delete-worktree.contract.test.ts
@@ -308,6 +308,38 @@ describe('workspace registry deleteWorktree', () => {
     expect((await listRecords())['wt-torn']).toBeUndefined();
   });
 
+  it('deleting a worktree that was never activated still runs its teardown script once', async () => {
+    const repoPath = await makeRepo(root, 'repo');
+    await wire.client.createWorkspace({ workspaceId: 'ws-repo', path: repoPath });
+    const worktree = await createWorktree('ws-repo', 'unactivated');
+    await fs.writeFile(
+      path.join(worktree.path, '.emdash.json'),
+      JSON.stringify({ scripts: { teardown: 'exit 9' } })
+    );
+    await wire.client.refresh({ workspaceId: 'wt-unactivated' });
+
+    // No activation this run: the delete verbs own the orphan-teardown settle.
+    const deleted = await wire.client.deleteWorktree({
+      workspaceId: 'wt-unactivated',
+      deleteBranch: false,
+    });
+    expect(deleted).toMatchObject({ success: false, error: { type: 'remove-failed' } });
+    expect((await listRecords())['wt-unactivated']?.lastRemovalAttempt).toMatchObject({
+      stage: 'teardown',
+      class: 'transient',
+    });
+    await expect(fs.stat(worktree.path)).resolves.toBeDefined();
+
+    // The orphan teardown settles at most once: the retry proceeds past it.
+    const retried = await wire.client.deleteWorktree({
+      workspaceId: 'wt-unactivated',
+      deleteBranch: false,
+    });
+    expect(retried).toEqual({ success: true, data: undefined });
+    await expect(fs.stat(worktree.path)).rejects.toThrow();
+    expect((await listRecords())['wt-unactivated']).toBeUndefined();
+  });
+
   it('deleteWorkspace records a failing teardown as a removal attempt and stays retryable', async () => {
     const repoPath = await makeRepo(root, 'repo');
     await wire.client.createWorkspace({ workspaceId: 'ws-repo', path: repoPath });

--- a/packages/core/src/runtimes/workspace-registry/node/runtime.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/runtime.ts
@@ -316,12 +316,18 @@ export class WorkspaceRegistryRuntime {
       resolveLifecycleConfig: async (id) => {
         await this.bootConfigHydration;
         const resolved = await this.resolveProjectConfigFor(id);
+        // An orphaned worktree (its parent repository record was already removed) has
+        // no project root to layer against, but its own `.emdash.json` still governs
+        // its lifecycle — without this fallback, deleting such a worktree would skip
+        // its teardown while the removal itself still resolves the repository from
+        // disk. Same cached workspace layer the layered resolution reads.
+        const ownScripts = resolved === null ? this.configs.get(id)?.config.scripts : undefined;
         return {
           scripts: {
-            prepare: resolved?.resolved.prepare?.value,
-            setup: resolved?.resolved.setup?.value,
-            run: resolved?.resolved.run?.value,
-            teardown: resolved?.resolved.teardown?.value,
+            prepare: resolved?.resolved.prepare?.value ?? ownScripts?.prepare,
+            setup: resolved?.resolved.setup?.value ?? ownScripts?.setup,
+            run: resolved?.resolved.run?.value ?? ownScripts?.run,
+            teardown: resolved?.resolved.teardown?.value ?? ownScripts?.teardown,
           },
           shellSetup: resolved?.resolved.shellSetup?.value ?? '',
           autoRunSetup: resolved?.resolved.autoRunSetup.value ?? true,
@@ -898,10 +904,11 @@ export class WorkspaceRegistryRuntime {
   }
 
   /**
-   * The delete verbs' deactivation step: a failed teardown counts as a removal stage
+   * The delete verbs' deactivation step: settle teardown (activation teardown or the
+   * no-activation orphan run), then kill the path's sessions best-effort — the same
+   * script-then-sessions order as Stop. A failed teardown counts as a removal stage
    * (ADR 0006) — recorded durably before the verb returns. Transient by design:
-   * teardown settles at most once (activation teardown or the no-activation orphan
-   * run), so the next attempt proceeds past it.
+   * teardown settles at most once, so the next attempt proceeds past it.
    */
   private async deactivateForRemoval(
     record: DurableWorkspaceRecord
@@ -910,6 +917,12 @@ export class WorkspaceRegistryRuntime {
       record.id,
       record.path
     );
+    try {
+      await this.killSessions(record.path);
+    } catch (error) {
+      // Best-effort by contract: the removal must still proceed.
+      this.logger.warn?.(`session cleanup for '${record.path}' failed`, { error });
+    }
     if (!teardownFailure) return null;
     return await this.recordRemovalFailure(record.id, {
       stage: 'teardown',

--- a/packages/core/src/runtimes/workspace-registry/node/runtime.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/runtime.ts
@@ -900,12 +900,16 @@ export class WorkspaceRegistryRuntime {
   /**
    * The delete verbs' deactivation step: a failed teardown counts as a removal stage
    * (ADR 0006) — recorded durably before the verb returns. Transient by design:
-   * teardown runs at most once per activation, so the next attempt proceeds past it.
+   * teardown settles at most once (activation teardown or the no-activation orphan
+   * run), so the next attempt proceeds past it.
    */
   private async deactivateForRemoval(
     record: DurableWorkspaceRecord
   ): Promise<DeleteWorkspaceError | null> {
-    const { teardownFailure } = await this.deactivateLocked(record);
+    const { teardownFailure } = await this.activationManager.deactivateForRemoval(
+      record.id,
+      record.path
+    );
     if (!teardownFailure) return null;
     return await this.recordRemovalFailure(record.id, {
       stage: 'teardown',


### PR DESCRIPTION
### Description

Deleting a task/workspace whose workspace was never activated in the current app run (archived tasks, tasks never opened since launch, or any delete after an app restart) silently skipped the `.emdash.json` teardown script: all three removal verbs funnel through `deactivateForRemoval`, which ran teardown only via `activationManager.deactivate()` — a no-op without a live activation — and then destroyed the worktree. Archived tasks therefore leaked whatever their teardown was responsible for cleaning up (the reporting case: iOS simulators created by setup).

Fix: `WorkspaceActivationManager` gains `deactivateForRemoval(id, path)` — the plain activation teardown when an activation exists, otherwise a one-time orphan teardown run through the same runner, time-boxed, notice-reported, and marked consumed even on failure so a retry proceeds past it (same semantics as a spent activation). A missing workspace path has nothing to settle, so already-vanished workspaces still delete. The runtime's removal verbs delegate to it; plain `deactivateWorkspace` (the Stop flow) is unchanged.

Note: archive of a live task already reaches host deactivation on current main; this closes the remaining destruction-path gap that also covers the archive-then-delete chain from the issue.

### Related issues

Fixes #2886

### Testing

- New contract test `deleting a worktree that was never activated still runs its teardown script once` in `delete-worktree.contract.test.ts`: mirrors the existing failing-teardown test minus activation — first delete fails at the durable `teardown`/`transient` removal stage with the artifact intact, retry converges and removes it.
  - `pnpm vitest run src/runtimes/workspace-registry/node/api/delete-worktree.contract.test.ts -t "never activated"` → 1 passed
- `pnpm vitest run src/runtimes/workspace-registry/node/api/delete-worktree.contract.test.ts` → same pre-existing results as baseline on this Windows machine (several tests assert POSIX shell output/exit codes that cmd.exe does not produce; verified identical failures with the change stashed)
- `packages/core`: `pnpm run typecheck` → clean; `pnpm run lint` → clean; `pnpm run format:check` → clean

### Screenshot/Recording (if applicable)

N/A — no UI change.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [ ] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>