### PR TITLE
feat(acp): preserve conversation state across rematerialization

### DIFF
--- a/agents/architecture/acp-runtime.md
+++ b/agents/architecture/acp-runtime.md
@@ -16,18 +16,23 @@ not mix cross-session routing with per-session state projection.
   `inspect()` seam exposes identifier-only lifecycle snapshots for deterministic ownership and leak
   assertions without revealing the directory maps.
 - `ConversationHandle` is the aggregate root for one conversation. It owns the wake descriptor,
-  configuration overrides, conversation-lifetime projection, explicit lifecycle state and epoch,
-  current `SessionRecord`, activation snapshot construction, and its single-key `LifecycleCell`.
-  Descriptor changes write through one intent-persistence seam, while killed/disposed state and the
-  epoch invalidate stale asynchronous materialization and command work before directory removal.
+  desired configuration, retained presentation snapshot, conversation-lifetime projection,
+  explicit lifecycle state and epoch, current `SessionRecord`, activation snapshot construction,
+  and its single-key `LifecycleCell`. Descriptor and retained-presentation changes write through one
+  intent-persistence seam, while killed/disposed state and the epoch invalidate stale asynchronous
+  materialization and command work before directory removal.
 - `LifecycleCell` provides coalesced starts, leases, interrupt-before-drain teardown, and bounded
   draining for one handle. The multi-key `LifecycleRegistry` remains available to other runtimes.
 - `SessionMaterializer` is stateless. It acquires a connection, loads or creates the provider
   session, creates the record's machine-state binding, applies retained configuration and mode, and
   returns a `SessionRecord` for the handle to adopt. Provisional loading registration and replay
   setup share one cleanup path so failures cannot leave routing residue.
-- `SessionRouter` owns ACP `sessionId` routing and the provisional loading-conversation fallback.
-  Its route maps stay private; identifier-only queries support lifecycle leak assertions.
+- `SessionRouter` owns ACP `sessionId` routing and one scoped provisional load route per process
+  generation. The materializer serializes `loadSession` handshakes for each generation, so a
+  provider that reports a rebound session ID still resolves unambiguously. Unknown or stale updates
+  outside that scope are dropped rather than retained across activations; generation invalidation
+  drops provisional and registered routes. Its maps stay private; identifier-only queries support
+  lifecycle leak assertions.
   `SessionsListProjector` composes live handle summaries with lightweight suspended-intent rows.
 - `SessionCell` owns one live activation: the state machine, transcript reducer, permission broker,
   prompt queue effects, and turn quiescence. It does not own the conversation-lifetime projection
@@ -99,10 +104,19 @@ hook, and asks the `SessionRouter` to resolve the owning conversation. The cell 
 through the reducer; its handle republishes the resulting activation snapshot through the
 conversation-keyed projection.
 
-The handle writes retained provider `sessionId`, mode, model, and configuration overrides through
-to the runtime's session intent after successful changes. The runtime also returns the session id
-from `start` and `resume`; desktop persists that value in its conversation record at the client
-boundary instead of using a child-to-host callback.
+The public API describes user intent instead of exposing lifecycle choreography. Desktop resolves
+the authoritative conversation configuration and fresh provider environment, then `attach` creates
+or refreshes the handle and publishes its retained projection without spawning a provider.
+`loadHistory` and `sendPrompt` ensure an activation internally and coalesce through the handle's
+lifecycle cell. `setOption` updates one of the provider's model, mode, or effort dimensions without
+waking a suspended session. Headless callers that need creation and activation as one atomic
+operation use `launch`; there is no public `ensureActivation`, `start`, or `resume` procedure.
+
+The handle persists an explicitly allowlisted, versioned intent containing provider/session
+identity, cwd, desired model/mode/effort, and a bounded non-secret presentation snapshot. Provider
+environment, MCP credentials, runtime endpoints, and unknown descriptor fields are never persisted.
+The runtime reports provider session identity and resume outcomes through the host conversation
+index. Interactive callers therefore never persist lifecycle response data themselves.
 
 Parsed transcript and raw ACP log exports are live-activation reads. They never wake a suspended
 conversation because the raw log is activation-local and a post-wake export would describe the
@@ -111,27 +125,34 @@ replay rather than the evicted process.
 ## Suspension and Rematerialization
 
 The public identity is always `conversationId`; provider process activations are internal. A
-retained conversation keeps its wake descriptor after its live `SessionCell` is evicted. During one
-runtime generation, its handle and projection explicitly move between `closed`, `suspended`, and
-`active` sources. On boot, suspended intents remain lightweight index entries instead of eagerly
-allocating handles and projections. The sessions-list projector still publishes an index-derived
-row so cleanup and discovery see every suspended conversation. First start or wake hydrates the
-handle; killing an index-only entry deletes its intent without starting a provider. Suspended state
-uses the existing `closed` lifecycle plus the additive `suspended: true` marker, keeps prompt
-submission enabled, and clears activation-local queues, permissions, terminals, and active turns.
+retained conversation keeps its wake descriptor and presentation after its live `SessionCell` is
+evicted. The presentation separates desired configuration from last-known provider catalogs, MCP
+summaries, usage, and observation time. During one runtime generation, its handle and projection
+move between `closed`, `suspended`, `materializing`, and `active`; suspended and materializing
+projections keep controls visible and prompt submission enabled while clearing activation-local
+queues, permissions, terminals, active turns, plans, and agents.
 
-Only explicit `start`/`resume` and state-changing user commands (`sendPrompt`, `setMode`, and
-`setConfigOption`) materialize a suspended activation. Reads, exports, callbacks, cancellation,
-permission resolution, and queued-prompt edits never wake one. In particular, suspended history
-returns a successful page marked `unavailable: true`; callers keep their existing transcript and
-wait for a later replay-completion refresh.
+On worker boot, every valid persisted intent is restored only as a lightweight suspended index row;
+the worker never starts a provider from disk. The first desktop `attach` hydrates a handle using a
+trusted fresh descriptor and publishes the retained presentation. Terminating an index-only entry
+deletes its intent without starting a provider. Legacy or over-broad intents are parsed through a
+restricted migration and rewritten in the safe schema.
 
-Materialization is server-side and coalesced by the handle's lifecycle cell. `sendPrompt` leases the
-activation for the full provider turn, while mode and config changes use shorter leases. Eviction,
-kill, and runtime disposal abort pending materialization and interrupt the cell and provider session
-before waiting for leases, then continue after a bounded drain timeout if a provider does not
-settle. Process-close callbacks carry a connection generation so a stale process cannot suspend
-sessions on its replacement.
+`loadHistory`, `sendPrompt`, and the headless `launch` operation materialize a suspended activation.
+Mode, model, and effort changes update desired state and persist without waking when suspended or
+materializing; the latest revision is applied after load and before the first queued prompt. Other
+reads, exports, callbacks, cancellation, permission resolution, and queued-prompt edits never wake
+one. If a provider cannot replay history, `loadHistory` returns a successful page marked
+`unavailable: true`; callers retain their existing transcript instead of replacing it with an empty
+one.
+
+Materialization is server-side and coalesced by the handle's lifecycle cell. A prompt submitted
+while materializing joins that activation and dispatches once after the latest desired configuration
+has been applied. Active mode and config changes use shorter leases. Eviction, termination, and runtime
+disposal abort pending materialization and interrupt the cell and provider session before waiting
+for leases, then continue after a bounded drain timeout if a provider does not settle. Process-close
+callbacks carry a connection generation so a stale process cannot suspend sessions on its
+replacement.
 
 ## Process Hosting
 
@@ -151,10 +172,10 @@ attachment cleanup must therefore use explicit attachment deletion or whole-conv
 absence from transcript history does not prove that stored bytes are orphaned.
 
 Desktop composes the ACP client and renderer exposure in
-`apps/emdash-desktop/src/main/core/wire-workers/desktop-workers.ts`: the raw
-stable worker client is wrapped there for session-ID persistence, then forwarded
-to Electron windows through `exposeWireToWindows()`. `WireWorkerHost` itself
-does not own client decoration, startup policy, or renderer exposure.
+`apps/emdash-desktop/src/main/gateway/desktop-workers.ts`. The raw stable worker client is consumed
+by typed desktop Wire controllers and by headless runtime services; renderer clients receive the
+smaller conversations contract. `WireWorkerHost` itself does not own client decoration, startup
+policy, or renderer exposure.
 
 The concrete plugin registry is injected by each host entry (`emdash-desktop` and
 `workspace-server`) rather than imported by `@emdash/core/runtimes`; this keeps runtime

