### PR TITLE
fix(workspace-server): prevent remote acp prompt timeouts

### DIFF
--- a/apps/workspace-server/src/api/controller.test.ts
+++ b/apps/workspace-server/src/api/controller.test.ts
@@ -51,6 +51,22 @@ describe('createWorkspaceWireController', () => {
       transport.close?.();
     }
   });
+
+  it('disables the worker deadline for the turn-long ACP prompt call', async () => {
+    const acp = createFakeAcpClient();
+    const controller = createTestWorkspaceWireController({ acp });
+    const signal = new AbortController().signal;
+    const input = {
+      conversationId: 'conversation-1',
+      prompt: { text: 'hello' },
+    };
+
+    await expect(controller.call('acp.sendPrompt', input, { signal })).resolves.toEqual(
+      ok({ queued: false })
+    );
+
+    expect(acp.sendPrompt).toHaveBeenCalledWith(input, { signal, timeoutMs: 0 });
+  });
 });
 
 function createFakeAcpClient(): ContractClient<AcpApiContract> {
@@ -75,7 +91,7 @@ function createFakeAcpClient(): ContractClient<AcpApiContract> {
     attach: vi.fn(),
     launch: vi.fn(async () => ok({ sessionId: 'acp-session-1' })),
     terminate: vi.fn(),
-    sendPrompt: vi.fn(),
+    sendPrompt: vi.fn(async () => ok({ queued: false })),
     editQueuedPrompt: vi.fn(),
     deleteQueuedPrompt: vi.fn(),
     changeQueuePromptOrder: vi.fn(),

--- a/apps/workspace-server/src/api/controller.ts
+++ b/apps/workspace-server/src/api/controller.ts
@@ -54,7 +54,11 @@ export function createWorkspaceWireController(deps: WorkspaceWireControllerDeps)
         },
       });
     },
-    acp: forwardContractImpl(workspaceWireContract.acp, deps.runtimes.acp),
+    acp: {
+      ...forwardContractImpl(workspaceWireContract.acp, deps.runtimes.acp),
+      sendPrompt: (input, meta) =>
+        deps.runtimes.acp.sendPrompt(input, { signal: meta.signal, timeoutMs: 0 }),
+    },
     agentConfig: forwardContractImpl(workspaceWireContract.agentConfig, deps.runtimes.agentConfig),
     automations: forwardContractImpl(workspaceWireContract.automations, deps.runtimes.automations),
     conversations: forwardContractImpl(


### PR DESCRIPTION
- disable the worker deadline for turn-long acp sendPrompt calls while preserving cancellation
- prevent successfully delivered prompts from showing a false failure toast and restoring the composer draft
- keep the default wire deadline unchanged for other workspace server procedures