### PR TITLE
fix(projects): settle remote directory picker loading

### DIFF
--- a/apps/emdash-desktop/src/core/features/projects/browser/components/add-project-modal/project-directory-picker.test.ts
+++ b/apps/emdash-desktop/src/core/features/projects/browser/components/add-project-modal/project-directory-picker.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @vitest-environment jsdom
+ */
+import {
+  parsePortableRelativePath,
+  ROOT_RELATIVE_PATH,
+  type HostAbsolutePath,
+} from '@emdash/core/primitives/path/api';
+import type { FileTreeModel } from '@emdash/core/runtimes/files/api';
+import { ok } from '@emdash/shared';
+import { waitFor } from '@emdash/shared/testing';
+import { defineContract } from '@emdash/wire/rpc';
+import { cell, expose } from '@emdash/wire/state';
+import { createTestWire } from '@emdash/wire/testing';
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { projectsWireContract } from '@core/features/projects/api';
+import {
+  ProjectDirectoryPicker,
+  type ProjectDirectoryPickerClient,
+} from './project-directory-picker';
+
+const homeRoot: HostAbsolutePath = {
+  root: { kind: 'posix' },
+  segments: ['home', 'dev'],
+};
+const repoPathResult = parsePortableRelativePath('repo');
+if (!repoPathResult.success) throw new Error(repoPathResult.error.message);
+const repoPath = repoPathResult.data;
+const testContract = defineContract({ directoryTree: projectsWireContract.directoryTree });
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('ProjectDirectoryPicker', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('reveals a remote root once and settles the directory listing', async () => {
+    const treeState = cell<FileTreeModel>(treeModel(false));
+    const reveal = vi.fn(async (context) => {
+      const revision = treeState.set(treeModel(true), {
+        mutationIds: [context.mutationId],
+      });
+      await context.observed('tree', revision);
+      return ok(undefined);
+    });
+    const directoryTree = expose(
+      projectsWireContract.directoryTree,
+      { tree: treeState },
+      {
+        mutations: {
+          expand: async () => ok(undefined),
+          reveal,
+        },
+      }
+    );
+    const wire = createTestWire(testContract, { directoryTree });
+    const getProjectsClient = async () => wire.client as unknown as ProjectDirectoryPickerClient;
+    const props = {
+      strategy: 'ssh' as const,
+      connectionId: 'machine-1',
+      initialPath: '/home/dev',
+      homePath: '/home/dev',
+      homePending: false,
+      homeError: null,
+      value: '/home/dev',
+      getProjectsClient,
+      onSelect: vi.fn(),
+    };
+
+    try {
+      await act(async () => root.render(createElement(ProjectDirectoryPicker, props)));
+      await act(async () => {
+        await waitFor(() => container.textContent?.includes('repo') ?? false);
+      });
+
+      expect(reveal).toHaveBeenCalledOnce();
+      expect(reveal.mock.calls[0]?.[0].input).toEqual({ path: '', depth: 2 });
+      expect(container.textContent).not.toContain('Loading folder');
+
+      await act(async () => root.render(createElement(ProjectDirectoryPicker, props)));
+      expect(reveal).toHaveBeenCalledOnce();
+    } finally {
+      await wire.dispose();
+      await directoryTree.dispose();
+    }
+  });
+});
+
+function treeModel(revealed: boolean): FileTreeModel {
+  return {
+    root: homeRoot,
+    entries: {
+      '': {
+        path: ROOT_RELATIVE_PATH,
+        name: 'dev',
+        parentPath: null,
+        kind: 'directory',
+        childrenLoaded: revealed,
+        children: revealed ? [repoPath] : [],
+        hasChildren: revealed,
+      },
+      ...(revealed
+        ? {
+            repo: {
+              path: repoPath,
+              name: 'repo',
+              parentPath: ROOT_RELATIVE_PATH,
+              kind: 'directory' as const,
+              childrenLoaded: true,
+              children: [],
+              hasChildren: false,
+            },
+          }
+        : {}),
+    },
+  };
+}

--- a/apps/emdash-desktop/src/core/features/projects/browser/components/add-project-modal/project-directory-picker.tsx
+++ b/apps/emdash-desktop/src/core/features/projects/browser/components/add-project-modal/project-directory-picker.tsx
@@ -20,13 +20,7 @@ import {
 } from '@emdash/ui/react/components';
 import { Button, Input, toast } from '@emdash/ui/react/primitives';
 import { type Contract, type ContractClient } from '@emdash/wire/rpc';