--- a/agents/architecture/workspace-server.md
+++ b/agents/architecture/workspace-server.md
@@ -68,7 +68,7 @@ The wire contract is versioned with a single [semver](https://semver.org) string
 [`packages/core/src/workspace-server/versions/index.ts`](../../packages/core/src/workspace-server/versions/index.ts):
 
 ```ts
-export const PROTOCOL_VERSION = '3.0.0';
+export const PROTOCOL_VERSION = '4.0.0';
 ```
 
 ### What each component means

--- a/apps/emdash-desktop/src/core/features/conversations/api/browser/conversation-manager.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/api/browser/conversation-manager.ts
@@ -459,7 +459,7 @@ export class ConversationManagerStore implements Disposable {
     const client = await getConversationsClient();
     const result =
       conversation.data.type === 'acp'
-        ? await client.acp.kill({ conversationId })
+        ? await client.acp.terminate({ conversationId })
         : await client.tui.kill({ conversationId });
     if (!result.success) {
       throw new Error(

--- a/apps/emdash-desktop/src/core/features/conversations/api/contract.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/api/contract.ts
@@ -88,9 +88,11 @@ const desktopTuiSessions = liveModel({
 });
 
 const conversationsAcpContract = defineContract({
-  start: runtimeFallibleProcedure(conversationKey, acpApiContract.start.output),
-  resume: runtimeFallibleProcedure(conversationKey, acpApiContract.resume.output),
-  kill: runtimeFallibleProcedure(acpApiContract.kill.input, acpApiContract.kill.output),
+  attach: runtimeFallibleProcedure(conversationKey, acpApiContract.attach.output),
+  terminate: runtimeFallibleProcedure(
+    acpApiContract.terminate.input,
+    acpApiContract.terminate.output
+  ),
   sendPrompt: runtimeFallibleProcedure(
     acpApiContract.sendPrompt.input,
     acpApiContract.sendPrompt.output
@@ -111,13 +113,9 @@ const conversationsAcpContract = defineContract({
     acpApiContract.cancelTurn.input,
     acpApiContract.cancelTurn.output
   ),
-  setModelOption: runtimeFallibleProcedure(
-    acpApiContract.setModelOption.input,
-    acpApiContract.setModelOption.output
-  ),
-  setModeOption: runtimeFallibleProcedure(
-    acpApiContract.setModeOption.input,
-    acpApiContract.setModeOption.output
+  setOption: runtimeFallibleProcedure(
+    acpApiContract.setOption.input,
+    acpApiContract.setOption.output
   ),
   resolvePermission: runtimeFallibleProcedure(
     acpApiContract.resolvePermission.input,
@@ -143,9 +141,9 @@ const conversationsAcpContract = defineContract({
     error: projectAttachmentErrorUnion(acpApiContract.downloadAttachment.error),
   }),
   deleteAttachment: runtimeFallibleProcedure(attachmentKey, acpApiContract.deleteAttachment.output),
-  getHistory: runtimeFallibleProcedure(
-    acpApiContract.getHistory.input,
-    acpApiContract.getHistory.output
+  loadHistory: runtimeFallibleProcedure(
+    acpApiContract.loadHistory.input,
+    acpApiContract.loadHistory.output
   ),
   sessions: desktopAcpSessions,
   session: acpApiContract.session,

--- a/apps/emdash-desktop/src/core/features/conversations/api/node/operations/conversation-removal.db.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/api/node/operations/conversation-removal.db.test.ts
@@ -87,16 +87,16 @@ describe('executeConversationRemoval', () => {
 
   function fakeBroker(overrides: {
     reachable?: boolean;
-    killAcp?: SessionKillMock;
+    terminateAcp?: SessionKillMock;
     deleteTui?: SessionKillMock;
     deleteRecord?: IndexDeleteMock;
-    deleteAttachments?: SessionKillMock;
+    purgeConversationData?: SessionKillMock;
   }) {
     const calls: string[] = [];
-    const killAcp: SessionKillMock =
-      overrides.killAcp ??
+    const terminateAcp: SessionKillMock =
+      overrides.terminateAcp ??
       vi.fn(async () => {
-        calls.push('acp.kill');
+        calls.push('acp.terminate');
         return ok(undefined);
       });
     const deleteTui: SessionKillMock =
@@ -111,23 +111,23 @@ describe('executeConversationRemoval', () => {
         calls.push('conversations.delete');
         return ok(undefined);
       });
-    const deleteAttachments: SessionKillMock =
-      overrides.deleteAttachments ??
+    const purgeConversationData: SessionKillMock =
+      overrides.purgeConversationData ??
       vi.fn(async () => {
-        calls.push('acp.deleteAttachments');
+        calls.push('acp.purgeConversationData');
         return ok(undefined);
       });
     const broker: ConversationRemovalBroker = {
       client: async () =>
         (overrides.reachable ?? true)
           ? ok({
-              acp: { kill: killAcp, deleteAttachments },
+              acp: { terminate: terminateAcp, purgeConversationData },
               tuiAgents: { delete: deleteTui },
               conversations: { delete: deleteRecord },
             })
           : err({ type: 'ssh-connection-failed', message: 'down' }),
     };
-    return { broker, calls, killAcp, deleteTui, deleteRecord, deleteAttachments };
+    return { broker, calls, terminateAcp, deleteTui, deleteRecord, purgeConversationData };
   }
 
   it('kills both session surfaces before deleting the index record', async () => {
@@ -139,20 +139,20 @@ describe('executeConversationRemoval', () => {
     // Session kill is part of the verb (spec §4.3) — strictly ordered before the delete;
     // attachment cleanup (spec §3.6) follows the successful index delete.
     expect(host.calls).toEqual([
-      'acp.kill',
+      'acp.terminate',
       'tuiAgents.delete',
       'conversations.delete',
-      'acp.deleteAttachments',
+      'acp.purgeConversationData',
     ]);
-    expect(host.killAcp).toHaveBeenCalledWith({ conversationId: 'conv-1' });
+    expect(host.terminateAcp).toHaveBeenCalledWith({ conversationId: 'conv-1' });
     expect(host.deleteTui).toHaveBeenCalledWith({ conversationId: 'conv-1' });
     expect(host.deleteRecord).toHaveBeenCalledWith({ conversationId: 'conv-1' });
-    expect(host.deleteAttachments).toHaveBeenCalledWith({ conversationId: 'conv-1' });
+    expect(host.purgeConversationData).toHaveBeenCalledWith({ conversationId: 'conv-1' });
   });
 
   it('deletes the record even when session kills fail', async () => {
     const host = fakeBroker({
-      killAcp: vi.fn(async () => {
+      terminateAcp: vi.fn(async () => {
         throw new Error('acp runtime crashed');
       }),
       deleteTui: vi.fn(async () => {
@@ -177,7 +177,7 @@ describe('executeConversationRemoval', () => {
 
   it('reports ok even when attachment cleanup fails after the record delete', async () => {
     const host = fakeBroker({
-      deleteAttachments: vi.fn(async () => {
+      purgeConversationData: vi.fn(async () => {
         throw new Error('acp runtime crashed');
       }),
     });
@@ -195,7 +195,7 @@ describe('executeConversationRemoval', () => {
 
     await executeConversationRemoval(host.broker, LOCAL_HOST_REF, 'conv-1');
 
-    expect(host.deleteAttachments).not.toHaveBeenCalled();
+    expect(host.purgeConversationData).not.toHaveBeenCalled();
   });
 
   it('classifies a mid-call unreachability error as unreachable, others as failed', async () => {

--- a/apps/emdash-desktop/src/core/features/conversations/api/node/operations/conversation-removal.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/api/node/operations/conversation-removal.ts
@@ -37,8 +37,8 @@ export type ConversationRemovalBroker = {
     Result<
       {
         acp: {
-          kill(input: { conversationId: string }): Promise<unknown>;
-          deleteAttachments(input: { conversationId: string }): Promise<unknown>;
+          terminate(input: { conversationId: string }): Promise<unknown>;
+          purgeConversationData(input: { conversationId: string }): Promise<unknown>;
         };
         tuiAgents: { delete(input: { conversationId: string }): Promise<unknown> };
         conversations: {
@@ -103,7 +103,7 @@ export async function executeConversationRemoval(
   // here, so both kills run; absent sessions are no-ops and kill failures must not
   // block record deletion (the host reaps orphaned sessions).
   try {
-    await client.data.acp.kill({ conversationId });
+    await client.data.acp.terminate({ conversationId });
   } catch {
     // Swallowed by design; see comment above.
   }
@@ -123,7 +123,7 @@ export async function executeConversationRemoval(
   // the acp runtime purges the conversation's attachment directory. Best effort — a failed
   // purge leaves an inert orphaned directory, never a blocked deletion.
   try {
-    await client.data.acp.deleteAttachments({ conversationId });
+    await client.data.acp.purgeConversationData({ conversationId });
   } catch {
     // Swallowed by design; see comment above.
   }

--- a/apps/emdash-desktop/src/core/features/conversations/api/node/utils.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/api/node/utils.ts
@@ -34,6 +34,7 @@ export function mapConversationRowToConversation(row: ConversationRow): Conversa
     sessionId: row.providerSessionId ?? undefined,
     model: config?.model,
     modeId: config?.type === 'acp' ? config.modeId : undefined,
+    effort: config?.type === 'acp' ? config.effort : undefined,
     initialQueue: initialQueueFromRow(row),
     lastInteractedAt: row.lastSessionActivityAt ?? null,
     isInitialConversation: row.isInitialConversation,

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-panel.tsx
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-panel.tsx
@@ -577,11 +577,18 @@ const ComposerForStore = observer(function ComposerForStore({
           {disabledReason}
         </div>
       )}
+      {store.loadError && (
+        <div className="border-destructive/30 bg-destructive/5 mx-3 mb-1 flex items-center justify-between gap-2 rounded-md border px-2 py-1 text-xs">
+          <span className="truncate text-foreground-muted">{store.loadError.message}</span>
+          <Button variant="secondary" size="sm" onClick={() => store.retry()}>
+            Retry
+          </Button>
+        </div>
+      )}
       <div inert={disabledReason ? true : undefined}>
         <ChatComposer
           isWorking={a.isWorking}
           canSubmit={a.canSubmit}
-          notice={a.isResuming ? { variant: 'info', message: 'Resuming conversation…' } : null}
           onSubmit={handleSubmit}
           onInputChange={(text) => store.setDraftText(text)}
           onSubmitWhileWorking={handleSubmit}
@@ -814,11 +821,11 @@ export const AcpChatPanel = observer(function AcpChatPanel() {
   const unavailableWithoutTranscript =
     store.loadError?.kind === 'unavailable' && store.messageCount === 0;
   const showBlockingOverlay =
-    store.historyLoading ||
-    (store.loadError !== null && store.loadError.kind !== 'unavailable') ||
-    unavailableWithoutTranscript;
-  const showComposer =
-    !store.historyLoading && (store.loadError === null || store.loadError.kind === 'unavailable');
+    store.session === null &&
+    (store.historyLoading ||
+      (store.loadError !== null && store.loadError.kind !== 'unavailable') ||
+      unavailableWithoutTranscript);
+  const showComposer = store.session !== null;
   const showHero = showComposer && store.isEmpty && store.loadError === null;
 
   return (
@@ -837,10 +844,8 @@ export const AcpChatPanel = observer(function AcpChatPanel() {
         style={{ position: 'absolute', inset: 0 }}
       />
 
-      {/* Loading / error overlay portaled into the library-owned slot.
-          The slot sits at z-index 15 (above pinned, below composer at 20).
-          Hide the composer in error state so the overlay owns the whole content area.
-          Precedence: error > loading. */}
+      {/* Before attach, loading/errors own the content area. Once attached, activation errors are
+          non-blocking and render beside the still-usable composer. */}
       {overlaySlot &&
         showBlockingOverlay &&
         createPortal(

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
@@ -1,4 +1,5 @@
 import type { ChatContext, ChatImageAttachment, ChatState, ChatView } from '@emdash/chat-ui';
+import { formatHostRef } from '@emdash/core/primitives/host/api';
 import type {
   AttachmentMimeType,
   AttachmentRef,
@@ -30,6 +31,7 @@ import {
   type ConversationsClient,
 } from '@core/features/conversations/api/browser/client';
 import { conversationRegistry } from '@core/features/conversations/api/browser/stores/conversation-registry';
+import { updateProviderPreference } from '@core/features/conversations/browser/provider-preferences';
 import {
   ACP_DRAFT_MAX_LENGTH,
   acpDraftMemento,
@@ -288,7 +290,7 @@ export class AcpChatStore {
     const isResuming = state?.lifecycle === 'starting' || state?.lifecycle === 'replaying';
     return {
       isWorking: state?.isGenerating ?? false,
-      isBusy: (state?.isGenerating ?? false) || isResuming,
+      isBusy: state?.isGenerating ?? false,
       isResuming,
       hasPendingPermission: (state?.pendingPermissions.length ?? 0) > 0,
       canSubmit: liveActionsEnabled && (state?.canSubmit ?? false),
@@ -450,27 +452,39 @@ export class AcpChatStore {
 
   setModel(model: string): void {
     void this.session
-      ?.setModelOption('model', model)
+      ?.setOption('model', model)
       .then((result) => {
-        if (!result.success) this._toastError('Failed to change model', result.error);
+        if (!result.success) {
+          this._toastError('Failed to change model', result.error);
+          return;
+        }
+        void this._rememberPreference({ model });
       })
       .catch((error: unknown) => this._toastError('Failed to change model', error));
   }
 
   setMode(modeId: string): void {
     void this.session
-      ?.setModeOption(modeId)
+      ?.setOption('mode', modeId)
       .then((result) => {
-        if (!result.success) this._toastError('Failed to change session mode', result.error);
+        if (!result.success) {
+          this._toastError('Failed to change session mode', result.error);
+          return;
+        }
+        void this._rememberPreference({ modeId });
       })
       .catch((error: unknown) => this._toastError('Failed to change session mode', error));
   }
 
   setEffort(effort: string): void {
     void this.session
-      ?.setModelOption('effort', effort)
+      ?.setOption('effort', effort)
       .then((result) => {
-        if (!result.success) this._toastError('Failed to change effort', result.error);
+        if (!result.success) {
+          this._toastError('Failed to change effort', result.error);
+          return;
+        }
+        void this._rememberPreference({ effort });
       })
       .catch((error: unknown) => this._toastError('Failed to change effort', error));
   }
@@ -549,19 +563,33 @@ export class AcpChatStore {
     }
     const providerId = conversationRegistry.get(this.taskId)?.conversations.get(this.conversationId)
       ?.data.providerId;
+    let clientSession: AcpLiveSession | null = null;
     try {
-      const clientSession = await AcpLiveSession.create(this.conversationId);
-
-      const history = await clientSession.getHistory(undefined, 100);
-      if (!history.success) throw resultError(history.error);
+      const attachedSession = await AcpLiveSession.create(this.conversationId);
+      clientSession = attachedSession;
 
       runInAction(() => {
         this.session?.dispose();
-        this.session = clientSession;
+        this.session = attachedSession;
+        this._subscribeLiveSession(attachedSession);
+      });
+
+      const history = await attachedSession.loadHistory(undefined, 100);
+      if (!history.success) throw new AcpStartError(history.error);
+      if (history.data.clearedConfiguration?.length) {
+        await this._rememberPreference(
+          Object.fromEntries(history.data.clearedConfiguration.map((key) => [key, null])) as {
+            model?: null;
+            modeId?: null;
+            effort?: null;
+          }
+        );
+      }
+
+      runInAction(() => {
         if (!history.data.unavailable) {
           this.chatState.transcript.history.seed(history.data.turns);
         }
-        this._subscribeLiveSession(clientSession);
         this.historyLoading = false;
         this.loadError = null;
         this._syncMessageCount();
@@ -575,6 +603,7 @@ export class AcpChatStore {
         error,
       });
       runInAction(() => {
+        if (clientSession && this.session !== clientSession) clientSession.dispose();
         this.historyLoading = false;
         this.loadError =
           this.hostAccess?.liveAction.kind === 'disabled'
@@ -769,6 +798,22 @@ export class AcpChatStore {
     return this._acpClientPromise;
   }
 
+  private async _rememberPreference(patch: {
+    model?: string | null;
+    modeId?: string | null;
+    effort?: string | null;
+  }): Promise<void> {
+    const providerId = conversationRegistry.get(this.taskId)?.conversations.get(this.conversationId)
+      ?.data.providerId;
+    if (!providerId) return;
+    const host = formatHostRef(hostRefFromConnectionId(getProjectSshConnectionId(this.projectId)));
+    try {
+      await updateProviderPreference(host, providerId, 'acp', patch);
+    } catch (error) {
+      getMementoClient().reportError(error);
+    }
+  }
+
   private _bindTerminalOutputs(session: AcpLiveSession): () => void {
     return bindSessionTerminalOutputs(session, (terminalId, snapshot) =>
       this.chatState.session.setTerminalOutput(terminalId, snapshot)
@@ -798,7 +843,7 @@ export class AcpChatStore {
     if (!session) return;
 
     try {
-      const history = await session.getHistory(undefined, 100);
+      const history = await session.loadHistory(undefined, 100);
       if (!history.success || history.data.unavailable || this.session !== session) return;
       // A waking prompt may begin between replay completion and this response. Do not let a
       // replay-history seed reset the newly active turn; its normal completion refresh will seed
@@ -883,16 +928,6 @@ function bytesToBase64(bytes: Uint8Array): string {
     binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
   }
   return btoa(binary);
-}
-
-function resultError(error: unknown): Error {
-  if (error instanceof Error) return error;
-  if (typeof error === 'object' && error !== null) {
-    const message = (error as { message?: unknown }).message;
-    const type = (error as { type?: unknown }).type;
-    return new Error(typeof message === 'string' ? message : String(type ?? 'Unknown error'));
-  }
-  return new Error(String(error));
 }
 
 function toLoadError(error: unknown): AcpLoadError {

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.test.ts
@@ -52,12 +52,11 @@ describe('AcpLiveSession.sendPrompt', () => {
   });
 });
 
-describe('AcpLiveSession.resume', () => {
-  it('preserves the unavailable history marker', async () => {
-    const resume = vi.fn(async () => ({
+describe('AcpLiveSession.loadHistory', () => {
+  it('loads activation-aware history by conversation id', async () => {
+    const loadHistory = vi.fn(async () => ({
       success: true as const,
       data: {
-        sessionId: 'session-1',
         turns: [],
         nextCursor: null,
         unavailable: true as const,
@@ -65,12 +64,17 @@ describe('AcpLiveSession.resume', () => {
     }));
     const session = Object.assign(Object.create(AcpLiveSession.prototype), {
       conversationId: 'conversation-1',
-      client: { resume },
+      client: { loadHistory },
     }) as AcpLiveSession;
 
-    await expect(session.resume()).resolves.toEqual({
+    await expect(session.loadHistory(undefined, 100)).resolves.toEqual({
       success: true,
       data: { turns: [], nextCursor: null, unavailable: true },
+    });
+    expect(loadHistory).toHaveBeenCalledWith({
+      conversationId: 'conversation-1',
+      before: undefined,
+      limit: 100,
     });
   });
 });

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.ts
@@ -7,7 +7,6 @@ import {
   terminalStateSchema,
   transcriptTurnSchema,
   type AcpRuntimeError,
-  type HistoryPage,
   type PromptInput,
   type PromptPlacement,
   type SessionState,
@@ -126,8 +125,8 @@ export class AcpLiveSession {
   static async create(conversationId: string): Promise<AcpLiveSession> {
     const client = (await getConversationsClient()).acp;
     const result = await withTimeout(
-      (signal) => client.start({ conversationId }, { signal }),
-      'Timed out starting ACP session'
+      (signal) => client.attach({ conversationId }, { signal }),
+      'Timed out attaching ACP session'
     );
     if (!result.success) {
       throw new AcpStartError(result.error);
@@ -153,25 +152,8 @@ export class AcpLiveSession {
     }
   }
 
-  start(): Promise<Result<{ sessionId: string }, unknown>> {
-    return this.client.start({ conversationId: this.conversationId });
-  }
-
-  async resume(): Promise<Result<HistoryPage, unknown>> {
-    const result = await this.client.resume({ conversationId: this.conversationId });
-    if (!result.success) return result;
-    return {
-      success: true,
-      data: {
-        turns: result.data.turns,
-        nextCursor: result.data.nextCursor,
-        ...(result.data.unavailable ? { unavailable: true as const } : {}),
-      },
-    };
-  }
-
-  getHistory(before?: number, limit = 50): Promise<Result<HistoryPage, unknown>> {
-    return this.client.getHistory({ conversationId: this.conversationId, before, limit });
+  loadHistory(before?: number, limit = 50) {
+    return this.client.loadHistory({ conversationId: this.conversationId, before, limit });
   }
 
   async exportTranscript(): Promise<Result<string, unknown>> {
@@ -214,12 +196,8 @@ export class AcpLiveSession {
     return this.client.cancelTurn({ conversationId: this.conversationId });
   }
 
-  setModelOption(dimension: 'model' | 'effort', value: string): Promise<Result<void, unknown>> {
-    return this.client.setModelOption({ conversationId: this.conversationId, dimension, value });
-  }
-
-  setModeOption(value: string): Promise<Result<void, unknown>> {
-    return this.client.setModeOption({ conversationId: this.conversationId, value });
+  setOption(key: 'model' | 'mode' | 'effort', value: string): Promise<Result<void, unknown>> {
+    return this.client.setOption({ conversationId: this.conversationId, key, value });
   }
 
   resolvePermission(requestId: string, optionId: string): Promise<Result<void, unknown>> {

--- a/apps/emdash-desktop/src/core/features/conversations/browser/create-conversation-modal.tsx
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/create-conversation-modal.tsx
@@ -1,3 +1,4 @@
+import { formatHostRef } from '@emdash/core/primitives/host/api';
 import { Dialog, Field, Select, Switch } from '@emdash/ui/react/primitives';
 import { observer } from 'mobx-react-lite';
 import { useCallback, useState } from 'react';
@@ -7,6 +8,7 @@ import { AgentSelector } from '@core/features/agents/contributions/browser/agent
 import { nextDefaultConversationTitle } from '@core/features/conversations/api/browser/conversation-title-utils';
 import { conversationRegistry } from '@core/features/conversations/api/browser/stores/conversation-registry';
 import { useEffectiveProvider } from '@core/features/conversations/api/browser/use-effective-provider';
+import { providerPreferencesMemento } from '@core/features/conversations/contributions/mementos';
 import { getProjectSshConnectionId } from '@core/features/projects/api/browser/stores/project-selectors';
 // TODO(conversations-extraction): Pass task settings into the modal instead of importing task hooks.
 import { useTaskSettings } from '@core/features/tasks/api/browser/hooks/useTaskSettings';
@@ -15,9 +17,16 @@ import { projectAvailabilityUi } from '@core/manifests/browser/project-availabil
 import { agentSupportsAcp, agentSupportsAutoApprove } from '@core/primitives/agents/api';
 import type { ConversationType } from '@core/primitives/conversations/api';
 import { ConfirmButton } from '@core/primitives/keybindings/browser/confirm-button';
+import { getMementoClient } from '@core/primitives/mementos/browser';
+import { useMemento } from '@core/primitives/mementos/react';
 import { defineModal } from '@core/primitives/modals/react';
 import { useCloseGuard } from '@core/primitives/modals/react/use-close-guard';
 import { useLocalStorage } from '@core/primitives/react-hooks/browser/useLocalStorage';
+import {
+  patchProviderPreference,
+  providerPreference,
+  providerPreferenceKey,
+} from './provider-preferences';
 
 export const CreateConversationModal = observer(function CreateConversationModal({
   projectId,
@@ -34,11 +43,12 @@ export const CreateConversationModal = observer(function CreateConversationModal
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [autoApproveOverride, setAutoApproveOverride] = useState<boolean | null>(null);
-  const [selectedModel, setSelectedModel] = useState<string | null>(null);
   const [useChatUiPreference, setUseChatUiPreference] = useLocalStorage(
     'initial-conversation:chat-ui-enabled',
     false
   );
+  const [providerPreferences, setProviderPreferences] = useMemento(providerPreferencesMemento);
+  const [modelOverrides, setModelOverrides] = useState<Record<string, string | null>>({});
   const liveActionDisabledReason = projectAvailabilityUi.getLiveActionDisabledReason(projectId);
   useCloseGuard(isSubmitting);
 
@@ -51,6 +61,31 @@ export const CreateConversationModal = observer(function CreateConversationModal
   const showAutoApproveToggle = agentSupportsAutoApprove(selectedAgent?.capabilities);
   const showAcpToggle = agentSupportsAcp(selectedAgent?.capabilities);
   const useAcp = showAcpToggle && useChatUiPreference;
+  const transport = useAcp ? 'acp' : 'pty';
+  const host = formatHostRef(hostRefFromConnectionId(connectionId));
+  const preferenceKey = providerId ? providerPreferenceKey(host, providerId, transport) : null;
+  const savedPreference = providerId
+    ? providerPreference(providerPreferences, host, providerId, transport)
+    : undefined;
+  const savedModelUnsupported =
+    savedPreference?.model !== undefined &&
+    modelOptions !== null &&
+    modelOptions[savedPreference.model] === undefined;
+  const hasModelOverride =
+    preferenceKey !== null && Object.prototype.hasOwnProperty.call(modelOverrides, preferenceKey);
+  const selectedModel =
+    preferenceKey !== null && hasModelOverride
+      ? (modelOverrides[preferenceKey] ?? null)
+      : savedModelUnsupported
+        ? null
+        : (savedPreference?.model ?? null);
+  const setSelectedModel = useCallback(
+    (model: string | null) => {
+      if (!preferenceKey) return;
+      setModelOverrides((current) => ({ ...current, [preferenceKey]: model }));
+    },
+    [preferenceKey]
+  );
   const skipPermissions =
     showAutoApproveToggle && (autoApproveOverride ?? taskSettings.autoApproveByDefault);
   const title = providerId
@@ -63,11 +98,9 @@ export const CreateConversationModal = observer(function CreateConversationModal
       )
     : 'Conversation';
 
-  // Reset model when the provider changes (ids are provider-specific).
   const handleProviderChange = useCallback(
     (next: typeof providerId) => {
       setProviderOverride(next);
-      setSelectedModel(null);
     },
     [setProviderOverride]
   );
@@ -95,8 +128,19 @@ export const CreateConversationModal = observer(function CreateConversationModal
         provider: providerId,
         title,
         model: selectedModel ?? undefined,
+        modeId: conversationType === 'acp' ? savedPreference?.modeId : undefined,
+        effort: conversationType === 'acp' ? savedPreference?.effort : undefined,
         type: conversationType,
       });
+      try {
+        setProviderPreferences((current) =>
+          patchProviderPreference(current, host, providerId, conversationType, {
+            model: selectedModel,
+          })
+        );
+      } catch (preferenceError) {
+        getMementoClient().reportError(preferenceError);
+      }
       setIsSubmitting(false);
       complete({ conversationId: id, type: conversationType });
     } catch {
@@ -116,6 +160,10 @@ export const CreateConversationModal = observer(function CreateConversationModal
     skipPermissions,
     selectedModel,
     useAcp,
+    host,
+    savedPreference?.effort,
+    savedPreference?.modeId,
+    setProviderPreferences,
   ]);
 
   return (

--- a/apps/emdash-desktop/src/core/features/conversations/browser/provider-preferences.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/provider-preferences.test.ts
@@ -1,0 +1,52 @@
+import { formatHostRef, hostRef, LOCAL_HOST_REF } from '@emdash/core/primitives/host/api';
+import { describe, expect, it } from 'vitest';
+import type { ProviderPreferencesState } from '@core/features/conversations/contributions/mementos';
+import {
+  patchProviderPreference,
+  providerPreference,
+  providerPreferenceKey,
+} from './provider-preferences';
+
+describe('providerPreferenceKey', () => {
+  it('isolates hosts, providers, and transports', () => {
+    const local = formatHostRef(LOCAL_HOST_REF);
+    const remote = formatHostRef(hostRef('remote', 'ssh-1'));
+    expect(providerPreferenceKey(local, 'claude', 'acp')).not.toBe(
+      providerPreferenceKey(local, 'claude', 'pty')
+    );
+    expect(providerPreferenceKey(local, 'claude', 'acp')).not.toBe(
+      providerPreferenceKey(local, 'codex', 'acp')
+    );
+    expect(providerPreferenceKey(remote, 'claude', 'acp')).not.toBe(
+      providerPreferenceKey(local, 'claude', 'acp')
+    );
+  });
+
+  it('reads and patches one keyed preference without mutating the source document', () => {
+    const local = formatHostRef(LOCAL_HOST_REF);
+    const initial: ProviderPreferencesState = { version: '1', entries: {} };
+
+    const updated = patchProviderPreference(initial, local, 'claude', 'acp', {
+      model: 'sonnet',
+      modeId: 'agent',
+    });
+
+    expect(initial.entries).toEqual({});
+    expect(providerPreference(updated, local, 'claude', 'acp')).toEqual({
+      model: 'sonnet',
+      modeId: 'agent',
+    });
+    expect(providerPreference(updated, local, 'claude', 'pty')).toEqual({});
+  });
+
+  it('removes null fields and drops empty preference entries', () => {
+    const local = formatHostRef(LOCAL_HOST_REF);
+    const initial = patchProviderPreference({ version: '1', entries: {} }, local, 'claude', 'acp', {
+      model: 'sonnet',
+    });
+
+    const updated = patchProviderPreference(initial, local, 'claude', 'acp', { model: null });
+
+    expect(updated.entries).toEqual({});
+  });
+});

--- a/apps/emdash-desktop/src/core/features/conversations/browser/provider-preferences.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/provider-preferences.ts
@@ -1,0 +1,71 @@
+import type { SerializedHostRef } from '@emdash/core/primitives/host/api';
+import {
+  providerPreferencesMemento,
+  type ProviderPreference,
+  type ProviderPreferencesState,
+} from '@core/features/conversations/contributions/mementos';
+import { getMementoClient, type MementoHandle } from '@core/primitives/mementos/browser';
+import { appSubject } from '@core/primitives/subjects/api';
+
+export type ConversationTransport = 'acp' | 'pty';
+export type ProviderPreferencePatch = Partial<Record<keyof ProviderPreference, string | null>>;
+
+let handle: MementoHandle<ProviderPreferencesState> | null = null;
+
+export function providerPreferenceKey(
+  host: SerializedHostRef,
+  providerId: string,
+  transport: ConversationTransport
+): string {
+  return JSON.stringify([host, providerId, transport]);
+}
+
+export function providerPreference(
+  state: ProviderPreferencesState,
+  host: SerializedHostRef,
+  providerId: string,
+  transport: ConversationTransport
+): ProviderPreference {
+  return state.entries[providerPreferenceKey(host, providerId, transport)] ?? {};
+}
+
+export function patchProviderPreference(
+  state: ProviderPreferencesState,
+  host: SerializedHostRef,
+  providerId: string,
+  transport: ConversationTransport,
+  patch: ProviderPreferencePatch
+): ProviderPreferencesState {
+  const key = providerPreferenceKey(host, providerId, transport);
+  const next = { ...(state.entries[key] ?? {}) };
+  for (const [field, value] of Object.entries(patch) as Array<
+    [keyof ProviderPreference, string | null]
+  >) {
+    if (value === null) delete next[field];
+    else next[field] = value;
+  }
+  const entries = { ...state.entries };
+  if (Object.keys(next).length === 0) delete entries[key];
+  else entries[key] = next;
+  return { ...state, entries };
+}
+
+export async function updateProviderPreference(
+  host: SerializedHostRef,
+  providerId: string,
+  transport: ConversationTransport,
+  patch: ProviderPreferencePatch
+): Promise<void> {
+  const preferences = preferencesHandle();
+  await preferences.ready;
+  preferences.update((current) =>
+    patchProviderPreference(current, host, providerId, transport, patch)
+  );
+}
+
+function preferencesHandle(): MementoHandle<ProviderPreferencesState> {
+  if (handle) return handle;
+  const space = getMementoClient().subject(appSubject({}));
+  handle = space.handle(providerPreferencesMemento);
+  return handle;
+}

--- a/apps/emdash-desktop/src/core/features/conversations/contributions/mementos.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/contributions/mementos.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { ACP_DRAFT_MAX_LENGTH, acpDraftMemento, acpDraftSchema } from './mementos';
+import {
+  ACP_DRAFT_MAX_LENGTH,
+  acpDraftMemento,
+  acpDraftSchema,
+  providerPreferencesMemento,
+  providerPreferencesSchema,
+} from './mementos';
 
 describe('ACP draft memento', () => {
   it('retains up to 5000 conversation drafts for 90 days', () => {
@@ -31,5 +37,27 @@ describe('ACP draft memento', () => {
         attachments: [{ id: 'attachment-1', mimeType: 'text/plain', bytes: [1, 2, 3] }],
       }).success
     ).toBe(false);
+  });
+});
+
+describe('provider preferences memento', () => {
+  it('stores provider-native selections without expiring', () => {
+    expect(
+      providerPreferencesSchema.safeParse({
+        version: '1',
+        entries: {
+          '["local","claude","acp"]': {
+            model: 'sonnet',
+            modeId: 'agent-full-access',
+            effort: 'high',
+          },
+        },
+      }).status
+    ).toBe('ok');
+    expect(providerPreferencesMemento.retention).toEqual({
+      tier: 'persisted',
+      maxAge: Number.MAX_SAFE_INTEGER,
+      maxEntries: 1,
+    });
   });
 });

--- a/apps/emdash-desktop/src/core/features/conversations/contributions/mementos.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/contributions/mementos.ts
@@ -2,6 +2,7 @@ import { defineVersionedSchema } from '@emdash/core/primitives/versioned-schema/
 import { attachmentMimeTypeSchema } from '@emdash/core/runtimes/acp/api/client';
 import { z } from 'zod';
 import { days, defineMemento } from '@core/primitives/mementos/api';
+import { appSubject } from '@core/primitives/subjects/api';
 import { conversationSubject } from './subject';
 
 export const ACP_DRAFT_MAX_LENGTH = 65_536;
@@ -21,6 +22,24 @@ const acpDraftV1Schema = z.object({
 export const acpDraftSchema = defineVersionedSchema().initial('1', acpDraftV1Schema).build();
 export type AcpDraftState = typeof acpDraftSchema.Type;
 
+const providerPreferenceSchema = z.object({
+  model: z.string().optional(),
+  modeId: z.string().optional(),
+  effort: z.string().optional(),
+});
+
+export const providerPreferencesSchema = defineVersionedSchema()
+  .initial(
+    '1',
+    z.object({
+      version: z.literal('1'),
+      entries: z.record(z.string(), providerPreferenceSchema),
+    })
+  )
+  .build();
+export type ProviderPreference = z.infer<typeof providerPreferenceSchema>;
+export type ProviderPreferencesState = typeof providerPreferencesSchema.Type;
+
 export const acpDraftMemento = defineMemento({
   id: 'conversations.acp-draft',
   subject: conversationSubject,
@@ -31,4 +50,17 @@ export const acpDraftMemento = defineMemento({
     attachments: [],
   },
   retention: { tier: 'persisted', maxAge: days(90), maxEntries: 5_000 },
+});
+
+export const providerPreferencesMemento = defineMemento({
+  id: 'conversations.provider-preferences',
+  subject: appSubject,
+  schema: providerPreferencesSchema,
+  default: { version: '1' as const, entries: {} },
+  retention: {
+    tier: 'persisted',
+    // Effectively non-expiring; the memento service requires a finite retention window.
+    maxAge: Number.MAX_SAFE_INTEGER,
+    maxEntries: 1,
+  },
 });

--- a/apps/emdash-desktop/src/core/features/conversations/node/createConversation.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/createConversation.test.ts
@@ -151,6 +151,28 @@ describe('createConversation', () => {
     expect(db.inserted[0]).toMatchObject({ cwd: '/work/repo', workspacePath: '/work/repo' });
   });
 
+  it('stores provider-native ACP model, mode, and effort defaults', async () => {
+    await createConversation(
+      {
+        ...baseParams,
+        model: 'sonnet',
+        modeId: 'agent-full-access',
+        effort: 'high',
+      },
+      dependencies()
+    );
+
+    expect(hostConversations.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          model: 'sonnet',
+          modeId: 'agent-full-access',
+          effort: 'high',
+        }),
+      })
+    );
+  });
+
   it('refuses creation against an unreachable remote host before touching the host or DB', async () => {
     const deps = dependencies({
       hostIsReachable: vi.fn(() => false),

--- a/apps/emdash-desktop/src/core/features/conversations/node/createConversation.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/createConversation.ts
@@ -97,6 +97,8 @@ export async function createConversation(
           type: 'acp',
           ...(params.autoApprove !== undefined && { autoApprove: params.autoApprove }),
           ...(params.model && { model: params.model }),
+          ...(params.modeId && { modeId: params.modeId }),
+          ...(params.effort && { effort: params.effort }),
           ...(initialQueue?.length && { initialQueue }),
         }
       : {

--- a/apps/emdash-desktop/src/core/features/conversations/node/set-acp-config-option.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/set-acp-config-option.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ConversationConfig } from '@core/primitives/conversations/api';
+import type { HostConversationMutationDeps } from './host-mutation';
+import { setConversationAcpConfigOption } from './set-acp-config-option';
+
+describe('setConversationAcpConfigOption', () => {
+  it('persists model and effort and can clear an unsupported stored selection', async () => {
+    const { deps, hostCalls } = fakeDeps({
+      version: '1',
+      type: 'acp',
+      model: 'old-model',
+      modeId: 'agent',
+    });
+
+    await expect(
+      setConversationAcpConfigOption(deps, 'conversation-1', 'effort', 'high')
+    ).resolves.toMatchObject({ success: true, data: { changed: true } });
+    expect(hostCalls.at(-1)?.config).toMatchObject({ effort: 'high' });
+
+    const clearing = fakeDeps({
+      version: '1',
+      type: 'acp',
+      model: 'unsupported-model',
+      modeId: 'agent',
+    });
+    await setConversationAcpConfigOption(clearing.deps, 'conversation-1', 'model', null);
+    expect(clearing.hostCalls.at(-1)?.config).toEqual({
+      version: '1',
+      type: 'acp',
+      modeId: 'agent',
+    });
+  });
+});
+
+function fakeDeps(config: ConversationConfig) {
+  const hostCalls: Array<{ conversationId: string; config: ConversationConfig }> = [];
+  const host = {
+    updateConfig: vi.fn(async (input: { conversationId: string; config: ConversationConfig }) => {
+      hostCalls.push(input);
+      return { success: true as const, data: { ...input, updatedAt: Date.now() } };
+    }),
+  };
+  const database = {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => [
+            {
+              config,
+              projectId: 'project-1',
+              taskId: 'task-1',
+              location: 'local',
+              sshConnectionId: null,
+            },
+          ],
+        }),
+      }),
+    }),
+    update: () => ({
+      set: () => ({ where: () => ({ run: () => ({ changes: 1 }) }) }),
+    }),
+  };
+  const deps: HostConversationMutationDeps = {
+    db: database as never,
+    runtimes: {
+      client: vi.fn(async () => ({
+        success: true as const,
+        data: { conversations: host },
+      })),
+    } as never,
+    hostIsReachable: () => true,
+  };
+  return { deps, hostCalls };
+}

--- a/apps/emdash-desktop/src/core/features/conversations/node/set-acp-config-option.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/set-acp-config-option.ts
@@ -1,0 +1,69 @@
+import { err, ok, type BaseError, type Result } from '@emdash/shared';
+import { createConversationRegistry } from '@core/features/conversations/api/node/registry';
+import type { ConversationConfig, ConversationConfigAcp } from '@core/primitives/conversations/api';
+import type { HostConversationMutationDeps } from './host-mutation';
+import { resolveConversationHostClient } from './host-mutation';
+
+export type AcpPersistedConfigKey = 'model' | 'modeId' | 'effort';
+
+export type SetAcpConfigOptionError = BaseError<
+  'empty-value' | 'conversation-not-found' | 'not-acp-conversation' | 'host-rejected'
+>;
+
+export type SetAcpConfigOptionResult = {
+  projectId: string | null;
+  taskId: string | null;
+  changed: boolean;
+};
+
+/** Persists one provider-native ACP selection through the authoritative host config. */
+export async function setConversationAcpConfigOption(
+  deps: HostConversationMutationDeps,
+  conversationId: string,
+  key: AcpPersistedConfigKey,
+  value: string | null
+): Promise<Result<SetAcpConfigOptionResult, SetAcpConfigOptionError>> {
+  const normalized = value?.trim() || null;
+  if (value !== null && normalized === null) return err({ type: 'empty-value' });
+
+  let resolved: Awaited<ReturnType<typeof resolveConversationHostClient>>;
+  try {
+    resolved = await resolveConversationHostClient(deps, conversationId);
+  } catch (error) {
+    return err({
+      type: 'conversation-not-found',
+      message: error instanceof Error ? error.message : conversationId,
+    });
+  }
+  const { row, client } = resolved;
+  if (row.config?.type !== 'acp') {
+    return err({ type: 'not-acp-conversation', message: conversationId });
+  }
+
+  const context = { projectId: row.projectId, taskId: row.taskId };
+  if ((row.config[key] ?? null) === normalized) return ok({ ...context, changed: false });
+
+  const config = patchAcpConfig(row.config, key, normalized);
+  const updated = await client.updateConfig({ conversationId, config });
+  if (!updated.success) {
+    return err({ type: 'host-rejected', message: updated.error.message });
+  }
+
+  createConversationRegistry(deps.db).refresh(conversationId, {
+    config: updated.data.config as ConversationConfig,
+    updatedAt: new Date(updated.data.updatedAt).toISOString(),
+    lastObservedAt: new Date().toISOString(),
+  });
+  return ok({ ...context, changed: true });
+}
+
+function patchAcpConfig(
+  config: ConversationConfigAcp,
+  key: AcpPersistedConfigKey,
+  value: string | null
+): ConversationConfigAcp {
+  if (value !== null) return { ...config, [key]: value };
+  const next = { ...config };
+  delete next[key];
+  return next;
+}

--- a/apps/emdash-desktop/src/core/features/conversations/node/set-mode-id.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/set-mode-id.ts
@@ -1,8 +1,6 @@
 import { err, ok, type BaseError, type Result } from '@emdash/shared';
-import { createConversationRegistry } from '@core/features/conversations/api/node/registry';
-import type { ConversationConfig } from '@core/primitives/conversations/api';
 import type { HostConversationMutationDeps } from './host-mutation';
-import { resolveConversationHostClient } from './host-mutation';
+import { setConversationAcpConfigOption } from './set-acp-config-option';
 
 export type SetModeIdError = BaseError<
   'empty-mode-id' | 'conversation-not-found' | 'not-acp-conversation' | 'host-rejected'
@@ -25,36 +23,7 @@ export async function setConversationModeId(
   const trimmed = modeId.trim();
   if (!trimmed) return err({ type: 'empty-mode-id' });
 
-  let resolved: Awaited<ReturnType<typeof resolveConversationHostClient>>;
-  try {
-    resolved = await resolveConversationHostClient(deps, conversationId);
-  } catch (error) {
-    return err({
-      type: 'conversation-not-found',
-      message: error instanceof Error ? error.message : conversationId,
-    });
-  }
-  const { row, client } = resolved;
-  if (row.config?.type !== 'acp') {
-    return err({ type: 'not-acp-conversation', message: conversationId });
-  }
-
-  const context = { projectId: row.projectId, taskId: row.taskId };
-  if (row.config.modeId === trimmed) return ok(context);
-
-  const updated = await client.updateConfig({
-    conversationId,
-    config: { ...row.config, modeId: trimmed },
-  });
-  if (!updated.success) {
-    return err({ type: 'host-rejected', message: updated.error.message });
-  }
-
-  createConversationRegistry(deps.db).refresh(conversationId, {
-    config: updated.data.config as ConversationConfig,
-    updatedAt: new Date(updated.data.updatedAt).toISOString(),
-    lastObservedAt: new Date().toISOString(),
-  });
-
-  return ok(context);
+  const result = await setConversationAcpConfigOption(deps, conversationId, 'modeId', trimmed);
+  if (!result.success) return err(result.error as SetModeIdError);
+  return ok({ projectId: result.data.projectId, taskId: result.data.taskId });
 }

--- a/apps/emdash-desktop/src/core/features/conversations/node/sweep/conversation-deletion-sweep.db.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/sweep/conversation-deletion-sweep.db.test.ts
@@ -26,10 +26,10 @@ describe('conversation deletion sweep (integration)', () => {
   let scope: Scope;
   let clock: ManualClock;
   let hostVerbs: {
-    killAcp: SessionKillMock;
+    terminateAcp: SessionKillMock;
     deleteTui: SessionKillMock;
     deleteRecord: IndexDeleteMock;
-    deleteAttachments: SessionKillMock;
+    purgeConversationData: SessionKillMock;
   };
   let reachable: boolean;
 
@@ -39,10 +39,10 @@ describe('conversation deletion sweep (integration)', () => {
     clock = new ManualClock(Date.parse('2026-02-01T00:00:00.000Z'));
     reachable = true;
     hostVerbs = {
-      killAcp: vi.fn(async () => ok(undefined)),
+      terminateAcp: vi.fn(async () => ok(undefined)),
       deleteTui: vi.fn(async () => ok(undefined)),
       deleteRecord: vi.fn(async () => ok(undefined)),
-      deleteAttachments: vi.fn(async () => ok(undefined)),
+      purgeConversationData: vi.fn(async () => ok(undefined)),
     };
   });
 
@@ -57,8 +57,8 @@ describe('conversation deletion sweep (integration)', () => {
         reachable
           ? ok({
               acp: {
-                kill: hostVerbs.killAcp,
-                deleteAttachments: hostVerbs.deleteAttachments,
+                terminate: hostVerbs.terminateAcp,
+                purgeConversationData: hostVerbs.purgeConversationData,
               },
               tuiAgents: { delete: hostVerbs.deleteTui },
               conversations: { delete: hostVerbs.deleteRecord },
@@ -112,7 +112,7 @@ describe('conversation deletion sweep (integration)', () => {
     service.attachHost(LOCAL_HOST_REF);
     await vi.waitFor(() => expect(hostVerbs.deleteRecord).toHaveBeenCalledTimes(1));
     // Killing the live session is part of the verb, ordered before the index delete.
-    expect(hostVerbs.killAcp).toHaveBeenCalledWith({ conversationId: 'conv-1' });
+    expect(hostVerbs.terminateAcp).toHaveBeenCalledWith({ conversationId: 'conv-1' });
     expect(hostVerbs.deleteTui).toHaveBeenCalledWith({ conversationId: 'conv-1' });
     expect(hostVerbs.deleteRecord).toHaveBeenCalledWith({ conversationId: 'conv-1' });
 

--- a/apps/emdash-desktop/src/core/features/conversations/node/wire-controller.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/wire-controller.test.ts
@@ -32,7 +32,9 @@ const target = {
   conversationType: 'acp',
   providerId: 'claude',
   sessionId: null,
+  model: null,
   modeId: null,
+  effort: null,
   workspacePath: '/repo',
   host: LOCAL_HOST_REF,
   acpInput: {
@@ -47,19 +49,71 @@ const target = {
 type TestRuntimeTarget = typeof target;
 
 describe('createConversationsWireController', () => {
-  it('passes ACP session start through without a client session id write', async () => {
-    const start = vi.fn(async () => ok({ sessionId: 'session-1' }));
-    const controller = setupController({
-      client: { acp: { start } },
-    });
+  it('attaches with the trusted descriptor and activates while loading history', async () => {
+    const attach = vi.fn(async () => ok(undefined));
+    const loadHistory = vi.fn(async () => ok({ turns: [], nextCursor: null }));
+    const controller = setupController({ client: { acp: { attach, loadHistory } } });
 
     await expect(
-      controller.call('acp.start', { conversationId: target.conversationId })
-    ).resolves.toEqual(ok({ sessionId: 'session-1' }));
+      controller.call('acp.attach', { conversationId: target.conversationId })
+    ).resolves.toEqual(ok(undefined));
+    await expect(
+      controller.call('acp.loadHistory', { conversationId: target.conversationId, limit: 100 })
+    ).resolves.toEqual(ok({ turns: [], nextCursor: null }));
 
-    // The ACP runtime reports the session id into the conversation index (spec §3.3);
-    // the desktop no longer persists it from the response.
-    expect(start).toHaveBeenCalledWith(target.acpInput, {});
+    expect(attach).toHaveBeenCalledWith(target.acpInput, {});
+    expect(loadHistory).toHaveBeenCalledWith(
+      { conversationId: target.conversationId, limit: 100 },
+      {}
+    );
+  });
+
+  it('acknowledges config mutations only after host config persistence succeeds', async () => {
+    const setOption = vi.fn(async () => ok(undefined));
+    const persistAcpConfigOption = vi.fn(async () => {});
+    const controller = setupController({
+      client: { acp: { setOption } },
+      hooks: { persistAcpConfigOption },
+    });
+    const input = {
+      conversationId: target.conversationId,
+      key: 'effort' as const,
+      value: 'high',
+    };
+
+    await expect(controller.call('acp.setOption', input)).resolves.toEqual(ok(undefined));
+    expect(persistAcpConfigOption).toHaveBeenCalledWith(target, 'effort', 'high');
+
+    persistAcpConfigOption.mockRejectedValueOnce(new Error('host rejected write'));
+    await expect(controller.call('acp.setOption', input)).resolves.toMatchObject({
+      success: false,
+      error: { type: 'set_config_failed', cause: { message: 'host rejected write' } },
+    });
+  });
+
+  it('clears unsupported selections reported by activation from host config', async () => {
+    const loadHistory = vi.fn(async () =>
+      ok({
+        turns: [],
+        nextCursor: null,
+        clearedConfiguration: ['model', 'modeId'] as const,
+      })
+    );
+    const persistAcpConfigOption = vi.fn(async () => {});
+    const controller = setupController({
+      client: { acp: { loadHistory } },
+      hooks: { persistAcpConfigOption },
+    });
+
+    await controller.call('acp.loadHistory', {
+      conversationId: target.conversationId,
+      limit: 50,
+    });
+
+    expect(persistAcpConfigOption.mock.calls).toEqual([
+      [target, 'model', null],
+      [target, 'modeId', null],
+    ]);
   });
 
   it('disables the worker Wire deadline for the turn-long ACP prompt call', async () => {
@@ -240,7 +294,10 @@ describe('createConversationsWireController', () => {
     });
 
     await expect(
-      controller.call('acp.start', { conversationId: target.conversationId })
+      controller.call('acp.loadHistory', {
+        conversationId: target.conversationId,
+        limit: 50,
+      })
     ).resolves.toEqual(err(resolveError));
     await expect(
       controller.call('acp.downloadAttachment', {
@@ -292,12 +349,16 @@ function setupController(options: {
   attachmentError?: { type: 'project-missing'; projectId: string };
   resolvedHosts?: HostRef[];
   hooks?: Partial<{
-    persistAcpMode: (target: TestRuntimeTarget, modeId: string) => Promise<void>;
+    persistAcpConfigOption: (
+      target: TestRuntimeTarget,
+      key: 'model' | 'modeId' | 'effort',
+      value: string | null
+    ) => Promise<void>;
     recordTuiInput: (target: TestRuntimeTarget) => Promise<void>;
   }>;
 }) {
   const hooks = {
-    persistAcpMode: async () => {},
+    persistAcpConfigOption: async () => {},
     recordTuiInput: async () => {},
     ...options.hooks,
   };

--- a/apps/emdash-desktop/src/core/features/conversations/node/wire-controller.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/wire-controller.ts
@@ -4,7 +4,8 @@ import {
   type HostRef,
   type SerializedHostRef,
 } from '@emdash/core/primitives/host/api';
-import { err, ok, type Result } from '@emdash/shared';
+import { acpErr } from '@emdash/core/runtimes/acp/api/client';
+import { err, ok, toSerializedError, type Result } from '@emdash/shared';
 import type { Logger } from '@emdash/shared/logger';
 import type { LiveSource } from '@emdash/wire/rpc';
 import { createController, type CallMeta, type Controller } from '@emdash/wire/rpc';
@@ -12,7 +13,10 @@ import { and, eq } from 'drizzle-orm';
 import { conversationRegistryTable as conversations } from '@core/features/conversations/api/node/registry';
 import { createConversationOperations } from '@core/features/conversations/node/controller';
 import type { CompensationRunner } from '@core/features/conversations/node/createConversation';
-import { setConversationModeId } from '@core/features/conversations/node/set-mode-id';
+import {
+  setConversationAcpConfigOption,
+  type AcpPersistedConfigKey,
+} from '@core/features/conversations/node/set-acp-config-option';
 import type { ProjectAttachmentError } from '@core/features/projects/api';
 import {
   requireAttachedProjectOrThrow,
@@ -41,7 +45,9 @@ type ConversationRuntimeTarget = Readonly<{
   conversationType: 'pty' | 'acp';
   providerId: string | null;
   sessionId: string | null;
+  model: string | null;
   modeId: string | null;
+  effort: string | null;
   workspacePath?: string;
   host: HostRef;
   acpInput?: ConversationsAcpStartInput;
@@ -52,7 +58,11 @@ type WorkspaceIdentityResolver = Readonly<{
 }>;
 
 type ConversationRuntimeHooks = Readonly<{
-  persistAcpMode(target: ConversationRuntimeTarget, modeId: string): Promise<void>;
+  persistAcpConfigOption(
+    target: ConversationRuntimeTarget,
+    key: AcpPersistedConfigKey,
+    value: string | null
+  ): Promise<void>;
   recordTuiInput(target: ConversationRuntimeTarget): Promise<void>;
 }>;
 
@@ -161,34 +171,24 @@ export function createConversationsWireController(
       conversationOperations.deleteHostConversation(conversationId),
     events: conversationWireEvents,
     acp: {
-      // The returned session id is not persisted client-side: the ACP runtime reports it
-      // into the conversation index (spec §3.3) and convergence caches it here.
-      start: async ({ conversationId }, meta) => {
-        const runtimeTarget = await target(conversationId);
-        if (!runtimeTarget.acpInput) {
-          throw missingAcpInputError(runtimeTarget);
-        }
-        const input = runtimeTarget.acpInput;
-        return withConversationRuntime(options, Promise.resolve(runtimeTarget), (client) =>
-          client.acp.start(input, callOptions(meta))
-        );
-      },
-      resume: async ({ conversationId }, meta) => {
+      attach: async ({ conversationId }, meta) => {
         const runtimeTarget = await target(conversationId);
         const input = runtimeTarget.acpInput;
-        if (!input) {
-          throw missingAcpInputError(runtimeTarget);
-        }
-        if (!input.sessionId) {
-          throw new Error(`Conversation '${conversationId}' has no ACP session to resume`);
-        }
-        const sessionId = input.sessionId;
+        if (!input) throw missingAcpInputError(runtimeTarget);
         return withConversationRuntime(options, Promise.resolve(runtimeTarget), (client) =>
-          client.acp.resume({ ...input, sessionId }, callOptions(meta))
+          client.acp.attach(input, callOptions(meta))
         );
       },
-      kill: (input, meta) =>
-        run(input.conversationId, (client) => client.acp.kill(input, callOptions(meta))),
+      loadHistory: async (input, meta) => {
+        const runtimeTarget = await target(input.conversationId);
+        return withConversationRuntime(options, Promise.resolve(runtimeTarget), async (client) => {
+          const result = await client.acp.loadHistory(input, callOptions(meta));
+          await persistClearedConfiguration(hooks, runtimeTarget, result, options.logger);
+          return result;
+        });
+      },
+      terminate: (input, meta) =>
+        run(input.conversationId, (client) => client.acp.terminate(input, callOptions(meta))),
       sendPrompt: (input, meta) =>
         run(input.conversationId, (client) =>
           client.acp.sendPrompt(input, { ...callOptions(meta), timeoutMs: 0 })
@@ -207,16 +207,23 @@ export function createConversationsWireController(
         ),
       cancelTurn: (input, meta) =>
         run(input.conversationId, (client) => client.acp.cancelTurn(input, callOptions(meta))),
-      setModelOption: (input, meta) =>
-        run(input.conversationId, (client) => client.acp.setModelOption(input, callOptions(meta))),
-      setModeOption: async (input, meta) => {
+      setOption: async (input, meta) => {
         const runtimeTarget = await target(input.conversationId);
         return withConversationRuntime(options, Promise.resolve(runtimeTarget), async (client) => {
-          const result = await client.acp.setModeOption(input, callOptions(meta));
-          if (result.success) {
-            await hooks.persistAcpMode(runtimeTarget, input.value);
+          const result = await client.acp.setOption(input, callOptions(meta));
+          if (!result.success) return result;
+          try {
+            await hooks.persistAcpConfigOption(
+              runtimeTarget,
+              input.key === 'mode' ? 'modeId' : input.key,
+              input.value
+            );
+            return result;
+          } catch (error) {
+            return input.key === 'mode'
+              ? acpErr.setModeFailed(toSerializedError(error))
+              : acpErr.setConfigFailed(toSerializedError(error));
           }
-          return result;
         });
       },
       resolvePermission: (input, meta) =>
@@ -239,8 +246,6 @@ export function createConversationsWireController(
         run(conversationId, (client) =>
           client.acp.deleteAttachment({ conversationId, attachmentId }, callOptions(meta))
         ),
-      getHistory: (input, meta) =>
-        run(input.conversationId, (client) => client.acp.getHistory(input, callOptions(meta))),
       sessions: acpSessions,
       session: acpSession,
       terminalOutput: async ({ conversationId, terminalId }) =>
@@ -288,27 +293,29 @@ function createDefaultRuntimeHooks(
 ): ConversationRuntimeHooks {
   const { db, logger, telemetry, runtimes, hostIsReachable } = options;
   return {
-    async persistAcpMode(target, modeId) {
-      const result = await setConversationModeId(
+    async persistAcpConfigOption(target, key, value) {
+      const result = await setConversationAcpConfigOption(
         { db, runtimes, hostIsReachable },
         target.conversationId,
-        modeId
+        key,
+        value
       );
       if (!result.success) {
-        logger.warn('ACP runtime failed to persist selected mode id', {
+        logger.warn('ACP runtime failed to persist selected configuration', {
           conversationId: target.conversationId,
+          key,
           error: result.error,
         });
-        return;
+        throw new Error(result.error.message ?? result.error.type);
       }
-      if (target.modeId === modeId) return;
+      if (!result.data.changed || value === null) return;
       if (result.data.taskId === null || result.data.projectId === null) return;
       conversationWireEvents.emit(undefined, {
         type: 'changed',
         conversationId: target.conversationId,
         taskId: result.data.taskId,
         projectId: result.data.projectId,
-        changes: { modeId },
+        changes: { [key]: value },
       });
     },
     // Recency is a host fact now: the runtime's activity report feeds
@@ -388,6 +395,7 @@ async function resolveConversationRuntimeTarget(
           sessionId: row.sessionId,
           model: acpConfig?.model ?? null,
           modeId: acpConfig?.modeId ?? null,
+          effort: acpConfig?.effort ?? null,
           ...(initialQueue && { initialQueue }),
           ...(providerEnv && { env: providerEnv }),
         }
@@ -400,7 +408,9 @@ async function resolveConversationRuntimeTarget(
     conversationType: row.type === 'acp' ? 'acp' : 'pty',
     providerId: row.providerId,
     sessionId: row.sessionId,
+    model: acpConfig?.model ?? null,
     modeId: acpConfig?.modeId ?? null,
+    effort: acpConfig?.effort ?? null,
     workspacePath,
     host: identity?.host ?? LOCAL_HOST_REF,
     acpInput,
@@ -425,6 +435,26 @@ async function withConversationRuntime<T, E>(
 
 function callOptions(meta: CallMeta): { signal?: AbortSignal } {
   return meta.signal ? { signal: meta.signal } : {};
+}
+
+async function persistClearedConfiguration(
+  hooks: ConversationRuntimeHooks,
+  target: ConversationRuntimeTarget,
+  result: Result<{ clearedConfiguration?: Array<'model' | 'modeId' | 'effort'> }, unknown>,
+  logger: Logger
+): Promise<void> {
+  if (!result.success) return;
+  for (const key of result.data.clearedConfiguration ?? []) {
+    try {
+      await hooks.persistAcpConfigOption(target, key, null);
+    } catch (error) {
+      logger.warn('ACP runtime failed to clear unsupported stored configuration', {
+        conversationId: target.conversationId,
+        key,
+        error: String(error),
+      });
+    }
+  }
 }
 
 async function resolveConversationRuntimeSource(

--- a/apps/emdash-desktop/src/core/manifests/shared/memento-catalog.ts
+++ b/apps/emdash-desktop/src/core/manifests/shared/memento-catalog.ts
@@ -1,4 +1,7 @@
-import { acpDraftMemento } from '@core/features/conversations/contributions/mementos';
+import {
+  acpDraftMemento,
+  providerPreferencesMemento,
+} from '@core/features/conversations/contributions/mementos';
 import {
   projectPanelLayoutsMemento,
   projectViewMemento,
@@ -26,6 +29,7 @@ import { workbenchHistoryMemento } from '@core/primitives/navigation/api/memento
  */
 export const mementoCatalog: readonly MementoCatalogEntry[] = [
   acpDraftMemento,
+  providerPreferencesMemento,
   projectViewMemento,
   projectPanelLayoutsMemento,
   workspaceChromeMemento,

--- a/apps/emdash-desktop/src/core/primitives/conversations/api/conversation-config.test.ts
+++ b/apps/emdash-desktop/src/core/primitives/conversations/api/conversation-config.test.ts
@@ -97,6 +97,21 @@ describe('conversation-config v1 schema', () => {
     }
   });
 
+  it('round-trips effort on a v1 acp config', () => {
+    const config = conversationConfig.safeParse({
+      version: '1',
+      type: 'acp',
+      effort: 'high',
+    });
+    expect(config.status).toBe('ok');
+    if (config.status === 'ok') {
+      expect(config.data.type === 'acp' && config.data.effort).toBe('high');
+      expect(conversationConfig.parseJson(conversationConfig.serialize(config.data))).toEqual(
+        config.data
+      );
+    }
+  });
+
   it('returns invalid for non-object input', () => {
     expect(conversationConfig.safeParse('not-json')).toMatchObject({ status: 'invalid' });
     expect(conversationConfig.safeParse(null)).toMatchObject({ status: 'invalid' });

--- a/apps/emdash-desktop/src/core/primitives/conversations/api/conversation-config.ts
+++ b/apps/emdash-desktop/src/core/primitives/conversations/api/conversation-config.ts
@@ -37,6 +37,8 @@ const acpConfigV1 = z.object({
   model: z.string().optional(),
   /** Last user-selected ACP session mode id (provider-specific), re-applied on session start. */
   modeId: z.string().optional(),
+  /** Last user-selected provider reasoning/effort id, re-applied on session start. */
+  effort: z.string().optional(),
 });
 
 export const conversationConfig = defineVersionedSchema()

--- a/apps/emdash-desktop/src/core/primitives/conversations/api/conversations.ts
+++ b/apps/emdash-desktop/src/core/primitives/conversations/api/conversations.ts
@@ -31,6 +31,8 @@ export type Conversation = {
   model?: string;
   /** Last user-selected ACP session mode id (provider-specific), re-applied on session start. */
   modeId?: string;
+  /** Last user-selected ACP reasoning/effort id, re-applied on session start. */
+  effort?: string;
   /** Initial queued prompts to deliver on first ACP spawn. Only present before sessionId is set. */
   initialQueue?: InitialQueuePrompt[];
   isInitialConversation: boolean | null;
@@ -47,7 +49,10 @@ export type ConversationEvent =
       taskId: string;
       projectId: string;
       changes: Partial<
-        Pick<Conversation, 'lastInteractedAt' | 'title' | 'sessionId' | 'model' | 'modeId'>
+        Pick<
+          Conversation,
+          'lastInteractedAt' | 'title' | 'sessionId' | 'model' | 'modeId' | 'effort'
+        >
       >;
     }
   | { type: 'created'; conversation: Conversation }
@@ -105,6 +110,10 @@ export type CreateConversationParams = {
   autoApprove?: boolean;
   /** Model to pass to the agent CLI. Absent or empty string means use the CLI default. */
   model?: string;
+  /** Provider-native ACP mode id to apply on first activation. */
+  modeId?: string;
+  /** Provider-native ACP reasoning/effort id to apply on first activation. */
+  effort?: string;
   isInitialConversation?: boolean;
   initialSize?: { cols: number; rows: number };
   initialPrompt?: string;

--- a/apps/emdash-desktop/src/main/core/runtime/operations/session-cleanup.ts
+++ b/apps/emdash-desktop/src/main/core/runtime/operations/session-cleanup.ts
@@ -119,7 +119,7 @@ export async function killLifecycleAcpSessions(
   if (targets.acpConversationIds.length === 0) return;
   const client = await dependencies.getAcpRuntimeClient();
   for (const conversationId of targets.acpConversationIds) {
-    const result = await client.kill({ conversationId });
+    const result = await client.terminate({ conversationId });
     if (!result.success && !isMissingError(result.error)) {
       throw new Error(errorMessage(result.error));
     }

--- a/apps/emdash-desktop/src/main/gateway/desktop-workers.ts
+++ b/apps/emdash-desktop/src/main/gateway/desktop-workers.ts
@@ -458,7 +458,7 @@ function startDesktopWorkersWithHost(
               // Creation admission is a desktop-mirror data check (ADR 0006): tombstones
               // live in the app db, so the main process answers for the worker.
               creationAdmission: createAutomationCreationAdmissionController(getAppDb),
-              acpSessions: acp,
+              acpLauncher: acp,
               tuiSessions: tuiAgents.client,
               conversationIndex: conversationsClient,
             },

--- a/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
@@ -469,25 +469,65 @@ describe('AcpChatStore prompt submission', () => {
     await vi.waitFor(() => expect(sendPrompt).toHaveBeenCalled());
     expect(chatSessionTestState.pendingPrompt).toMatchObject({ text: 'wake up' });
 
-    live.getHistory.mockClear();
+    live.loadHistory.mockClear();
     connectSessionOptions?.onTurnCommitted?.();
-    await vi.waitFor(() => expect(live.getHistory).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(live.loadHistory).toHaveBeenCalledTimes(1));
     expect(chatSessionTestState.pendingPrompt).toMatchObject({ text: 'wake up' });
 
     finishPrompt();
     store.dispose();
   });
 
+  it('keeps the attached composer available when background activation fails', async () => {
+    const loadHistory = vi.fn(async () => ({
+      success: false as const,
+      error: { type: 'initialize_failed' as const, cause: { message: 'restore failed' } },
+    }));
+    const live = fakeLiveSession(suspendedState(), unavailableHistory(), {
+      loadHistory,
+    });
+
+    const store = await bootstrapWithSession(live.session);
+
+    expect(store.session).toBe(live.session);
+    expect(store.loadError).not.toBeNull();
+    expect(store.affordances).toMatchObject({ isBusy: false, canSubmit: true });
+    expect(loadHistory).toHaveBeenCalledTimes(1);
+    store.dispose();
+  });
+
+  it('does not remember a rejected provider change as a future default', async () => {
+    const setOption = vi.fn(async () => ({
+      success: false as const,
+      error: { type: 'set_mode_failed' as const, cause: { message: 'rejected' } },
+    }));
+    const store = createStore(idleState(), vi.fn(), { setOption });
+    const rememberPreference = vi
+      .spyOn(
+        store as unknown as {
+          _rememberPreference(patch: { modeId: string }): Promise<void>;
+        },
+        '_rememberPreference'
+      )
+      .mockResolvedValue();
+
+    store.setMode('agent-full-access');
+
+    await vi.waitFor(() => expect(setOption).toHaveBeenCalledWith('mode', 'agent-full-access'));
+    expect(rememberPreference).not.toHaveBeenCalled();
+    store.dispose();
+  });
+
   it('keeps the ordinary active-turn completion history refresh', async () => {
     const live = fakeLiveSession(idleState(), historyPage('initial'));
     const store = await bootstrapWithSession(live.session);
-    live.getHistory.mockClear();
+    live.loadHistory.mockClear();
     historySeed.mockClear();
-    live.getHistory.mockResolvedValueOnce({ success: true, data: historyPage('completed') });
+    live.loadHistory.mockResolvedValueOnce({ success: true, data: historyPage('completed') });
 
     connectSessionOptions?.onTurnCommitted?.();
 
-    await vi.waitFor(() => expect(live.getHistory).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(live.loadHistory).toHaveBeenCalledTimes(1));
     expect(historySeed).toHaveBeenCalledTimes(1);
     expect(historySeed).toHaveBeenCalledWith([expect.objectContaining({ id: 'completed' })]);
     store.dispose();
@@ -496,13 +536,13 @@ describe('AcpChatStore prompt submission', () => {
   it('keeps rendered history when a suspension-driven refresh is unavailable', async () => {
     const live = fakeLiveSession(idleState(), historyPage('rendered'));
     const store = await bootstrapWithSession(live.session);
-    live.getHistory.mockClear();
+    live.loadHistory.mockClear();
     historySeed.mockClear();
-    live.getHistory.mockResolvedValueOnce({ success: true, data: unavailableHistory() });
+    live.loadHistory.mockResolvedValueOnce({ success: true, data: unavailableHistory() });
 
     connectSessionOptions?.onTurnCommitted?.();
 
-    await vi.waitFor(() => expect(live.getHistory).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(live.loadHistory).toHaveBeenCalledTimes(1));
     expect(historySeed).not.toHaveBeenCalled();
     expect(transcriptTestState.committedTurns).toEqual([
       expect.objectContaining({ id: 'rendered' }),
@@ -513,26 +553,26 @@ describe('AcpChatStore prompt submission', () => {
   it('coalesces replay completion into one refresh without dropping the pending prompt', async () => {
     const live = fakeLiveSession(suspendedState(), historyPage('rendered'));
     const store = await bootstrapWithSession(live.session);
-    live.getHistory.mockClear();
+    live.loadHistory.mockClear();
     historySeed.mockClear();
     historySeed.mockImplementation((turns) => {
       transcriptTestState.committedTurns = turns;
       setPendingPrompt(null);
     });
-    live.getHistory.mockResolvedValue({ success: true, data: historyPage('replayed') });
+    live.loadHistory.mockResolvedValue({ success: true, data: historyPage('replayed') });
     setPendingPrompt({ id: 'optimistic-1', text: 'continue' });
 
-    live.sessionState.set({ ...idleState(), lifecycle: 'replaying', canSubmit: false });
+    live.sessionState.set({ ...idleState(), lifecycle: 'replaying', canSubmit: true });
     expect(store.affordances).toMatchObject({
       isWorking: false,
-      isBusy: true,
+      isBusy: false,
       isResuming: true,
-      canSubmit: false,
+      canSubmit: true,
     });
     live.sessionState.set(idleState());
     live.sessionState.set(idleState());
 
-    await vi.waitFor(() => expect(live.getHistory).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(live.loadHistory).toHaveBeenCalledTimes(1));
     expect(historySeed).toHaveBeenCalledTimes(1);
     expect(historySeed).toHaveBeenCalledWith([expect.objectContaining({ id: 'replayed' })]);
     expect(chatSessionTestState.pendingPrompt).toEqual({
@@ -546,18 +586,18 @@ describe('AcpChatStore prompt submission', () => {
     let finishHistory!: (result: { success: true; data: HistoryPage }) => void;
     const live = fakeLiveSession(suspendedState(), historyPage('rendered'));
     const store = await bootstrapWithSession(live.session);
-    live.getHistory.mockClear();
+    live.loadHistory.mockClear();
     historySeed.mockClear();
-    live.getHistory.mockImplementationOnce(
+    live.loadHistory.mockImplementationOnce(
       () =>
         new Promise<{ success: true; data: HistoryPage }>((resolve) => {
           finishHistory = resolve;
         })
     );
 
-    live.sessionState.set({ ...idleState(), lifecycle: 'replaying', canSubmit: false });
+    live.sessionState.set({ ...idleState(), lifecycle: 'replaying', canSubmit: true });
     live.sessionState.set(idleState());
-    await vi.waitFor(() => expect(live.getHistory).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(live.loadHistory).toHaveBeenCalledTimes(1));
     transcriptTestState.activeTurnSnapshot = historyPage('active').turns[0];
     finishHistory({ success: true, data: historyPage('replayed') });
     await Promise.resolve();
@@ -594,7 +634,7 @@ function fakeLiveSession(
   overrides: Record<string, unknown> = {}
 ) {
   const sessionState = new FakeRemote(state);
-  const getHistory = vi.fn(async () => ({ success: true as const, data: initialHistory }));
+  const loadHistory = vi.fn(async () => ({ success: true as const, data: initialHistory }));
   const session = {
     sessionState,
     config: new FakeRemote({ availableCommands: [] }),
@@ -603,13 +643,13 @@ function fakeLiveSession(
     activeTurn: new FakeRemote(null),
     terminals: new FakeRemote([]),
     mcpServers: new FakeRemote([]),
-    getHistory,
+    loadHistory,
     terminalOutput: vi.fn(),
     sendPrompt: vi.fn(async () => ({ success: true, data: { queued: false } })),
     dispose: vi.fn(),
     ...overrides,
   } as unknown as AcpLiveSession;
-  return { session, sessionState, getHistory };
+  return { session, sessionState, loadHistory };
 }
 
 async function bootstrapWithSession(session: AcpLiveSession): Promise<AcpChatStore> {

--- a/apps/workspace-server/docs/docker-remote.md
+++ b/apps/workspace-server/docs/docker-remote.md
@@ -51,7 +51,7 @@ pnpm run dev:remote
 The script packages a Linux artifact for the host's native architecture (`linux-arm64` on Apple
 Silicon, `linux-x64` otherwise), starts the Compose services (`minio`, `minio-setup`, and
 `workspace-remote`), uploads the artifact layout to `http://localhost:9000/emdash-releases`, and
-verifies that minio's stable and canary `workspace-server/channels/*/protocol-3.json` pointers name
+verifies that minio's stable and canary `workspace-server/channels/*/protocol-4.json` pointers name
 the new version. Override the target with `EMDASH_WS_DEV_REMOTE_TARGET=linux-x64` or
 `EMDASH_WS_DEV_REMOTE_TARGET=linux-arm64`.
 

--- a/apps/workspace-server/docs/packaging.md
+++ b/apps/workspace-server/docs/packaging.md
@@ -60,8 +60,8 @@ All workspace-server objects live under the `workspace-server/` prefix:
 ```text
 workspace-server/
   channels/
-    stable/protocol-3.json
-    canary/protocol-3.json
+    stable/protocol-4.json
+    canary/protocol-4.json
   <version>/
     install.sh
     emdash-workspace-server-<version>-linux-x64.tar.gz

--- a/apps/workspace-server/src/api/controller.test.ts
+++ b/apps/workspace-server/src/api/controller.test.ts
@@ -33,7 +33,7 @@ describe('createWorkspaceWireController', () => {
     const wireClient = createClient(workspaceWireContract, connect(transport));
 
     try {
-      const result = await wireClient.acp.start({
+      const result = await wireClient.acp.launch({
         conversationId: 'conversation-1',
         providerId: 'codex',
         cwd: '/tmp/project',
@@ -42,7 +42,7 @@ describe('createWorkspaceWireController', () => {
       });
 
       expect(result).toEqual(ok({ sessionId: 'acp-session-1' }));
-      expect(acp.start).toHaveBeenCalledWith(
+      expect(acp.launch).toHaveBeenCalledWith(
         expect.objectContaining({ conversationId: 'conversation-1' }),
         expect.any(Object)
       );
@@ -72,24 +72,23 @@ function createFakeAcpClient(): ContractClient<AcpApiContract> {
   });
 
   return {
-    start: vi.fn(async () => ok({ sessionId: 'acp-session-1' })),
-    resume: vi.fn(),
-    kill: vi.fn(),
+    attach: vi.fn(),
+    launch: vi.fn(async () => ok({ sessionId: 'acp-session-1' })),
+    terminate: vi.fn(),
     sendPrompt: vi.fn(),
     editQueuedPrompt: vi.fn(),
     deleteQueuedPrompt: vi.fn(),
     changeQueuePromptOrder: vi.fn(),
     cancelTurn: vi.fn(),
-    setModelOption: vi.fn(),
-    setModeOption: vi.fn(),
+    setOption: vi.fn(),
     resolvePermission: vi.fn(),
     exportAcpTranscript: vi.fn(),
     exportRawAcpLog: vi.fn(),
     uploadAttachment: vi.fn(),
     downloadAttachment: vi.fn(),
     deleteAttachment: vi.fn(),
-    deleteAttachments: vi.fn(),
-    getHistory: vi.fn(),
+    purgeConversationData: vi.fn(),
+    loadHistory: vi.fn(),
     sessions: liveModel(workspaceWireContract.acp.sessions),
     session: liveModel(workspaceWireContract.acp.session),
     terminalOutput: liveLog(workspaceWireContract.acp.terminalOutput),

--- a/apps/workspace-server/src/gateway/workspace-workers.ts
+++ b/apps/workspace-server/src/gateway/workspace-workers.ts
@@ -285,7 +285,7 @@ export async function createWorkspaceServerRuntimeHost(
         creationAdmission: createController(workspaceCreationAdmissionContract, {
           checkWorktreeCreation: async () => ok(undefined),
         }),
-        acpSessions: acp,
+        acpLauncher: acp,
         tuiSessions: tuiAgents,
         conversationIndex: conversations,
       },

--- a/packages/core/src/runtimes/acp/api/client.ts
+++ b/packages/core/src/runtimes/acp/api/client.ts
@@ -4,7 +4,7 @@ export {
   promptPlacementSchema,
   type AcpStartInputWire,
   type HistoryPage,
+  type LoadHistoryResult,
   type PromptPlacement,
-  type ResumeResult,
 } from './schemas';
 export * from './models';

--- a/packages/core/src/runtimes/acp/api/contract.ts
+++ b/packages/core/src/runtimes/acp/api/contract.ts
@@ -30,63 +30,62 @@ import {
   acpEditQueuedPromptErrorSchema,
   acpExportRawLogErrorSchema,
   acpExportTranscriptErrorSchema,
-  acpGetHistoryErrorSchema,
-  acpKillErrorSchema,
+  acpLaunchErrorSchema,
+  acpLoadHistoryErrorSchema,
+  acpPurgeConversationDataErrorSchema,
   acpResolvePermissionErrorSchema,
-  acpResumeErrorSchema,
   acpSendPromptErrorSchema,
-  acpSetModeOptionErrorSchema,
-  acpSetModelOptionErrorSchema,
+  acpSetOptionErrorSchema,
   acpStartErrorSchema,
+  acpTerminateErrorSchema,
 } from './errors';
 import {
-  acpResumeInputSchema,
   acpStartInputSchema,
   cancelTurnCommandSchema,
   changeQueuePromptOrderCommandSchema,
   deleteAttachmentCommandSchema,
-  deleteAttachmentsCommandSchema,
   deleteQueuedPromptCommandSchema,
   downloadAttachmentCommandSchema,
   editQueuedPromptCommandSchema,
   exportAcpTranscriptCommandSchema,
   exportRawAcpLogCommandSchema,
   historyPageInputSchema,
-  historyPageSchema,
-  killCommandSchema,
+  loadHistoryResultSchema,
+  purgeConversationDataCommandSchema,
   resolvePermissionCommandSchema,
-  resumeResultSchema,
   sendPromptCommandSchema,
   sendPromptResponseSchema,
-  setModeOptionCommandSchema,
-  setModelOptionCommandSchema,
+  setOptionCommandSchema,
+  terminateCommandSchema,
   uploadAttachmentCommandSchema,
   uploadAttachmentResponseSchema,
 } from './schemas';
 
-const startResultSchema = z.object({ sessionId: z.string() });
+const launchResultSchema = z.object({
+  sessionId: z.string(),
+  clearedConfiguration: z.array(z.enum(['model', 'modeId', 'effort'])).optional(),
+});
 const sessionKeySchema = z.object({ conversationId: z.string() });
 const terminalOutputKeySchema = z.object({ terminalId: z.string() });
 
 export const acpApiContract = defineContract({
-  start: fallible({
+  attach: fallible({
     input: acpStartInputSchema,
-    data: startResultSchema,
     error: acpStartErrorSchema,
   }),
-  resume: fallible({
-    input: acpResumeInputSchema,
-    data: resumeResultSchema,
-    error: acpResumeErrorSchema,
+  launch: fallible({
+    input: acpStartInputSchema,
+    data: launchResultSchema,
+    error: acpLaunchErrorSchema,
   }),
   /**
    * Terminates any active process and removes the persisted active intent — the session no
    * longer auto-resumes across daemon restarts. The conversation record stays resumable
    * manually.
    */
-  kill: fallible({
-    input: killCommandSchema,
-    error: acpKillErrorSchema,
+  terminate: fallible({
+    input: terminateCommandSchema,
+    error: acpTerminateErrorSchema,
   }),
   sendPrompt: fallible({
     input: sendPromptCommandSchema,
@@ -109,13 +108,9 @@ export const acpApiContract = defineContract({
     input: cancelTurnCommandSchema,
     error: acpCancelTurnErrorSchema,
   }),
-  setModelOption: fallible({
-    input: setModelOptionCommandSchema,
-    error: acpSetModelOptionErrorSchema,
-  }),
-  setModeOption: fallible({
-    input: setModeOptionCommandSchema,
-    error: acpSetModeOptionErrorSchema,
+  setOption: fallible({
+    input: setOptionCommandSchema,
+    error: acpSetOptionErrorSchema,
   }),
   resolvePermission: fallible({
     input: resolvePermissionCommandSchema,
@@ -146,19 +141,14 @@ export const acpApiContract = defineContract({
     input: deleteAttachmentCommandSchema,
     error: acpAttachmentErrorSchema,
   }),
-  /**
-   * Maintenance verb for conversation deletion (spec §3.6, §4.2): removes every attachment
-   * stored for the conversation. Invoked by the conversation removal verb alongside
-   * `kill`; idempotent for absent conversations.
-   */
-  deleteAttachments: fallible({
-    input: deleteAttachmentsCommandSchema,
-    error: acpAttachmentErrorSchema,
+  purgeConversationData: fallible({
+    input: purgeConversationDataCommandSchema,
+    error: acpPurgeConversationDataErrorSchema,
   }),
-  getHistory: fallible({
+  loadHistory: fallible({
     input: historyPageInputSchema,
-    data: historyPageSchema,
-    error: acpGetHistoryErrorSchema,
+    data: loadHistoryResultSchema,
+    error: acpLoadHistoryErrorSchema,
   }),
   sessions: liveModel({
     key: z.void().optional(),

--- a/packages/core/src/runtimes/acp/api/errors.ts
+++ b/packages/core/src/runtimes/acp/api/errors.ts
@@ -78,8 +78,9 @@ export const ACP_UNAMBIGUOUS_START_ERROR_TYPES = [
   'initialize_failed',
   'new_session_failed',
 ] as const satisfies readonly AcpStartError['type'][];
-export type AcpResumeError = AcpStartError;
-export type AcpKillError = IntentPersistenceFailedError;
+export type AcpLaunchError = AcpStartError;
+export type AcpLoadHistoryError = AcpStartError;
+export type AcpTerminateError = IntentPersistenceFailedError;
 export type AcpSendPromptError = ConversationNotFoundError | InvalidStateError | PromptFailedError;
 export type AcpQueueMutationError = ConversationNotFoundError | InvalidStateError;
 export type AcpEditQueuedPromptError = AcpQueueMutationError;
@@ -87,18 +88,15 @@ export type AcpDeleteQueuedPromptError = AcpQueueMutationError;
 export type AcpChangeQueuePromptOrderError = AcpQueueMutationError;
 export type AcpResolvePermissionError = AcpQueueMutationError;
 export type AcpCancelTurnError = InvalidStateError | CancelFailedError;
-export type AcpSetModelOptionError =
+export type AcpSetOptionError =
   | ConversationNotFoundError
   | InvalidStateError
-  | SetConfigFailedError;
-export type AcpSetModeOptionError =
-  | ConversationNotFoundError
-  | InvalidStateError
+  | SetConfigFailedError
   | SetModeFailedError;
 export type AcpExportTranscriptError = ConversationNotFoundError;
 export type AcpExportRawLogError = ConversationNotFoundError;
 export type AcpAttachmentError = InvalidStateError | AttachmentNotFoundError;
-export type AcpGetHistoryError = never;
+export type AcpPurgeConversationDataError = AcpTerminateError | AcpAttachmentError;
 
 export const acpErr = {
   providerUnsupported: (providerId: string) =>
@@ -173,8 +171,9 @@ export const acpStartErrorSchema = z.discriminatedUnion('type', [
   newSessionFailedErrorSchema,
   invalidStateErrorSchema,
 ]);
-export const acpResumeErrorSchema = acpStartErrorSchema;
-export const acpKillErrorSchema = intentPersistenceFailedErrorSchema;
+export const acpLaunchErrorSchema = acpStartErrorSchema;
+export const acpLoadHistoryErrorSchema = acpStartErrorSchema;
+export const acpTerminateErrorSchema = intentPersistenceFailedErrorSchema;
 export const acpSendPromptErrorSchema = z.discriminatedUnion('type', [
   conversationNotFoundErrorSchema,
   invalidStateErrorSchema,
@@ -192,14 +191,10 @@ export const acpCancelTurnErrorSchema = z.discriminatedUnion('type', [
   invalidStateErrorSchema,
   cancelFailedErrorSchema,
 ]);
-export const acpSetModelOptionErrorSchema = z.discriminatedUnion('type', [
+export const acpSetOptionErrorSchema = z.discriminatedUnion('type', [
   conversationNotFoundErrorSchema,
   invalidStateErrorSchema,
   setConfigFailedErrorSchema,
-]);
-export const acpSetModeOptionErrorSchema = z.discriminatedUnion('type', [
-  conversationNotFoundErrorSchema,
-  invalidStateErrorSchema,
   setModeFailedErrorSchema,
 ]);
 export const acpExportTranscriptErrorSchema = conversationNotFoundErrorSchema;
@@ -208,7 +203,11 @@ export const acpAttachmentErrorSchema = z.discriminatedUnion('type', [
   invalidStateErrorSchema,
   attachmentNotFoundErrorSchema,
 ]);
-export const acpGetHistoryErrorSchema = z.never();
+export const acpPurgeConversationDataErrorSchema = z.discriminatedUnion('type', [
+  intentPersistenceFailedErrorSchema,
+  invalidStateErrorSchema,
+  attachmentNotFoundErrorSchema,
+]);
 
 export const acpRuntimeErrorSchema = z.discriminatedUnion('type', [
   providerUnsupportedErrorSchema,

--- a/packages/core/src/runtimes/acp/api/schemas.ts
+++ b/packages/core/src/runtimes/acp/api/schemas.ts
@@ -11,16 +11,15 @@ export const acpStartInputSchema = z.object({
   sessionId: z.string().nullable(),
   model: z.string().nullable(),
   modeId: z.string().nullable().optional(),
+  effort: z.string().nullable().optional(),
   initialQueue: z.array(promptInputSchema).optional(),
   env: z.record(z.string(), z.string()).optional(),
 });
 export type AcpStartInputWire = z.infer<typeof acpStartInputSchema>;
 
-export const acpResumeInputSchema = acpStartInputSchema.extend({ sessionId: z.string() });
-
 export const sendPromptResponseSchema = z.object({ queued: z.boolean() });
 
-export const killCommandSchema = z.object({ conversationId: z.string() });
+export const terminateCommandSchema = z.object({ conversationId: z.string() });
 export const promptPlacementSchema = z.enum(['auto', 'queue']);
 export type PromptPlacement = z.infer<typeof promptPlacementSchema>;
 export const sendPromptCommandSchema = z.object({
@@ -43,13 +42,9 @@ export const changeQueuePromptOrderCommandSchema = z.object({
   ids: z.array(z.string()),
 });
 export const cancelTurnCommandSchema = z.object({ conversationId: z.string() });
-export const setModelOptionCommandSchema = z.object({
+export const setOptionCommandSchema = z.object({
   conversationId: z.string(),
-  dimension: z.enum(['model', 'effort']),
-  value: z.string(),
-});
-export const setModeOptionCommandSchema = z.object({
-  conversationId: z.string(),
+  key: z.enum(['model', 'mode', 'effort']),
   value: z.string(),
 });
 export const resolvePermissionCommandSchema = permissionDecisionSchema.extend({
@@ -70,7 +65,7 @@ export const attachmentKeySchema = z.object({
 });
 export const downloadAttachmentCommandSchema = attachmentKeySchema;
 export const deleteAttachmentCommandSchema = attachmentKeySchema;
-export const deleteAttachmentsCommandSchema = z.object({
+export const purgeConversationDataCommandSchema = z.object({
   conversationId: z.string(),
 });
 
@@ -88,9 +83,9 @@ export const historyPageSchema = z.object({
 });
 export type HistoryPage = z.infer<typeof historyPageSchema>;
 
-export const resumeResultSchema = historyPageSchema.extend({
-  sessionId: z.string(),
+export const loadHistoryResultSchema = historyPageSchema.extend({
+  clearedConfiguration: z.array(z.enum(['model', 'modeId', 'effort'])).optional(),
 });
-export type ResumeResult = z.infer<typeof resumeResultSchema>;
+export type LoadHistoryResult = z.infer<typeof loadHistoryResultSchema>;
 
 export { queuedPromptSchema };

--- a/packages/core/src/runtimes/acp/node/acp-test-support.ts
+++ b/packages/core/src/runtimes/acp/node/acp-test-support.ts
@@ -366,7 +366,7 @@ export function makeAcpHarness(options: AcpHarnessOptions = {}) {
     ptySpawner,
     client(): Client {
       if (!agent.capturedClient) {
-        throw new Error('capturedClient is null — has startSession() been called?');
+        throw new Error('capturedClient is null — has launchSession() been called?');
       }
       return agent.capturedClient;
     },

--- a/packages/core/src/runtimes/acp/node/api/contract.test.ts
+++ b/packages/core/src/runtimes/acp/node/api/contract.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   acpApiContract,
   acpAttachmentErrorSchema,
-  acpKillErrorSchema,
+  acpTerminateErrorSchema,
   acpRuntimeErrorSchema,
   historyPageSchema,
   sessionConfigStateSchema,
@@ -22,7 +22,7 @@ describe('ACP API contract schemas', () => {
   it('parses runtime live model snapshots with the public schemas', async () => {
     const h = makeAcpHarness();
     const rt = new AcpRuntime(h.deps);
-    const started = await rt.startSession(makeStartInput({ conversationId: 'conv-contract' }));
+    const started = await rt.launchSession(makeStartInput({ conversationId: 'conv-contract' }));
     expect(isOk(started)).toBe(true);
 
     const live = rt.sessionLiveModels('conv-contract');
@@ -47,7 +47,7 @@ describe('ACP API contract schemas', () => {
     try {
       await summaries.states.list.refresh();
       const input = makeStartInput({ conversationId: 'conv-wire' });
-      const started = await contractClient.start(input);
+      const started = await contractClient.launch(input);
       expect(started).toEqual({ success: true, data: { sessionId: 'session-1' } });
 
       await vi.waitFor(() => {
@@ -67,29 +67,31 @@ describe('ACP API contract schemas', () => {
     }
   });
 
-  it('keeps suspended reads inert and maps implicit wake failures into existing errors', async () => {
+  it('loads history through activation and keeps dormant settings non-waking', async () => {
     const h = makeAcpHarness({ lifecycle: { connectionIdleTtlMs: 0 } });
     const rt = new AcpRuntime(h.deps);
     const wire = createTestWire(acpApiContract, createAcpController(rt));
     const input = makeStartInput({ conversationId: 'conv-wire-suspended' });
 
     try {
-      await wire.client.start(input);
+      await wire.client.launch(input);
       await rt.stopSession(input.conversationId);
       h.agent.loadSession.mockClear();
       h.agent.newSession.mockClear();
 
       await expect(
-        wire.client.getHistory({
+        wire.client.loadHistory({
           conversationId: input.conversationId,
           limit: 50,
         })
-      ).resolves.toEqual({
+      ).resolves.toMatchObject({
         success: true,
-        data: { turns: [], nextCursor: null, unavailable: true },
+        data: { turns: [], nextCursor: null },
       });
-      expect(h.agent.loadSession).not.toHaveBeenCalled();
+      expect(h.agent.loadSession).toHaveBeenCalled();
       expect(h.agent.newSession).not.toHaveBeenCalled();
+
+      await rt.stopSession(input.conversationId);
 
       h.agent.loadSession.mockRejectedValue(new Error('replay failed'));
       h.agent.newSession.mockRejectedValue(new Error('replacement failed'));
@@ -106,31 +108,24 @@ describe('ACP API contract schemas', () => {
           cause: { name: 'Error', message: 'replacement failed' },
         },
       });
+      h.agent.loadSession.mockClear();
+      h.agent.newSession.mockClear();
       await expect(
-        wire.client.setModeOption({
+        wire.client.setOption({
           conversationId: input.conversationId,
+          key: 'mode',
           value: 'agent',
         })
-      ).resolves.toMatchObject({
-        success: false,
-        error: {
-          type: 'set_mode_failed',
-          cause: { name: 'Error', message: 'replacement failed' },
-        },
-      });
+      ).resolves.toEqual({ success: true, data: undefined });
       await expect(
-        wire.client.setModelOption({
+        wire.client.setOption({
           conversationId: input.conversationId,
-          dimension: 'effort',
+          key: 'effort',
           value: 'high',
         })
-      ).resolves.toMatchObject({
-        success: false,
-        error: {
-          type: 'set_config_failed',
-          cause: { name: 'Error', message: 'replacement failed' },
-        },
-      });
+      ).resolves.toEqual({ success: true, data: undefined });
+      expect(h.agent.loadSession).not.toHaveBeenCalled();
+      expect(h.agent.newSession).not.toHaveBeenCalled();
     } finally {
       wire.dispose();
     }
@@ -159,7 +154,7 @@ describe('ACP API contract schemas', () => {
 
   it('accepts typed durable intent failures from kill', () => {
     expect(() =>
-      acpKillErrorSchema.parse({
+      acpTerminateErrorSchema.parse({
         type: 'intent_persistence_failed',
         message: 'Failed to remove the durable session intent for conv-1',
         cause: { name: 'SessionIntentError', message: 'disk full' },

--- a/packages/core/src/runtimes/acp/node/api/procedures.ts
+++ b/packages/core/src/runtimes/acp/node/api/procedures.ts
@@ -8,40 +8,36 @@ import type {
   AcpEditQueuedPromptError,
   AcpExportRawLogError,
   AcpExportTranscriptError,
-  AcpGetHistoryError,
-  AcpKillError,
+  AcpLoadHistoryError,
+  AcpPurgeConversationDataError,
   AcpResolvePermissionError,
-  AcpResumeError,
   AcpSendPromptError,
-  AcpSetModeOptionError,
-  AcpSetModelOptionError,
+  AcpSetOptionError,
   AcpStartError,
   AcpStartInputWire,
+  AcpTerminateError,
   AttachmentMimeType,
   AttachmentRef,
-  HistoryPage,
+  LoadHistoryResult,
   PromptInput,
   PromptPlacement,
-  ResumeResult,
 } from '#runtimes/acp/api';
 import { acpErr } from '#runtimes/acp/api';
 import type { AcpRuntime } from '#runtimes/acp/node/runtime/runtime';
 import { isAcpWakeFailure, type AcpWakeFailure } from '#runtimes/acp/node/runtime/session-manager';
 
-export type StartSessionInput = AcpStartInputWire;
+export type SessionDescriptorInput = AcpStartInputWire;
 
 export function createAcpProcedures(runtime: AcpRuntime) {
   return {
-    start(input: StartSessionInput): Promise<Result<{ sessionId: string }, AcpStartError>> {
-      return runtime.startSession(input);
+    attach(input: SessionDescriptorInput): Promise<Result<void, AcpStartError>> {
+      return runtime.attachSession(input);
     },
-    resume(
-      input: StartSessionInput & { sessionId: string }
-    ): Promise<Result<ResumeResult, AcpResumeError>> {
-      return runtime.resumeSession(input);
+    launch(input: SessionDescriptorInput): ReturnType<AcpRuntime['launchSession']> {
+      return runtime.launchSession(input);
     },
-    kill(input: { conversationId: string }): Promise<Result<void, AcpKillError>> {
-      return runtime.killSession(input.conversationId);
+    terminate(input: { conversationId: string }): Promise<Result<void, AcpTerminateError>> {
+      return runtime.terminateSession(input.conversationId);
     },
     async sendPrompt(input: {
       conversationId: string;
@@ -76,30 +72,18 @@ export function createAcpProcedures(runtime: AcpRuntime) {
     cancelTurn(input: { conversationId: string }): Promise<Result<void, AcpCancelTurnError>> {
       return runtime.cancelTurn(input.conversationId);
     },
-    async setModelOption(input: {
+    async setOption(input: {
       conversationId: string;
-      dimension: 'model' | 'effort';
+      key: 'model' | 'mode' | 'effort';
       value: string;
-    }): Promise<Result<void, AcpSetModelOptionError>> {
-      const result = await runtime.setModelOption(
-        input.conversationId,
-        input.dimension,
-        input.value
-      );
+    }): Promise<Result<void, AcpSetOptionError>> {
+      const result = await runtime.setOption(input.conversationId, input.key, input.value);
       if (!result.success && isAcpWakeFailure(result.error)) {
-        return acpErr.setConfigFailed(wakeFailureCause(result.error));
+        return input.key === 'mode'
+          ? acpErr.setModeFailed(wakeFailureCause(result.error))
+          : acpErr.setConfigFailed(wakeFailureCause(result.error));
       }
-      return result as Result<void, AcpSetModelOptionError>;
-    },
-    async setModeOption(input: {
-      conversationId: string;
-      value: string;
-    }): Promise<Result<void, AcpSetModeOptionError>> {
-      const result = await runtime.setModeOption(input.conversationId, input.value);
-      if (!result.success && isAcpWakeFailure(result.error)) {
-        return acpErr.setModeFailed(wakeFailureCause(result.error));
-      }
-      return result as Result<void, AcpSetModeOptionError>;
+      return result as Result<void, AcpSetOptionError>;
     },
     resolvePermission(input: {
       conversationId: string;
@@ -155,17 +139,17 @@ export function createAcpProcedures(runtime: AcpRuntime) {
     }): Promise<Result<void, AcpAttachmentError>> {
       return runtime.deleteAttachment(input.conversationId, input.attachmentId);
     },
-    deleteAttachments(input: {
+    purgeConversationData(input: {
       conversationId: string;
-    }): Promise<Result<void, AcpAttachmentError>> {
-      return runtime.deleteConversationAttachments(input.conversationId);
+    }): Promise<Result<void, AcpPurgeConversationDataError>> {
+      return runtime.purgeConversationData(input.conversationId);
     },
-    getHistory(input: {
+    loadHistory(input: {
       conversationId: string;
       before?: number;
       limit: number;
-    }): Result<HistoryPage, AcpGetHistoryError> {
-      return runtime.getHistory(input.conversationId, input.before, input.limit);
+    }): Promise<Result<LoadHistoryResult, AcpLoadHistoryError>> {
+      return runtime.loadHistory(input.conversationId, input.before, input.limit);
     },
   };
 }

--- a/packages/core/src/runtimes/acp/node/index.ts
+++ b/packages/core/src/runtimes/acp/node/index.ts
@@ -22,7 +22,7 @@ export { SessionMachine, isPromptReady } from './machine/machine';
 export * from './state/live-models';
 export { createAcpController } from './api/controller';
 export { createAcpProcedures } from './api/procedures';
-export type { AcpProcedures, StartSessionInput } from './api/procedures';
+export type { AcpProcedures, SessionDescriptorInput } from './api/procedures';
 export { acpComponentConfigSchema, createAcpComponent } from './component';
 export { AgentTerminalManager } from './agent-ports/terminal-manager';
 export type { AgentTerminalHooks as AgentTerminalListener } from './agent-ports/terminal-manager';

--- a/packages/core/src/runtimes/acp/node/runtime/conversation-handle.test.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/conversation-handle.test.ts
@@ -1,7 +1,7 @@
 import { systemClock } from '@emdash/shared/scheduling';
 import { cell, peek } from '@emdash/wire/state';
 import { describe, expect, it, vi } from 'vitest';
-import { acpErr } from '#runtimes/acp/api';
+import { acpErr, initialSessionConfigState } from '#runtimes/acp/api';
 import { makeStartInput } from '#runtimes/acp/node/acp-test-support';
 import {
   closedSessionState,
@@ -69,12 +69,36 @@ describe('ConversationHandle', () => {
     expect(setup.saveIntent).toHaveBeenCalledTimes(3);
     expect(setup.handle.intentPayload()).toMatchObject({
       payload: {
-        modeId: 'plan',
         sessionId: 'session-2',
-        configOverrides: { effort: 'high' },
+        configured: { modeId: 'plan', effort: 'high' },
       },
       sessionId: 'session-2',
     });
+  });
+
+  it('persists an allowlisted versioned intent without provider environment secrets', () => {
+    const setup = makeHandle({ everMaterialized: true });
+    setup.handle.refreshDescriptor({
+      ...setup.handle.descriptor,
+      env: { API_TOKEN: 'must-not-be-persisted' },
+      model: 'sonnet',
+      modeId: 'agent',
+      effort: 'high',
+    });
+
+    const intent = setup.handle.intentPayload();
+
+    expect(intent).toMatchObject({
+      payload: {
+        version: '1',
+        conversationId: 'conv-handle',
+        providerId: 'claude',
+        cwd: '/tmp/workspace',
+        configured: { model: 'sonnet', modeId: 'agent', effort: 'high' },
+      },
+    });
+    expect(JSON.stringify(intent)).not.toContain('API_TOKEN');
+    expect(JSON.stringify(intent)).not.toContain('must-not-be-persisted');
   });
 
   it('aborts in-flight materialization before disposal waits for activation drain', async () => {
@@ -159,6 +183,7 @@ function makeHandle(
       activationDrainTimeoutMs: 100,
       onLeaseDrainTimeout: () => {},
       onActivationObserverError: () => {},
+      now: () => 123,
     },
     makeStartInput({ conversationId: 'conv-handle' }),
     {},
@@ -196,13 +221,16 @@ function makeRecord(handle: ConversationHandle, epoch: number): SessionRecord {
     epoch,
     input,
     resumeOutcome: null,
+    clearedConfiguration: [],
     processKey: 'claude:/tmp/workspace',
     processGeneration: 1,
     connectionLeaseState: { release: true },
     cell: {
       sessionState: { ...closedSessionState, lifecycle: 'ready', canSubmit: true },
-      transcript: { title: null },
-    } as SessionRecord['cell'],
+      config: initialSessionConfigState,
+      usage: null,
+      transcript: { title: null, plan: null, agents: [], activeTurn: null },
+    } as unknown as SessionRecord['cell'],
     mcpServers: [],
     machineStateBinding: { dispose: () => {} },
     disposed: false,

--- a/packages/core/src/runtimes/acp/node/runtime/conversation-handle.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/conversation-handle.ts
@@ -1,12 +1,15 @@
 import type { Lease, Result, Serializable } from '@emdash/shared';
 import { ok } from '@emdash/shared';
 import { createLifecycleCell, type LifecycleCell, type Scope } from '@emdash/shared/concurrency';
-import { acpErr, initialSessionConfigState } from '#runtimes/acp/api';
+import { acpErr } from '#runtimes/acp/api';
 import type { AgentTerminalManager } from '#runtimes/acp/node/agent-ports/terminal-manager';
 import {
   closedSessionState,
+  emptyRetainedPresentation,
+  retainedConfig,
   suspendedSessionState,
   type ActivationSnapshot,
+  type RetainedPresentation,
   type SessionLiveModels,
 } from '#runtimes/acp/node/state/live-models';
 import type {
@@ -38,6 +41,7 @@ export interface ConversationHandleDeps {
   activationDrainTimeoutMs: number;
   onLeaseDrainTimeout(event: { leaseCount: number; timeoutMs: number }): void;
   onActivationObserverError(error: unknown): void;
+  now(): number;
 }
 
 export class ConversationHandle {
@@ -49,6 +53,8 @@ export class ConversationHandle {
   private projectionReleased = false;
   private disposedValue = false;
   private evictionPromiseValue: Promise<void> | null = null;
+  private retainedValue: RetainedPresentation;
+  private desiredRevisionValue = 0;
   private readonly activation: LifecycleCell<
     void,
     SessionRecord,
@@ -62,9 +68,12 @@ export class ConversationHandle {
     public descriptor: AcpStartInput,
     public configOverrides: ConfigOverrides,
     public initialQueueConsumed: boolean,
-    public everMaterialized: boolean
+    public everMaterialized: boolean,
+    retained?: RetainedPresentation
   ) {
     this.conversationId = descriptor.conversationId;
+    this.retainedValue =
+      retained ?? emptyRetainedPresentation(configuredFromDescriptor(descriptor));
     this.activation = createLifecycleCell({
       label: `acp-conversation:${this.conversationId}`,
       start: (_input, scope) => this.deps.materialize(scope),
@@ -93,6 +102,10 @@ export class ConversationHandle {
     return this.disposedValue;
   }
 
+  get desiredRevision(): number {
+    return this.desiredRevisionValue;
+  }
+
   get projection(): SessionLiveModels {
     return this.deps.projection;
   }
@@ -109,7 +122,10 @@ export class ConversationHandle {
     this.materializationAbort = new AbortController();
     this.stateValue = 'materializing';
     this.recordValue = null;
-    this.deps.projection.source.set({ kind: 'active', snapshot: startingSnapshot() });
+    this.deps.projection.source.set({
+      kind: 'active',
+      snapshot: startingSnapshot(this.retainedValue),
+    });
     this.deps.listProjector.upsert(this.materializationInput(), null, {
       lifecycle: 'starting',
       isGenerating: false,
@@ -271,9 +287,11 @@ export class ConversationHandle {
 
   syncRecord(record: SessionRecord): void {
     if (!this.canPublishRecord(record)) return;
+    if (this.stateValue === 'active') this.captureRetained(record);
+    const snapshot = this.buildSnapshot(record);
     this.deps.projection.source.set({
       kind: 'active',
-      snapshot: this.buildSnapshot(record),
+      snapshot,
     });
     this.deps.listProjector.upsert(record.input, record.cell, record.cell.sessionState);
   }
@@ -302,6 +320,7 @@ export class ConversationHandle {
   }
 
   updateMode(modeId: string): void {
+    this.updateConfigured({ modeId });
     this.updateDescriptor({ modeId });
   }
 
@@ -311,7 +330,38 @@ export class ConversationHandle {
 
   updateConfig(dimension: ConfigDimension, value: string): void {
     this.configOverrides = { ...this.configOverrides, [dimension]: value };
-    this.updateDescriptor(dimension === 'model' ? { model: value } : {}, true);
+    this.updateConfigured({ [dimension]: value });
+    this.updateDescriptor(dimension === 'model' ? { model: value } : { effort: value }, true);
+  }
+
+  clearMode(): void {
+    this.updateConfigured({ modeId: null });
+    this.updateDescriptor({ modeId: null });
+  }
+
+  clearConfig(dimension: ConfigDimension): void {
+    const { [dimension]: _removed, ...remaining } = this.configOverrides;
+    this.configOverrides = remaining;
+    this.updateConfigured({ [dimension]: null });
+    this.updateDescriptor(dimension === 'model' ? { model: null } : { effort: null }, true);
+  }
+
+  refreshDescriptor(descriptor: AcpStartInput): void {
+    if (!this.isCurrent()) return;
+    this.descriptor = {
+      ...descriptor,
+      // The runtime can observe a replacement session id before the host report converges. A
+      // stale host value must not discard that newer runtime fact on the next activation.
+      sessionId:
+        this.everMaterialized && this.descriptor.sessionId
+          ? this.descriptor.sessionId
+          : descriptor.sessionId,
+    };
+    this.configOverrides = {
+      ...(descriptor.model ? { model: descriptor.model } : {}),
+      ...(descriptor.effort ? { effort: descriptor.effort } : {}),
+    };
+    this.updateConfigured(configuredFromDescriptor(descriptor));
   }
 
   saveIntent(): void {
@@ -320,13 +370,15 @@ export class ConversationHandle {
 
   intentPayload(): { payload: Serializable; sessionId?: string | null } | null {
     if (!this.isCurrent()) return null;
-    const { initialQueue: _initialQueue, ...persisted } = this.descriptor;
     return {
       payload: {
-        ...persisted,
-        ...(Object.keys(this.configOverrides).length > 0
-          ? { configOverrides: this.configOverrides }
-          : {}),
+        version: '1',
+        conversationId: this.conversationId,
+        providerId: this.descriptor.providerId,
+        cwd: this.descriptor.cwd,
+        sessionId: this.descriptor.sessionId,
+        configured: this.retainedValue.configured,
+        presentation: this.retainedValue,
       } as unknown as Serializable,
       sessionId: this.descriptor.sessionId,
     };
@@ -393,20 +445,29 @@ export class ConversationHandle {
   }
 
   private publishSuspended(): void {
-    this.deps.projection.source.set({ kind: 'suspended' });
+    this.deps.projection.source.set({ kind: 'suspended', retained: this.retainedValue });
     this.deps.listProjector.suspend(this.descriptor);
   }
 
   private buildSnapshot(record: SessionRecord): ActivationSnapshot {
+    const state = record.cell.sessionState;
+    const lastKnownCapabilities = mergeCapabilities(
+      this.retainedValue.lastKnownCapabilities,
+      record.cell.config,
+      this.stateValue === 'materializing'
+    );
     return {
-      state: record.cell.sessionState,
-      config: record.cell.config,
-      usage: record.cell.usage,
+      state: this.stateValue === 'materializing' ? { ...state, canSubmit: true } : state,
+      config: retainedConfig({ ...this.retainedValue, lastKnownCapabilities }),
+      usage: record.cell.usage ?? this.retainedValue.lastKnownUsage,
       plan: record.cell.transcript.plan,
       agents: record.cell.transcript.agents,
       activeTurn: record.cell.transcript.activeTurn,
       terminals: this.deps.terminals.listByConversation(this.conversationId),
-      mcpServers: record.mcpServers,
+      mcpServers:
+        this.stateValue === 'materializing' && record.mcpServers.length === 0
+          ? this.retainedValue.lastKnownMcpServers
+          : record.mcpServers,
     };
   }
 
@@ -415,17 +476,81 @@ export class ConversationHandle {
     this.projectionReleased = true;
     this.deps.releaseProjection();
   }
+
+  private captureRetained(record: SessionRecord): void {
+    const nextContent = {
+      configured: this.retainedValue.configured,
+      lastKnownCapabilities: mergeCapabilities(
+        this.retainedValue.lastKnownCapabilities,
+        record.cell.config
+      ),
+      lastKnownMcpServers: record.mcpServers,
+      lastKnownUsage: record.cell.usage ?? this.retainedValue.lastKnownUsage,
+    };
+    if (sameRetainedContent(this.retainedValue, nextContent)) return;
+    this.retainedValue = { ...nextContent, observedAt: this.deps.now() };
+    if (this.everMaterialized) this.deps.saveIntent();
+  }
+
+  private updateConfigured(patch: Partial<RetainedPresentation['configured']>): void {
+    this.desiredRevisionValue += 1;
+    this.retainedValue = {
+      ...this.retainedValue,
+      configured: { ...this.retainedValue.configured, ...patch },
+    };
+    if (this.stateValue === 'suspended') this.publishSuspended();
+    if (this.stateValue === 'materializing' && this.recordValue === null) {
+      this.deps.projection.source.set({
+        kind: 'active',
+        snapshot: startingSnapshot(this.retainedValue),
+      });
+    }
+    const record = this.recordValue;
+    if (record && this.canPublishRecord(record)) this.syncRecord(record);
+  }
 }
 
-function startingSnapshot(): ActivationSnapshot {
+function startingSnapshot(retained: RetainedPresentation): ActivationSnapshot {
   return {
-    state: { ...closedSessionState, lifecycle: 'starting' },
-    config: initialSessionConfigState,
-    usage: null,
+    state: { ...closedSessionState, lifecycle: 'starting', canSubmit: true },
+    config: retainedConfig(retained),
+    usage: retained.lastKnownUsage,
     plan: null,
     agents: [],
     activeTurn: null,
     terminals: [],
-    mcpServers: [],
+    mcpServers: retained.lastKnownMcpServers,
+  };
+}
+
+function configuredFromDescriptor(descriptor: AcpStartInput): RetainedPresentation['configured'] {
+  return {
+    model: descriptor.model ?? null,
+    modeId: descriptor.modeId ?? null,
+    effort: descriptor.effort ?? null,
+  };
+}
+
+function sameRetainedContent(
+  retained: RetainedPresentation,
+  next: Omit<RetainedPresentation, 'observedAt'>
+): boolean {
+  const { observedAt: _observedAt, ...current } = retained;
+  return JSON.stringify(current) === JSON.stringify(next);
+}
+
+function mergeCapabilities(
+  retained: RetainedPresentation['lastKnownCapabilities'],
+  current: RetainedPresentation['lastKnownCapabilities'],
+  preservePendingCommands = false
+): RetainedPresentation['lastKnownCapabilities'] {
+  return {
+    modelOptions: current.modelOptions ?? retained.modelOptions,
+    efforts: current.efforts ?? retained.efforts,
+    modeOptions: current.modeOptions ?? retained.modeOptions,
+    availableCommands:
+      preservePendingCommands && current.availableCommands.length === 0
+        ? retained.availableCommands
+        : current.availableCommands,
   };
 }

--- a/packages/core/src/runtimes/acp/node/runtime/conversation-types.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/conversation-types.ts
@@ -16,6 +16,7 @@ export interface SessionRecord {
   epoch: number;
   input: AcpStartInput;
   resumeOutcome: 'loaded' | 'replaced-by-new' | null;
+  clearedConfiguration: Array<'model' | 'modeId' | 'effort'>;
   processKey: string;
   processGeneration: number;
   connectionLeaseState: ConnectionLeaseState;

--- a/packages/core/src/runtimes/acp/node/runtime/lazy-session-restoration.test.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/lazy-session-restoration.test.ts
@@ -43,7 +43,7 @@ describe('lazy ACP session restoration', () => {
     await runtime.dispose();
   });
 
-  it('hydrates one indexed conversation on first touch without waking the provider', async () => {
+  it('hydrates one indexed conversation on attach without waking the provider', async () => {
     const intents = createMemorySessionIntentStore();
     await seedSuspendedIntent(intents, makeStartInput({ conversationId: 'conv-one' }));
     await seedSuspendedIntent(intents, makeStartInput({ conversationId: 'conv-two' }));
@@ -54,6 +54,9 @@ describe('lazy ACP session restoration', () => {
     expect(runtime.getSessionState('conv-one')).toMatchObject({ suspended: true });
     expect(runtime.manager.inspect().retained).toEqual([]);
 
+    await runtime.attachSession(
+      makeStartInput({ conversationId: 'conv-one', sessionId: 'conv-one-session' })
+    );
     expect(runtime.sessionLiveModels('conv-one')).not.toBeNull();
 
     expect(runtime.manager.inspect().retained).toContain('conv-one');
@@ -82,7 +85,7 @@ describe('lazy ACP session restoration', () => {
     await runtime.reconcile();
     const remove = vi.spyOn(intents, 'remove');
 
-    await runtime.killSession('conv-cleanup');
+    await runtime.terminateSession('conv-cleanup');
 
     expect(remove).toHaveBeenCalledWith('conv-cleanup');
     expect(intents.snapshot()).toEqual([]);
@@ -121,7 +124,7 @@ describe('lazy ACP session restoration', () => {
     const runtime = new AcpRuntime(harness.deps);
     await runtime.reconcile();
 
-    const failed = await runtime.killSession('conv-delete-retry');
+    const failed = await runtime.terminateSession('conv-delete-retry');
 
     expect(failed).toMatchObject({
       success: false,
@@ -137,7 +140,7 @@ describe('lazy ACP session restoration', () => {
     await runtime.reconcile();
     expect(runtime.manager.inspect().indexedSuspended).toEqual(['conv-delete-retry']);
 
-    const retried = await runtime.killSession('conv-delete-retry');
+    const retried = await runtime.terminateSession('conv-delete-retry');
 
     expect(retried.success).toBe(true);
     expect(persistedIntents.snapshot()).toEqual([]);

--- a/packages/core/src/runtimes/acp/node/runtime/runtime-attachments.test.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/runtime-attachments.test.ts
@@ -68,7 +68,7 @@ describe('AcpRuntime conversation-scoped attachments', () => {
     });
     if (!first.success || !second.success || !other.success) throw new Error('upload failed');
 
-    const cleaned = await rt.deleteConversationAttachments('conv-1');
+    const cleaned = await rt.purgeConversationData('conv-1');
     expect(cleaned).toEqual({ success: true, data: undefined });
 
     await expect(rt.downloadAttachment('conv-1', first.data.id)).resolves.toMatchObject({
@@ -83,7 +83,7 @@ describe('AcpRuntime conversation-scoped attachments', () => {
     });
 
     // Idempotent for already-cleaned conversations.
-    await expect(rt.deleteConversationAttachments('conv-1')).resolves.toEqual({
+    await expect(rt.purgeConversationData('conv-1')).resolves.toEqual({
       success: true,
       data: undefined,
     });
@@ -92,7 +92,7 @@ describe('AcpRuntime conversation-scoped attachments', () => {
   it('cleanup is a no-op success when no attachment store is configured', async () => {
     const h = makeAcpHarness();
     const rt = new AcpRuntime(h.deps);
-    await expect(rt.deleteConversationAttachments('conv-1')).resolves.toEqual({
+    await expect(rt.purgeConversationData('conv-1')).resolves.toEqual({
       success: true,
       data: undefined,
     });

--- a/packages/core/src/runtimes/acp/node/runtime/runtime.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/runtime.ts
@@ -9,20 +9,18 @@ import type {
   AcpEditQueuedPromptError,
   AcpExportRawLogError,
   AcpExportTranscriptError,
-  AcpGetHistoryError,
+  AcpLoadHistoryError,
+  AcpPurgeConversationDataError,
   AcpResolvePermissionError,
-  AcpResumeError,
   AcpSendPromptError,
-  AcpSetModeOptionError,
-  AcpSetModelOptionError,
+  AcpSetOptionError,
   AcpStartError,
-  AcpKillError,
+  AcpTerminateError,
   AttachmentMimeType,
   AttachmentRef,
-  HistoryPage,
+  LoadHistoryResult,
   PromptInput,
   PromptPlacement,
-  ResumeResult,
   SessionState,
   TerminalState,
 } from '#runtimes/acp/api';
@@ -74,18 +72,12 @@ export class AcpRuntime {
     this.manager = manager;
   }
 
-  startSession(input: AcpStartInput): Promise<Result<{ sessionId: string }, AcpStartError>> {
-    return this.manager.start(input);
+  attachSession(input: AcpStartInput): Promise<Result<void, AcpStartError>> {
+    return this.manager.attach(input);
   }
 
-  async resumeSession(
-    input: AcpStartInput & { sessionId: string },
-    limit = 50
-  ): Promise<Result<ResumeResult, AcpResumeError>> {
-    const result = await this.manager.start(input);
-    if (!result.success) return result;
-    const page = this.manager.getHistory(input.conversationId, undefined, limit);
-    return ok({ sessionId: result.data.sessionId, ...page });
+  launchSession(input: AcpStartInput): ReturnType<SessionManager['launch']> {
+    return this.manager.launch(input);
   }
 
   /** Runtime-internal graceful stop (persists suspended intent); not exposed on the wire. */
@@ -93,7 +85,7 @@ export class AcpRuntime {
     return this.manager.stop(conversationId);
   }
 
-  killSession(conversationId: string): Promise<Result<void, AcpKillError>> {
+  terminateSession(conversationId: string): Promise<Result<void, AcpTerminateError>> {
     return this.manager.kill(conversationId);
   }
 
@@ -140,27 +132,29 @@ export class AcpRuntime {
     return this.manager.resolvePermission(conversationId, requestId, optionId);
   }
 
-  setModeOption(
+  setOption(
     conversationId: string,
-    modeId: string
-  ): Promise<Result<void, AcpSetModeOptionError | AcpWakeFailure>> {
-    return this.manager.setMode(conversationId, modeId);
-  }
-
-  setModelOption(
-    conversationId: string,
-    dimension: 'model' | 'effort',
+    key: 'model' | 'mode' | 'effort',
     value: string
-  ): Promise<Result<void, AcpSetModelOptionError | AcpWakeFailure>> {
-    return this.manager.setConfigOption(conversationId, dimension, value);
+  ): Promise<Result<void, AcpSetOptionError | AcpWakeFailure>> {
+    return key === 'mode'
+      ? this.manager.setMode(conversationId, value)
+      : this.manager.setConfigOption(conversationId, key, value);
   }
 
-  getHistory(
+  async loadHistory(
     conversationId: string,
     before?: number,
     limit?: number
-  ): Result<HistoryPage, AcpGetHistoryError> {
-    return ok(this.manager.getHistory(conversationId, before, limit));
+  ): Promise<Result<LoadHistoryResult, AcpLoadHistoryError>> {
+    const activation = await this.manager.ensureActivation(conversationId);
+    if (!activation.success) return activation;
+    return ok({
+      ...this.manager.getHistory(conversationId, before, limit),
+      ...(activation.data.clearedConfiguration && {
+        clearedConfiguration: activation.data.clearedConfiguration,
+      }),
+    });
   }
 
   exportParsedTranscript(conversationId: string): Result<string, AcpExportTranscriptError> {
@@ -217,9 +211,11 @@ export class AcpRuntime {
    * Conversation-deletion cleanup (spec §3.6): removes the conversation's attachment
    * directory. Idempotent; a runtime without attachment storage has nothing to clean.
    */
-  async deleteConversationAttachments(
+  async purgeConversationData(
     conversationId: string
-  ): Promise<Result<void, AcpAttachmentError>> {
+  ): Promise<Result<void, AcpPurgeConversationDataError>> {
+    const terminated = await this.terminateSession(conversationId);
+    if (!terminated.success) return terminated;
     if (!this.deps.attachmentStore) return ok();
     await this.deps.attachmentStore.deleteConversation(conversationId);
     return ok();

--- a/packages/core/src/runtimes/acp/node/runtime/session-intent-schemas.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/session-intent-schemas.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+import {
+  acpStartInputSchema,
+  sessionConfigStateSchema,
+  sessionMcpServerSchema,
+  sessionUsageSchema,
+} from '#runtimes/acp/api';
+
+const retainedConfiguredSchema = z.object({
+  model: z.string().nullable(),
+  modeId: z.string().nullable(),
+  effort: z.string().nullable(),
+});
+
+const retainedPresentationSchema = z.object({
+  configured: retainedConfiguredSchema,
+  lastKnownCapabilities: sessionConfigStateSchema,
+  lastKnownMcpServers: z.array(sessionMcpServerSchema),
+  lastKnownUsage: sessionUsageSchema.nullable(),
+  observedAt: z.number().int().nullable(),
+});
+
+export const persistedIntentV1Schema = z.object({
+  version: z.literal('1'),
+  conversationId: z.string(),
+  providerId: z.string(),
+  cwd: z.string(),
+  sessionId: z.string().nullable(),
+  configured: retainedConfiguredSchema,
+  presentation: retainedPresentationSchema,
+});
+
+export const legacyRetainedIntentSchema = acpStartInputSchema.extend({
+  configOverrides: z
+    .object({
+      model: z.string().optional(),
+      effort: z.string().optional(),
+    })
+    .optional(),
+});

--- a/packages/core/src/runtimes/acp/node/runtime/session-manager.test.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/session-manager.test.ts
@@ -17,21 +17,71 @@ import {
 } from '#services/session-lifecycle/node/testing';
 import { AcpRuntime } from './runtime';
 
-async function startHarness(conversationId = 'conv-1') {
+async function launchHarness(conversationId = 'conv-1') {
   const h = makeAcpHarness();
   const rt = new AcpRuntime(h.deps);
-  const result = await rt.startSession(makeStartInput({ conversationId }));
+  const result = await rt.launchSession(makeStartInput({ conversationId }));
   expect(isOk(result)).toBe(true);
   return { h, rt, client: h.client(), sessionId: 'session-1', conversationId };
 }
 
 describe('AcpRuntime session manager', () => {
+  it('attaches and exposes a suspended projection without spawning, then activates separately', async () => {
+    const h = makeAcpHarness();
+    const rt = new AcpRuntime(h.deps);
+    const input = makeStartInput({ conversationId: 'conv-attach', model: 'sonnet' });
+
+    await expect(rt.attachSession(input)).resolves.toEqual(ok());
+
+    expect(h.children).toHaveLength(0);
+    expect(peek(rt.sessionLiveModels(input.conversationId)!.states.state)).toMatchObject({
+      suspended: true,
+      canSubmit: true,
+    });
+
+    await expect(rt.loadHistory(input.conversationId)).resolves.toMatchObject({
+      success: true,
+      data: { turns: [], nextCursor: null },
+    });
+    expect(h.children).toHaveLength(1);
+  });
+
+  it('clears stored selections only when an authoritative provider catalog excludes them', async () => {
+    const h = makeAcpHarness();
+    h.agent.newSession.mockResolvedValueOnce({
+      sessionId: 'session-1',
+      configOptions: [modelConfigOption('supported-model')],
+    });
+    const rt = new AcpRuntime(h.deps);
+
+    const result = await rt.launchSession(
+      makeStartInput({ conversationId: 'conv-unsupported-model', model: 'removed-model' })
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      data: { clearedConfiguration: ['model'] },
+    });
+    expect(h.agent.setSessionConfigOption).not.toHaveBeenCalled();
+
+    const missingCatalogHarness = makeAcpHarness();
+    missingCatalogHarness.agent.newSession.mockResolvedValueOnce({ sessionId: 'session-2' });
+    const missingCatalogRuntime = new AcpRuntime(missingCatalogHarness.deps);
+    const missingCatalogResult = await missingCatalogRuntime.launchSession(
+      makeStartInput({ conversationId: 'conv-missing-catalog', model: 'keep-me' })
+    );
+    expect(missingCatalogResult).toMatchObject({ success: true, data: { sessionId: 'session-2' } });
+    if (missingCatalogResult.success) {
+      expect(missingCatalogResult.data.clearedConfiguration).toBeUndefined();
+    }
+  });
+
   it('maps ACP auth_required JSON-RPC errors to auth_required', async () => {
     const h = makeAcpHarness();
     const rt = new AcpRuntime(h.deps);
     h.agent.newSession.mockRejectedValueOnce({ code: -32000, message: 'Authentication required' });
 
-    const result = await rt.startSession(makeStartInput({ conversationId: 'conv-auth-required' }));
+    const result = await rt.launchSession(makeStartInput({ conversationId: 'conv-auth-required' }));
 
     expect(result.success).toBe(false);
     if (!result.success) expect(result.error.type).toBe('auth_required');
@@ -45,8 +95,8 @@ describe('AcpRuntime session manager', () => {
       .mockResolvedValueOnce({ sessionId: 'session-a' })
       .mockResolvedValueOnce({ sessionId: 'session-b' });
 
-    await rt.startSession(makeStartInput({ conversationId: 'conv-a' }));
-    await rt.startSession(makeStartInput({ conversationId: 'conv-b' }));
+    await rt.launchSession(makeStartInput({ conversationId: 'conv-a' }));
+    await rt.launchSession(makeStartInput({ conversationId: 'conv-b' }));
 
     expect(h.children).toHaveLength(1);
     await rt.stopSession('conv-a');
@@ -69,7 +119,7 @@ describe('AcpRuntime session manager', () => {
       },
     });
     const rt = new AcpRuntime(h.deps);
-    await rt.startSession(makeStartInput({ conversationId: 'conv-idle' }));
+    await rt.launchSession(makeStartInput({ conversationId: 'conv-idle' }));
     const live = rt.sessionLiveModels('conv-idle');
     if (!live) throw new Error('expected stable live projection');
 
@@ -90,7 +140,7 @@ describe('AcpRuntime session manager', () => {
     const h = makeAcpHarness({ lifecycle: { connectionIdleTtlMs: 0 } });
     const rt = new AcpRuntime(h.deps);
     const input = makeStartInput({ conversationId: 'conv-wake-prompt' });
-    await rt.startSession(input);
+    await rt.launchSession(input);
     const live = rt.sessionLiveModels(input.conversationId);
     if (!live) throw new Error('expected stable live projection');
     await rt.stopSession(input.conversationId);
@@ -119,11 +169,58 @@ describe('AcpRuntime session manager', () => {
     expect(peek(live.states.state)).toMatchObject({ lifecycle: 'ready' });
   });
 
+  it('applies settings changed while materializing before one joined prompt', async () => {
+    const h = makeAcpHarness({ lifecycle: { connectionIdleTtlMs: 0 } });
+    h.agent.newSession.mockResolvedValueOnce({
+      sessionId: 'session-1',
+      configOptions: [effortConfigOption('low')],
+    });
+    const rt = new AcpRuntime(h.deps);
+    const input = makeStartInput({ conversationId: 'conv-materializing-preferences' });
+    await rt.launchSession(input);
+    await rt.stopSession(input.conversationId);
+
+    const replay = deferred<{ configOptions: ReturnType<typeof effortConfigOption>[] }>();
+    h.agent.loadSession.mockImplementationOnce(async () => replay.promise);
+    h.agent.setSessionConfigOption.mockClear();
+    h.agent.prompt.mockClear();
+
+    const activation = rt.loadHistory(input.conversationId);
+    await vi.waitFor(() => expect(h.agent.loadSession).toHaveBeenCalledTimes(1));
+    expect(peek(rt.sessionLiveModels(input.conversationId)!.states.state)).toMatchObject({
+      canSubmit: true,
+    });
+
+    await expect(rt.setOption(input.conversationId, 'effort', 'high')).resolves.toEqual(ok());
+    expect(peek(rt.sessionLiveModels(input.conversationId)!.states.config)).toMatchObject({
+      efforts: { selected: 'high' },
+    });
+    const prompt = rt.sendPrompt(input.conversationId, { text: 'join activation' });
+
+    expect(h.agent.loadSession).toHaveBeenCalledTimes(1);
+    expect(h.agent.prompt).not.toHaveBeenCalled();
+
+    replay.resolve({ configOptions: [effortConfigOption('low')] });
+    await expect(activation).resolves.toMatchObject({ success: true });
+    await expect(prompt).resolves.toEqual(ok({ queued: false }));
+
+    expect(h.agent.setSessionConfigOption).toHaveBeenCalledTimes(1);
+    expect(h.agent.setSessionConfigOption).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      configId: 'reasoning_effort',
+      value: 'high',
+    });
+    expect(h.agent.prompt).toHaveBeenCalledTimes(1);
+    expect(h.agent.setSessionConfigOption.mock.invocationCallOrder[0]).toBeLessThan(
+      h.agent.prompt.mock.invocationCallOrder[0]!
+    );
+  });
+
   it('keeps no-wake operations suspended and activation-local', async () => {
     const h = makeAcpHarness({ lifecycle: { connectionIdleTtlMs: 0 } });
     const rt = new AcpRuntime(h.deps);
     const input = makeStartInput({ conversationId: 'conv-no-wake' });
-    await rt.startSession(input);
+    await rt.launchSession(input);
     await rt.stopSession(input.conversationId);
     h.agent.loadSession.mockClear();
     h.agent.newSession.mockClear();
@@ -133,9 +230,6 @@ describe('AcpRuntime session manager', () => {
     expect(rt.changeQueuePromptOrder(input.conversationId, [])).toEqual(ok());
     expect(rt.resolvePermission(input.conversationId, 'stale', 'allow')).toEqual(ok());
     await expect(rt.cancelTurn(input.conversationId)).resolves.toEqual(ok());
-    expect(rt.getHistory(input.conversationId)).toEqual(
-      ok({ turns: [], nextCursor: null, unavailable: true })
-    );
     expect(rt.exportParsedTranscript(input.conversationId)).toMatchObject({
       success: false,
       error: { type: 'conversation_not_found' },
@@ -148,13 +242,67 @@ describe('AcpRuntime session manager', () => {
     expect(h.agent.newSession).not.toHaveBeenCalled();
   });
 
+  it('persists dormant settings without waking and applies them before the next prompt', async () => {
+    const intents = createMemorySessionIntentStore();
+    const h = makeAcpHarness({
+      intents,
+      lifecycle: { connectionIdleTtlMs: 0 },
+    });
+    h.agent.newSession.mockResolvedValueOnce({
+      sessionId: 'session-1',
+      configOptions: [modeConfigOption('agent'), effortConfigOption('low')],
+    });
+    const rt = new AcpRuntime(h.deps);
+    const input = makeStartInput({ conversationId: 'conv-dormant-settings' });
+    await rt.launchSession(input);
+    await rt.stopSession(input.conversationId);
+    h.agent.loadSession.mockClear();
+    h.agent.newSession.mockClear();
+    h.agent.setSessionConfigOption.mockClear();
+    h.agent.prompt.mockClear();
+
+    await expect(rt.setOption(input.conversationId, 'mode', 'agent-full-access')).resolves.toEqual(
+      ok()
+    );
+    await expect(rt.setOption(input.conversationId, 'effort', 'high')).resolves.toEqual(ok());
+
+    expect(h.agent.loadSession).not.toHaveBeenCalled();
+    expect(h.agent.newSession).not.toHaveBeenCalled();
+    expect(h.agent.setSessionConfigOption).not.toHaveBeenCalled();
+    expect(intents.snapshot()[0]?.payload).toMatchObject({
+      configured: { modeId: 'agent-full-access', effort: 'high' },
+    });
+    expect(peek(rt.sessionLiveModels(input.conversationId)!.states.config)).toMatchObject({
+      modeOptions: { selected: 'agent-full-access' },
+      efforts: { selected: 'high' },
+    });
+
+    h.agent.loadSession.mockResolvedValueOnce({
+      configOptions: [modeConfigOption('agent'), effortConfigOption('low')],
+    });
+    await rt.sendPrompt(input.conversationId, { text: 'wake once' });
+
+    expect(h.agent.loadSession).toHaveBeenCalledTimes(1);
+    expect(h.agent.setSessionConfigOption).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      configId: 'mode',
+      value: 'agent-full-access',
+    });
+    expect(h.agent.setSessionConfigOption).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      configId: 'reasoning_effort',
+      value: 'high',
+    });
+    expect(h.agent.prompt).toHaveBeenCalledTimes(1);
+  });
+
   it('does not wake or block no-wake operations while an activation is stopping', async () => {
     const promptDeferred = deferred<{ stopReason: 'end_turn' }>();
     const h = makeAcpHarness({ lifecycle: { activationDrainTimeoutMs: 1_000 } });
     h.agent.prompt.mockImplementationOnce(async () => promptDeferred.promise);
     const rt = new AcpRuntime(h.deps);
     const input = makeStartInput({ conversationId: 'conv-no-wake-stopping' });
-    await rt.startSession(input);
+    await rt.launchSession(input);
     const prompt = rt.sendPrompt(input.conversationId, { text: 'long turn' });
     await vi.waitFor(() => expect(h.agent.prompt).toHaveBeenCalledTimes(1));
 
@@ -166,9 +314,6 @@ describe('AcpRuntime session manager', () => {
     expect(rt.changeQueuePromptOrder(input.conversationId, [])).toEqual(ok());
     expect(rt.resolvePermission(input.conversationId, 'stale', 'allow')).toEqual(ok());
     await expect(rt.cancelTurn(input.conversationId)).resolves.toEqual(ok());
-    expect(rt.getHistory(input.conversationId)).toEqual(
-      ok({ turns: [], nextCursor: null, unavailable: true })
-    );
     expect(h.agent.loadSession).not.toHaveBeenCalled();
 
     promptDeferred.resolve({ stopReason: 'end_turn' });
@@ -180,7 +325,7 @@ describe('AcpRuntime session manager', () => {
     const h = makeAcpHarness({ lifecycle: { connectionIdleTtlMs: 0 } });
     const rt = new AcpRuntime(h.deps);
     const input = makeStartInput({ conversationId: 'conv-wake-failure' });
-    await rt.startSession(input);
+    await rt.launchSession(input);
     const live = rt.sessionLiveModels(input.conversationId);
     if (!live) throw new Error('expected stable live projection');
     await rt.stopSession(input.conversationId);
@@ -205,7 +350,7 @@ describe('AcpRuntime session manager', () => {
     h.agent.prompt.mockImplementationOnce(async () => pendingPrompt.promise);
     const rt = new AcpRuntime(h.deps);
     const input = makeStartInput({ conversationId: 'conv-crash-mid-turn' });
-    await rt.startSession(input);
+    await rt.launchSession(input);
     const prompt = rt.sendPrompt(input.conversationId, { text: 'in flight' });
     await vi.waitFor(() => expect(h.agent.prompt).toHaveBeenCalledTimes(1));
     h.agent.loadSession.mockClear();
@@ -230,16 +375,16 @@ describe('AcpRuntime session manager', () => {
     h.agent.prompt.mockImplementationOnce(async () => never.promise);
     const rt = new AcpRuntime(h.deps);
     const input = makeStartInput({ conversationId: 'conv-kill-long-turn' });
-    await rt.startSession(input);
+    await rt.launchSession(input);
     void rt.sendPrompt(input.conversationId, { text: 'long turn' });
     await vi.waitFor(() => expect(h.agent.prompt).toHaveBeenCalledTimes(1));
 
-    const kill = rt.killSession(input.conversationId);
+    const termination = rt.terminateSession(input.conversationId);
     await expect(rt.sendPrompt(input.conversationId, { text: 'too late' })).resolves.toMatchObject({
       success: false,
       error: { type: 'conversation_not_found' },
     });
-    await kill;
+    await termination;
 
     expect(h.agent.cancel).toHaveBeenCalledWith({ sessionId: 'session-1' });
     expect(h.agent.closeSession).toHaveBeenCalledWith({ sessionId: 'session-1' });
@@ -252,12 +397,12 @@ describe('AcpRuntime session manager', () => {
     h.agent.newSession.mockImplementationOnce(async () => starting.promise);
     const rt = new AcpRuntime(h.deps);
     const input = makeStartInput({ conversationId: 'conv-kill-starting' });
-    const start = rt.startSession(input);
+    const launch = rt.launchSession(input);
     await vi.waitFor(() => expect(h.agent.newSession).toHaveBeenCalledTimes(1));
 
-    await rt.killSession(input.conversationId);
+    await rt.terminateSession(input.conversationId);
 
-    await expect(start).resolves.toMatchObject({ success: false });
+    await expect(launch).resolves.toMatchObject({ success: false });
     expectNoSessionResidue(input.conversationId, leakContainers(rt));
   });
 
@@ -270,12 +415,12 @@ describe('AcpRuntime session manager', () => {
       ...makeStartInput({ conversationId: 'conv-kill-replaying' }),
       sessionId: 'old',
     };
-    const start = rt.resumeSession(input);
+    const launch = rt.launchSession(input);
     await vi.waitFor(() => expect(h.agent.loadSession).toHaveBeenCalledTimes(1));
 
-    await rt.killSession(input.conversationId);
+    await rt.terminateSession(input.conversationId);
 
-    await expect(start).resolves.toMatchObject({ success: false });
+    await expect(launch).resolves.toMatchObject({ success: false });
     expect(h.agent.closeSession).toHaveBeenCalledWith({ sessionId: 'old' });
     expectNoSessionResidue(input.conversationId, leakContainers(rt));
   });
@@ -288,12 +433,12 @@ describe('AcpRuntime session manager', () => {
       initialQueue: [{ text: 'bootstrap' }],
     });
 
-    await rt.startSession(input);
+    await rt.launchSession(input);
     await vi.waitFor(() => expect(h.agent.prompt).toHaveBeenCalledTimes(1));
-    await rt.startSession(input);
+    await rt.launchSession(input);
     expect(h.agent.prompt).toHaveBeenCalledTimes(1);
     await rt.stopSession(input.conversationId);
-    await rt.startSession(input);
+    await rt.launchSession(input);
 
     expect(h.agent.loadSession).toHaveBeenCalledWith({
       cwd: '/tmp/workspace',
@@ -316,12 +461,12 @@ describe('AcpRuntime session manager', () => {
       ...makeStartInput({ conversationId: 'conv-retained-config' }),
       sessionId: 'old',
     };
-    await rt.resumeSession(input);
-    await rt.setModelOption(input.conversationId, 'effort', 'high');
+    await rt.launchSession(input);
+    await rt.setOption(input.conversationId, 'effort', 'high');
     await vi.waitFor(() =>
       expect(intents.snapshot()[0]?.payload).toMatchObject({
         sessionId: 'replacement',
-        configOverrides: { effort: 'high' },
+        configured: { effort: 'high' },
       })
     );
     await rt.stopSession(input.conversationId);
@@ -331,7 +476,7 @@ describe('AcpRuntime session manager', () => {
       configOptions: [effortConfigOption('low')],
     });
 
-    await rt.startSession(input);
+    await rt.launchSession(input);
 
     expect(h.agent.loadSession).toHaveBeenCalledWith({
       cwd: '/tmp/workspace',
@@ -345,6 +490,25 @@ describe('AcpRuntime session manager', () => {
     });
   });
 
+  it('keeps a newer runtime session id when attach races host-report convergence', async () => {
+    const h = makeAcpHarness({ lifecycle: { connectionIdleTtlMs: 0 } });
+    h.agent.newSession.mockResolvedValueOnce({ sessionId: 'replacement' });
+    const rt = new AcpRuntime(h.deps);
+    const input = makeStartInput({ conversationId: 'conv-attach-session-race' });
+    await rt.launchSession(input);
+    await rt.stopSession(input.conversationId);
+    h.agent.loadSession.mockResolvedValueOnce({});
+
+    await rt.attachSession({ ...input, sessionId: 'stale-host-session' });
+    await rt.loadHistory(input.conversationId);
+
+    expect(h.agent.loadSession).toHaveBeenCalledWith({
+      cwd: '/tmp/workspace',
+      sessionId: 'replacement',
+      mcpServers: [],
+    });
+  });
+
   it('retains mode changes across rematerialization despite stale bootstrap input', async () => {
     const h = makeAcpHarness({ lifecycle: { connectionIdleTtlMs: 0 } });
     h.agent.newSession.mockResolvedValueOnce({
@@ -353,15 +517,15 @@ describe('AcpRuntime session manager', () => {
     });
     const rt = new AcpRuntime(h.deps);
     const input = makeStartInput({ conversationId: 'conv-retained-mode', modeId: null });
-    await rt.startSession(input);
-    await rt.setModeOption(input.conversationId, 'agent-full-access');
+    await rt.launchSession(input);
+    await rt.setOption(input.conversationId, 'mode', 'agent-full-access');
     await rt.stopSession(input.conversationId);
     h.agent.setSessionConfigOption.mockClear();
     h.agent.loadSession.mockResolvedValueOnce({
       configOptions: [modeConfigOption('agent')],
     });
 
-    await rt.startSession(input);
+    await rt.launchSession(input);
 
     expect(h.agent.setSessionConfigOption).toHaveBeenCalledWith({
       sessionId: 'session-1',
@@ -379,8 +543,8 @@ describe('AcpRuntime session manager', () => {
     });
     const firstRuntime = new AcpRuntime(firstHarness.deps);
     const input = makeStartInput({ conversationId: 'conv-boot-retained' });
-    await firstRuntime.startSession(input);
-    await firstRuntime.setModelOption(input.conversationId, 'effort', 'high');
+    await firstRuntime.launchSession(input);
+    await firstRuntime.setOption(input.conversationId, 'effort', 'high');
     await firstRuntime.stopSession(input.conversationId);
     await vi.waitFor(() => expect(intents.snapshot()[0]?.status).toBe('suspended'));
     await firstRuntime.dispose();
@@ -393,6 +557,7 @@ describe('AcpRuntime session manager', () => {
     await secondRuntime.reconcile();
 
     expect(secondHarness.agent.loadSession).not.toHaveBeenCalled();
+    await secondRuntime.attachSession({ ...input, sessionId: 'session-1', effort: 'high' });
     expect(peek(secondRuntime.sessionLiveModels(input.conversationId)!.states.state)).toMatchObject(
       {
         suspended: true,
@@ -416,9 +581,9 @@ describe('AcpRuntime session manager', () => {
     const h = makeAcpHarness({ lifecycle: { connectionIdleTtlMs: 0 } });
     const rt = new AcpRuntime(h.deps);
     const input = makeStartInput({ conversationId: 'conv-stale-close' });
-    await rt.startSession(input);
+    await rt.launchSession(input);
     await rt.stopSession(input.conversationId);
-    await rt.startSession(input);
+    await rt.launchSession(input);
 
     rt.manager.onProcessClosed('claude:/tmp/workspace', 1, 42);
 
@@ -428,7 +593,7 @@ describe('AcpRuntime session manager', () => {
     expect(state?.suspended).toBeUndefined();
   });
 
-  it('reconciles legacy session intents and strips desktop identifiers', async () => {
+  it('reconciles legacy intents without spawning and activates only with fresh attached env', async () => {
     const intents = createMemorySessionIntentStore();
     const { sessionId: _, ...legacyInput } = makeStartInput({
       conversationId: 'conv-reconcile',
@@ -441,6 +606,7 @@ describe('AcpRuntime session manager', () => {
         projectId: 'project-1',
         taskId: 'task-1',
         workspaceId: 'workspace-1',
+        env: { API_TOKEN: 'legacy-secret' },
         sessionId: 'session-old',
       },
     });
@@ -449,12 +615,35 @@ describe('AcpRuntime session manager', () => {
 
     await rt.reconcile();
 
-    expect(h.agent.loadSession).toHaveBeenCalledWith({
-      cwd: '/tmp/workspace',
-      sessionId: 'session-old',
-      mcpServers: [],
-    });
+    expect(h.agent.loadSession).not.toHaveBeenCalled();
+    expect(h.agent.newSession).not.toHaveBeenCalled();
     expect(peek(rt.sessionsListLiveModel().states.list)).toHaveProperty('conv-reconcile');
+    await expect(
+      rt.sendPrompt('conv-reconcile', { text: 'must attach first' })
+    ).resolves.toMatchObject({
+      success: false,
+      error: { type: 'conversation_not_found' },
+    });
+    expect(h.children).toHaveLength(0);
+    const [sanitized] = intents.snapshot();
+    expect(sanitized).toMatchObject({ status: 'suspended' });
+    expect(JSON.stringify(sanitized)).not.toContain('API_TOKEN');
+    expect(JSON.stringify(sanitized)).not.toContain('legacy-secret');
+
+    const spawn = vi.spyOn(h.fakeHost, 'spawn');
+    await rt.attachSession({
+      ...makeStartInput({ conversationId: 'conv-reconcile' }),
+      sessionId: 'session-old',
+      env: { API_TOKEN: 'fresh-secret' },
+    });
+    expect(spawn).not.toHaveBeenCalled();
+
+    await rt.loadHistory('conv-reconcile');
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({ env: expect.objectContaining({ API_TOKEN: 'fresh-secret' }) })
+    );
+    expect(JSON.stringify(intents.snapshot())).not.toContain('fresh-secret');
   });
 
   it('injects host-scoped MCP servers into new ACP sessions', async () => {
@@ -479,7 +668,7 @@ describe('AcpRuntime session manager', () => {
     );
     const rt = new AcpRuntime(h.deps);
 
-    const result = await rt.startSession(makeStartInput({ conversationId: 'conv-mcp' }));
+    const result = await rt.launchSession(makeStartInput({ conversationId: 'conv-mcp' }));
 
     expect(isOk(result)).toBe(true);
     expect(h.agent.newSession).toHaveBeenCalledWith({
@@ -512,7 +701,7 @@ describe('AcpRuntime session manager', () => {
     );
     const rt = new AcpRuntime(h.deps);
 
-    const result = await rt.resumeSession({
+    const result = await rt.launchSession({
       ...makeStartInput({ conversationId: 'conv-load-mcp' }),
       sessionId: 'session-old',
     });
@@ -536,7 +725,7 @@ describe('AcpRuntime session manager', () => {
     });
     const rt = new AcpRuntime(h.deps);
 
-    const result = await rt.startSession(
+    const result = await rt.launchSession(
       makeStartInput({ conversationId: 'conv-mode', modeId: 'agent-full-access' })
     );
 
@@ -555,7 +744,7 @@ describe('AcpRuntime session manager', () => {
     });
     const rt = new AcpRuntime(h.deps);
 
-    const result = await rt.resumeSession({
+    const result = await rt.launchSession({
       ...makeStartInput({ conversationId: 'conv-mode-load', modeId: 'agent-full-access' }),
       sessionId: 'session-old',
     });
@@ -576,7 +765,7 @@ describe('AcpRuntime session manager', () => {
     });
     const rt = new AcpRuntime(h.deps);
 
-    const result = await rt.startSession(
+    const result = await rt.launchSession(
       makeStartInput({ conversationId: 'conv-mode-unknown', modeId: 'bypass-everything' })
     );
 
@@ -593,7 +782,7 @@ describe('AcpRuntime session manager', () => {
     });
     const rt = new AcpRuntime(h.deps);
 
-    const result = await rt.startSession(
+    const result = await rt.launchSession(
       makeStartInput({ conversationId: 'conv-mode-selected', modeId: 'agent-full-access' })
     );
 
@@ -611,7 +800,7 @@ describe('AcpRuntime session manager', () => {
     h.agent.setSessionConfigOption.mockRejectedValueOnce(new Error('mode change rejected'));
     const rt = new AcpRuntime(h.deps);
 
-    const result = await rt.startSession(
+    const result = await rt.launchSession(
       makeStartInput({ conversationId: 'conv-mode-error', modeId: 'agent-full-access' })
     );
 
@@ -623,15 +812,16 @@ describe('AcpRuntime session manager', () => {
     const h = makeAcpHarness({ intents });
     const rt = new AcpRuntime(h.deps);
 
-    await rt.startSession(makeStartInput({ conversationId: 'conv-persisted' }));
+    await rt.launchSession(makeStartInput({ conversationId: 'conv-persisted' }));
 
     await vi.waitFor(() => expect(intents.snapshot()).toHaveLength(1));
-    expect(intents.snapshot()[0]?.payload).toEqual({
+    expect(intents.snapshot()[0]?.payload).toMatchObject({
+      version: '1',
       conversationId: 'conv-persisted',
       providerId: 'claude',
       cwd: '/tmp/workspace',
       sessionId: 'session-1',
-      model: null,
+      configured: { model: null, modeId: null, effort: null },
     });
   });
 
@@ -647,7 +837,7 @@ describe('AcpRuntime session manager', () => {
       },
     });
     const rt = new AcpRuntime(h.deps);
-    await rt.startSession(makeStartInput({ conversationId: 'conv-idle-intent' }));
+    await rt.launchSession(makeStartInput({ conversationId: 'conv-idle-intent' }));
 
     await clock.advanceBy(1_200);
 
@@ -664,17 +854,17 @@ describe('AcpRuntime session manager', () => {
     const intents = createMemorySessionIntentStore();
     const h = makeAcpHarness({ intents });
     const rt = new AcpRuntime(h.deps);
-    await rt.startSession(makeStartInput({ conversationId: 'conv-kill' }));
+    await rt.launchSession(makeStartInput({ conversationId: 'conv-kill' }));
 
     await vi.waitFor(() => expect(intents.snapshot()).toHaveLength(1));
-    await rt.killSession('conv-kill');
+    await rt.terminateSession('conv-kill');
 
     await vi.waitFor(() => expect(intents.snapshot()).toEqual([]));
     expectNoSessionResidue('conv-kill', leakContainers(rt));
   });
 
   it('publishes activeTurn patches without root replacement during incremental text growth', async () => {
-    const { h, rt, client, sessionId } = await startHarness('conv-live');
+    const { h, rt, client, sessionId } = await launchHarness('conv-live');
     let resolvePrompt!: (value: { stopReason: 'end_turn' }) => void;
     h.agent.prompt = vi.fn(
       () =>
@@ -719,7 +909,7 @@ describe('AcpRuntime session manager', () => {
   });
 
   it('publishes usage updates through live models', async () => {
-    const { rt, client, sessionId } = await startHarness('conv-usage');
+    const { rt, client, sessionId } = await launchHarness('conv-usage');
     const live = rt.sessionLiveModels('conv-usage');
     if (!live) throw new Error('expected live models');
     const scope = createScope({ label: 'test:usage' });
@@ -753,7 +943,7 @@ describe('AcpRuntime session manager', () => {
     });
     const h = makeAcpHarness({ resolveAttachment });
     const rt = new AcpRuntime(h.deps);
-    const started = await rt.startSession(makeStartInput({ conversationId: 'conv-attachment' }));
+    const started = await rt.launchSession(makeStartInput({ conversationId: 'conv-attachment' }));
     expect(isOk(started)).toBe(true);
 
     const sent = await rt.sendPrompt('conv-attachment', {
@@ -783,7 +973,7 @@ describe('AcpRuntime session manager', () => {
       ],
     });
 
-    const history = rt.getHistory('conv-attachment');
+    const history = await rt.loadHistory('conv-attachment');
     expect(isOk(history)).toBe(true);
     if (!isOk(history)) return;
     expect(history.data.turns[0].items[0]).toMatchObject({
@@ -796,7 +986,7 @@ describe('AcpRuntime session manager', () => {
   it('sends hidden prompt context to the agent without adding it to the transcript', async () => {
     const h = makeAcpHarness();
     const rt = new AcpRuntime(h.deps);
-    const started = await rt.startSession(
+    const started = await rt.launchSession(
       makeStartInput({ conversationId: 'conv-hidden-context' })
     );
     expect(isOk(started)).toBe(true);
@@ -815,7 +1005,7 @@ describe('AcpRuntime session manager', () => {
       ],
     });
 
-    const history = rt.getHistory('conv-hidden-context');
+    const history = await rt.loadHistory('conv-hidden-context');
     expect(isOk(history)).toBe(true);
     if (!isOk(history)) return;
     expect(history.data.turns[0].items[0]).toMatchObject({
@@ -826,7 +1016,7 @@ describe('AcpRuntime session manager', () => {
   });
 
   it('delivers a prompt immediately with default placement when the session is idle', async () => {
-    const { h, rt } = await startHarness('conv-placement-auto');
+    const { h, rt } = await launchHarness('conv-placement-auto');
 
     const sent = await rt.sendPrompt('conv-placement-auto', { text: 'now' });
 
@@ -838,7 +1028,7 @@ describe('AcpRuntime session manager', () => {
   });
 
   it('queues a prompt with default placement while a turn is active', async () => {
-    const { h, rt } = await startHarness('conv-placement-active');
+    const { h, rt } = await launchHarness('conv-placement-active');
     let resolvePrompt!: (value: { stopReason: 'end_turn' }) => void;
     h.agent.prompt = vi.fn(
       () =>
@@ -865,7 +1055,7 @@ describe('AcpRuntime session manager', () => {
   });
 
   it("delivers a prompt with placement 'queue' immediately when idle", async () => {
-    const { h, rt } = await startHarness('conv-placement-queue');
+    const { h, rt } = await launchHarness('conv-placement-queue');
 
     const result = await rt.sendPrompt('conv-placement-queue', { text: 'later' }, 'queue');
 
@@ -877,7 +1067,7 @@ describe('AcpRuntime session manager', () => {
   });
 
   it("keeps placement 'queue' queued while a turn is active", async () => {
-    const { h, rt } = await startHarness('conv-placement-queue-active');
+    const { h, rt } = await launchHarness('conv-placement-queue-active');
     let resolvePrompt!: (value: { stopReason: 'end_turn' }) => void;
     h.agent.prompt = vi.fn(
       () =>
@@ -900,7 +1090,7 @@ describe('AcpRuntime session manager', () => {
     await first;
   });
 
-  it('returns a resume result with replayed history', async () => {
+  it('loads replayed history after attaching a resumable conversation', async () => {
     const h = makeAcpHarness();
     const rt = new AcpRuntime(h.deps);
     h.agent.loadSession = vi.fn(async () => {
@@ -916,14 +1106,15 @@ describe('AcpRuntime session manager', () => {
       return {};
     });
 
-    const result = await rt.resumeSession({
+    const input = {
       ...makeStartInput({ conversationId: 'conv-resume' }),
       sessionId: 'session-old',
-    });
+    };
+    await rt.attachSession(input);
+    const result = await rt.loadHistory(input.conversationId);
 
     expect(isOk(result)).toBe(true);
     if (!isOk(result)) return;
-    expect(result.data.sessionId).toBe('session-old');
     expect(result.data.turns).toHaveLength(1);
     expect(result.data.turns[0].items[0]).toMatchObject({
       kind: 'message',
@@ -932,7 +1123,7 @@ describe('AcpRuntime session manager', () => {
   });
 
   it('publishes terminal state and output through live primitives', async () => {
-    const { h, rt, client, sessionId } = await startHarness('conv-terminal');
+    const { h, rt, client, sessionId } = await launchHarness('conv-terminal');
     const terminal = new FakeAcpTerminalProcess();
     h.fakeHost.nextTerminal = terminal;
     const created = await client.createTerminal!({
@@ -966,7 +1157,7 @@ describe('AcpRuntime session manager', () => {
   });
 
   it('suspends sessions when the process closes', async () => {
-    const { h, rt } = await startHarness('conv-close');
+    const { h, rt } = await launchHarness('conv-close');
     const live = rt.sessionLiveModels('conv-close');
     if (!live) throw new Error('expected stable live projection');
 
@@ -987,8 +1178,8 @@ describe('AcpRuntime session manager', () => {
       .mockResolvedValueOnce({ sessionId: 'session-a' })
       .mockResolvedValueOnce({ sessionId: 'session-b' });
 
-    await rt.startSession(makeStartInput({ conversationId: 'conv-a' }));
-    await rt.startSession(makeStartInput({ conversationId: 'conv-b' }));
+    await rt.launchSession(makeStartInput({ conversationId: 'conv-a' }));
+    await rt.launchSession(makeStartInput({ conversationId: 'conv-b' }));
     expect(h.children).toHaveLength(1);
 
     h.lastChild.emitExit(42);
@@ -1015,7 +1206,7 @@ describe('AcpRuntime conversation lifecycle reports', () => {
     const h = makeAcpHarness({ conversationReports: reports });
     const rt = new AcpRuntime(h.deps);
 
-    await rt.startSession(makeStartInput({ conversationId: 'conv-fresh' }));
+    await rt.launchSession(makeStartInput({ conversationId: 'conv-fresh' }));
 
     expect(reports.started).toEqual([
       { conversationId: 'conv-fresh', providerSessionId: 'session-1', resumeOutcome: null },
@@ -1029,7 +1220,7 @@ describe('AcpRuntime conversation lifecycle reports', () => {
     const rt = new AcpRuntime(h.deps);
     h.agent.loadSession = vi.fn(async () => ({}));
 
-    await rt.resumeSession({
+    await rt.launchSession({
       ...makeStartInput({ conversationId: 'conv-resume' }),
       sessionId: 'session-old',
     });
@@ -1047,7 +1238,7 @@ describe('AcpRuntime conversation lifecycle reports', () => {
       throw new Error('session file is gone');
     });
 
-    const result = await rt.resumeSession({
+    const result = await rt.launchSession({
       ...makeStartInput({ conversationId: 'conv-fallback' }),
       sessionId: 'session-old',
     });
@@ -1079,7 +1270,7 @@ describe('AcpRuntime conversation lifecycle reports', () => {
       return {};
     });
 
-    await rt.resumeSession({
+    await rt.launchSession({
       ...makeStartInput({ conversationId: 'conv-rebind' }),
       sessionId: 'session-old',
     });
@@ -1093,7 +1284,7 @@ describe('AcpRuntime conversation lifecycle reports', () => {
     const reports = createRecordingConversationLifecycleReporter();
     const h = makeAcpHarness({ conversationReports: reports });
     const rt = new AcpRuntime(h.deps);
-    await rt.startSession(makeStartInput({ conversationId: 'conv-stop' }));
+    await rt.launchSession(makeStartInput({ conversationId: 'conv-stop' }));
 
     await rt.stopSession('conv-stop');
 
@@ -1106,7 +1297,7 @@ describe('AcpRuntime conversation lifecycle reports', () => {
     const reports = createRecordingConversationLifecycleReporter();
     const h = makeAcpHarness({ conversationReports: reports });
     const rt = new AcpRuntime(h.deps);
-    await rt.startSession(makeStartInput({ conversationId: 'conv-died' }));
+    await rt.launchSession(makeStartInput({ conversationId: 'conv-died' }));
 
     h.lastChild.emitExit(42);
 
@@ -1128,7 +1319,7 @@ describe('AcpRuntime conversation lifecycle reports', () => {
     const intents = createMemorySessionIntentStore();
     const h = makeAcpHarness({ intents });
     const rt = new AcpRuntime(h.deps);
-    await rt.startSession(makeStartInput({ conversationId: 'conv-crash' }));
+    await rt.launchSession(makeStartInput({ conversationId: 'conv-crash' }));
     await vi.waitFor(() => expect(intents.snapshot()).toHaveLength(1));
 
     h.lastChild.emitExit(42);
@@ -1147,7 +1338,7 @@ describe('AcpRuntime conversation lifecycle reports', () => {
     const rt = new AcpRuntime(h.deps);
     h.agent.newSession.mockRejectedValueOnce(new Error('agent refused'));
 
-    const result = await rt.startSession(makeStartInput({ conversationId: 'conv-start-fail' }));
+    const result = await rt.launchSession(makeStartInput({ conversationId: 'conv-start-fail' }));
 
     expect(result.success).toBe(false);
     expect(reports.ended).toEqual(['conv-start-fail']);
@@ -1161,7 +1352,7 @@ describe('AcpRuntime conversation lifecycle reports', () => {
       throw new Error('session file is gone');
     });
 
-    const result = await rt.resumeSession({
+    const result = await rt.launchSession({
       ...makeStartInput({ conversationId: 'conv-lease' }),
       sessionId: 'session-old',
     });
@@ -1197,6 +1388,17 @@ function leakContainers(rt: AcpRuntime): LeakCheckContainer[] {
       has: (key) => key in peek(rt.sessionsListLiveModel().states.list),
     },
   ];
+}
+
+function modelConfigOption(currentValue: string) {
+  return {
+    id: 'model',
+    name: 'Model',
+    category: 'model',
+    type: 'select',
+    currentValue,
+    options: [{ value: 'supported-model', name: 'Supported model' }],
+  };
 }
 
 function modeConfigOption(currentValue: string) {

--- a/packages/core/src/runtimes/acp/node/runtime/session-manager.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/session-manager.ts
@@ -6,12 +6,11 @@ import type {
   SessionNotification,
   SessionUpdate,
 } from '@agentclientprotocol/sdk';
-import type { Result } from '@emdash/shared';
+import type { Result, Serializable } from '@emdash/shared';
 import { err, ok, toSerializedError } from '@emdash/shared';
 import type { Scope } from '@emdash/shared/concurrency';
 import type { Logger } from '@emdash/shared/logger';
 import { systemClock, type Clock } from '@emdash/shared/scheduling';
-import { z } from 'zod';
 import type {
   AcpCancelTurnError,
   AcpChangeQueuePromptOrderError,
@@ -19,18 +18,17 @@ import type {
   AcpEditQueuedPromptError,
   AcpExportRawLogError,
   AcpExportTranscriptError,
-  AcpKillError,
+  AcpTerminateError,
   AcpResolvePermissionError,
   AcpSendPromptError,
-  AcpSetModeOptionError,
-  AcpSetModelOptionError,
+  AcpSetOptionError,
   AcpStartError,
   HistoryPage,
   NormalizedEvent,
   SessionState,
   TerminalState,
 } from '#runtimes/acp/api';
-import { ACP_UNAMBIGUOUS_START_ERROR_TYPES, acpErr, acpStartInputSchema } from '#runtimes/acp/api';
+import { ACP_UNAMBIGUOUS_START_ERROR_TYPES, acpErr } from '#runtimes/acp/api';
 import type { FsPort } from '#runtimes/acp/node/agent-ports/fs-port';
 import type { AgentTerminalManager } from '#runtimes/acp/node/agent-ports/terminal-manager';
 import type { TerminalPort } from '#runtimes/acp/node/agent-ports/terminal-port';
@@ -43,10 +41,12 @@ import {
   closedSessionState,
   createAcpSessionLiveHost,
   createAcpSessionsLiveHost,
+  emptyRetainedPresentation,
   suspendedSessionState,
   type AcpSessionLiveHost,
   type AcpSessionsLiveHost,
   type SessionLiveModels,
+  type RetainedPresentation,
   type SessionsListModel,
 } from '#runtimes/acp/node/state/live-models';
 import type { SessionIntent } from '#services/session-intents/api';
@@ -64,21 +64,13 @@ import type {
   ConfigOverrides,
   SessionRecord,
 } from './conversation-types';
+import { legacyRetainedIntentSchema, persistedIntentV1Schema } from './session-intent-schemas';
 import { SessionMaterializer } from './session-materializer';
 import { routeOwnerId, SessionRouter } from './session-router';
 import { SessionsListProjector, type SuspendedIntentListEntry } from './sessions-list-projector';
 import type { AcpRuntimeDeps, AcpStartInput, SendPromptInput } from './types';
 
 const DEFAULT_ACTIVATION_DRAIN_TIMEOUT_MS = 5_000;
-
-const retainedConfigOverridesSchema = z.object({
-  model: z.string().optional(),
-  effort: z.string().optional(),
-});
-
-const retainedIntentSchema = acpStartInputSchema.extend({
-  configOverrides: retainedConfigOverridesSchema.optional(),
-});
 
 export type AcpWakeFailure = {
   kind: 'wake-failed';
@@ -106,6 +98,7 @@ export function isAcpWakeFailure(error: unknown): error is AcpWakeFailure {
 type SuspendedIntentEntry = {
   descriptor: AcpStartInput;
   configOverrides: ConfigOverrides;
+  retained: RetainedPresentation;
   summary: SuspendedIntentListEntry;
 };
 
@@ -161,10 +154,8 @@ export class SessionManager {
       },
       registerRoute: (processOwner, acpSessionId, conversationId) =>
         this.router.register(processOwner, acpSessionId, conversationId),
-      addLoading: (processOwner, conversationId) =>
-        this.router.addLoading(processOwner, conversationId),
-      removeLoading: (processOwner, conversationId) =>
-        this.router.removeLoading(processOwner, conversationId),
+      beginLoad: (processOwner, acpSessionId, conversationId) =>
+        this.router.beginLoad(processOwner, acpSessionId, conversationId),
     });
     this.lifecycle = createSessionLifecycle({
       name: 'SessionManager',
@@ -191,29 +182,71 @@ export class SessionManager {
         intents: deps.intents,
         reports: deps.conversationReports,
         activePayload: (conversationId) => this.activeIntentPayload(conversationId),
-        reconcile: {
-          parse: (intent): { input: ConversationHandle } | { suspend: string } => {
-            const entry = this.restoreActiveIntent(intent);
-            return entry ? { input: entry } : { suspend: 'reconcile-failed' };
-          },
-          resume: (entry) => this.startRetained(entry),
-        },
       },
     });
   }
 
-  async start(input: AcpStartInput): Promise<Result<{ sessionId: string }, AcpStartError>> {
+  async attach(input: AcpStartInput): Promise<Result<void, AcpStartError>> {
     await this.retained.get(input.conversationId)?.waitForEviction();
     const existing = this.getOrRestoreHandle(input.conversationId);
-    const entry = existing ?? this.createHandle(input, { suspended: false });
+    const entry =
+      existing ??
+      this.createHandle(input, {
+        suspended: true,
+        consumed: input.sessionId !== null,
+        everMaterialized: input.sessionId !== null,
+      });
+    if (existing) entry.refreshDescriptor(input);
+    entry.saveIntent();
+    return ok();
+  }
+
+  async ensureActivation(
+    conversationId: string
+  ): Promise<
+    Result<
+      { sessionId: string; clearedConfiguration?: Array<'model' | 'modeId' | 'effort'> },
+      AcpStartError
+    >
+  > {
+    const entry = this.retained.get(conversationId);
+    if (!entry) return acpErr.invalidState(`ACP conversation '${conversationId}' is not attached`);
+    return this.activateEntry(entry, false);
+  }
+
+  async launch(
+    input: AcpStartInput
+  ): Promise<
+    Result<
+      { sessionId: string; clearedConfiguration?: Array<'model' | 'modeId' | 'effort'> },
+      AcpStartError
+    >
+  > {
+    await this.retained.get(input.conversationId)?.waitForEviction();
+    const existing = this.retained.get(input.conversationId);
+    const restored = existing ? null : this.getOrRestoreHandle(input.conversationId);
+    const entry = existing ?? restored ?? this.createHandle(input, { suspended: false });
+    if (restored) entry.refreshDescriptor(input);
     this.lifecycle.recordInput(input.conversationId);
 
+    return this.activateEntry(entry, !existing);
+  }
+
+  private async activateEntry(
+    entry: ConversationHandle,
+    removeOnInitialFailure: boolean
+  ): Promise<
+    Result<
+      { sessionId: string; clearedConfiguration?: Array<'model' | 'modeId' | 'effort'> },
+      AcpStartError
+    >
+  > {
     const started = await entry.ensure();
     if (!started.success) {
       if (started.error.type === 'conversation_not_found') {
         return acpErr.invalidState('ACP conversation was deleted while starting');
       }
-      if (!entry.everMaterialized && entry.state !== 'killed') {
+      if (removeOnInitialFailure && !entry.everMaterialized && entry.state !== 'killed') {
         entry.kill(started.error);
         await entry.forceRemove(started.error);
         this.removeHandle(entry);
@@ -224,14 +257,13 @@ export class SessionManager {
       return err(started.error);
     }
 
-    if (existing) entry.saveIntent();
-    return ok({ sessionId: started.data.cell.acpSessionId });
-  }
-
-  private startRetained(
-    entry: ConversationHandle
-  ): Promise<Result<{ sessionId: string }, AcpStartError>> {
-    return this.start(entry.descriptor);
+    entry.saveIntent();
+    return ok({
+      sessionId: started.data.cell.acpSessionId,
+      ...(started.data.clearedConfiguration.length > 0 && {
+        clearedConfiguration: started.data.clearedConfiguration,
+      }),
+    });
   }
 
   private async startActivation(
@@ -259,7 +291,7 @@ export class SessionManager {
   async prompt(
     input: SendPromptInput
   ): Promise<Result<{ queued: boolean }, AcpSendPromptError | AcpWakeFailure>> {
-    const entry = this.getOrRestoreHandle(input.conversationId);
+    const entry = this.retained.get(input.conversationId);
     if (!entry || entry.deleted) return acpErr.conversationNotFound(input.conversationId);
     await entry.waitForEviction();
     if (!entry.isCurrent()) return acpErr.conversationNotFound(input.conversationId);
@@ -330,7 +362,7 @@ export class SessionManager {
     return ok();
   }
 
-  async kill(conversationId: string): Promise<Result<void, AcpKillError>> {
+  async kill(conversationId: string): Promise<Result<void, AcpTerminateError>> {
     const entry = this.retained.get(conversationId);
     if (entry) {
       this.removeSuspendedIntentEntry(conversationId);
@@ -396,17 +428,20 @@ export class SessionManager {
   async setMode(
     conversationId: string,
     modeId: string
-  ): Promise<Result<void, AcpSetModeOptionError | AcpWakeFailure>> {
-    const entry = this.getOrRestoreHandle(conversationId);
+  ): Promise<Result<void, AcpSetOptionError | AcpWakeFailure>> {
+    const entry = this.retained.get(conversationId);
     if (!entry) return acpErr.conversationNotFound(conversationId);
     await entry.waitForEviction();
     if (!entry.isCurrent()) return acpErr.conversationNotFound(conversationId);
-    const started = await entry.ensure();
-    if (!started.success) return this.mapWakeError(started.error);
+    if (entry.state !== 'active') {
+      entry.updateMode(modeId);
+      entry.saveIntent();
+      return ok();
+    }
     const result = await entry.use((record) => record.cell.setMode(modeId));
     if (!result.success) {
       if (isUnambiguousStartError(result.error)) return this.mapWakeError(result.error);
-      return result as Result<void, AcpSetModeOptionError>;
+      return result as Result<void, AcpSetOptionError>;
     }
     if (!entry.isCurrent()) return acpErr.conversationNotFound(conversationId);
     entry.updateMode(modeId);
@@ -417,17 +452,20 @@ export class SessionManager {
     conversationId: string,
     dimension: ConfigDimension,
     value: string
-  ): Promise<Result<void, AcpSetModelOptionError | AcpWakeFailure>> {
-    const entry = this.getOrRestoreHandle(conversationId);
+  ): Promise<Result<void, AcpSetOptionError | AcpWakeFailure>> {
+    const entry = this.retained.get(conversationId);
     if (!entry) return acpErr.conversationNotFound(conversationId);
     await entry.waitForEviction();
     if (!entry.isCurrent()) return acpErr.conversationNotFound(conversationId);
-    const started = await entry.ensure();
-    if (!started.success) return this.mapWakeError(started.error);
+    if (entry.state !== 'active') {
+      entry.updateConfig(dimension, value);
+      entry.saveIntent();
+      return ok();
+    }
     const result = await entry.use((record) => record.cell.setConfigOption(dimension, value));
     if (!result.success) {
       if (isUnambiguousStartError(result.error)) return this.mapWakeError(result.error);
-      return result as Result<void, AcpSetModelOptionError>;
+      return result as Result<void, AcpSetOptionError>;
     }
     if (!entry.isCurrent()) return acpErr.conversationNotFound(conversationId);
     entry.updateConfig(dimension, value);
@@ -472,7 +510,7 @@ export class SessionManager {
   }
 
   getLiveModels(conversationId: string): SessionLiveModels | null {
-    return this.getOrRestoreHandle(conversationId)?.projection ?? null;
+    return this.retained.get(conversationId)?.projection ?? null;
   }
 
   syncTerminals(conversationId: string): void {
@@ -538,6 +576,7 @@ export class SessionManager {
   }
 
   onProcessClosed(processKey: string, processGeneration: number, exitCode: number | null): void {
+    this.router.invalidate(routeOwnerId(processKey, processGeneration));
     const records = new Set(
       [...this.retained.values()]
         .map((entry) => entry.currentRecord())
@@ -575,10 +614,11 @@ export class SessionManager {
     if (listed.success) {
       const suspended = new Map<string, SuspendedIntentEntry>();
       for (const intent of listed.data) {
-        if (intent.status !== 'suspended') continue;
         if (this.retained.has(intent.conversationId)) continue;
         const indexed = this.parseIntent(intent);
-        if (indexed) suspended.set(intent.conversationId, indexed);
+        if (!indexed) continue;
+        suspended.set(intent.conversationId, indexed);
+        await this.sanitizeIntent(intent, indexed);
       }
       this.suspendedIntents.clear();
       for (const [conversationId, entry] of suspended) {
@@ -592,7 +632,6 @@ export class SessionManager {
         error: listed.error,
       });
     }
-    await this.lifecycle.reconcile();
   }
 
   /** Deterministic lifecycle sweep seam used by runtime tests. */
@@ -642,9 +681,13 @@ export class SessionManager {
 
   private createHandle(
     input: AcpStartInput,
-    options: { suspended: boolean; configOverrides?: ConfigOverrides; consumed?: boolean } = {
-      suspended: false,
-    }
+    options: {
+      suspended: boolean;
+      configOverrides?: ConfigOverrides;
+      consumed?: boolean;
+      everMaterialized?: boolean;
+      retained?: RetainedPresentation;
+    } = { suspended: false }
   ): ConversationHandle {
     const projection = this.sessionHost.models(input.conversationId);
     const releaseProjection = this.sessionHost.models.retain(input.conversationId);
@@ -679,11 +722,17 @@ export class SessionManager {
             error: String(error),
           });
         },
+        now: () => this.clock.now(),
       },
       input,
-      options.configOverrides ?? (input.model ? { model: input.model } : {}),
+      options.configOverrides ??
+        ({
+          ...(input.model ? { model: input.model } : {}),
+          ...(input.effort ? { effort: input.effort } : {}),
+        } satisfies ConfigOverrides),
       options.consumed ?? false,
-      options.suspended
+      options.everMaterialized ?? options.suspended,
+      options.retained
     );
     this.retained.set(input.conversationId, entry);
     if (options.suspended) entry.initializeSuspended();
@@ -692,19 +741,48 @@ export class SessionManager {
   }
 
   private parseIntent(intent: SessionIntent): SuspendedIntentEntry | null {
-    const parsed = retainedIntentSchema.safeParse(intent.payload);
-    const sessionId = intent.sessionId ?? (parsed.success ? parsed.data.sessionId : null);
-    if (!parsed.success || !sessionId) return null;
-    const { configOverrides, ...input } = parsed.data;
-    const descriptor = {
-      ...input,
-      conversationId: intent.conversationId,
-      sessionId,
-      initialQueue: undefined,
-    };
+    const parsedV1 = persistedIntentV1Schema.safeParse(intent.payload);
+    let descriptor: AcpStartInput;
+    let configOverrides: ConfigOverrides;
+    let retained: RetainedPresentation;
+    if (parsedV1.success) {
+      const configured = parsedV1.data.configured;
+      descriptor = {
+        conversationId: intent.conversationId,
+        providerId: parsedV1.data.providerId,
+        cwd: parsedV1.data.cwd,
+        sessionId: intent.sessionId ?? parsedV1.data.sessionId,
+        model: configured.model,
+        modeId: configured.modeId,
+        effort: configured.effort,
+      };
+      configOverrides = configuredOverrides(configured);
+      retained = { ...parsedV1.data.presentation, configured };
+    } else {
+      const parsedLegacy = legacyRetainedIntentSchema.safeParse(intent.payload);
+      if (!parsedLegacy.success) return null;
+      const { configOverrides: legacyOverrides, ...legacy } = parsedLegacy.data;
+      const configured = {
+        model: legacyOverrides?.model ?? legacy.model ?? null,
+        modeId: legacy.modeId ?? null,
+        effort: legacyOverrides?.effort ?? legacy.effort ?? null,
+      };
+      descriptor = {
+        conversationId: intent.conversationId,
+        providerId: legacy.providerId,
+        cwd: legacy.cwd,
+        sessionId: intent.sessionId ?? legacy.sessionId,
+        model: configured.model,
+        modeId: configured.modeId,
+        effort: configured.effort,
+      };
+      configOverrides = configuredOverrides(configured);
+      retained = emptyRetainedPresentation(configured);
+    }
     return {
       descriptor,
-      configOverrides: configOverrides ?? (input.model ? { model: input.model } : {}),
+      configOverrides,
+      retained,
       summary: {
         conversationId: intent.conversationId,
         providerId: descriptor.providerId,
@@ -712,18 +790,6 @@ export class SessionManager {
         updatedAt: intent.updatedAt,
       },
     };
-  }
-
-  private restoreActiveIntent(intent: SessionIntent): ConversationHandle | null {
-    const existing = this.retained.get(intent.conversationId);
-    if (existing) return existing;
-    const indexed = this.parseIntent(intent);
-    if (!indexed) return null;
-    return this.createHandle(indexed.descriptor, {
-      suspended: true,
-      configOverrides: indexed.configOverrides,
-      consumed: true,
-    });
   }
 
   private getOrRestoreHandle(conversationId: string): ConversationHandle | null {
@@ -735,6 +801,8 @@ export class SessionManager {
       suspended: true,
       configOverrides: indexed.configOverrides,
       consumed: true,
+      everMaterialized: indexed.descriptor.sessionId !== null,
+      retained: indexed.retained,
     });
   }
 
@@ -745,6 +813,37 @@ export class SessionManager {
 
   private activeIntentPayload(conversationId: string) {
     return this.retained.get(conversationId)?.intentPayload() ?? null;
+  }
+
+  private async sanitizeIntent(
+    intent: SessionIntent,
+    indexed: SuspendedIntentEntry
+  ): Promise<void> {
+    const payload = persistedIntentPayload(indexed.descriptor, indexed.retained);
+    if (
+      intent.status === 'suspended' &&
+      JSON.stringify(intent.payload) === JSON.stringify(payload)
+    ) {
+      return;
+    }
+    try {
+      const saved = await this.deps.intents.saveActive({
+        conversationId: intent.conversationId,
+        payload,
+        sessionId: indexed.descriptor.sessionId,
+      });
+      if (!saved.success) throw new Error(saved.error.message);
+      const suspended = await this.deps.intents.markSuspended(
+        intent.conversationId,
+        intent.suspendedCause ?? 'worker-restart'
+      );
+      if (!suspended.success) throw new Error(suspended.error.message);
+    } catch (error) {
+      this.deps.logger.warn('SessionManager: failed to sanitize persisted ACP intent', {
+        conversationId: intent.conversationId,
+        error: String(error),
+      });
+    }
   }
 
   private readyRecord(conversationId: string): SessionRecord | undefined {
@@ -837,6 +936,28 @@ export class SessionManager {
         break;
     }
   }
+}
+
+function configuredOverrides(configured: RetainedPresentation['configured']): ConfigOverrides {
+  return {
+    ...(configured.model ? { model: configured.model } : {}),
+    ...(configured.effort ? { effort: configured.effort } : {}),
+  };
+}
+
+function persistedIntentPayload(
+  descriptor: AcpStartInput,
+  retained: RetainedPresentation
+): Serializable {
+  return {
+    version: '1',
+    conversationId: descriptor.conversationId,
+    providerId: descriptor.providerId,
+    cwd: descriptor.cwd,
+    sessionId: descriptor.sessionId,
+    configured: retained.configured,
+    presentation: retained,
+  } as unknown as Serializable;
 }
 
 function isUnambiguousStartError(error: unknown): error is ActivationStartError {

--- a/packages/core/src/runtimes/acp/node/runtime/session-materializer.test.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/session-materializer.test.ts
@@ -1,4 +1,5 @@
 import { createScope, type Scope } from '@emdash/shared/concurrency';
+import { deferred } from '@emdash/shared/testing';
 import { describe, expect, it, vi } from 'vitest';
 import { makeAcpHarness, makeStartInput } from '#runtimes/acp/node/acp-test-support';
 import type { AcpConnectionEntry, AcpConnectionSource } from '#runtimes/acp/node/connection/source';
@@ -91,6 +92,92 @@ describe('SessionMaterializer', () => {
     });
     await setup.scope.dispose();
   });
+
+  it('serializes provider load handshakes on one process generation', async () => {
+    const h = makeAcpHarness();
+    const firstLoad = deferred<Record<string, never>>();
+    const secondLoad = deferred<Record<string, never>>();
+    h.agent.loadSession
+      .mockImplementationOnce(async () => firstLoad.promise)
+      .mockImplementationOnce(async () => secondLoad.promise);
+    const setup = materializerHarness(h);
+    const secondInput = makeStartInput({
+      conversationId: 'conv-materializer-2',
+      sessionId: 'retained-session-2',
+    });
+    const secondEntry = {
+      conversationId: secondInput.conversationId,
+      descriptor: secondInput,
+      configOverrides: {},
+    } as ConversationHandle;
+
+    const first = setup.materializer.materialize(
+      setup.entry,
+      setup.entry.descriptor,
+      1,
+      setup.scope,
+      setup.controller.signal
+    );
+    await vi.waitFor(() => expect(h.agent.loadSession).toHaveBeenCalledTimes(1));
+    const second = setup.materializer.materialize(
+      secondEntry,
+      secondEntry.descriptor,
+      1,
+      setup.scope,
+      setup.controller.signal
+    );
+    await Promise.resolve();
+
+    expect(h.agent.loadSession).toHaveBeenCalledTimes(1);
+    expect(setup.loading).toEqual(['conv-materializer']);
+    firstLoad.resolve({});
+    await first;
+    await vi.waitFor(() => expect(h.agent.loadSession).toHaveBeenCalledTimes(2));
+    expect(setup.loading).toEqual(['conv-materializer-2']);
+    secondLoad.resolve({});
+    await second;
+    await setup.scope.dispose();
+  });
+
+  it('does not serialize new-session requests that need no provisional routing', async () => {
+    const h = makeAcpHarness();
+    const firstNew = deferred<{ sessionId: string }>();
+    const secondNew = deferred<{ sessionId: string }>();
+    h.agent.newSession
+      .mockImplementationOnce(async () => firstNew.promise)
+      .mockImplementationOnce(async () => secondNew.promise);
+    const setup = materializerHarness(h, {}, { sessionId: null });
+    const secondInput = makeStartInput({
+      conversationId: 'conv-materializer-2',
+      sessionId: null,
+    });
+    const secondEntry = {
+      conversationId: secondInput.conversationId,
+      descriptor: secondInput,
+      configOverrides: {},
+    } as ConversationHandle;
+
+    const first = setup.materializer.materialize(
+      setup.entry,
+      setup.entry.descriptor,
+      1,
+      setup.scope,
+      setup.controller.signal
+    );
+    const second = setup.materializer.materialize(
+      secondEntry,
+      secondEntry.descriptor,
+      1,
+      setup.scope,
+      setup.controller.signal
+    );
+
+    await vi.waitFor(() => expect(h.agent.newSession).toHaveBeenCalledTimes(2));
+    firstNew.resolve({ sessionId: 'new-session-1' });
+    secondNew.resolve({ sessionId: 'new-session-2' });
+    await Promise.all([first, second]);
+    await setup.scope.dispose();
+  });
 });
 
 function materializerHarness(
@@ -147,10 +234,13 @@ function materializerHarness(
     registerRoute: (processOwner, sessionId, conversationId) => {
       routes.push({ processOwner, sessionId, conversationId });
     },
-    addLoading: (_processOwner, conversationId) => loading.push(conversationId),
-    removeLoading: (_processOwner, conversationId) => {
-      const index = loading.indexOf(conversationId);
-      if (index >= 0) loading.splice(index, 1);
+    beginLoad: (processOwner, sessionId, conversationId) => {
+      routes.push({ processOwner, sessionId, conversationId });
+      loading.push(conversationId);
+      return () => {
+        const index = loading.indexOf(conversationId);
+        if (index >= 0) loading.splice(index, 1);
+      };
     },
   };
   const materializer = new SessionMaterializer(

--- a/packages/core/src/runtimes/acp/node/runtime/session-materializer.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/session-materializer.ts
@@ -38,11 +38,12 @@ export interface SessionMaterializerCallbacks {
   onRecordClosed(record: SessionRecord): void;
   discardRecord(record: SessionRecord): void;
   registerRoute(processOwner: string, acpSessionId: string, conversationId: string): void;
-  addLoading(processOwner: string, conversationId: string): void;
-  removeLoading(processOwner: string, conversationId: string): void;
+  beginLoad(processOwner: string, acpSessionId: string, conversationId: string): () => void;
 }
 
 export class SessionMaterializer {
+  private readonly handshakeTails = new Map<string, Promise<void>>();
+
   constructor(
     private readonly deps: Pick<AcpRuntimeDeps, 'agentHost' | 'resolveAttachment'> & {
       logger: Logger;
@@ -85,11 +86,18 @@ export class SessionMaterializer {
     const connection = acquired.value;
     const mcpServers = await this.resolveSessionMcpServers(input.providerId, connection);
     const mcpServerSummary = summarizeAcpMcpServers(mcpServers);
+    const processOwner = routeOwnerId(connection.key, connection.generation);
     let record: SessionRecord | null = null;
     let resumeOutcome: SessionRecord['resumeOutcome'] = input.sessionId ? 'replaced-by-new' : null;
 
     try {
       if (input.sessionId && connection.supportsLoadSession && connection.agent.loadSession) {
+        let releaseHandshake: () => void;
+        try {
+          releaseHandshake = await this.acquireHandshake(processOwner, signal);
+        } catch {
+          return acpErr.conversationNotFound(entry.conversationId);
+        }
         record = this.createRecord(
           entry,
           input,
@@ -99,11 +107,10 @@ export class SessionMaterializer {
           epoch,
           scope
         );
-        const processOwner = routeOwnerId(connection.key, connection.generation);
         let loaded = false;
+        let endLoad = () => {};
         try {
-          this.callbacks.addLoading(processOwner, input.conversationId);
-          this.callbacks.registerRoute(processOwner, input.sessionId, input.conversationId);
+          endLoad = this.callbacks.beginLoad(processOwner, input.sessionId, input.conversationId);
           record.cell.beginReplay();
           const response = await abortable(
             connection.agent.loadSession(
@@ -118,8 +125,7 @@ export class SessionMaterializer {
             modes: response.modes,
             configOptions: response.configOptions,
           });
-          await this.applyConfigOverrides(record, entry);
-          await this.applyInitialMode(record, input);
+          await this.applyDesiredConfiguration(record, entry);
           const queueResult = this.queueInitialPrompts(record, input);
           if (!queueResult.success) return queueResult;
           record.cell.endReplay();
@@ -134,7 +140,8 @@ export class SessionMaterializer {
             conversationId: input.conversationId,
           });
         } finally {
-          this.callbacks.removeLoading(processOwner, input.conversationId);
+          endLoad();
+          releaseHandshake();
         }
 
         if (!loaded) {
@@ -173,8 +180,7 @@ export class SessionMaterializer {
           modes: response.modes,
           configOptions: response.configOptions,
         });
-        await this.applyConfigOverrides(record, entry);
-        await this.applyInitialMode(record, input);
+        await this.applyDesiredConfiguration(record, entry);
         const queueResult = this.queueInitialPrompts(record, input);
         if (!queueResult.success) return queueResult;
         record.cell.applySessionReady();
@@ -192,6 +198,41 @@ export class SessionMaterializer {
       if (isAuthRequiredError(error)) return acpErr.authRequired(toSerializedError(error));
       return acpErr.initializeFailed(toSerializedError(error));
     }
+  }
+
+  private async acquireHandshake(processOwner: string, signal: AbortSignal): Promise<() => void> {
+    const predecessor = this.handshakeTails.get(processOwner) ?? Promise.resolve();
+    let releaseCurrent = () => {};
+    const current = new Promise<void>((resolve) => {
+      releaseCurrent = resolve;
+    });
+    const tail = predecessor.catch(() => {}).then(() => current);
+    this.handshakeTails.set(processOwner, tail);
+    try {
+      await abortable(
+        predecessor.catch(() => {}),
+        signal
+      );
+    } catch (error) {
+      releaseCurrent();
+      this.cleanupHandshake(processOwner, tail);
+      throw error;
+    }
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      releaseCurrent();
+      this.cleanupHandshake(processOwner, tail);
+    };
+  }
+
+  private cleanupHandshake(processOwner: string, tail: Promise<void>): void {
+    void tail.then(() => {
+      if (this.handshakeTails.get(processOwner) === tail) {
+        this.handshakeTails.delete(processOwner);
+      }
+    });
   }
 
   private createRecord(
@@ -232,6 +273,7 @@ export class SessionMaterializer {
       epoch,
       input,
       resumeOutcome: null,
+      clearedConfiguration: [],
       processKey: connection.key,
       processGeneration: connection.generation,
       connectionLeaseState,
@@ -263,10 +305,18 @@ export class SessionMaterializer {
   private async applyConfigOverrides(
     record: SessionRecord,
     entry: ConversationHandle
-  ): Promise<void> {
+  ): Promise<Array<'model' | 'effort'>> {
+    const cleared: Array<'model' | 'effort'> = [];
     for (const dimension of ['model', 'effort'] as const) {
       const value = entry.configOverrides[dimension];
       if (!value) continue;
+      const catalog =
+        dimension === 'model' ? record.cell.config.modelOptions : record.cell.config.efforts;
+      if (catalog && !catalog.available.some((option) => option.id === value)) {
+        entry.clearConfig(dimension);
+        cleared.push(dimension);
+        continue;
+      }
       const result = await record.cell.setConfigOption(dimension, value);
       if (!result.success) {
         this.deps.logger.warn('SessionMaterializer: failed to apply retained config option', {
@@ -277,6 +327,22 @@ export class SessionMaterializer {
         });
       }
     }
+    return cleared;
+  }
+
+  private async applyDesiredConfiguration(
+    record: SessionRecord,
+    entry: ConversationHandle
+  ): Promise<void> {
+    let revision: number;
+    do {
+      revision = entry.desiredRevision;
+      const cleared = await this.applyConfigOverrides(record, entry);
+      const clearedMode = await this.applyInitialMode(record, entry);
+      for (const key of [...cleared, ...(clearedMode ? [clearedMode] : [])]) {
+        if (!record.clearedConfiguration.includes(key)) record.clearedConfiguration.push(key);
+      }
+    } while (entry.desiredRevision !== revision);
   }
 
   private async resolveSessionMcpServers(providerId: string, connection: AcpConnectionEntry) {
@@ -299,28 +365,34 @@ export class SessionMaterializer {
     }
   }
 
-  private async applyInitialMode(record: SessionRecord, input: AcpStartInput): Promise<void> {
-    const modeId = input.modeId;
-    if (!modeId) return;
+  private async applyInitialMode(
+    record: SessionRecord,
+    entry: ConversationHandle
+  ): Promise<'modeId' | null> {
+    const modeId = entry.descriptor.modeId;
+    if (!modeId) return null;
     const modeOptions = record.cell.config.modeOptions;
-    if (!modeOptions?.available.some((mode) => mode.id === modeId)) {
+    if (!modeOptions) return null;
+    if (!modeOptions.available.some((mode) => mode.id === modeId)) {
       this.deps.logger.debug('SessionMaterializer: persisted mode not advertised, skipping', {
-        conversationId: input.conversationId,
-        providerId: input.providerId,
+        conversationId: entry.conversationId,
+        providerId: entry.descriptor.providerId,
         modeId,
       });
-      return;
+      entry.clearMode();
+      return 'modeId';
     }
-    if (modeOptions.selected === modeId) return;
+    if (modeOptions.selected === modeId) return null;
     const result = await record.cell.setMode(modeId);
     if (!result.success) {
       this.deps.logger.warn('SessionMaterializer: failed to apply initial mode', {
-        conversationId: input.conversationId,
-        providerId: input.providerId,
+        conversationId: entry.conversationId,
+        providerId: entry.descriptor.providerId,
         modeId,
         error: result.error,
       });
     }
+    return null;
   }
 
   private buildNewSessionRequest(

--- a/packages/core/src/runtimes/acp/node/runtime/session-router.test.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/session-router.test.ts
@@ -1,0 +1,99 @@
+import type { SessionNotification } from '@agentclientprotocol/sdk';
+import { noopLogger } from '@emdash/shared/logger';
+import { describe, expect, it, vi } from 'vitest';
+import type { NormalizedEvent } from '#runtimes/acp/api';
+import type { AcpConnectionContext } from '#runtimes/acp/node/connection/source';
+import { SessionRouter, type SessionRouteTarget } from './session-router';
+
+describe('SessionRouter', () => {
+  it('drops unknown updates instead of retaining them for a later registration', () => {
+    const target = targetSpy();
+    const router = new SessionRouter(target, noopLogger);
+    const connection = context(1);
+    const owner = 'claude:/repo:1';
+
+    router.onSessionUpdate(connection, notification('late', 'first'), event('first'));
+    router.register(owner, 'late', 'conversation-a');
+
+    expect(target.onSessionUpdate).not.toHaveBeenCalled();
+  });
+
+  it('routes the requested and rebound session ids during one scoped load', () => {
+    const target = targetSpy();
+    const router = new SessionRouter(target, noopLogger);
+    const connection = context(1);
+    const endLoad = router.beginLoad('claude:/repo:1', 'requested', 'conversation-a');
+
+    router.onSessionUpdate(connection, notification('requested', 'first'), event('first'));
+    router.onSessionUpdate(connection, notification('rebound', 'first'), event('first'));
+
+    expect(target.onSessionUpdate).toHaveBeenCalledTimes(2);
+    expect(target.onSessionUpdate.mock.calls.map(([, , params]) => params.sessionId)).toEqual([
+      'requested',
+      'rebound',
+    ]);
+
+    endLoad();
+    router.onSessionUpdate(connection, notification('unknown', 'after'), event('after'));
+    expect(target.onSessionUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects overlapping provisional loads for one process owner', () => {
+    const router = new SessionRouter(targetSpy(), noopLogger);
+    const owner = 'claude:/repo:1';
+    const endLoad = router.beginLoad(owner, 'session-a', 'conversation-a');
+
+    expect(() => router.beginLoad(owner, 'session-b', 'conversation-b')).toThrow(
+      'ACP load already active'
+    );
+
+    endLoad();
+    const endSecondLoad = router.beginLoad(owner, 'session-b', 'conversation-b');
+    endSecondLoad();
+  });
+
+  it('drops routes and provisional loading state when a generation is invalidated', () => {
+    const target = targetSpy();
+    const router = new SessionRouter(target, noopLogger);
+    const connection = context(1);
+    const owner = 'claude:/repo:1';
+    router.beginLoad(owner, 'loaded', 'conversation-a');
+
+    router.invalidate(owner);
+    router.onSessionUpdate(connection, notification('loaded', 'first'), event('first'));
+    router.onSessionUpdate(connection, notification('rebound', 'second'), event('second'));
+
+    expect(target.onSessionUpdate).not.toHaveBeenCalled();
+    expect(router.hasRoutesFor('conversation-a')).toBe(false);
+    expect(router.isLoadingConversation('conversation-a')).toBe(false);
+  });
+});
+
+function targetSpy() {
+  return {
+    onSessionUpdate: vi.fn<SessionRouteTarget['onSessionUpdate']>(),
+    onPermissionRequest: vi.fn<SessionRouteTarget['onPermissionRequest']>(),
+    onCreateTerminal: vi.fn<SessionRouteTarget['onCreateTerminal']>(),
+  };
+}
+
+function context(generation: number): AcpConnectionContext {
+  return {
+    key: 'claude:/repo',
+    generation,
+    providerId: 'claude',
+    cwd: '/repo',
+    normalize: vi.fn(),
+  };
+}
+
+function notification(sessionId: string, sessionUpdate: string): SessionNotification {
+  return {
+    sessionId,
+    update: { sessionUpdate } as SessionNotification['update'],
+  };
+}
+
+function event(id: string): NormalizedEvent {
+  return { type: 'unknown', raw: { id } } as unknown as NormalizedEvent;
+}

--- a/packages/core/src/runtimes/acp/node/runtime/session-router.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/session-router.ts
@@ -31,7 +31,7 @@ export interface SessionRouteTarget {
 
 export class SessionRouter implements InboundRouter {
   private readonly routes = new Map<string, Map<string, string>>();
-  private readonly loadingConversations = new Map<string, Set<string>>();
+  private readonly loadingConversationByOwner = new Map<string, string>();
 
   constructor(
     private readonly target: SessionRouteTarget,
@@ -43,12 +43,11 @@ export class SessionRouter implements InboundRouter {
     params: SessionNotification,
     event: NormalizedEvent
   ): void {
-    const conversationId = this.resolveConversationForSession(
-      routeOwnerId(connection.key, connection.generation),
-      params.sessionId
-    );
+    const processOwner = routeOwnerId(connection.key, connection.generation);
+    const conversationId = this.resolveConversationForSession(processOwner, params.sessionId);
     if (!conversationId) {
       this.logger.warn('SessionManager: sessionUpdate for unknown sessionId', {
+        processOwner,
         sessionId: params.sessionId,
       });
       return;
@@ -100,20 +99,20 @@ export class SessionRouter implements InboundRouter {
     if (bySession.size === 0) this.routes.delete(processOwner);
   }
 
-  addLoading(processOwner: string, conversationId: string): void {
-    let loading = this.loadingConversations.get(processOwner);
-    if (!loading) {
-      loading = new Set();
-      this.loadingConversations.set(processOwner, loading);
+  beginLoad(processOwner: string, acpSessionId: string, conversationId: string): () => void {
+    if (this.loadingConversationByOwner.has(processOwner)) {
+      throw new Error(`SessionManager: ACP load already active for process owner ${processOwner}`);
     }
-    loading.add(conversationId);
-  }
-
-  removeLoading(processOwner: string, conversationId: string): void {
-    const loading = this.loadingConversations.get(processOwner);
-    if (!loading) return;
-    loading.delete(conversationId);
-    if (loading.size === 0) this.loadingConversations.delete(processOwner);
+    this.loadingConversationByOwner.set(processOwner, conversationId);
+    this.register(processOwner, acpSessionId, conversationId);
+    let ended = false;
+    return () => {
+      if (ended) return;
+      ended = true;
+      if (this.loadingConversationByOwner.get(processOwner) === conversationId) {
+        this.loadingConversationByOwner.delete(processOwner);
+      }
+    };
   }
 
   hasRoutesFor(conversationId: string): boolean {
@@ -124,17 +123,18 @@ export class SessionRouter implements InboundRouter {
   }
 
   isLoadingConversation(conversationId: string): boolean {
-    for (const loading of this.loadingConversations.values()) {
-      if (loading.has(conversationId)) return true;
-    }
-    return false;
+    return [...this.loadingConversationByOwner.values()].includes(conversationId);
+  }
+
+  invalidate(processOwner: string): void {
+    this.routes.delete(processOwner);
+    this.loadingConversationByOwner.delete(processOwner);
   }
 
   private resolveConversationForSession(processOwner: string, acpSessionId: string): string | null {
     const route = this.routes.get(processOwner)?.get(acpSessionId);
     if (route) return route;
-    const loading = this.loadingConversations.get(processOwner);
-    const pending = loading?.values().next().value;
+    const pending = this.loadingConversationByOwner.get(processOwner);
     if (!pending) return null;
     this.register(processOwner, acpSessionId, pending);
     return pending;

--- a/packages/core/src/runtimes/acp/node/session/cell.ts
+++ b/packages/core/src/runtimes/acp/node/session/cell.ts
@@ -13,8 +13,7 @@ import type {
   AcpPermissionRequest,
   AcpRuntimeError,
   AcpSendPromptError,
-  AcpSetModeOptionError,
-  AcpSetModelOptionError,
+  AcpSetOptionError,
   InvalidStateError,
   NormalizedEvent,
   PromptInput,
@@ -323,8 +322,8 @@ export class SessionCell {
     return this.permissions.request(request);
   }
 
-  async setMode(modeId: string): Promise<Result<void, AcpSetModeOptionError>> {
-    const result = this.dispatchFor<AcpSetModeOptionError>({ type: 'SetMode', modeId }, [
+  async setMode(modeId: string): Promise<Result<void, AcpSetOptionError>> {
+    const result = this.dispatchFor<AcpSetOptionError>({ type: 'SetMode', modeId }, [
       'invalid_state',
       'set_mode_failed',
     ]);
@@ -363,7 +362,7 @@ export class SessionCell {
   async setConfigOption(
     dimension: ConfigDimension,
     value: string
-  ): Promise<Result<void, AcpSetModelOptionError>> {
+  ): Promise<Result<void, AcpSetOptionError>> {
     const configId = this.configIdForDimension(dimension);
     if (!configId) {
       return acpErr.setConfigFailed({
@@ -371,7 +370,7 @@ export class SessionCell {
         message: `Agent connection does not expose ${dimension} configuration`,
       });
     }
-    const result = this.dispatchFor<AcpSetModelOptionError>(
+    const result = this.dispatchFor<AcpSetOptionError>(
       { type: 'SetConfigOption', configId, value },
       ['invalid_state', 'set_config_failed']
     );

--- a/packages/core/src/runtimes/acp/node/state/live-models.test.ts
+++ b/packages/core/src/runtimes/acp/node/state/live-models.test.ts
@@ -44,4 +44,53 @@ describe('ACP live models', () => {
     expect(peek(projection.states.state)).toBe(closedSessionState);
     await host.dispose();
   });
+
+  it('keeps retained config, MCP servers, and usage visible while suspended', async () => {
+    const host = createAcpSessionLiveHost();
+    const projection = host.models('conversation-retained');
+
+    projection.source.set({
+      kind: 'suspended',
+      retained: {
+        configured: { model: 'sonnet', modeId: 'agent-full-access', effort: 'high' },
+        lastKnownCapabilities: {
+          modelOptions: {
+            configId: 'model',
+            selected: 'sonnet',
+            available: [{ id: 'sonnet', name: 'Sonnet' }],
+          },
+          efforts: {
+            configId: 'effort',
+            selected: 'high',
+            available: [{ id: 'high', name: 'High' }],
+          },
+          modeOptions: {
+            configId: 'mode',
+            selected: 'agent-full-access',
+            available: [{ id: 'agent-full-access', name: 'Full access' }],
+          },
+          availableCommands: [],
+        },
+        lastKnownMcpServers: [{ name: 'filesystem', transport: 'stdio' }],
+        lastKnownUsage: { contextSize: 200_000, contextUsed: 1_000, cost: null },
+        observedAt: 123,
+      },
+    });
+    flushStateTurn();
+
+    expect(peek(projection.states.config)).toMatchObject({
+      modelOptions: { selected: 'sonnet' },
+      efforts: { selected: 'high' },
+      modeOptions: { selected: 'agent-full-access' },
+    });
+    expect(peek(projection.states.mcpServers)).toEqual([
+      { name: 'filesystem', transport: 'stdio' },
+    ]);
+    expect(peek(projection.states.usage)).toEqual({
+      contextSize: 200_000,
+      contextUsed: 1_000,
+      cost: null,
+    });
+    await host.dispose();
+  });
 });

--- a/packages/core/src/runtimes/acp/node/state/live-models.ts
+++ b/packages/core/src/runtimes/acp/node/state/live-models.ts
@@ -61,9 +61,23 @@ export type ActivationSnapshot = {
   mcpServers: readonly SessionMcpServer[];
 };
 
+export type RetainedConfiguredState = {
+  model: string | null;
+  modeId: string | null;
+  effort: string | null;
+};
+
+export type RetainedPresentation = {
+  configured: RetainedConfiguredState;
+  lastKnownCapabilities: SessionConfigState;
+  lastKnownMcpServers: readonly SessionMcpServer[];
+  lastKnownUsage: SessionUsage | null;
+  observedAt: number | null;
+};
+
 export type SessionProjectionSource =
   | { kind: 'closed' }
-  | { kind: 'suspended' }
+  | { kind: 'suspended'; retained?: RetainedPresentation }
   | { kind: 'active'; snapshot: ActivationSnapshot };
 
 export type SessionLiveModels = {
@@ -148,11 +162,20 @@ export type {
 
 function createProjection(): SessionLiveModels {
   const source = cell<SessionProjectionSource>({ kind: 'closed' }, { name: 'acp-session-source' });
-  const activeSlice = <T>(read: (current: ActivationSnapshot) => T, inactive: T, name: string) =>
+  const retainedSlice = <T>(
+    readActive: (current: ActivationSnapshot) => T,
+    readRetained: (retained: RetainedPresentation) => T,
+    inactive: T,
+    name: string
+  ) =>
     derived(
       () => {
         const current = snapshot(source).value;
-        return current.kind === 'active' ? read(current.snapshot) : inactive;
+        if (current.kind === 'active') return readActive(current.snapshot);
+        if (current.kind === 'suspended' && current.retained) {
+          return readRetained(current.retained);
+        }
+        return inactive;
       },
       { name }
     );
@@ -168,31 +191,79 @@ function createProjection(): SessionLiveModels {
         },
         { name: 'acp-session-state' }
       ),
-      config: activeSlice(
+      config: retainedSlice(
         (current) => current.config,
+        retainedConfig,
         initialSessionConfigState,
         'acp-session-config'
       ),
-      usage: activeSlice((current) => current.usage, null, 'acp-session-usage'),
-      plan: activeSlice((current) => current.plan, null, 'acp-session-plan'),
-      agents: activeSlice(
+      usage: retainedSlice(
+        (current) => current.usage,
+        (retained) => retained.lastKnownUsage,
+        null,
+        'acp-session-usage'
+      ),
+      plan: retainedSlice(
+        (current) => current.plan,
+        () => null,
+        null,
+        'acp-session-plan'
+      ),
+      agents: retainedSlice(
         (current) => asMutable(current.agents),
+        () => EMPTY_AGENTS,
         EMPTY_AGENTS,
         'acp-session-agents'
       ),
-      activeTurn: activeSlice((current) => current.activeTurn, null, 'acp-session-active-turn'),
-      terminals: activeSlice(
+      activeTurn: retainedSlice(
+        (current) => current.activeTurn,
+        () => null,
+        null,
+        'acp-session-active-turn'
+      ),
+      terminals: retainedSlice(
         (current) => asMutable(current.terminals),
+        () => EMPTY_TERMINALS,
         EMPTY_TERMINALS,
         'acp-session-terminals'
       ),
-      mcpServers: activeSlice(
+      mcpServers: retainedSlice(
         (current) => asMutable(current.mcpServers),
+        (retained) => asMutable(retained.lastKnownMcpServers),
         EMPTY_MCP_SERVERS,
         'acp-session-mcp-servers'
       ),
     },
   };
+}
+
+export function emptyRetainedPresentation(
+  configured: RetainedConfiguredState
+): RetainedPresentation {
+  return {
+    configured,
+    lastKnownCapabilities: initialSessionConfigState,
+    lastKnownMcpServers: EMPTY_MCP_SERVERS,
+    lastKnownUsage: null,
+    observedAt: null,
+  };
+}
+
+export function retainedConfig(retained: RetainedPresentation): SessionConfigState {
+  const { configured, lastKnownCapabilities } = retained;
+  return {
+    ...lastKnownCapabilities,
+    modelOptions: selected(lastKnownCapabilities.modelOptions, configured.model),
+    efforts: selected(lastKnownCapabilities.efforts, configured.effort),
+    modeOptions: selected(lastKnownCapabilities.modeOptions, configured.modeId),
+  };
+}
+
+function selected<T extends { selected: string | null }>(
+  group: T | null,
+  value: string | null
+): T | null {
+  return group ? { ...group, selected: value ?? group.selected } : null;
 }
 
 function asMutable<T>(value: readonly T[]): T[] {

--- a/packages/core/src/runtimes/automations/api/deployment.ts
+++ b/packages/core/src/runtimes/automations/api/deployment.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { hostAbsolutePathSchema, hostFileRefSchema } from '#primitives/path/api';
 import {
-  acpSessionStartInputSchema,
+  acpSessionLaunchInputSchema,
   tuiSessionStartInputSchema,
 } from '#services/session-start/api';
 
@@ -63,7 +63,7 @@ export const automationScheduleSchema = z.object({
 
 export const automationAcpAgentConfigSchema = z.object({
   type: z.literal('acp'),
-  start: acpSessionStartInputSchema.omit({
+  start: acpSessionLaunchInputSchema.omit({
     conversationId: true,
     cwd: true,
     sessionId: true,

--- a/packages/core/src/runtimes/automations/node/component.ts
+++ b/packages/core/src/runtimes/automations/node/component.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 // oxlint-disable-next-line emdash/core-module-boundaries -- runs await the registry's plain createWorktree verb (operation-log retirement §5); the contract has no services-level home yet
 import { workspaceRegistryContract } from '#runtimes/workspace-registry/api';
 import { conversationIndexContract } from '#services/conversation-index/api';
-import { acpSessionStartContract, tuiSessionStartContract } from '#services/session-start/api';
+import { acpSessionLaunchContract, tuiSessionStartContract } from '#services/session-start/api';
 import { automationsContract } from '../api';
 import { workspaceCreationAdmissionContract } from '../api/creation-admission';
 import { createAutomationsController } from './api/controller';
@@ -27,7 +27,7 @@ export function createAutomationsComponent() {
       // Creation admission is client-plane data (deletion tombstones live on the
       // embedding app's mirror, ADR 0006), so the app supplies the check.
       creationAdmission: requireContract(workspaceCreationAdmissionContract),
-      acpSessions: requireContract(acpSessionStartContract),
+      acpLauncher: requireContract(acpSessionLaunchContract),
       tuiSessions: requireContract(tuiSessionStartContract),
       conversationIndex: requireContract(conversationIndexContract),
     },
@@ -44,7 +44,7 @@ export function createAutomationsComponent() {
         ),
         sessionPort: createSessionPortFromDependencies({
           workspaceRegistry: dependencies.workspaceRegistry,
-          acp: dependencies.acpSessions,
+          acp: dependencies.acpLauncher,
           tui: dependencies.tuiSessions,
           conversationIndex: dependencies.conversationIndex,
         }),

--- a/packages/core/src/runtimes/automations/node/ports/session-start.test.ts
+++ b/packages/core/src/runtimes/automations/node/ports/session-start.test.ts
@@ -6,7 +6,10 @@ import { hostFileRef, parseAbsolute } from '#primitives/path/api';
 // oxlint-disable-next-line emdash/core-module-boundaries -- exercises the port's registry rewiring (workspaceHost retirement, spec §4.1)
 import type { WorkspaceRegistryContract } from '#runtimes/workspace-registry/api';
 import type { ConversationIndexContract } from '#services/conversation-index/api';
-import type { AcpSessionStartContract, TuiSessionStartContract } from '#services/session-start/api';
+import type {
+  AcpSessionLaunchContract,
+  TuiSessionStartContract,
+} from '#services/session-start/api';
 import { createSessionPortFromDependencies } from './session-start';
 
 const cwd = absolute('/tmp/workspace');
@@ -22,7 +25,7 @@ describe('createSessionPortFromDependencies', () => {
         createWorkspace,
         activateWorkspace,
       } as unknown as ContractClient<WorkspaceRegistryContract>,
-      acp: { start } as ContractClient<AcpSessionStartContract>,
+      acp: { launch: start } as ContractClient<AcpSessionLaunchContract>,
       tui: unusedTuiClient(),
       conversationIndex: { create } as unknown as ContractClient<ConversationIndexContract>,
     });
@@ -99,7 +102,7 @@ describe('createSessionPortFromDependencies', () => {
         createWorkspace: vi.fn(async () => ok({ id: 'existing-workspace' })),
         activateWorkspace,
       } as unknown as ContractClient<WorkspaceRegistryContract>,
-      acp: { start } as ContractClient<AcpSessionStartContract>,
+      acp: { launch: start } as ContractClient<AcpSessionLaunchContract>,
       tui: unusedTuiClient(),
       conversationIndex: creatingConversationIndex(),
     });
@@ -180,7 +183,7 @@ describe('createSessionPortFromDependencies', () => {
       workspaceRegistry: {
         createWorkspace,
       } as unknown as ContractClient<WorkspaceRegistryContract>,
-      acp: { start } as unknown as ContractClient<AcpSessionStartContract>,
+      acp: { launch: start } as unknown as ContractClient<AcpSessionLaunchContract>,
       tui: unusedTuiClient(),
       conversationIndex: {
         create: async () => err({ type: 'invalid-input', message: 'Bad record' }),
@@ -210,7 +213,7 @@ describe('createSessionPortFromDependencies', () => {
         createWorkspace: async () => err({ type: 'path-not-found', path: '/tmp/workspace' }),
         activateWorkspace: vi.fn(),
       } as unknown as ContractClient<WorkspaceRegistryContract>,
-      acp: { start } as unknown as ContractClient<AcpSessionStartContract>,
+      acp: { launch: start } as unknown as ContractClient<AcpSessionLaunchContract>,
       tui: unusedTuiClient(),
       conversationIndex: creatingConversationIndex(),
     });
@@ -240,7 +243,7 @@ describe('createSessionPortFromDependencies', () => {
         activateWorkspace: async () =>
           err({ type: 'workspace-missing', workspaceId: 'workspace-1' }),
       } as unknown as ContractClient<WorkspaceRegistryContract>,
-      acp: { start } as unknown as ContractClient<AcpSessionStartContract>,
+      acp: { launch: start } as unknown as ContractClient<AcpSessionLaunchContract>,
       tui: unusedTuiClient(),
       conversationIndex: creatingConversationIndex(),
     });
@@ -269,7 +272,7 @@ describe('createSessionPortFromDependencies', () => {
     const unavailable = createSessionPortFromDependencies({
       workspaceRegistry: activatingWorkspaceRegistry(),
       acp: {
-        start: async () => err({ type: 'runtime-unavailable', message: 'ACP is unavailable' }),
+        launch: async () => err({ type: 'runtime-unavailable', message: 'ACP is unavailable' }),
       },
       tui: unusedTuiClient(),
       conversationIndex: creatingConversationIndex(),
@@ -277,7 +280,7 @@ describe('createSessionPortFromDependencies', () => {
     const rejected = createSessionPortFromDependencies({
       workspaceRegistry: activatingWorkspaceRegistry(),
       acp: {
-        start: async () => {
+        launch: async () => {
           throw new Error('connection closed');
         },
       },
@@ -321,8 +324,8 @@ function creatingConversationIndex(): ContractClient<ConversationIndexContract> 
   } as unknown as ContractClient<ConversationIndexContract>;
 }
 
-function unusedAcpClient(): ContractClient<AcpSessionStartContract> {
-  return { start: vi.fn() };
+function unusedAcpClient(): ContractClient<AcpSessionLaunchContract> {
+  return { launch: vi.fn() };
 }
 
 function unusedTuiClient(): ContractClient<TuiSessionStartContract> {

--- a/packages/core/src/runtimes/automations/node/ports/session-start.ts
+++ b/packages/core/src/runtimes/automations/node/ports/session-start.ts
@@ -12,7 +12,10 @@ import type {
   ConversationIndexContract,
   CreateConversationIndexRecordInput,
 } from '#services/conversation-index/api';
-import type { AcpSessionStartContract, TuiSessionStartContract } from '#services/session-start/api';
+import type {
+  AcpSessionLaunchContract,
+  TuiSessionStartContract,
+} from '#services/session-start/api';
 import type { AutomationAgentConfig } from '../../api/deployment';
 import type { AutomationPortError } from './port-error';
 
@@ -32,7 +35,7 @@ export interface AutomationSessionPort {
 
 export function createSessionPortFromDependencies(dependencies: {
   workspaceRegistry: ContractClient<WorkspaceRegistryContract>;
-  acp: ContractClient<AcpSessionStartContract>;
+  acp: ContractClient<AcpSessionLaunchContract>;
   tui: ContractClient<TuiSessionStartContract>;
   conversationIndex: ContractClient<ConversationIndexContract>;
 }): AutomationSessionPort {
@@ -81,7 +84,7 @@ export function createSessionPortFromDependencies(dependencies: {
           });
         }
         if (input.agent.type === 'acp') {
-          const result = await dependencies.acp.start(
+          const result = await dependencies.acp.launch(
             {
               conversationId: input.conversationId,
               cwd,

--- a/packages/core/src/runtimes/workspace-registry/node/session-cleanup.test.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/session-cleanup.test.ts
@@ -7,7 +7,7 @@ import {
 
 describe('workspace session cleanup', () => {
   it('kills suspended ACP entries but excludes them from active session counts', async () => {
-    const kill = vi.fn().mockResolvedValue({ success: true, data: undefined });
+    const terminate = vi.fn().mockResolvedValue({ success: true, data: undefined });
     const clients = {
       acp: {
         sessions: {
@@ -27,7 +27,7 @@ describe('workspace session cleanup', () => {
             }),
           }),
         },
-        kill,
+        terminate,
       },
       terminals: {
         sessions: { state: () => ({ snapshot: async () => ({ data: {} }) }) },
@@ -40,8 +40,8 @@ describe('workspace session cleanup', () => {
     await expect(createSessionCounter(clients)('/workspace/repo')).resolves.toBe(1);
     await createSessionKiller(clients)('/workspace/repo');
 
-    expect(kill).toHaveBeenCalledTimes(2);
-    expect(kill).toHaveBeenCalledWith({ conversationId: 'active' });
-    expect(kill).toHaveBeenCalledWith({ conversationId: 'suspended' });
+    expect(terminate).toHaveBeenCalledTimes(2);
+    expect(terminate).toHaveBeenCalledWith({ conversationId: 'active' });
+    expect(terminate).toHaveBeenCalledWith({ conversationId: 'suspended' });
   });
 });

--- a/packages/core/src/runtimes/workspace-registry/node/session-cleanup.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/session-cleanup.ts
@@ -63,7 +63,7 @@ export function createSessionKiller(
 
     for (const session of Object.values(acpSnapshot.data)) {
       if (!cwdUnder(root, session.cwd)) continue;
-      const result = await clients.acp.kill({ conversationId: session.conversationId });
+      const result = await clients.acp.terminate({ conversationId: session.conversationId });
       if (!result.success) {
         logger?.warn?.(`failed to kill ACP session ${session.conversationId}`, {
           error: result.error,

--- a/packages/core/src/runtimes/workspace-registry/node/session-gc.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/session-gc.ts
@@ -114,7 +114,7 @@ export async function killSessionsUnderPath(
   const targets = await resolveSessionTargets(clients, path);
 
   for (const conversationId of targets.acpConversationIds) {
-    const result = await clients.acp.kill({ conversationId });
+    const result = await clients.acp.terminate({ conversationId });
     if (!result.success && !isMissingError(result.error)) {
       return sessionError(
         `Failed to kill ACP session ${conversationId}: ${errorMessage(result.error)}`

--- a/packages/core/src/services/session-start/api/contract.ts
+++ b/packages/core/src/services/session-start/api/contract.ts
@@ -1,16 +1,16 @@
 import { defineContract, fallible } from '@emdash/wire/rpc';
 import {
-  acpSessionStartInputSchema,
-  acpSessionStartResultSchema,
+  acpSessionLaunchInputSchema,
+  acpSessionLaunchResultSchema,
   sessionStartErrorSchema,
   tuiSessionStartInputSchema,
   tuiSessionStartResultSchema,
 } from './schemas';
 
-export const acpSessionStartContract = defineContract({
-  start: fallible({
-    input: acpSessionStartInputSchema,
-    data: acpSessionStartResultSchema,
+export const acpSessionLaunchContract = defineContract({
+  launch: fallible({
+    input: acpSessionLaunchInputSchema,
+    data: acpSessionLaunchResultSchema,
     error: sessionStartErrorSchema,
   }),
 });
@@ -23,5 +23,5 @@ export const tuiSessionStartContract = defineContract({
   }),
 });
 
-export type AcpSessionStartContract = typeof acpSessionStartContract;
+export type AcpSessionLaunchContract = typeof acpSessionLaunchContract;
 export type TuiSessionStartContract = typeof tuiSessionStartContract;

--- a/packages/core/src/services/session-start/api/schemas.ts
+++ b/packages/core/src/services/session-start/api/schemas.ts
@@ -17,7 +17,7 @@ export const headlessPromptInputSchema = z.object({
   hiddenContext: z.string().optional(),
 });
 
-export const acpSessionStartInputSchema = z.object({
+export const acpSessionLaunchInputSchema = z.object({
   conversationId: nonBlankStringSchema,
   providerId: nonBlankStringSchema,
   cwd: nonBlankStringSchema,
@@ -27,7 +27,7 @@ export const acpSessionStartInputSchema = z.object({
   initialQueue: z.array(headlessPromptInputSchema).min(1),
 });
 
-export const acpSessionStartResultSchema = z.object({
+export const acpSessionLaunchResultSchema = z.object({
   sessionId: nonBlankStringSchema,
 });
 
@@ -48,7 +48,7 @@ export const tuiSessionStartResultSchema = z.object({
 });
 
 export type SessionStartError = z.infer<typeof sessionStartErrorSchema>;
-export type AcpSessionStartInput = z.infer<typeof acpSessionStartInputSchema>;
-export type AcpSessionStartResult = z.infer<typeof acpSessionStartResultSchema>;
+export type AcpSessionLaunchInput = z.infer<typeof acpSessionLaunchInputSchema>;
+export type AcpSessionLaunchResult = z.infer<typeof acpSessionLaunchResultSchema>;
 export type TuiSessionStartInput = z.infer<typeof tuiSessionStartInputSchema>;
 export type TuiSessionStartResult = z.infer<typeof tuiSessionStartResultSchema>;

--- a/packages/core/src/workspace-server/releases.test.ts
+++ b/packages/core/src/workspace-server/releases.test.ts
@@ -100,8 +100,8 @@ describe('workspace-server release contracts', () => {
   );
 
   it('extracts a protocol major and rejects invalid protocol versions', () => {
-    expect(PROTOCOL_VERSION).toBe('3.0.0');
-    expect(protocolMajor()).toBe(3);
+    expect(PROTOCOL_VERSION).toBe('4.0.0');
+    expect(protocolMajor()).toBe(4);
     expect(protocolMajor('2.3.4')).toBe(2);
     expect(() => protocolMajor('not-a-version')).toThrow(
       "Invalid protocol version 'not-a-version'"

--- a/packages/core/src/workspace-server/versions/index.ts
+++ b/packages/core/src/workspace-server/versions/index.ts
@@ -1,6 +1,6 @@
 import semver from 'semver';
 
-export const PROTOCOL_VERSION = '3.0.0';
+export const PROTOCOL_VERSION = '4.0.0';
 
 export function protocolMajor(version: string = PROTOCOL_VERSION): number {
   const parsed = semver.parse(version);

--- a/packages/core/src/workspace-server/wire/contract.test.ts
+++ b/packages/core/src/workspace-server/wire/contract.test.ts
@@ -9,7 +9,7 @@ describe('workspaceWireContract', () => {
   });
 
   it('mounts the ACP contract under the acp domain without changing protocol shape elsewhere', () => {
-    expect(workspaceWireContract.acp.start.kind).toBe('procedure');
+    expect(workspaceWireContract.acp.launch.kind).toBe('procedure');
     expect(workspaceWireContract.acp.sessions.kind).toBe('liveModel');
     expect(workspaceWireContract.acp.sessions.id).toBe('acp.sessions');
     expect(workspaceWireContract.acp.terminalOutput.kind).toBe('liveLog');


### PR DESCRIPTION
- replaces lifecycle choreography with attach launch loadHistory terminate and setOption
- retains model mode effort mcp server and usage presentation while sessions are suspended
- rematerializes provider sessions invisibly and keeps the composer usable during activation
- applies configuration changes made while suspended or materializing before queued prompts
- persists provider defaults by host provider and transport for new conversations
- scopes provisional routing to serialized session loads and drops unknown or stale updates
- bumps the workspace server protocol major to 4 for the breaking wire changes