### PR TITLE
fix(editor): prevent file reveal and expand timeouts

### DIFF
--- a/apps/emdash-desktop/src/core/features/editor/api/browser/task-editor/stores/editor-view-store.test.ts
+++ b/apps/emdash-desktop/src/core/features/editor/api/browser/task-editor/stores/editor-view-store.test.ts
@@ -1,0 +1,130 @@
+import { ok, type Result } from '@emdash/shared';
+import { deferred } from '@emdash/shared/testing';
+import { describe, expect, it, vi } from 'vitest';
+import type { TreeMutationError } from '@core/features/editor/browser/task-editor/stores/files-store';
+import type { TaskEditorTreeState } from '@core/features/tasks/contributions/mementos';
+import type { MementoHandle } from '@core/primitives/mementos/browser';
+import type { PaneLayoutStore } from '@core/primitives/workbench-shell/browser/tabs/pane-layout-store';
+import { EditorViewStore } from './editor-view-store';
+
+function mementoHandle(initial: TaskEditorTreeState): MementoHandle<TaskEditorTreeState> {
+  let value = initial;
+  return {
+    get value() {
+      return value;
+    },
+    ready: Promise.resolve(),
+    isPending: false,
+    hasStoredValue: true,
+    read: () => value,
+    update: (next) => {
+      value = typeof next === 'function' ? next(value) : next;
+    },
+    reset: async () => {},
+    flush: async () => {},
+    autoPersist: () => (() => {}) as ReturnType<MementoHandle<TaskEditorTreeState>['autoPersist']>,
+    dispose: async () => {},
+  };
+}
+
+describe('EditorViewStore file reveal', () => {
+  it('runs Runtime reveal once and exposes a consumable presentation request', async () => {
+    const treeHandle = mementoHandle({ version: '1', expandedPaths: [] });
+    const store = new EditorViewStore(
+      { groups: [] } as unknown as PaneLayoutStore,
+      'project-1',
+      'workspace-1',
+      treeHandle
+    );
+    const revealFile = vi.fn().mockResolvedValue(ok(['/repo/src']));
+    store.files = { revealFile } as unknown as NonNullable<EditorViewStore['files']>;
+
+    await store.revealFile('/repo/src/app.ts');
+
+    expect(revealFile).toHaveBeenCalledOnce();
+    expect(revealFile).toHaveBeenCalledWith('/repo/src/app.ts', {
+      signal: expect.any(AbortSignal),
+    });
+    expect(treeHandle.value.expandedPaths).toEqual(['/repo/src']);
+    expect(store.revealFileRequest).toEqual({
+      id: 1,
+      path: '/repo/src/app.ts',
+      status: 'ready',
+    });
+
+    store.consumeRevealFileRequest(2);
+    expect(store.revealFileRequest?.id).toBe(1);
+    store.consumeRevealFileRequest(1);
+    expect(store.revealFileRequest).toBeNull();
+    expect(revealFile).toHaveBeenCalledOnce();
+  });
+
+  it('ignores a reveal completion superseded by a newer request', async () => {
+    const treeHandle = mementoHandle({ version: '1', expandedPaths: [] });
+    const store = new EditorViewStore(
+      { groups: [] } as unknown as PaneLayoutStore,
+      'project-1',
+      'workspace-1',
+      treeHandle
+    );
+    const first = deferred<Result<string[], TreeMutationError>>();
+    const second = deferred<Result<string[], TreeMutationError>>();
+    const revealFile = vi
+      .fn()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    store.files = { revealFile } as unknown as NonNullable<EditorViewStore['files']>;
+
+    const firstRun = store.revealFile('/repo/old/file.ts');
+    await vi.waitFor(() => expect(revealFile).toHaveBeenCalledOnce());
+    const secondRun = store.revealFile('/repo/new/file.ts');
+    second.resolve(ok(['/repo/new']));
+    await secondRun;
+    first.resolve(ok(['/repo/old']));
+    await firstRun;
+
+    expect(treeHandle.value.expandedPaths).toEqual(['/repo/new']);
+    expect(store.revealFileRequest).toEqual({
+      id: 2,
+      path: '/repo/new/file.ts',
+      status: 'ready',
+    });
+  });
+
+  it('cancels the Runtime reveal superseded by a newer request', async () => {
+    const treeHandle = mementoHandle({ version: '1', expandedPaths: [] });
+    const store = new EditorViewStore(
+      { groups: [] } as unknown as PaneLayoutStore,
+      'project-1',
+      'workspace-1',
+      treeHandle
+    );
+    const first = deferred<Result<string[], TreeMutationError>>();
+    let firstSignal: AbortSignal | undefined;
+    const revealFile = vi.fn(
+      (
+        path: string,
+        options?: { signal?: AbortSignal }
+      ): Promise<Result<string[], TreeMutationError>> => {
+        if (path === '/repo/old/file.ts') {
+          firstSignal = options?.signal;
+          return first.promise;
+        }
+        return Promise.resolve(ok(['/repo/new']));
+      }
+    );
+    store.files = { revealFile } as unknown as NonNullable<EditorViewStore['files']>;
+
+    const firstRun = store.revealFile('/repo/old/file.ts');
+    await vi.waitFor(() => expect(firstSignal).toBeDefined());
+    const secondRun = store.revealFile('/repo/new/file.ts');
+
+    expect(firstSignal?.aborted).toBe(true);
+    first.resolve(ok(['/repo/old']));
+    await Promise.all([firstRun, secondRun]);
+    expect(store.revealFileRequest).toMatchObject({
+      path: '/repo/new/file.ts',
+      status: 'ready',
+    });
+  });
+});

--- a/apps/emdash-desktop/src/core/features/editor/api/browser/task-editor/stores/editor-view-store.ts
+++ b/apps/emdash-desktop/src/core/features/editor/api/browser/task-editor/stores/editor-view-store.ts
@@ -1,4 +1,6 @@
 import { decodeResourceUri, hostFileRef } from '@emdash/core/primitives/path/api';
