### PR TITLE
fix(chat-ui): render reference-style markdown links and images

### DIFF
--- a/packages/chat-ui/src/core/markdown/parse.test.ts
+++ b/packages/chat-ui/src/core/markdown/parse.test.ts
@@ -258,3 +258,35 @@ describe('blockquote paragraphs → variant: quote', () => {
     expect(prose?.depth).toBe(1);
   });
 });
+
+describe('reference-style links and images', () => {
+  const linkRun = (runs: InlineRun[]): InlineText | undefined =>
+    runs.find((r): r is InlineText => r.kind === 'text' && r.href !== undefined);
+
+  it('resolves a full reference link to its definition URL (text is not dropped)', () => {
+    const runs = firstProseRuns('See [the docs][d] for more.\n\n[d]: https://example.com/docs');
+    const link = linkRun(runs);
+    expect(link?.text).toBe('the docs');
+    expect(link?.href).toBe('https://example.com/docs');
+    expect(textSegments(runs).join('')).toContain('the docs');
+  });
+
+  it('resolves collapsed and shortcut references', () => {
+    for (const md of ['See [x][] now.\n\n[x]: https://c.com', 'See [x] now.\n\n[x]: https://c.com']) {
+      const link = linkRun(firstProseRuns(md));
+      expect(link?.text).toBe('x');
+      expect(link?.href).toBe('https://c.com');
+    }
+  });
+
+  it('resolves an image reference to its alt text and URL', () => {
+    const link = linkRun(firstProseRuns('![the alt][img]\n\n[img]: https://i.com/x.png'));
+    expect(link?.text).toBe('the alt');
+    expect(link?.href).toBe('https://i.com/x.png');
+  });
+
+  it('leaves an undefined reference as literal text', () => {
+    const runs = firstProseRuns('See [text][missing] here.', nullProvider);
+    expect(textSegments(runs).join('')).toContain('[text][missing]');
+  });
+});

