### PR TITLE
fix(exclude): support leading glob pattern **/ when checking git exclude entries (#3033)

### DIFF
--- a/apps/emdash-desktop/src/core/features/projects/node/ensure-emdash-excluded.test.ts
+++ b/apps/emdash-desktop/src/core/features/projects/node/ensure-emdash-excluded.test.ts
@@ -116,6 +116,15 @@ describe('ensureEmdashGitExcluded', () => {
     expect(writeFile).not.toHaveBeenCalled();
   });
 
+  it('treats glob patterns like **/.emdash/ and leading slashes as already excluded (#3033)', async () => {
+    const { files, writeFile } = makeFs({
+      gitType: 'directory',
+      excludeContent: '**/.emdash/\n',
+    });
+    await ensureEmdashGitExcluded(files, '/repo');
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
   it('does not rewrite when the exclude read was truncated', async () => {
     // A truncated view could miss an existing entry past the cut; rewriting it would
     // drop the tail of the file, so bail instead.

--- a/apps/emdash-desktop/src/core/features/projects/node/ensure-emdash-excluded.ts
+++ b/apps/emdash-desktop/src/core/features/projects/node/ensure-emdash-excluded.ts
@@ -53,7 +53,14 @@ export async function ensureEmdashGitExcluded(
   const alreadyExcluded = existing
     .split(/\r?\n/)
     .map((line) => line.trim())
-    .some((line) => line === SSH_PROJECT_STATE_DIR_NAME || line === IGNORE_PATTERN);
+    .some((line) => {
+      const norm = line.replace(/^\/+/, '').replace(/^\*\*\//, '');
+      return (
+        norm === SSH_PROJECT_STATE_DIR_NAME ||
+        norm === IGNORE_PATTERN ||
+        norm === `${SSH_PROJECT_STATE_DIR_NAME}/`
+      );
+    });
   if (alreadyExcluded) return;
 
   const base = existing.replace(/\s*$/, '');


### PR DESCRIPTION
### Summary

Fixes #3033.

When `ensureEmdashGitExcluded` checks whether the runtime state directory is already excluded, it failed to recognize existing entries defined with a leading glob prefix such as `**/`. This caused redundant duplicate entries to be appended.

### Changes
- Normalize leading `/` and `**/` glob prefixes when checking lines in `.git/info/exclude`.