-import {
-  observe,
-  remote,
-  whenReady,
-  type RemoteModel,
-  type RemoteMember,
-} from '@emdash/wire/state';
+import { observe, remote, whenReady, type RemoteModel } from '@emdash/wire/state';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   projectsWireContract,
@@ -39,7 +33,6 @@ import { projectDirectoryLocation } from './project-directory-location';
 
 type DirectoryTreeModel = typeof projectsWireContract.directoryTree;
 type DirectoryTreeRemote = RemoteModel<DirectoryTreeModel>;
-type DirectoryTreeMember = RemoteMember<DirectoryTreeModel>;
 type ContractDefinitionsOf<TContract> = TContract extends Contract<infer Defs> ? Defs : never;
 const DIRECTORY_TREE_READY_TIMEOUT_MS = 30_000;
 export type ProjectDirectoryPickerClient = ContractClient<
@@ -104,13 +97,12 @@ export function ProjectDirectoryPicker({
   const separator = location?.separator ?? '/';
   const sessionId = useMemo(() => crypto.randomUUID(), []);
   const tree = useProjectDirectoryTree(host, root, sessionId, getProjectsClient);
-  const reveal = useRevealDirectory(tree.member, ROOT_RELATIVE_PATH, () => false);
 
   const listing = directoryListing({
     homePending,
     homeError,
-    syncError: tree.error ?? reveal.error,
-    pending: reveal.pending,
+    syncError: tree.error,
+    pending: tree.pending,
     model: tree.model,
     path: ROOT_RELATIVE_PATH,
   });
@@ -203,18 +195,19 @@ function useProjectDirectoryTree(
   sessionId: string,
   getProjectsClient: () => Promise<ProjectDirectoryPickerClient>
 ): {
-  member: DirectoryTreeMember | null;
   model: FileTreeModel | null;
   error: string | null;
+  pending: boolean;
 } {
-  const [member, setMember] = useState<DirectoryTreeMember | null>(null);
   const [model, setModel] = useState<FileTreeModel | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
 
   useEffect(() => {
     if (!host || !root) {
-      setMember(null);
       setModel(null);
+      setError(null);
+      setPending(false);
       return;
     }
 
@@ -224,6 +217,9 @@ function useProjectDirectoryTree(
     const scope = createScope({ label: `project-directory-picker:${sessionId}` });
 
     async function start() {
+      setModel(null);
+      setError(null);
+      setPending(true);
       try {
         const client = await getProjectsClient();
         if (disposed) return;
@@ -259,7 +255,16 @@ function useProjectDirectoryTree(
         });
         if (ready.status === 'error') throw ready.error;
         if (disposed) return;
-        setMember(treeMember);
+
+        const mutation = await treeMember.mutations.reveal({
+          path: ROOT_RELATIVE_PATH,
+          depth: 2,
+        });
+        if (!mutation.result.success) {
+          throw new Error(fsErrorMessage(mutation.result.error));
+        }
+        await mutation.settled;
+        if (disposed) return;
         setError(null);
       } catch (caught) {
         if (!disposed) {
@@ -270,60 +275,19 @@ function useProjectDirectoryTree(
           );
         }
         void scope.dispose();
+      } finally {
+        if (!disposed) setPending(false);
       }
     }
 
     void start();
     return () => {
       disposed = true;
-      setMember(null);
-      setModel(null);
-      setError(null);
       void scope.dispose();
     };
   }, [getProjectsClient, host, root, sessionId]);
 
-  return { member, model, error };
-}
-
-function useRevealDirectory(
-  member: DirectoryTreeMember | null,
-  path: PortableRelativePath,
-  onNotFound: (path: PortableRelativePath) => boolean
-): { pending: boolean; error: string | null } {
-  const [pending, setPending] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!member) return;
-    const currentMember = member;
-    let cancelled = false;
-    setPending(true);
-    setError(null);
-
-    async function reveal() {
-      try {
-        const mutation = await currentMember.mutations.reveal({ path, depth: 2 });
-        if (!mutation.result.success) {
-          if (mutation.result.error.type === 'not-found' && onNotFound(path)) return;
-          throw new Error(fsErrorMessage(mutation.result.error));
-        }
-        await mutation.settled;
-        if (!cancelled) setError(null);
-      } catch (caught) {
-        if (!cancelled) setError(errorMessage(caught));
-      } finally {
-        if (!cancelled) setPending(false);
-      }
-    }
-
-    void reveal();
-    return () => {
-      cancelled = true;
-    };
-  }, [member, onNotFound, path]);
-
-  return { pending, error };
+  return { model, error, pending };
 }
 
 function directoryListing({


### PR DESCRIPTION
- stabilizes useRevealDirectory inputs to prevent repeated remote filesystem requests
- coordinates filesystem attachment and initial path reveal without duplicate loading cycles
- keeps remote directory contents responsive while navigating the project picker