### PR TITLE
fix(pty): pack tmux session names to keep them short

### DIFF
--- a/packages/core/src/services/pty/api/tmux.test.ts
+++ b/packages/core/src/services/pty/api/tmux.test.ts
@@ -1,6 +1,45 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { IExecutionContext } from '#primitives/exec/api';
-import { listTmuxSessionActivity, parseTmuxSessionActivity } from './tmux';
+import {
+  decodeTmuxSessionName,
+  listTmuxSessionActivity,
+  makeTmuxSessionName,
+  parseTmuxSessionActivity,
+  TMUX_SESSION_PREFIX,
+} from './tmux';
+
+describe('tmux session names', () => {
+  const uuidSessionId =
+    '5ecb5f07-2f59-4c17-a3a2-bfc21eefa2d5:9d0f68e1-15e6-4a8b-98a7-d4e3f0c2b1aa:0f3be1c2-77d8-4b5f-a111-2ce4f5a6b9d0';
+
+  it('keeps UUID-backed session names short and decodable', () => {
+    const name = makeTmuxSessionName(uuidSessionId);
+
+    expect(name.startsWith(TMUX_SESSION_PREFIX)).toBe(true);
+    // The previous encoding base64url-ed the full 110-character id text (~154 chars).
+    expect(name.length).toBeLessThan(80);
+    expect(decodeTmuxSessionName(name)).toBe(uuidSessionId);
+  });
+
+  it('round-trips non-UUID session ids through the legacy encoding', () => {
+    const sessionId = 'project:task:leaf';
+
+    expect(decodeTmuxSessionName(makeTmuxSessionName(sessionId))).toBe(sessionId);
+  });
+
+  it('still decodes long names created by older builds', () => {
+    const legacy = TMUX_SESSION_PREFIX + Buffer.from(uuidSessionId, 'utf8').toString('base64url');
+
+    expect(legacy.length).toBeGreaterThan(100);
+    expect(decodeTmuxSessionName(legacy)).toBe(uuidSessionId);
+  });
+
+  it('rejects names that are not emdash session encodings', () => {
+    expect(decodeTmuxSessionName('someone-elses-session')).toBeNull();
+    expect(decodeTmuxSessionName(TMUX_SESSION_PREFIX)).toBeNull();
+    expect(decodeTmuxSessionName(`${TMUX_SESSION_PREFIX}not base64!`)).toBeNull();
+  });
+});
 
 describe('parseTmuxSessionActivity', () => {
   it('parses session activity timestamps as milliseconds', () => {

--- a/packages/core/src/services/pty/api/tmux.ts
+++ b/packages/core/src/services/pty/api/tmux.ts
@@ -16,8 +16,15 @@ export function buildTmuxShellLine(sessionName: string, commandLine: string): st
   return `/bin/sh -c ${JSON.stringify(script)}`;
 }
 
+/**
+ * Session names show up in tmux status bars (#2706), so UUID-backed session ids
+ * (`uuid:uuid:uuid`) pack into their raw 48 bytes instead of base64url-ing the
+ * 110-character text. Anything else keeps the legacy utf8 encoding, and decoding
+ * still accepts names created by older builds.
+ */
 export function makeTmuxSessionName(sessionId: string): string {
-  const encoded = Buffer.from(sessionId, 'utf8').toString('base64url');
+  const packed = packUuidSessionId(sessionId);
+  const encoded = (packed ?? Buffer.from(sessionId, 'utf8')).toString('base64url');
   return `${TMUX_SESSION_PREFIX}${encoded}`;
 }
 
@@ -25,13 +32,47 @@ export function decodeTmuxSessionName(sessionName: string): string | null {
   if (!sessionName.startsWith(TMUX_SESSION_PREFIX)) return null;
   const encoded = sessionName.slice(TMUX_SESSION_PREFIX.length);
   if (!encoded) return null;
+  let bytes: Buffer;
   try {
-    const sessionId = Buffer.from(encoded, 'base64url').toString('utf8');
-    if (makeTmuxSessionName(sessionId) !== sessionName) return null;
-    return sessionId;
+    bytes = Buffer.from(encoded, 'base64url');
   } catch {
     return null;
   }
+  // The round-trip guard disambiguates packed from legacy encodings: a candidate
+  // is accepted when this name is any of its valid encodings.
+  const candidates = [unpackUuidSessionId(bytes), bytes.toString('utf8')];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const encodings = [Buffer.from(candidate, 'utf8'), packUuidSessionId(candidate)].filter(
+      (buffer) => buffer !== null
+    );
+    if (encodings.some((buffer) => buffer.toString('base64url') === encoded)) return candidate;
+  }
+  return null;
+}
+
+const UUID_TEXT_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+function packUuidSessionId(sessionId: string): Buffer | null {
+  const parts = sessionId.split(':');
+  if (parts.length !== 3 || !parts.every((part) => UUID_TEXT_PATTERN.test(part))) return null;
+  return Buffer.concat(parts.map((part) => Buffer.from(part.replace(/-/g, ''), 'hex')));
+}
+
+function unpackUuidSessionId(bytes: Buffer): string | null {
+  if (bytes.length !== 48) return null;
+  const hex = bytes.toString('hex');
+  return [0, 32, 64].map((offset) => formatUuidText(hex.slice(offset, offset + 32))).join(':');
+}
+
+function formatUuidText(hex: string): string {
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20, 32),
+  ].join('-');
 }
 
 export async function listTmuxSessionActivity(


### PR DESCRIPTION
### Description

tmux session names are `emdash-` + base64url of the full PTY session id text (`uuid:uuid:uuid`, 110 characters), producing ~154-character names that crowd out everything else in a tmux status bar (#2706).

UUIDs carry only 16 bytes of entropy each, so `makeTmuxSessionName` now packs UUID-backed session ids into their raw 48 bytes — `emdash-` + 64 base64url chars (~71 total, less than half the length) — while any non-UUID id keeps the legacy utf8 encoding. `decodeTmuxSessionName` accepts both encodings via its existing round-trip guard, so names written by older builds still decode, and every consumer keeps deriving identical names from DB rows through the same two functions. No reaper or cleanup logic changes.

Upgrade note: tmux sessions created by a previous release keep their long names until their tmux server exits; emdash creates fresh short-named sessions on next attach (`has-session || new-session`), and kill flows target the new canonical names.

### Related issues

Fixes #2706

### Testing

- Extended `packages/core/src/services/pty/api/tmux.test.ts` with a `tmux session names` suite: packed names stay under 80 chars and round-trip; non-UUID ids round-trip legacy; long legacy-encoded names still decode; foreign/garbage names reject.
  - `pnpm vitest run src/services/pty/api/tmux.test.ts` → 10 passed
- `pnpm vitest run src/main/db/legacy-port/importers/relational/relational.test.ts` (consumes `makeTmuxSessionName`) → 6 passed
- `packages/core`: `pnpm run typecheck` → clean; `pnpm run lint` → clean; `pnpm run format:check` → clean

### Screenshot/Recording (if applicable)

N/A — no UI change in this repo (session-name length shows in the user's own tmux status bar).

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [ ] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>