--- a/packages/chat-ui/src/core/markdown/parse.test.ts
+++ b/packages/chat-ui/src/core/markdown/parse.test.ts
@@ -272,7 +272,10 @@ describe('reference-style links and images', () => {
   });
 
   it('resolves collapsed and shortcut references', () => {
-    for (const md of ['See [x][] now.\n\n[x]: https://c.com', 'See [x] now.\n\n[x]: https://c.com']) {
+    for (const md of [
+      'See [x][] now.\n\n[x]: https://c.com',
+      'See [x] now.\n\n[x]: https://c.com',
+    ]) {
       const link = linkRun(firstProseRuns(md));
       expect(link?.text).toBe('x');
       expect(link?.href).toBe('https://c.com');
@@ -283,6 +286,14 @@ describe('reference-style links and images', () => {
     const link = linkRun(firstProseRuns('![the alt][img]\n\n[img]: https://i.com/x.png'));
     expect(link?.text).toBe('the alt');
     expect(link?.href).toBe('https://i.com/x.png');
+  });
+
+  it('uses the first definition when normalized identifiers are duplicated', () => {
+    for (const reference of ['[link][duplicate]', '![image][DUPLICATE]']) {
+      const markdown = `${reference}\n\n[duplicate]: https://first.example\n[DUPLICATE]: https://last.example`;
+      const link = linkRun(firstProseRuns(markdown));
+      expect(link?.href).toBe('https://first.example');
+    }
   });
 
   it('leaves an undefined reference as literal text', () => {

--- a/packages/chat-ui/src/core/markdown/parse.ts
+++ b/packages/chat-ui/src/core/markdown/parse.ts
@@ -56,6 +56,7 @@ import type { MdastMention } from './mdast-mention';
 import type { MentionProvider } from './mention-provider';
 import { remarkInlineMentions } from './remark-inline-mentions';
 import type { ParseData } from './remark-inline-mentions';
+import { remarkResolveReferences } from './remark-resolve-references';
 
 // ── Shared processor instance ────────────────────────────────────────────────
 //
@@ -66,6 +67,7 @@ const processor = unified()
   .use(remarkParse)
   .use(remarkGfm)
   .use(remarkMath)
+  .use(remarkResolveReferences)
   .use(remarkInlineMentions)
   .freeze();
 

--- a/packages/chat-ui/src/core/markdown/remark-resolve-references.ts
+++ b/packages/chat-ui/src/core/markdown/remark-resolve-references.ts
@@ -1,0 +1,46 @@
+import type { Definition, ImageReference, LinkReference, Root } from 'mdast';
+import { visit } from 'unist-util-visit';
+
+/**
+ * Resolve reference-style links and images into their inline equivalents.
+ *
+ * `[text][id]` parses to a `linkReference` node and `![alt][id]` to an
+ * `imageReference` node, neither of which the block/inline walk in `parse.ts`
+ * handles — so without this transform they (and their visible text) are dropped
+ * entirely. This plugin rewrites each reference to the `link` / `image` node the
+ * walk already renders, using the document's `definition` nodes for the URL.
+ *
+ * remark-parse only emits `linkReference` / `imageReference` when a matching
+ * definition exists — an undefined reference such as `[text][missing]` is
+ * already plain text — so every reference reached here has a definition.
+ * Matching is case-insensitive on the identifier, per CommonMark.
+ */
+export function remarkResolveReferences() {
+  return (tree: Root): void => {
+    const definitions = new Map<string, Definition>();
+    visit(tree, 'definition', (node) => {
+      definitions.set(node.identifier.toLowerCase(), node);
+    });
+    if (definitions.size === 0) return;
+
+    visit(tree, 'linkReference', (node: LinkReference) => {
+      const def = definitions.get(node.identifier.toLowerCase());
+      if (!def) return;
+      const link = node as unknown as { type: string; url: string; title: string | null };
+      link.type = 'link';
+      link.url = def.url;
+      link.title = def.title ?? null;
+    });
+
+    visit(tree, 'imageReference', (node: ImageReference) => {
+      const def = definitions.get(node.identifier.toLowerCase());
+      if (!def) return;
+      // `alt` already lives on the imageReference node and is what the `image`
+      // renderer reads, so only the node type, url, and title need to change.
+      const image = node as unknown as { type: string; url: string; title: string | null };
+      image.type = 'image';
+      image.url = def.url;
+      image.title = def.title ?? null;
+    });
+  };
+}

--- a/packages/chat-ui/src/core/markdown/remark-resolve-references.ts
+++ b/packages/chat-ui/src/core/markdown/remark-resolve-references.ts
@@ -19,7 +19,10 @@ export function remarkResolveReferences() {
   return (tree: Root): void => {
     const definitions = new Map<string, Definition>();
     visit(tree, 'definition', (node) => {
-      definitions.set(node.identifier.toLowerCase(), node);
+      const identifier = node.identifier.toLowerCase();
+      if (!definitions.has(identifier)) {
+        definitions.set(identifier, node);
+      }
     });
     if (definitions.size === 0) return;
 


### PR DESCRIPTION
## Summary

Reference-style markdown links and images are dropped when rendering a message.

The block/inline walk in `parse.ts` handles inline `link` / `image` mdast nodes, but reference-style syntax parses to `linkReference` / `imageReference` nodes, which hit the `default` case in `phrasingsToRuns` and are ignored. The result is that the link's **visible text disappears too**, leaving a gap:

```md
See [the docs][d] for more.

[d]: https://example.com/docs
```

Before this change that rendered as `See  for more.` — "the docs" and its URL both gone.

## Fix

Add a small remark plugin (`remark-resolve-references.ts`, in the same style as `remark-inline-mentions.ts`) that rewrites `linkReference` → `link` and `imageReference` → `image` using the document's `definition` nodes, before the walk. The existing `link` / `image` renderers then handle them unchanged, so there are no changes to `phrasingsToRuns` / `blockToBlocks`.

`remark-parse` only emits reference nodes when a matching definition exists (an undefined reference like `[text][missing]` is already plain text), so every reference resolves. Identifier matching is case-insensitive per CommonMark.

## Before / after (real parser output)

```ts
parseMarkdownToBlocks("m", "See [the docs][d].\n\n[d]: https://example.com/docs")
// before: runs = [{ text: "See " }, { text: "." }]                                   ❌ "the docs" dropped
// after:  runs = [{ text: "See " }, { text: "the docs", href: "https://example.com/docs" }, { text: "." }]
```

Covers full (`[t][id]`), collapsed (`[id][]`), and shortcut (`[id]`) references, plus image references (`![alt][id]`). Inline links (`[t](url)`) are unchanged; undefined references stay literal.

## Testing

Added a `reference-style links and images` block to `parse.test.ts`. I verified the fix by running the real `parseMarkdownToBlocks` through `tsx` against all reference variants (output shown above); the assertions match. I wasn't able to run the full `pnpm` vitest suite locally (monorepo install was too slow in my environment), so the jsdom Vitest project runs in CI. The change is scoped to `packages/chat-ui/src/core/markdown/`.