+import { type Result } from '@emdash/shared';
+import { createScope, type Run, type Scope } from '@emdash/shared/concurrency';
 import { action, computed, makeObservable, observable, runInAction } from 'mobx';
 import { getEditorClient } from '@core/features/editor/api/browser/client';
 import {
@@ -16,7 +18,14 @@ import { log } from '@core/primitives/logging/browser/logger';
 import type { MementoHandle } from '@core/primitives/mementos/browser';
 import type { PaneLayoutStore } from '@core/primitives/workbench-shell/browser/tabs/pane-layout-store';
 import { allOpenFileResources } from '../../../../browser/task-editor/pane-selectors';
-import { FilesStore } from '../../../../browser/task-editor/stores/files-store';
+import {
+  FilesStore,
+  type TreeMutationError,
+} from '../../../../browser/task-editor/stores/files-store';
+
+export type RevealFileRequest =
+  | { id: number; path: string; status: 'ready' }
+  | { id: number; path: string; status: 'error'; error: TreeMutationError };
 
 /**
  * Manages file persistence (save, conflict resolution) and sidebar navigation state.
@@ -36,8 +45,8 @@ export class EditorViewStore {
   /** Monotonic signal used by the task-level search command to focus the sidebar input. */
   fileSearchFocusRequest = 0;
 
-  /** Monotonic signal consumed by the file tree adapter to reveal a path in the sidebar. */
-  revealFileRequest: { path: string; counter: number } = { path: '', counter: 0 };
+  /** One-shot presentation request consumed by the file tree after Runtime reveal settles. */
+  revealFileRequest: RevealFileRequest | null = null;
 
   /**
    * Per-view file-tree projection store. Created when the task session starts (`startFiles`) and
@@ -49,6 +58,10 @@ export class EditorViewStore {
   private readonly projectId: string;
   private readonly workspaceId: string;
   private readonly paneLayout: PaneLayoutStore;
+  private readonly revealScope: Scope;
+  private nextRevealFileRequestId = 1;
+  private activeRevealFileRequestId = 0;
+  private activeRevealRun: Run<Result<string[], TreeMutationError>> | null = null;
 
   constructor(
     paneLayout: PaneLayoutStore,
@@ -60,6 +73,7 @@ export class EditorViewStore {
     this.paneLayout = paneLayout;
     this.projectId = projectId;
     this.workspaceId = workspaceId;
+    this.revealScope = createScope({ label: `editor-view:${workspaceId}:reveal` });
 
     makeObservable<EditorViewStore, 'treeHandle'>(this, {
       isSaving: observable,
@@ -69,7 +83,7 @@ export class EditorViewStore {
       files: observable.ref,
       expandedPaths: computed.struct,
       requestFileSearchFocus: action,
-      requestRevealFile: action,
+      consumeRevealFileRequest: action,
       treeHandle: false,
     });
   }
@@ -82,11 +96,51 @@ export class EditorViewStore {
     this.fileSearchFocusRequest += 1;
   }
 
-  requestRevealFile(path: string): void {
-    this.revealFileRequest = {
-      path,
-      counter: this.revealFileRequest.counter + 1,
-    };
+  async revealFile(path: string): Promise<void> {
+    const id = this.nextRevealFileRequestId;
+    this.nextRevealFileRequestId += 1;
+    this.activeRevealFileRequestId = id;
+    this.activeRevealRun?.cancel(new Error('File reveal superseded'));
+    runInAction(() => {
+      this.revealFileRequest = null;
+    });
+
+    const files = this.files;
+    if (!files) {
+      this.presentRevealFileError(id, path, {
+        type: 'unavailable',
+        message: 'File tree is unavailable',
+      });
+      return;
+    }
+    const run = this.revealScope.run(`reveal:${id}`, (signal) =>
+      files.revealFile(path, { signal })
+    );
+    this.activeRevealRun = run;
+    const exit = await run.exit;
+    if (this.activeRevealRun === run) this.activeRevealRun = null;
+    if (this.activeRevealFileRequestId !== id) return;
+    if (exit.kind === 'cancelled') return;
+    if (exit.kind === 'failure') {
+      this.presentRevealFileError(id, path, {
+        type: 'unavailable',
+        message: exit.error instanceof Error ? exit.error.message : String(exit.error),
+      });
+      return;
+    }
+    const result = exit.value;
+    if (!result.success) {
+      this.presentRevealFileError(id, path, result.error);
+      return;
+    }
+    this.expandPaths(result.data);
+    runInAction(() => {
+      this.revealFileRequest = { id, path, status: 'ready' };
+    });
+  }
+
+  consumeRevealFileRequest(id: number): void {
+    if (this.revealFileRequest?.id === id) this.revealFileRequest = null;
   }
 
   /** Opens the per-view file-tree projection. Idempotent. */
@@ -108,8 +162,13 @@ export class EditorViewStore {
   /** Closes the projection subscription and clears the per-view tree state. */
   disposeFiles(): void {
     const store = this.files;
+    this.activeRevealRun?.cancel(new Error('File tree disposed'));
+    this.activeRevealRun = null;
     runInAction(() => {
       this.files = null;
+      this.activeRevealFileRequestId = this.nextRevealFileRequestId;
+      this.nextRevealFileRequestId += 1;
+      this.revealFileRequest = null;
     });
     store?.dispose();
   }
@@ -277,10 +336,18 @@ export class EditorViewStore {
 
   dispose(): void {
     this.disposeFiles();
+    void this.revealScope.dispose();
   }
 
   private openEntryForPath(filePath: string): OpenFileEntry | undefined {
     return this.openFileResources.find((resource) => resource.path === filePath)?.entry;
+  }
+
+  private presentRevealFileError(id: number, path: string, error: TreeMutationError): void {
+    if (this.activeRevealFileRequestId !== id) return;
+    runInAction(() => {
+      this.revealFileRequest = { id, path, status: 'error', error };
+    });
   }
 
   private retargetExpandedPaths(oldPath: string, newPath: string): void {

--- a/apps/emdash-desktop/src/core/features/editor/browser/task-editor/stores/files-store.test.ts
+++ b/apps/emdash-desktop/src/core/features/editor/browser/task-editor/stores/files-store.test.ts
@@ -3,9 +3,9 @@ import {
   DEFAULT_TREE_EXCLUDE,
 } from '@emdash/core/primitives/exclusion-policy/api';
 import { encodeResourceUri } from '@emdash/core/primitives/path/api';
-import type { FileTreeModel } from '@emdash/core/runtimes/files/api';
-import { ok } from '@emdash/shared';
-import { waitFor } from '@emdash/shared/testing';
+import type { FileTreeModel, FsError } from '@emdash/core/runtimes/files/api';
+import { ok, type Result } from '@emdash/shared';
+import { deferred, waitFor } from '@emdash/shared/testing';
 import { defineContract } from '@emdash/wire/rpc';
 import { cell, expose } from '@emdash/wire/state';
 import { createTestWire } from '@emdash/wire/testing';
@@ -35,10 +35,27 @@ vi.mock('@core/features/settings/api/browser/app-settings-client', () => ({
 
 type RecordedMutation = { name: string; key: FilesTreeKey; input: unknown };
 
+function expandedMutationPaths(calls: RecordedMutation[]): string[] {
+  return calls.flatMap((call) => {
+    if (call.name !== 'expand' || call.input === undefined) return [];
+    const path = (call.input as { path: string }).path;
+    return path === '' ? [] : [path];
+  });
+}
+
+function treeMutationOrder(calls: RecordedMutation[]): string[] {
+  return calls.flatMap((call) => {
+    if ((call.name !== 'expand' && call.name !== 'reveal') || call.input === undefined) return [];
+    const path = (call.input as { path: string }).path;
+    return path === '' ? [] : [`${call.name}:${path}`];
+  });
+}
+
 function makeEntry(
   path: string,
   kind: 'file' | 'directory',
-  children: readonly string[] = []
+  children: readonly string[] = [],
+  childrenLoaded = kind === 'directory'
 ): FileTreeModel['entries'][string] {
   return {
     path: portablePath(path),
@@ -46,7 +63,7 @@ function makeEntry(
     parentPath:
       path === '' ? null : portablePath(path.slice(0, Math.max(path.lastIndexOf('/'), 0))),
     kind,
-    childrenLoaded: kind === 'directory',
+    childrenLoaded,
     children: children.map((child) => portablePath(child)),
   };
 }
@@ -63,8 +80,15 @@ function makeTreeModel(root: string): FileTreeModel {
   };
 }
 
-function setup(options: { sshConnectionId?: string; hostAccess?: ProjectHostAccess } = {}) {
-  const treeCell = cell<FileTreeModel>(makeTreeModel('/repo'));
+function setup(
+  options: {
+    sshConnectionId?: string;
+    hostAccess?: ProjectHostAccess;
+    tree?: FileTreeModel;
+    beforeMutation?: (name: string, input: unknown) => Promise<Result<void, FsError> | undefined>;
+  } = {}
+) {
+  const treeCell = cell<FileTreeModel>(options.tree ?? makeTreeModel('/repo'));
   const stateKeys: FilesTreeKey[] = [];
   const mutationCalls: RecordedMutation[] = [];
   const fsCalls: Array<{ name: string; input: unknown }> = [];
@@ -79,6 +103,8 @@ function setup(options: { sshConnectionId?: string; hostAccess?: ProjectHostAcce
     }
   ) => {
     mutationCalls.push({ name, key: context.key, input: context.input });
+    const intercepted = await options.beforeMutation?.(name, context.input);
+    if (intercepted) return intercepted;
     const revision = treeCell.update((previous) => ({ ...previous }), {
       mutationIds: [context.mutationId],
     });
@@ -142,7 +168,7 @@ afterEach(() => {
 });
 
 describe('FilesStore', () => {
-  it('binds the files domain tree model keyed by the root ResourceUri', async () => {
+  it('binds the files domain tree model without re-expanding a populated root', async () => {
     const { store, stateKeys, mutationCalls } = setup();
     disposeStore = () => store.dispose();
 
@@ -153,7 +179,7 @@ describe('FilesStore', () => {
       sessionId: 'workspace-1',
       exclusions: canonicalExclusionPatterns(DEFAULT_TREE_EXCLUDE),
     });
-    expect(mutationCalls).toContainEqual({
+    expect(mutationCalls).not.toContainEqual({
       name: 'expand',
       key: stateKeys[0],
       input: { path: '' },
@@ -213,6 +239,237 @@ describe('FilesStore', () => {
     expect(mutationCalls.filter((call) => call.name === 'reveal')[0]?.input).toEqual({
       path: 'src/index.ts',
     });
+  });
+
+  it('cancels a superseded reveal through the Wire mutation signal', async () => {
+    const revealGate = deferred<void>();
+    const { store, mutationCalls } = setup({
+      beforeMutation: async (name) => {
+        if (name === 'reveal') await revealGate.promise;
+      },
+    });
+    disposeStore = () => store.dispose();
+    await store.start();
+    const abort = new AbortController();
+
+    const reveal = store.revealFile('/repo/src/index.ts', { signal: abort.signal });
+    await vi.waitFor(() =>
+      expect(mutationCalls).toContainEqual(
+        expect.objectContaining({ name: 'reveal', input: { path: 'src/index.ts' } })
+      )
+    );
+    abort.abort(new Error('File reveal superseded'));
+
+    await expect(reveal).resolves.toMatchObject({
+      success: false,
+      error: { type: 'unavailable' },
+    });
+    revealGate.resolve();
+  });
+
+  it('attaches the Replica before background root hydration settles', async () => {
+    const rootGate = deferred<void>();
+    const tree = makeTreeModel('/repo');
+    tree.entries = { '': makeEntry('', 'directory', [], false) };
+    const { store, mutationCalls } = setup({
+      tree,
+      beforeMutation: async (name, input) => {
+        if (name === 'expand' && (input as { path: string }).path === '') {
+          await rootGate.promise;
+        }
+        return undefined;
+      },
+    });
+    disposeStore = () => store.dispose();
+
+    await expect(store.start()).resolves.toBeUndefined();
+    await vi.waitFor(() =>
+      expect(mutationCalls).toContainEqual(
+        expect.objectContaining({ name: 'expand', input: { path: '' } })
+      )
+    );
+    expect(store.error).toBeUndefined();
+    expect(store.isLoading).toBe(true);
+
+    rootGate.resolve();
+    await vi.waitFor(() => expect(store.pendingPaths.size).toBe(0));
+  });
+
+  it('hydrates restored directories serially and prioritizes a foreground request', async () => {
+    const gates: Array<ReturnType<typeof deferred<void>>> = [];
+    const tree = makeTreeModel('/repo');
+    tree.entries = {
+      '': makeEntry('', 'directory', ['a', 'b', 'c']),
+      a: makeEntry('a', 'directory', [], false),
+      b: makeEntry('b', 'directory', [], false),
+      c: makeEntry('c', 'directory', [], false),
+    };
+    const { store, mutationCalls } = setup({
+      tree,
+      beforeMutation: async (name, input) => {
+        if (name !== 'expand' || (input as { path: string }).path === '') return;
+        const gate = deferred<void>();
+        gates.push(gate);
+        await gate.promise;
+      },
+    });
+    disposeStore = () => store.dispose();
+    await store.start();
+
+    store.reconcileVisibleScopes(new Set(['/repo/a', '/repo/b']));
+    await vi.waitFor(() => expect(expandedMutationPaths(mutationCalls)).toEqual(['a']));
+
+    const foreground = store.registerDir('/repo/c');
+    gates[0]?.resolve();
+    await vi.waitFor(() => expect(expandedMutationPaths(mutationCalls)).toEqual(['a', 'c']));
+    gates[1]?.resolve();
+    await expect(foreground).resolves.toEqual(ok(undefined));
+    await vi.waitFor(() => expect(expandedMutationPaths(mutationCalls)).toEqual(['a', 'c', 'b']));
+    gates[2]?.resolve();
+    await vi.waitFor(() => expect(store.pendingPaths.size).toBe(0));
+  });
+
+  it('prioritizes a foreground reveal over queued restored directories', async () => {
+    const gates: Array<ReturnType<typeof deferred<void>>> = [];
+    const tree = makeTreeModel('/repo');
+    tree.entries = {
+      '': makeEntry('', 'directory', ['a', 'b', 'c']),
+      a: makeEntry('a', 'directory', [], false),
+      b: makeEntry('b', 'directory', [], false),
+      c: makeEntry('c', 'directory', ['c/file.ts']),
+      'c/file.ts': makeEntry('c/file.ts', 'file'),
+    };
+    const { store, mutationCalls } = setup({
+      tree,
+      beforeMutation: async (name, input) => {
+        if (name !== 'expand' || (input as { path: string }).path === '') return;
+        const gate = deferred<void>();
+        gates.push(gate);
+        await gate.promise;
+      },
+    });
+    disposeStore = () => store.dispose();
+    await store.start();
+
+    store.reconcileVisibleScopes(new Set(['/repo/a', '/repo/b']));
+    await vi.waitFor(() => expect(treeMutationOrder(mutationCalls)).toEqual(['expand:a']));
+    const reveal = store.revealFile('/repo/c/file.ts');
+
+    gates[0]?.resolve();
+    await expect(reveal).resolves.toEqual(ok(['/repo/c']));
+    await vi.waitFor(() =>
+      expect(treeMutationOrder(mutationCalls).slice(0, 3)).toEqual([
+        'expand:a',
+        'reveal:c/file.ts',
+        'expand:b',
+      ])
+    );
+    gates[1]?.resolve();
+    await vi.waitFor(() => expect(store.pendingPaths.size).toBe(0));
+  });
+
+  it('runs a trailing forced load when a normal load is already active', async () => {
+    const gates: Array<ReturnType<typeof deferred<void>>> = [];
+    const tree = makeTreeModel('/repo');
+    tree.entries = {
+      '': makeEntry('', 'directory', ['src']),
+      src: makeEntry('src', 'directory', [], false),
+    };
+    const { store, mutationCalls } = setup({
+      tree,
+      beforeMutation: async (name, input) => {
+        if (name !== 'expand' || (input as { path: string }).path !== 'src') return;
+        const gate = deferred<void>();
+        gates.push(gate);
+        await gate.promise;
+      },
+    });
+    disposeStore = () => store.dispose();
+    await store.start();
+    const refresh = vi
+      .spyOn(
+        (
+          store as unknown as {
+            treeModel: { states: { tree: { refresh(): Promise<void> } } };
+          }
+        ).treeModel.states.tree,
+        'refresh'
+      )
+      .mockResolvedValue();
+
+    const normal = store.registerDir('/repo/src');
+    await vi.waitFor(() => expect(expandedMutationPaths(mutationCalls)).toEqual(['src']));
+    const forced = store.registerDir('/repo/src', true);
+
+    gates[0]?.resolve();
+    await expect(normal).resolves.toEqual(ok(undefined));
+    await vi.waitFor(() => expect(expandedMutationPaths(mutationCalls)).toEqual(['src', 'src']));
+    gates[1]?.resolve();
+    await expect(forced).resolves.toEqual(ok(undefined));
+    expect(refresh).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(store.pendingPaths.size).toBe(0));
+  });
+
+  it('settles a queued directory load when the tree Runtime is disposed', async () => {
+    const gate = deferred<void>();
+    const tree = makeTreeModel('/repo');
+    tree.entries = {
+      '': makeEntry('', 'directory', ['src']),
+      src: makeEntry('src', 'directory', [], false),
+    };
+    const { store, mutationCalls } = setup({
+      tree,
+      beforeMutation: async (name, input) => {
+        if (name === 'expand' && (input as { path: string }).path === 'src') {
+          await gate.promise;
+        }
+      },
+    });
+    await store.start();
+
+    const load = store.registerDir('/repo/src');
+    await vi.waitFor(() => expect(expandedMutationPaths(mutationCalls)).toEqual(['src']));
+    store.dispose();
+
+    await expect(load).resolves.toMatchObject({
+      success: false,
+      error: { type: 'unavailable', message: 'File tree is unavailable' },
+    });
+    gate.resolve();
+  });
+
+  it('keeps a directory-load failure scoped to the requested path', async () => {
+    const tree = makeTreeModel('/repo');
+    tree.entries.src = makeEntry('src', 'directory', [], false);
+    const { store } = setup({
+      tree,
+      beforeMutation: async (name, input) => {
+        if (name === 'expand' && (input as { path: string }).path === 'src') {
+          return {
+            success: false,
+            error: {
+              type: 'io',
+              path: 'src',
+              message: "Wire call 'files.tree.model.expand' timed out after 30000ms",
+            },
+          };
+        }
+        return undefined;
+      },
+    });
+    disposeStore = () => store.dispose();
+    await store.start();
+
+    await expect(store.registerDir('/repo/src')).resolves.toMatchObject({
+      success: false,
+      error: {
+        type: 'io',
+        path: 'src',
+        message: "Wire call 'files.tree.model.expand' timed out after 30000ms",
+      },
+    });
+    expect(store.error).toBeUndefined();
+    expect(store.rootNodes.map((node) => node.path)).toEqual(['/repo/src', '/repo/README.md']);
   });
 
   it('retains the observed tree as stale and blocks writes while offline', async () => {

--- a/apps/emdash-desktop/src/core/features/editor/browser/task-editor/stores/files-store.test.ts
+++ b/apps/emdash-desktop/src/core/features/editor/browser/task-editor/stores/files-store.test.ts
@@ -410,6 +410,39 @@ describe('FilesStore', () => {
     await vi.waitFor(() => expect(store.pendingPaths.size).toBe(0));
   });
 
+  it('runs a trailing forced load when a forced load is already active', async () => {
+    const tree = makeTreeModel('/repo');
+    tree.entries = {
+      '': makeEntry('', 'directory', ['src']),
+      src: makeEntry('src', 'directory', [], false),
+    };
+    const { store, mutationCalls } = setup({ tree });
+    disposeStore = () => store.dispose();
+    await store.start();
+    const firstRefresh = deferred<void>();
+    const refresh = vi
+      .spyOn(
+        (
+          store as unknown as {
+            treeModel: { states: { tree: { refresh(): Promise<void> } } };
+          }
+        ).treeModel.states.tree,
+        'refresh'
+      )
+      .mockImplementationOnce(() => firstRefresh.promise)
+      .mockResolvedValue();
+
+    const first = store.registerDir('/repo/src', true);
+    await vi.waitFor(() => expect(refresh).toHaveBeenCalledOnce());
+    const second = store.registerDir('/repo/src', true);
+    firstRefresh.resolve();
+
+    await expect(Promise.all([first, second])).resolves.toEqual([ok(undefined), ok(undefined)]);
+    expect(refresh).toHaveBeenCalledTimes(2);
+    expect(expandedMutationPaths(mutationCalls)).toEqual(['src', 'src']);
+    expect(store.pendingPaths.size).toBe(0);
+  });
+
   it('settles a queued directory load when the tree Runtime is disposed', async () => {
     const gate = deferred<void>();
     const tree = makeTreeModel('/repo');

--- a/apps/emdash-desktop/src/core/features/editor/browser/task-editor/stores/files-store.ts
+++ b/apps/emdash-desktop/src/core/features/editor/browser/task-editor/stores/files-store.ts
@@ -103,7 +103,6 @@ export class FilesStore {
   private readonly pendingPathSet = observable.set<string>();
   private readonly directoryLoadErrors = observable.map<string, TreeMutationError>();
   private readonly forcedDirectoryLoadPaths = new Set<string>();
-  private readonly activeForcedDirectoryLoadPaths = new Set<string>();
   private treeHydrationScheduler: RequestScheduler | null = null;
   private treeHydrationAbort: AbortController | null = null;
 
@@ -689,9 +688,7 @@ export class FilesStore {
       return err({ type: 'unavailable', message: 'File tree is unavailable' });
     }
 
-    if (force && !this.activeForcedDirectoryLoadPaths.has(absolute)) {
-      this.forcedDirectoryLoadPaths.add(absolute);
-    }
+    if (force) this.forcedDirectoryLoadPaths.add(absolute);
     runInAction(() => this.pendingPathSet.add(absolute));
 
     try {
@@ -727,7 +724,6 @@ export class FilesStore {
     signal: AbortSignal
   ): Promise<Result<void, TreeMutationError>> {
     const force = this.forcedDirectoryLoadPaths.delete(path);
-    if (force) this.activeForcedDirectoryLoadPaths.add(path);
     let result: Result<void, TreeMutationError>;
     try {
       const model = this.treeModel ?? (await this.requireModel());
@@ -750,7 +746,6 @@ export class FilesStore {
     } catch (error) {
       result = err(treeMutationError(error));
     }
-    if (force) this.activeForcedDirectoryLoadPaths.delete(path);
     if (this.treeHydrationScheduler === scheduler && !abort.signal.aborted) {
       runInAction(() => {
         if (result.success) this.directoryLoadErrors.delete(path);
@@ -771,7 +766,6 @@ export class FilesStore {
     }
     void scheduler?.dispose();
     this.forcedDirectoryLoadPaths.clear();
-    this.activeForcedDirectoryLoadPaths.clear();
     runInAction(() => {
       this.pendingPathSet.clear();
       this.directoryLoadErrors.clear();

--- a/apps/emdash-desktop/src/core/features/editor/browser/task-editor/stores/files-store.ts
+++ b/apps/emdash-desktop/src/core/features/editor/browser/task-editor/stores/files-store.ts
@@ -15,6 +15,12 @@ import { protocolUpgradeMessage } from '@emdash/core/workspace-server';
 import { err, ok, type Result } from '@emdash/shared';
 import { createScope, type Scope } from '@emdash/shared/concurrency';
 import {
+  createRequestScheduler,
+  requestPriorities,
+  type RequestScheduler,
+} from '@emdash/shared/requests';
+import { throwIfAborted, waitWithSignal } from '@emdash/shared/scheduling';
+import {
   observe,
   optimistic,
   pin,
@@ -64,6 +70,7 @@ export type TreeMutationError =
     }
   | { type: 'unavailable'; message: string };
 type PendingUploadNode = { node: RenderableFileNode };
+type DirectoryLoadPriority = 'foreground' | 'background';
 type ViewData = {
   nodes: Map<string, RenderableFileNode>;
   rootNodes: RenderableFileNode[];
@@ -94,6 +101,11 @@ export class FilesStore {
 
   private readonly pendingUploadNodes = observable.map<FileNodeId, PendingUploadNode>();
   private readonly pendingPathSet = observable.set<string>();
+  private readonly directoryLoadErrors = observable.map<string, TreeMutationError>();
+  private readonly forcedDirectoryLoadPaths = new Set<string>();
+  private readonly activeForcedDirectoryLoadPaths = new Set<string>();
+  private treeHydrationScheduler: RequestScheduler | null = null;
+  private treeHydrationAbort: AbortController | null = null;
 
   constructor(
     private readonly projectId: string,
@@ -161,12 +173,16 @@ export class FilesStore {
   get isLoading(): boolean {
     if (this.hostAccess?.liveAction.kind === 'disabled' && this.treeData === null) return false;
     if (this.syncError !== null) return false;
+    if (this.directoryLoadErrors.has(this.rootPath)) return false;
     if (this.optimistic === null) return true;
     return this.tree?.entries['']?.childrenLoaded !== true;
   }
 
   get error(): string | undefined {
-    return this.syncError ?? undefined;
+    if (this.syncError !== null) return this.syncError;
+    if (this.tree?.entries['']?.childrenLoaded === true) return undefined;
+    const rootError = this.directoryLoadErrors.get(this.rootPath);
+    return rootError ? treeMutationErrorMessage(rootError) : undefined;
   }
 
   get observation(): LiveRuntimeObservation<FilesTreeModel> {
@@ -217,10 +233,11 @@ export class FilesStore {
   }
 
   reconcileVisibleScopes(expandedPaths: Set<string>): void {
+    const missing = new Set<string>();
     for (const expandedPath of expandedPaths) {
       const node = this.viewData.nodes.get(normalizeFileTreePath(expandedPath));
       if (node && isExpandableFileTreeNode(node) && !this.loadedPaths.has(node.path)) {
-        void this.registerDir(node.path);
+        missing.add(node.path);
       }
     }
     const rows = buildFileTreeVisibleRows(
@@ -235,42 +252,42 @@ export class FilesStore {
         expandedPaths.has(row.node.path) &&
         !this.loadedPaths.has(row.node.path)
       ) {
-        void this.registerDir(row.node.path);
+        missing.add(row.node.path);
       }
     }
-  }
-
-  async registerDir(dirPath: string, force = false): Promise<void> {
-    const model = await this.requireModel();
-    const absolute = this.resolveWorkspacePath(dirPath);
-    if (this.pendingPathSet.has(absolute)) return;
-    if (!force && this.loadedPaths.has(absolute)) return;
-    runInAction(() => this.pendingPathSet.add(absolute));
-    try {
-      if (force) await model.states.tree.refresh();
-      const invocation = await model.mutations.expand({ path: this.relative(absolute) });
-      if (invocation.result.success) await invocation.settled;
-    } finally {
-      runInAction(() => this.pendingPathSet.delete(absolute));
+    for (const path of [...missing].sort(compareDirectoryDepth)) {
+      void this.requestDirectoryLoad(path, 'background');
     }
   }
 
-  async revealFile(filePath: string): Promise<Result<string[], TreeMutationError>> {
+  registerDir(dirPath: string, force = false): Promise<Result<void, TreeMutationError>> {
+    return this.requestDirectoryLoad(dirPath, 'foreground', force);
+  }
+
+  async revealFile(
+    filePath: string,
+    options: { signal?: AbortSignal } = {}
+  ): Promise<Result<string[], TreeMutationError>> {
     try {
       const model = await this.requireModel();
+      throwIfAborted(options.signal, 'File reveal cancelled');
+      const scheduler = this.treeHydrationScheduler;
+      const abort = this.treeHydrationAbort;
+      if (!scheduler || !abort || abort.signal.aborted) {
+        return err({ type: 'unavailable', message: 'File tree is unavailable' });
+      }
       const absolute = this.resolveWorkspacePath(filePath);
-      const relative = this.relative(absolute);
-      const invocation = await model.mutations.reveal({ path: relative });
-      if (!invocation.result.success) {
-        return invocation.result;
-      }
-      await invocation.settled;
-      const segments = relative.split('/').filter(Boolean);
-      const ancestors: string[] = [];
-      for (let index = 1; index < segments.length; index += 1) {
-        ancestors.push(this.absolute(portablePath(segments.slice(0, index).join('/'))));
-      }
-      return ok(ancestors);
+      const waiterSignal = options.signal
+        ? AbortSignal.any([abort.signal, options.signal])
+        : abort.signal;
+      return await scheduler.submit(
+        {
+          key: `reveal:${absolute}`,
+          priority: requestPriorities.interactive,
+          run: (signal) => this.performFileReveal(model, absolute, signal),
+        },
+        { signal: waiterSignal }
+      );
     } catch (error) {
       return err(treeMutationError(error));
     }
@@ -432,11 +449,15 @@ export class FilesStore {
       await model.states.tree.refresh();
       runInAction(() => {
         this.syncError = null;
+        this.directoryLoadErrors.clear();
       });
+      if (this.tree?.entries['']?.childrenLoaded !== true) {
+        void this.requestDirectoryLoad(this.rootPath, 'background');
+      }
     } catch (error) {
-      runInAction(() => {
-        this.syncError = error instanceof Error ? error.message : String(error);
-      });
+      if (this.tree?.entries['']?.childrenLoaded !== true) {
+        runInAction(() => this.directoryLoadErrors.set(this.rootPath, treeMutationError(error)));
+      }
     }
   }
 
@@ -503,19 +524,31 @@ export class FilesStore {
         await scope.dispose();
         return;
       }
+      const treeHydrationAbort = new AbortController();
+      runtimeScope.add(() => {
+        if (!treeHydrationAbort.signal.aborted) {
+          treeHydrationAbort.abort(new Error('File tree runtime disposed'));
+        }
+      });
+      const treeHydrationScheduler = createRequestScheduler({
+        scope: runtimeScope,
+        maxConcurrency: 1,
+        label: 'tree-hydration',
+      });
       runInAction(() => {
         this.treeScope = runtimeScope;
         this.treeRemote = treeRemote;
         this.treeModel = model;
         this.optimistic = view;
+        this.treeHydrationAbort = treeHydrationAbort;
+        this.treeHydrationScheduler = treeHydrationScheduler;
         this.syncError = null;
       });
       scope = null;
       treeRemote = null;
-      if (refresh) await model.states.tree.refresh();
-      const expanded = await model.mutations.expand({ path: portablePath('') });
-      if (expanded.result.success) await expanded.settled;
-      else this.setError(expanded.result.error);
+      if (refresh || this.tree?.entries['']?.childrenLoaded !== true) {
+        void this.requestDirectoryLoad(this.rootPath, 'background', refresh);
+      }
     } catch (error) {
       try {
         await treeRemote?.dispose();
@@ -598,18 +631,157 @@ export class FilesStore {
     return normalizeFileTreePath(nativePathFromHost(resolveRelativePath(this.root, relativePath)));
   }
 
-  private setError(error: unknown): void {
+  private async performFileReveal(
+    model: TreeRemoteMember,
+    absolutePath: string,
+    signal: AbortSignal
+  ): Promise<Result<string[], TreeMutationError>> {
+    try {
+      throwIfAborted(signal, 'File reveal cancelled');
+      const relative = this.relative(absolutePath);
+      const invocation = await model.mutations.reveal({ path: relative }, { signal });
+      if (!invocation.result.success) return invocation.result;
+      await waitWithSignal(invocation.settled, signal, 'File reveal cancelled');
+      const segments = relative.split('/').filter(Boolean);
+      const ancestors: string[] = [];
+      for (let index = 1; index < segments.length; index += 1) {
+        ancestors.push(this.absolute(portablePath(segments.slice(0, index).join('/'))));
+      }
+      return ok(ancestors);
+    } catch (error) {
+      return err(treeMutationError(error));
+    }
+  }
+
+  private async requestDirectoryLoad(
+    dirPath: string,
+    priority: DirectoryLoadPriority,
+    force = false
+  ): Promise<Result<void, TreeMutationError>> {
+    let absolute: string;
+    try {
+      absolute = this.resolveWorkspacePath(dirPath);
+    } catch (error) {
+      return Promise.resolve(err(treeMutationError(error)));
+    }
+
+    if (priority === 'foreground') {
+      runInAction(() => this.directoryLoadErrors.delete(absolute));
+    }
+    if (!force && this.loadedPaths.has(absolute)) {
+      runInAction(() => this.directoryLoadErrors.delete(absolute));
+      return Promise.resolve(ok<void>());
+    }
+    if (priority === 'background' && this.directoryLoadErrors.has(absolute)) {
+      return Promise.resolve(err(this.directoryLoadErrors.get(absolute)!));
+    }
+
+    if (!this.treeHydrationScheduler) {
+      try {
+        await this.ensureStarted();
+      } catch (error) {
+        return err(treeMutationError(error));
+      }
+    }
+    const scheduler = this.treeHydrationScheduler;
+    const abort = this.treeHydrationAbort;
+    if (!scheduler || !abort || abort.signal.aborted) {
+      return err({ type: 'unavailable', message: 'File tree is unavailable' });
+    }
+
+    if (force && !this.activeForcedDirectoryLoadPaths.has(absolute)) {
+      this.forcedDirectoryLoadPaths.add(absolute);
+    }
+    runInAction(() => this.pendingPathSet.add(absolute));
+
+    try {
+      const result = await scheduler.submit(
+        {
+          key: `directory:${absolute}`,
+          priority:
+            priority === 'foreground'
+              ? requestPriorities.interactive
+              : requestPriorities.background,
+          run: (signal) => this.performDirectoryLoad(scheduler, abort, absolute, signal),
+        },
+        { signal: abort.signal }
+      );
+      if (
+        force &&
+        this.treeHydrationScheduler === scheduler &&
+        !abort.signal.aborted &&
+        this.forcedDirectoryLoadPaths.has(absolute)
+      ) {
+        return this.requestDirectoryLoad(absolute, 'foreground', true);
+      }
+      return result;
+    } catch (error) {
+      return err(treeMutationError(error));
+    }
+  }
+
+  private async performDirectoryLoad(
+    scheduler: RequestScheduler,
+    abort: AbortController,
+    path: string,
+    signal: AbortSignal
+  ): Promise<Result<void, TreeMutationError>> {
+    const force = this.forcedDirectoryLoadPaths.delete(path);
+    if (force) this.activeForcedDirectoryLoadPaths.add(path);
+    let result: Result<void, TreeMutationError>;
+    try {
+      const model = this.treeModel ?? (await this.requireModel());
+      throwIfAborted(signal, 'Directory load cancelled');
+      if (!force && this.loadedPaths.has(path)) {
+        result = ok<void>();
+      } else {
+        if (force) {
+          await model.states.tree.refresh();
+          throwIfAborted(signal, 'Directory load cancelled');
+        }
+        const invocation = await model.mutations.expand({ path: this.relative(path) }, { signal });
+        if (!invocation.result.success) {
+          result = invocation.result;
+        } else {
+          await waitWithSignal(invocation.settled, signal, 'Directory load cancelled');
+          result = ok<void>();
+        }
+      }
+    } catch (error) {
+      result = err(treeMutationError(error));
+    }
+    if (force) this.activeForcedDirectoryLoadPaths.delete(path);
+    if (this.treeHydrationScheduler === scheduler && !abort.signal.aborted) {
+      runInAction(() => {
+        if (result.success) this.directoryLoadErrors.delete(path);
+        else this.directoryLoadErrors.set(path, result.error);
+        if (!this.forcedDirectoryLoadPaths.has(path)) this.pendingPathSet.delete(path);
+      });
+    }
+    return result;
+  }
+
+  private cancelTreeHydration(): void {
+    const scheduler = this.treeHydrationScheduler;
+    const abort = this.treeHydrationAbort;
+    this.treeHydrationScheduler = null;
+    this.treeHydrationAbort = null;
+    if (abort && !abort.signal.aborted) {
+      abort.abort(new Error('File tree is unavailable'));
+    }
+    void scheduler?.dispose();
+    this.forcedDirectoryLoadPaths.clear();
+    this.activeForcedDirectoryLoadPaths.clear();
     runInAction(() => {
-      this.syncError =
-        typeof error === 'object' && error && 'message' in error
-          ? String(error.message)
-          : String(error);
+      this.pendingPathSet.clear();
+      this.directoryLoadErrors.clear();
     });
   }
 
   private disposeRuntime(preserveData = false): void {
     const remote = this.treeRemote;
     const scope = this.treeScope;
+    this.cancelTreeHydration();
     runInAction(() => {
       this.optimistic = null;
       if (!preserveData) this.treeData = null;
@@ -635,6 +807,17 @@ function treeMutationError(error: unknown): TreeMutationError {
     return { type: 'unavailable', message: protocolUpgradeMessage('upgrade-server') };
   }
   return { type: 'unavailable', message };
+}
+
+function treeMutationErrorMessage(error: TreeMutationError): string {
+  if ('message' in error && error.message) return error.message;
+  if ('path' in error && error.path) return `${error.type}: ${error.path}`;
+  return error.type;
+}
+
+function compareDirectoryDepth(left: string, right: string): number {
+  const depth = (path: string) => path.split('/').filter(Boolean).length;
+  return depth(left) - depth(right) || left.localeCompare(right);
 }
 
 function pushChild(

--- a/apps/emdash-desktop/src/core/features/editor/contributions/browser/editor-file-tree.tsx
+++ b/apps/emdash-desktop/src/core/features/editor/contributions/browser/editor-file-tree.tsx
@@ -281,10 +281,6 @@ export const EditorFileTree = observer(function EditorFileTree() {
   }, [files, filesSettings?.treeExclude]);
 
   React.useEffect(() => {
-    files?.reconcileVisibleScopes(expandedPaths);
-  }, [expandedPaths, files]);
-
-  React.useEffect(() => {
     const activePath = activeFile?.path ?? null;
     if (!activePath) {
       lastSyncedActivePathRef.current = null;
@@ -317,19 +313,20 @@ export const EditorFileTree = observer(function EditorFileTree() {
   }, [pendingDraft, searchQuery]);
 
   React.useEffect(() => {
-    if (revealRequest.counter === 0 || !files) return;
-    void (async () => {
-      const result = await files.revealFile(revealRequest.path);
-      if (!result.success) {
-        toast.error('Reveal failed', { description: resultErrorMessage(result.error) });
-        return;
-      }
-      editorView.expandPaths(result.data);
-      setSelectedPaths(new Set([revealRequest.path]));
-      setSelectionAnchorPath(revealRequest.path);
-      window.requestAnimationFrame(() => treeRef.current?.scrollToPath(revealRequest.path));
-    })();
-  }, [editorView, files, revealRequest.counter, revealRequest.path]);
+    if (!revealRequest) return;
+    if (revealRequest.status === 'error') {
+      editorView.consumeRevealFileRequest(revealRequest.id);
+      toast.error('Reveal failed', { description: resultErrorMessage(revealRequest.error) });
+      return;
+    }
+    setSelectedPaths(new Set([revealRequest.path]));
+    setSelectionAnchorPath(revealRequest.path);
+    const frame = window.requestAnimationFrame(() => {
+      treeRef.current?.scrollToPath(revealRequest.path);
+      editorView.consumeRevealFileRequest(revealRequest.id);
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [editorView, revealRequest]);
 
   // Route through the openFile seam (spec §10): sidebar clicks resolve the
   // file's identity here at the edge and never reveal (the tree already shows
@@ -351,6 +348,17 @@ export const EditorFileTree = observer(function EditorFileTree() {
   };
 
   const collapseAll = () => editorView.collapsePaths([...expandedPaths]);
+  const loadDirectory = useCallback(
+    (path: string) => {
+      if (!files) return;
+      void files.registerDir(path).then((result) => {
+        if (!result.success) {
+          toast.error('Folder load failed', { description: resultErrorMessage(result.error) });
+        }
+      });
+    },
+    [files]
+  );
   const expandAll = () => {
     const directoryPaths = [...nodeByPath.values()]
       .filter(isExpandableFileTreeNode)
@@ -835,7 +843,7 @@ export const EditorFileTree = observer(function EditorFileTree() {
           if (expanded) {
             editorView.expandPath(node.path);
             if (files && isExpandableFileTreeNode(node) && !files.loadedPaths.has(node.path)) {
-              void files.registerDir(node.path);
+              loadDirectory(node.path);
             }
           } else {
             editorView.collapsePath(node.path);
@@ -843,7 +851,7 @@ export const EditorFileTree = observer(function EditorFileTree() {
         }}
         onRequestExpand={(path) => {
           editorView.expandPath(path);
-          void files?.registerDir(path);
+          loadDirectory(path);
         }}
         onSelectionChange={(paths, anchorPath) => {
           setSelectedPaths(new Set(paths));

--- a/apps/emdash-desktop/src/core/features/workbench/api/browser/task-composition-file-navigation.test.ts
+++ b/apps/emdash-desktop/src/core/features/workbench/api/browser/task-composition-file-navigation.test.ts
@@ -3,20 +3,20 @@ import { TaskComposition } from '@core/features/workbench/api/browser/task-compo
 
 function createTaskCompositionHarness() {
   const open = vi.fn();
-  const requestRevealFile = vi.fn();
+  const revealFile = vi.fn();
   const focusRegion = vi.fn();
   const openSidebarTab = vi.fn();
   const taskView = Object.create(TaskComposition.prototype) as TaskComposition;
 
   Object.defineProperties(taskView, {
-    editorView: { value: { requestRevealFile } },
+    editorView: { value: { revealFile } },
     paneLayout: { value: { open } },
     chrome: { value: { commands: { focusRegion, openSidebarTab } } },
   });
 
   return {
     open,
-    requestRevealFile,
+    revealFile,
     focusRegion,
     openSidebarTab,
     taskView,
@@ -31,6 +31,6 @@ describe('TaskComposition workspace file navigation', () => {
 
     expect(harness.open).not.toHaveBeenCalled();
     expect(harness.openSidebarTab).toHaveBeenCalledWith('files');
-    expect(harness.requestRevealFile).toHaveBeenCalledWith('/repo/src/already-open.ts');
+    expect(harness.revealFile).toHaveBeenCalledWith('/repo/src/already-open.ts');
   });
 });

--- a/apps/emdash-desktop/src/core/features/workbench/api/browser/task-composition.ts
+++ b/apps/emdash-desktop/src/core/features/workbench/api/browser/task-composition.ts
@@ -503,7 +503,7 @@ export class TaskComposition {
 
   revealWorkspaceFile(path: string): void {
     this.chrome.commands.openSidebarTab('files');
-    this.editorView.requestRevealFile(path);
+    void this.editorView.revealFile(path);
   }
 
   setFocusedRegion(region: TaskFocusedRegion): void {

--- a/packages/core/src/runtimes/files/node/tree/tree-resource.test.ts
+++ b/packages/core/src/runtimes/files/node/tree/tree-resource.test.ts
@@ -50,6 +50,24 @@ describe('TreeResource', () => {
     expect(model.entries.repo?.children).toEqual([]);
   });
 
+  it('does not reread or republish an already materialized directory', async () => {
+    const { rootPath, tree } = await createHarness({ exclusions: [] });
+    await writeFile(path.join(rootPath, 'existing.ts'), '');
+    const diagnostic = tree as unknown as DiagnosticTreeResource;
+    await diagnostic.expandPath(ROOT_RELATIVE_PATH);
+    const before = snapshot(tree.source()).revision;
+    await writeFile(path.join(rootPath, 'late.ts'), '');
+
+    const result = await tree.expand(
+      treeContext(tree, { path: ROOT_RELATIVE_PATH }, 'expand-loaded-test')
+    );
+
+    expect(result.success).toBe(true);
+    expect(snapshot(tree.source()).revision).toBe(before);
+    expect(diagnostic.current().entries['existing.ts']).toBeDefined();
+    expect(diagnostic.current().entries['late.ts']).toBeUndefined();
+  });
+
   it('filters excluded entries from expanded directories', async () => {
     const { rootPath, tree } = await createHarness({ exclusions: ['generated'] });
     await mkdir(path.join(rootPath, 'src', 'generated'), { recursive: true });
@@ -237,11 +255,22 @@ describe('TreeResource', () => {
     await diagnostic.expandPath(ROOT_RELATIVE_PATH);
     await diagnostic.expandPath(portable('src'));
     const before = snapshot(tree.source()).revision;
+    const blockedLane = deferred<void>();
+    diagnostic.lane = blockedLane.promise;
+    let settled = false;
 
-    const result = await tree.reveal(
-      treeContext(tree, { path: portable('src/app.ts') }, 'reveal-visible-test')
-    );
+    const reveal = tree
+      .reveal(treeContext(tree, { path: portable('src/app.ts') }, 'reveal-visible-test'))
+      .then((result) => {
+        settled = true;
+        return result;
+      });
+    await new Promise<void>((resolve) => setImmediate(resolve));
 
+    const settledBeforeUnblock = settled;
+    blockedLane.resolve();
+    const result = await reveal;
+    expect(settledBeforeUnblock).toBe(true);
     expect(result.success).toBe(true);
     expect(snapshot(tree.source()).revision).toBe(before);
   });

--- a/packages/core/src/runtimes/files/node/tree/tree-resource.ts
+++ b/packages/core/src/runtimes/files/node/tree/tree-resource.ts
@@ -68,21 +68,41 @@ export class TreeResource {
     return this.state;
   }
 
-  expand(context: TreeMutationContext<'expand'>): Promise<Result<void, FsError>> {
+  async expand(context: TreeMutationContext<'expand'>): Promise<Result<void, FsError>> {
+    const depth = normalizeExpansionDepth(context.input.depth);
+    const currentRevision = this.materializedExpansionRevision(context.input.path, depth);
+    if (currentRevision !== null) {
+      await context.observed('tree', currentRevision);
+      return ok<void>();
+    }
+
     return this.run(async () => {
-      const result = await this.expandPath(
-        context.input.path,
-        context.mutationId,
-        normalizeExpansionDepth(context.input.depth)
-      );
+      const queuedRevision = this.materializedExpansionRevision(context.input.path, depth);
+      if (queuedRevision !== null) {
+        await context.observed('tree', queuedRevision);
+        return ok<void>();
+      }
+      const result = await this.expandPath(context.input.path, context.mutationId, depth);
       if (!result.success) return result;
       await context.observed('tree', result.data);
       return ok<void>();
     });
   }
 
-  reveal(context: TreeMutationContext<'reveal'>): Promise<Result<void, FsError>> {
+  async reveal(context: TreeMutationContext<'reveal'>): Promise<Result<void, FsError>> {
+    const depth = normalizeExpansionDepth(context.input.depth);
+    const currentRevision = this.materializedRevealRevision(context.input.path, depth);
+    if (currentRevision !== null) {
+      await context.observed('tree', currentRevision);
+      return ok<void>();
+    }
+
     return this.run(async () => {
+      const queuedRevision = this.materializedRevealRevision(context.input.path, depth);
+      if (queuedRevision !== null) {
+        await context.observed('tree', queuedRevision);
+        return ok<void>();
+      }
       const validated = this.options.root.paths.resolveEntry(context.input.path);
       if (!validated.success) return validated;
       const target = validated.data.path;
@@ -98,11 +118,6 @@ export class TreeResource {
         return { success: false, error: { type: 'not-found', path: target } };
       }
       if (isExpandableFileEntry(targetEntry)) {
-        const depth = normalizeExpansionDepth(context.input.depth);
-        if (depth === 1 && this.directoryChildrenLoaded(target)) {
-          await context.observed('tree', revision);
-          return ok<void>();
-        }
         const expanded = await this.expandPath(target, context.mutationId, depth);
         if (!expanded.success) return expanded;
         revision = expanded.data;
@@ -298,6 +313,38 @@ export class TreeResource {
   private directoryChildrenLoaded(entryPath: PortableRelativePath): boolean {
     const entry = snapshot(this.state).value.entries[entryPath];
     return !!entry && isExpandableFileEntry(entry) && entry.childrenLoaded;
+  }
+
+  private materializedExpansionRevision(
+    entryPath: PortableRelativePath,
+    depth: ExpansionDepth
+  ): Revision | null {
+    const validated = this.options.root.paths.resolveEntry(entryPath);
+    if (!validated.success) return null;
+    const current = snapshot(this.state);
+    const entry = current.value.entries[validated.data.path];
+    if (!entry || !isExpandableFileEntry(entry) || !entry.childrenLoaded) return null;
+    if (depth === 2) {
+      for (const childPath of entry.children) {
+        const child = current.value.entries[childPath];
+        if (child && isExpandableFileEntry(child) && !child.childrenLoaded) return null;
+      }
+    }
+    return revisionOf(this.state);
+  }
+
+  private materializedRevealRevision(
+    entryPath: PortableRelativePath,
+    depth: ExpansionDepth
+  ): Revision | null {
+    const validated = this.options.root.paths.resolveEntry(entryPath);
+    if (!validated.success) return null;
+    const entry = snapshot(this.state).value.entries[validated.data.path];
+    if (!entry) return null;
+    if (isExpandableFileEntry(entry)) {
+      return this.materializedExpansionRevision(entry.path, depth);
+    }
+    return revisionOf(this.state);
   }
 
   private run<T>(work: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
- route file reveals and directory expansions through a shared prioritized scheduler
- cancel superseded reveal requests and consume sidebar presentation state once
- acknowledge already materialized tree mutations without rereading the filesystem
- preserve live-model updates while preventing stale work after sidebar remounts