### PR TITLE
fix(agents): replace chat ui pill with capability icons

### DIFF
--- a/apps/emdash-desktop/src/core/features/agents/browser/components/agent-selector/agent-selector.browser.test.tsx
+++ b/apps/emdash-desktop/src/core/features/agents/browser/components/agent-selector/agent-selector.browser.test.tsx
@@ -80,6 +80,25 @@ describe('AgentSelector', () => {
     host.remove();
   });
 
+  it('shows Chat UI and TUI capability icons instead of a Chat UI pill', async () => {
+    await act(async () => {
+      root.render(<AgentSelector value="codex" onChange={vi.fn()} />);
+    });
+
+    const trigger = host.querySelector<HTMLElement>('[data-slot="combobox-trigger"]');
+    expect(trigger).not.toBeNull();
+    await act(async () => trigger!.click());
+
+    const codexOption = page.getByRole('option', { name: 'Codex' }).element();
+    expect(codexOption.querySelector('[aria-label="Supports Chat UI"]')).not.toBeNull();
+    expect(codexOption.querySelector('[aria-label="Supports TUI"]')).not.toBeNull();
+    expect(codexOption.textContent).not.toContain('Chat UI');
+
+    const grokOption = page.getByRole('option', { name: 'Grok' }).element();
+    expect(grokOption.querySelector('[aria-label="Supports Chat UI"]')).toBeNull();
+    expect(grokOption.querySelector('[aria-label="Supports TUI"]')).not.toBeNull();
+  });
+
   it('shows agent details when an uninstalled agent is hovered', async () => {
     await act(async () => {
       root.render(<AgentSelector value="codex" onChange={vi.fn()} />);

--- a/apps/emdash-desktop/src/core/features/agents/contributions/browser/agent-capability-icons.tsx
+++ b/apps/emdash-desktop/src/core/features/agents/contributions/browser/agent-capability-icons.tsx
@@ -1,0 +1,31 @@
+import { Tooltip } from '@emdash/ui/react/primitives';
+import { MessageSquare, SquareTerminal } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+export function AgentCapabilityIcons({ supportsChatUi }: { supportsChatUi: boolean }) {
+  return (
+    <div className="flex shrink-0 items-center gap-2">
+      {supportsChatUi && (
+        <CapabilityIcon label="Supports Chat UI">
+          <MessageSquare className="size-3.5 text-foreground-passive" aria-hidden />
+        </CapabilityIcon>
+      )}
+      <CapabilityIcon label="Supports TUI">
+        <SquareTerminal className="size-3.5 text-foreground-passive" aria-hidden />
+      </CapabilityIcon>
+    </div>
+  );
+}
+
+function CapabilityIcon({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <Tooltip.Provider delay={150}>
+      <Tooltip.Root>
+        <Tooltip.Trigger render={<span className="inline-flex" aria-label={label} />}>
+          {children}
+        </Tooltip.Trigger>
+        <Tooltip.Content>{label}</Tooltip.Content>
+      </Tooltip.Root>
+    </Tooltip.Provider>
+  );
+}

--- a/apps/emdash-desktop/src/core/features/agents/contributions/browser/agent-selector.tsx
+++ b/apps/emdash-desktop/src/core/features/agents/contributions/browser/agent-selector.tsx
@@ -1,6 +1,5 @@
 import type { ComboboxRootChangeEventDetails } from '@base-ui/react/combobox';
 import type { AgentProviderId } from '@emdash/plugins/agents/types';
-import { Pill } from '@emdash/ui/react/components';
 import { Combobox } from '@emdash/ui/react/primitives';
 import { ChevronDown } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
@@ -18,6 +17,7 @@ import {
   isEventInsideAgentHoverCard,
   useAgentHoverCard,
 } from '@core/features/agents/browser/components/agent-selector/agent-hover-card';
+import { AgentCapabilityIcons } from '@core/features/agents/contributions/browser/agent-capability-icons';
 import { AgentIcon } from '@core/features/agents/contributions/browser/agent-icon';
 import { cn } from '@core/primitives/styling/browser/cn';
 
@@ -151,7 +151,7 @@ export const AgentSelector: React.FC<AgentSelectorProps> = observer(
                             </span>
                           ) : null}
                         </span>
-                        {item.supportsAcp && <Pill variant="info">Chat UI</Pill>}
+                        <AgentCapabilityIcons supportsChatUi={item.supportsAcp} />
                       </Combobox.Item>
                     );
                   }}

--- a/apps/emdash-desktop/src/core/features/settings/browser/agents-page/AgentRow.tsx
+++ b/apps/emdash-desktop/src/core/features/settings/browser/agents-page/AgentRow.tsx
@@ -1,7 +1,5 @@
-import { Tooltip } from '@emdash/ui/react/primitives';
-import { MessageSquare, SquareTerminal } from 'lucide-react';
-import type { ReactNode } from 'react';
 import { getAgentUpdateActionState } from '@core/features/agents/api/browser/components/agent-selector/agent-install';
+import { AgentCapabilityIcons } from '@core/features/agents/contributions/browser/agent-capability-icons';
 import { AgentIcon } from '@core/features/agents/contributions/browser/agent-icon';
 import { UpdateAvailableBadge } from '@core/features/settings/browser/agents-page/agent-status-badge';
 import { agentSupportsAcp, type AgentPayload } from '@core/primitives/agents/api';
@@ -30,30 +28,9 @@ export const AgentRow = ({ agent }: { agent: AgentPayload }) => {
         <span className="text-sm text-foreground">{agent.name}</span>
         <div className="flex items-center gap-2">
           {updateState.render && <UpdateAvailableBadge />}
-          {/* Every agent runs in the terminal; ACP-capable ones also offer the chat UI. */}
-          {supportsChatUi && (
-            <CapabilityIcon label="Supports Chat UI">
-              <MessageSquare className="size-3.5 text-foreground-passive" aria-hidden />
-            </CapabilityIcon>
-          )}
-          <CapabilityIcon label="Supports TUI">
-            <SquareTerminal className="size-3.5 text-foreground-passive" aria-hidden />
-          </CapabilityIcon>
+          <AgentCapabilityIcons supportsChatUi={supportsChatUi} />
         </div>
       </div>
     </div>
   );
 };
-
-function CapabilityIcon({ label, children }: { label: string; children: ReactNode }) {
-  return (
-    <Tooltip.Provider delay={150}>
-      <Tooltip.Root>
-        <Tooltip.Trigger render={<span className="inline-flex" aria-label={label} />}>
-          {children}
-        </Tooltip.Trigger>
-        <Tooltip.Content>{label}</Tooltip.Content>
-      </Tooltip.Root>
-    </Tooltip.Provider>
-  );
-}


### PR DESCRIPTION
- replaces the blue chat ui pill in agent dropdowns with chat ui and tui icons
- shares AgentCapabilityIcons between agent dropdowns and agent settings
- preserves tooltips and accessible labels for both capability icons