### PR TITLE
fix(tasks): activate restored tasks when host becomes ready

### DIFF
--- a/agents/architecture/renderer.md
+++ b/agents/architecture/renderer.md
@@ -41,6 +41,12 @@ Task children have two explicit lifetimes: lightweight persistent stores survive
 for as long as the task row exists (`task-persistent-stores.ts`), while operational task stores are
 disposed when the task session is torn down (`task-scoped-stores.ts`).
 
+The Tasks slice owns current-task workspace activation in its app-scoped
+`TaskActivationCoordinator`. It derives activation from navigation, Project context hydration,
+Task state, and Host generation readiness. Views and navigation handlers only express which Task
+is current; they do not opportunistically provision it. Explicit Retry and Re-provision actions
+remain direct user commands.
+
 Feature views, modals, and task tabs are exposed through `contributions/` and aggregated by
 `src/core/manifests/browser/browser-contributions.ts` and
 `src/core/manifests/browser/task-tab-contributions.ts`.

--- a/apps/emdash-desktop/src/core/features/projects/api/browser/stores/project-manager.ts
+++ b/apps/emdash-desktop/src/core/features/projects/api/browser/stores/project-manager.ts
@@ -570,27 +570,7 @@ export class ProjectManagerStore {
   }
 
   private async _hydrateProjectContext(context: ProjectContext): Promise<void> {
-    const taskManager = context.get(taskManagerStoreToken);
-    await taskManager.loadTasks();
-    const currentContext = this.projects.get(context.project.id)?.context;
-    if (
-      this._disposed ||
-      currentContext?.kind !== 'available' ||
-      currentContext.context !== context
-    ) {
-      return;
-    }
-
-    const nav = getNavigation();
-    const navParams = nav.currentRef.params as {
-      projectId?: string;
-      taskId?: string;
-    };
-    const navTaskId =
-      nav.currentViewId === 'task' && navParams.projectId === context.project.id
-        ? navParams.taskId
-        : undefined;
-    if (navTaskId) void taskManager.provisionTask(navTaskId).catch(() => {});
+    await context.get(taskManagerStoreToken).loadTasks();
   }
 
   async deleteProject(projectId: string): Promise<void> {

--- a/apps/emdash-desktop/src/core/features/projects/browser/components/task-view/task-list.tsx
+++ b/apps/emdash-desktop/src/core/features/projects/browser/components/task-view/task-list.tsx
@@ -242,7 +242,6 @@ const TaskListContent = observer(function TaskListContent({
         }
         onItemClick={(task) => {
           if (task.data.archivedAt) return;
-          void taskManager.provisionTask(task.data.id);
           navigate(taskViewDef({ projectId, taskId: task.data.id }));
         }}
         emptySlot={

--- a/apps/emdash-desktop/src/core/features/tasks/api/browser/stores/task-manager.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/api/browser/stores/task-manager.ts
@@ -59,6 +59,12 @@ type TaskMutationInvocation<Data, Error> = {
 
 type TaskListRemoteMember = ReturnType<RemoteModel<typeof tasksWireContract.taskList>>;
 
+export type TaskProvisionOutcome =
+  | { kind: 'active'; disposition: 'activated' | 'already-active' }
+  | { kind: 'deferred'; reason: 'host-unavailable' }
+  | { kind: 'skipped'; reason: 'task-missing' | 'task-not-provisionable' }
+  | { kind: 'failed'; message: string };
+
 function formatCreateTaskError(error: CreateTaskError, opts?: { isSshProject?: boolean }): string {
   return match(error)
     .with({ type: 'project-not-found' }, () => 'Project not found.')
@@ -144,7 +150,7 @@ export class TaskManagerStore {
   private readonly _settingsStore: ProjectSettingsStore;
   private _loadPromise: Promise<void> | null = null;
   private _teardownPromises = new Map<string, Promise<void>>();
-  private _provisionPromises = new Map<string, Promise<void>>();
+  private _provisionPromises = new Map<string, Promise<TaskProvisionOutcome>>();
   private readonly _taskListScope: Scope = createScope({ label: 'task-list-replica' });
   private _taskListRemote: RemoteModel<typeof tasksWireContract.taskList> | null = null;
   private _taskStatsRemote: RemoteModel<typeof tasksWireContract.taskStats> | null = null;
@@ -447,32 +453,68 @@ export class TaskManagerStore {
     await this.provisionTask(params.id);
   }
 
-  async provisionTask(taskId: string): Promise<void> {
-    if (!this.host.requireLive().success) return;
-    await this.loadTasks();
-
+  async provisionTask(taskId: string): Promise<TaskProvisionOutcome> {
     const inFlight = this._provisionPromises.get(taskId);
     if (inFlight) return inFlight;
 
+    const knownTask = this.tasks.get(taskId);
+    if (knownTask && isProvisioned(knownTask)) {
+      return { kind: 'active', disposition: 'already-active' };
+    }
+    if (!this.host.requireLive().success) {
+      return { kind: 'deferred', reason: 'host-unavailable' };
+    }
+
+    await this.loadTasks();
+
+    const loadedInFlight = this._provisionPromises.get(taskId);
+    if (loadedInFlight) return loadedInFlight;
+
     const task = this.tasks.get(taskId);
-    if (!task || !isUnprovisioned(task)) return;
+    if (!task) return { kind: 'skipped', reason: 'task-missing' };
+    if (isProvisioned(task)) return { kind: 'active', disposition: 'already-active' };
+    if (!isUnprovisioned(task)) {
+      return { kind: 'skipped', reason: 'task-not-provisionable' };
+    }
 
     runInAction(() => {
       task.phase = 'provision';
       task.errorMessage = undefined;
     });
 
-    const promise = this._doProvision(taskId).finally(() => {
-      this._provisionPromises.delete(taskId);
-    });
+    const promise = this._doProvision(taskId)
+      .catch((error): TaskProvisionOutcome => {
+        const message = formatErrorMessage(error);
+        log.error('Unexpected error provisioning task', {
+          projectId: this.projectId,
+          taskId,
+          error,
+        });
+        runInAction(() => {
+          const current = this.tasks.get(taskId);
+          if (current && isUnprovisioned(current)) {
+            current.phase = 'provision-error';
+            current.errorMessage = message;
+          }
+        });
+        return { kind: 'failed', message };
+      })
+      .finally(() => {
+        this._provisionPromises.delete(taskId);
+      });
 
     this._provisionPromises.set(taskId, promise);
     return promise;
   }
 
-  private async _doProvision(taskId: string): Promise<void> {
+  private async _doProvision(taskId: string): Promise<TaskProvisionOutcome> {
     const task = this.tasks.get(taskId);
-    if (!task || !isUnprovisioned(task)) return;
+    if (!task) return { kind: 'skipped', reason: 'task-missing' };
+    if (!isUnprovisioned(task)) {
+      return isProvisioned(task)
+        ? { kind: 'active', disposition: 'already-active' }
+        : { kind: 'skipped', reason: 'task-not-provisionable' };
+    }
 
     const wsId = task.data.workspaceId;
     if (!wsId) {
@@ -484,7 +526,7 @@ export class TaskManagerStore {
           current.errorMessage = message;
         }
       });
-      return;
+      return { kind: 'failed', message };
     }
 
     // Activation gates on registry/outbox state, then assembles and registers the task session.
@@ -514,7 +556,7 @@ export class TaskManagerStore {
           current.errorMessage = message;
         }
       });
-      return;
+      return { kind: 'failed', message };
     }
 
     const taskBeforeTransition = this.tasks.get(taskId);
@@ -522,7 +564,7 @@ export class TaskManagerStore {
       await taskBeforeTransition.ready();
     }
 
-    runInAction(() => {
+    const activated = runInAction(() => {
       const current = this.tasks.get(taskId);
       if (current && isUnprovisioned(current)) {
         current.transitionToProvisioned(
@@ -532,8 +574,16 @@ export class TaskManagerStore {
           result.data.sshConnectionId ?? undefined
         );
         current.activate();
+        return true;
       }
+      return false;
     });
+    if (activated) return { kind: 'active', disposition: 'activated' };
+
+    const current = this.tasks.get(taskId);
+    return current && isProvisioned(current)
+      ? { kind: 'active', disposition: 'already-active' }
+      : { kind: 'skipped', reason: current ? 'task-not-provisionable' : 'task-missing' };
   }
 
   private async _doHandleProvisioned(

--- a/apps/emdash-desktop/src/core/features/tasks/browser/main-panel.tsx
+++ b/apps/emdash-desktop/src/core/features/tasks/browser/main-panel.tsx
@@ -113,9 +113,9 @@ const TaskMainPanelContent = observer(function TaskMainPanelContent() {
         title="Workspace is unavailable"
         description="The Task is still available, but its workspace needs live Project access."
         actionDisabledReason={hostActionDisabledReason}
-        reprovision={() =>
-          getTaskManagerStore(projectId)?.provisionTask(taskId) ?? Promise.resolve()
-        }
+        reprovision={async () => {
+          await getTaskManagerStore(projectId)?.provisionTask(taskId);
+        }}
       />
     );
   }

--- a/apps/emdash-desktop/src/core/features/tasks/browser/stores/task-activation-coordinator.test.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/browser/stores/task-activation-coordinator.test.ts
@@ -1,0 +1,155 @@
+import { observable } from 'mobx';
+import { describe, expect, it, vi } from 'vitest';
+import type { ProjectHostAccessState } from '@core/features/projects/api/browser/stores/project-context';
+import { taskManagerStoreToken } from '@core/features/tasks/contributions/browser/project-store-tokens';
+import { taskViewDef } from '@core/features/tasks/contributions/views';
+import { homeViewDef } from '@core/features/workbench/contributions/views';
+import type { ViewRef } from '@core/primitives/views/api';
+import { TaskActivationCoordinator } from './task-activation-coordinator';
+
+describe('TaskActivationCoordinator', () => {
+  it('activates a restored Task when its Host becomes ready without a view remount', async () => {
+    const currentRef = observable.box<ViewRef>(homeViewDef());
+    const hostState = observable.box<ProjectHostAccessState>({
+      kind: 'degraded',
+      situation: 'attaching',
+      recovery: 'automatic',
+    });
+    const task = observable({
+      state: 'unprovisioned' as const,
+      phase: 'idle' as const,
+      data: { id: 'task-1', projectId: 'project-1', archivedAt: undefined },
+    });
+    const provisionTask = vi.fn(async () => ({
+      kind: 'deferred' as const,
+      reason: 'host-unavailable' as const,
+    }));
+    const taskManager = {
+      tasks: observable.map([['task-1', task]]),
+      provisionTask,
+    };
+    const projects = observable.map<string, unknown>();
+    const coordinator = new TaskActivationCoordinator(
+      {
+        get currentRef() {
+          return currentRef.get();
+        },
+      } as never,
+      { projects } as never
+    );
+    coordinator.start();
+
+    currentRef.set(taskViewDef({ projectId: 'project-1', taskId: 'task-1' }));
+    expect(coordinator.state).toEqual({
+      kind: 'waiting-for-project',
+      projectId: 'project-1',
+      taskId: 'task-1',
+    });
+
+    projects.set('project-1', {
+      context: {
+        kind: 'available',
+        context: {
+          host: {
+            get state() {
+              return hostState.get();
+            },
+            get liveAction() {
+              const state = hostState.get();
+              return state.kind === 'ready'
+                ? { kind: 'enabled' as const }
+                : { kind: 'disabled' as const, state };
+            },
+          },
+          get: (token: unknown) => {
+            expect(token).toBe(taskManagerStoreToken);
+            return taskManager;
+          },
+        },
+      },
+    });
+    expect(coordinator.state).toEqual({
+      kind: 'waiting-for-host',
+      projectId: 'project-1',
+      taskId: 'task-1',
+    });
+    expect(provisionTask).not.toHaveBeenCalled();
+
+    hostState.set({ kind: 'ready', hostGeneration: 1 });
+    await vi.waitFor(() => expect(provisionTask).toHaveBeenCalledOnce());
+    expect(coordinator.state).toEqual({
+      kind: 'ready-to-activate',
+      projectId: 'project-1',
+      taskId: 'task-1',
+      hostGeneration: 1,
+    });
+
+    hostState.set({ kind: 'degraded', situation: 'recovering', recovery: 'automatic' });
+    hostState.set({ kind: 'ready', hostGeneration: 2 });
+    await vi.waitFor(() => expect(provisionTask).toHaveBeenCalledTimes(2));
+
+    coordinator.dispose();
+    hostState.set({ kind: 'degraded', situation: 'recovering', recovery: 'automatic' });
+    hostState.set({ kind: 'ready', hostGeneration: 3 });
+    expect(provisionTask).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not activate an archived Task', () => {
+    const currentRef = observable.box<ViewRef>(
+      taskViewDef({ projectId: 'project-1', taskId: 'task-1' })
+    );
+    const provisionTask = vi.fn();
+    const projects = observable.map([
+      [
+        'project-1',
+        {
+          context: {
+            kind: 'available' as const,
+            context: {
+              host: {
+                state: { kind: 'ready' as const, hostGeneration: 1 },
+                liveAction: { kind: 'enabled' as const },
+              },
+              get: () => ({
+                tasks: observable.map([
+                  [
+                    'task-1',
+                    observable({
+                      state: 'unprovisioned' as const,
+                      phase: 'idle' as const,
+                      data: {
+                        id: 'task-1',
+                        projectId: 'project-1',
+                        archivedAt: '2026-08-28T00:00:00.000Z',
+                      },
+                    }),
+                  ],
+                ]),
+                provisionTask,
+              }),
+            },
+          },
+        },
+      ],
+    ]);
+    const coordinator = new TaskActivationCoordinator(
+      {
+        get currentRef() {
+          return currentRef.get();
+        },
+      } as never,
+      { projects } as never
+    );
+
+    coordinator.start();
+
+    expect(coordinator.state).toEqual({
+      kind: 'inactive',
+      reason: 'archived',
+      projectId: 'project-1',
+      taskId: 'task-1',
+    });
+    expect(provisionTask).not.toHaveBeenCalled();
+    coordinator.dispose();
+  });
+});

--- a/apps/emdash-desktop/src/core/features/tasks/browser/stores/task-activation-coordinator.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/browser/stores/task-activation-coordinator.ts
@@ -1,0 +1,121 @@
+import { comparer, computed, makeObservable, reaction, type IReactionDisposer } from 'mobx';
+import type { ProjectManagerStore } from '@core/features/projects/api/browser/stores/project-manager';
+import { asAvailableProject } from '@core/features/projects/api/browser/stores/project-selectors';
+import { taskManagerStoreToken } from '@core/features/tasks/contributions/browser/project-store-tokens';
+import { log } from '@core/primitives/logging/browser/logger';
+import type { NavigationStore } from '@core/primitives/navigation/browser/navigation-store';
+import {
+  isProvisioned,
+  isUnprovisioned,
+  isUnregistered,
+} from '@core/primitives/task-state/browser/task-state';
+
+type TaskActivationIdentity = {
+  projectId: string;
+  taskId: string;
+};
+
+export type TaskActivationState =
+  | { kind: 'inactive'; reason: 'not-a-task-view' }
+  | ({ kind: 'inactive'; reason: 'archived' | 'tearing-down' } & TaskActivationIdentity)
+  | ({ kind: 'waiting-for-project' } & TaskActivationIdentity)
+  | ({ kind: 'waiting-for-task' } & TaskActivationIdentity)
+  | ({ kind: 'waiting-for-host' } & TaskActivationIdentity)
+  | ({ kind: 'ready-to-activate'; hostGeneration: number } & TaskActivationIdentity)
+  | ({ kind: 'activating' } & TaskActivationIdentity)
+  | ({ kind: 'active' } & TaskActivationIdentity)
+  | ({ kind: 'failed'; message: string | undefined } & TaskActivationIdentity);
+
+/**
+ * Owns the invariant that the Task selected by navigation has an active workspace session.
+ *
+ * Activation is app lifecycle, not component lifecycle: restored navigation can become current
+ * before its Project Host is live, and no React remount is required when that Host later recovers.
+ */
+export class TaskActivationCoordinator {
+  private disposeReaction: IReactionDisposer | undefined;
+
+  constructor(
+    private readonly navigation: NavigationStore,
+    private readonly projects: ProjectManagerStore
+  ) {
+    makeObservable(this, { state: computed });
+  }
+
+  get state(): TaskActivationState {
+    const current = this.navigation.currentRef;
+    if (current.viewId !== 'task') {
+      return { kind: 'inactive', reason: 'not-a-task-view' };
+    }
+
+    const { projectId, taskId } = current.params as {
+      projectId?: string;
+      taskId?: string;
+    };
+    if (!projectId || !taskId) {
+      return { kind: 'inactive', reason: 'not-a-task-view' };
+    }
+
+    const identity = { projectId, taskId };
+    const project = asAvailableProject(this.projects.projects.get(projectId));
+    if (!project) return { kind: 'waiting-for-project', ...identity };
+
+    const task = project.get(taskManagerStoreToken).tasks.get(taskId);
+    if (!task) return { kind: 'waiting-for-task', ...identity };
+    if ('archivedAt' in task.data && task.data.archivedAt) {
+      return { kind: 'inactive', reason: 'archived', ...identity };
+    }
+    if (isProvisioned(task)) return { kind: 'active', ...identity };
+    if (isUnregistered(task)) {
+      return task.phase === 'create-error'
+        ? { kind: 'failed', message: task.errorMessage, ...identity }
+        : { kind: 'waiting-for-task', ...identity };
+    }
+    if (!isUnprovisioned(task)) return { kind: 'waiting-for-task', ...identity };
+
+    switch (task.phase) {
+      case 'provision':
+        return { kind: 'activating', ...identity };
+      case 'provision-error':
+      case 'teardown-error':
+        return { kind: 'failed', message: task.errorMessage, ...identity };
+      case 'teardown':
+        return { kind: 'inactive', reason: 'tearing-down', ...identity };
+      case 'idle': {
+        const host = project.host.state;
+        return host.kind === 'ready'
+          ? { kind: 'ready-to-activate', hostGeneration: host.hostGeneration, ...identity }
+          : { kind: 'waiting-for-host', ...identity };
+      }
+    }
+  }
+
+  start(): void {
+    if (this.disposeReaction) return;
+    this.disposeReaction = reaction(
+      () => this.state,
+      (state) => {
+        if (state.kind !== 'ready-to-activate') return;
+        const project = asAvailableProject(this.projects.projects.get(state.projectId));
+        if (!project) return;
+
+        void project
+          .get(taskManagerStoreToken)
+          .provisionTask(state.taskId)
+          .catch((error) => {
+            log.error('Failed to activate current task', {
+              projectId: state.projectId,
+              taskId: state.taskId,
+              error,
+            });
+          });
+      },
+      { equals: comparer.structural, fireImmediately: true }
+    );
+  }
+
+  dispose(): void {
+    this.disposeReaction?.();
+    this.disposeReaction = undefined;
+  }
+}

--- a/apps/emdash-desktop/src/core/features/tasks/browser/stores/task-manager.test.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/browser/stores/task-manager.test.ts
@@ -415,7 +415,10 @@ describe('TaskManagerStore lifecycle', () => {
       recovery: 'automatic',
     };
 
-    await manager.provisionTask('task-1');
+    await expect(manager.provisionTask('task-1')).resolves.toEqual({
+      kind: 'deferred',
+      reason: 'host-unavailable',
+    });
 
     expect(task).toMatchObject({ state: 'unprovisioned', phase: 'idle' });
     manager.dispose();

--- a/apps/emdash-desktop/src/core/features/tasks/browser/view.tsx
+++ b/apps/emdash-desktop/src/core/features/tasks/browser/view.tsx
@@ -1,12 +1,8 @@
 import { observer } from 'mobx-react-lite';
-import { useEffect, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { getProjectManagerStore } from '@core/features/projects/api/browser/stores/project-selectors';
 import { projectViewDef } from '@core/features/projects/contributions/views';
-import {
-  getTaskManagerStore,
-  getTaskStore,
-  taskViewKind,
-} from '@core/features/tasks/api/browser/task-state/task-selectors';
+import { getTaskManagerStore } from '@core/features/tasks/api/browser/task-state/task-selectors';
 import { TaskViewWrapper } from '@core/features/tasks/contributions/browser/task-view-context';
 import { taskViewDef } from '@core/features/tasks/contributions/views';
 import { getTaskComposition } from '@core/features/workbench/api/browser/task-composition-selectors';
@@ -25,21 +21,6 @@ const TaskViewWrapperWithProviders = observer(function TaskViewWrapperWithProvid
   projectId: string;
   taskId: string;
 }) {
-  const taskStore = getTaskStore(projectId, taskId);
-  const kind = taskViewKind(taskStore, projectId);
-
-  // Auto-provision when the task view is rendered with an idle task — covers
-  // session restore where the task wasn't in openTaskIds, direct navigation,
-  // and any other path that lands on the task view before provisioning runs.
-  useEffect(() => {
-    if (kind !== 'idle') return;
-    if (taskStore && 'archivedAt' in taskStore.data && taskStore.data.archivedAt) return;
-
-    getTaskManagerStore(projectId)
-      ?.provisionTask(taskId)
-      .catch(() => {});
-  }, [kind, projectId, taskId, taskStore]);
-
   // Single hydration gate for the task view (spec §Hydration gating): nothing
   // below this boundary may paint persisted view state (titlebar chrome
   // toggles, sidebar, pane layout) before the memento space has hydrated.

--- a/apps/emdash-desktop/src/core/features/tasks/contributions/app-stores.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/contributions/app-stores.ts
@@ -1,0 +1,30 @@
+import { projectManagerStoreToken } from '@core/features/projects/contributions/app-store-tokens';
+import { TaskActivationCoordinator } from '@core/features/tasks/browser/stores/task-activation-coordinator';
+import { navigationStoreToken } from '@core/primitives/navigation/browser/app-stores';
+import {
+  contributeScopedStore,
+  getAppStores,
+  scopedStoreToken,
+  type AppScopedStoreContribution,
+} from '@core/primitives/scoped-stores/browser';
+
+const taskActivationCoordinatorToken = scopedStoreToken<TaskActivationCoordinator>(
+  'tasks.activation-coordinator'
+);
+
+export const taskAppStoreContributions: readonly AppScopedStoreContribution[] = [
+  contributeScopedStore({
+    token: taskActivationCoordinatorToken,
+    create: (_context, stores) =>
+      new TaskActivationCoordinator(
+        stores.get(navigationStoreToken),
+        stores.get(projectManagerStoreToken)
+      ),
+    activate: (coordinator) => coordinator.start(),
+    dispose: (coordinator) => coordinator.dispose(),
+  }),
+];
+
+export function getTaskActivationCoordinator(): TaskActivationCoordinator {
+  return getAppStores().get(taskActivationCoordinatorToken);
+}

--- a/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/task-item.tsx
+++ b/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/task-item.tsx
@@ -55,13 +55,7 @@ export const SidebarTaskItem = observer(function SidebarTaskItem({
 
   const taskName = task.data.name;
 
-  const handleProvision = () => {
-    if (task.state !== 'unprovisioned' || task.phase !== 'idle') return;
-    void taskManager?.provisionTask(taskId);
-  };
-
   const openTask = () => {
-    handleProvision();
     navigate(taskViewDef({ projectId, taskId }));
   };
 

--- a/apps/emdash-desktop/src/core/manifests/browser/app-scoped-stores.ts
+++ b/apps/emdash-desktop/src/core/manifests/browser/app-scoped-stores.ts
@@ -1,17 +1,19 @@
 import { machinesAppStoreContributions } from '@core/features/machines/contributions/app-stores';
 import { createProjectsAppStoreContributions } from '@core/features/projects/contributions/app-stores';
+import { taskAppStoreContributions } from '@core/features/tasks/contributions/app-stores';
 import { updateAppStoreContributions } from '@core/features/updates/contributions/app-stores';
 import { workbenchAppStoreContributions } from '@core/features/workbench/contributions/browser/app-stores';
 import { navigationAppStoreContributions } from '@core/primitives/navigation/browser/app-stores';
 import type { AppScopedStoreContribution } from '@core/primitives/scoped-stores/browser';
 import { projectStoreContributions } from './project-scoped-stores';
 
-// Order matters: the workbench sidebar resolves the projects store at create
-// time, so projects must come first. Navigation is registered before the
-// feature slices so their stores can reach it as soon as they are created.
+// Order matters: Tasks and the workbench resolve the Projects store at create time, so Projects
+// must come first. Navigation is registered before the feature slices so their stores can reach it
+// as soon as they are created.
 export const appStoreContributions: readonly AppScopedStoreContribution[] = [
   ...navigationAppStoreContributions,
   ...createProjectsAppStoreContributions(projectStoreContributions),
+  ...taskAppStoreContributions,
   ...machinesAppStoreContributions,
   ...workbenchAppStoreContributions,
   ...updateAppStoreContributions,


### PR DESCRIPTION
- move current-task workspace activation into the app-scoped TaskActivationCoordinator that observes navigation project hydration and host readiness
- remove opportunistic provisioning from react mounts project hydration and navigation handlers
- make provisionTask return explicit active deferred skipped or failed outcomes instead of silently returning when the host is unavailable