### PR TITLE
feat(terminals): allow docking terminal on the right

### DIFF
--- a/agents/conventions/renderer-patterns.md
+++ b/agents/conventions/renderer-patterns.md
@@ -87,8 +87,8 @@ Views use a contributions + catalog + parameterized navigation pattern.
 Workbench layout follows a strict ownership model (see
 `.scratch/workbench-state-architecture/spec.md` history for rationale):
 
-- **Chrome state lives in command stores, one per subject.** Task chrome
-  (`sidebarCollapsed`, `sidebarTab`, `terminalDrawerOpen`) and workspace chrome
+- **Chrome state lives in command stores, one per subject.** Task chrome (`sidebarCollapsed`,
+  `sidebarTab`, `terminalDrawerOpen`, `terminalDockPosition`) and workspace chrome
   (`leftSidebarOpen`, `zen`) are memento-backed state objects mutated only through
   named commands (`toggleSidebar`, `openSidebarTab`, `enterZenMode`, ...) — never
   through field setters. The shared mechanism is `defineChromeStore` in
@@ -102,7 +102,8 @@ Workbench layout follows a strict ownership model (see
 - **Pixel sizes belong to react-resizable-panels alone**, persisted via
   `useResizableDefaultLayout` with a memento-backed `LayoutStorage` facade
   (`createLayoutStorage` in `src/core/primitives/mementos/browser/`). Sizes are never
-  MobX observables and never persisted to localStorage.
+  MobX observables and never persisted to localStorage. Each terminal dock position uses a
+  separate resize-group key so bottom and right sizes restore independently.
 - **Persisted view state renders below a hydration gate.** The task view gates on
   `space.isHydrated`; the storage facade dev-asserts on reads before hydration.
 

--- a/apps/emdash-desktop/src/core/features/tasks/api/browser/stores/task-chrome-store.test.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/api/browser/stores/task-chrome-store.test.ts
@@ -44,6 +44,7 @@ describe('taskChromeStore sidebar commands', () => {
     expect(store.state.sidebarCollapsed).toBe(true);
     expect(store.state.sidebarTab).toBe('conversations');
     expect(store.state.terminalDrawerOpen).toBe(false);
+    expect(store.state.terminalDockPosition).toBe('bottom');
   });
 
   it('toggleSidebar flips collapsed without touching the tab', () => {
@@ -159,6 +160,17 @@ describe('taskChromeStore terminal drawer commands', () => {
 
     store.commands.openTerminalDrawer();
 
+    expect(store.state.terminalDrawerOpen).toBe(true);
+    expect(store.ephemeral.focusedRegion).toBe('bottom');
+  });
+
+  it('changes the terminal dock without affecting visibility or focus', () => {
+    const store = createStore({ terminalDrawerOpen: true });
+    store.commands.focusRegion('bottom');
+
+    store.commands.setTerminalDockPosition('right');
+
+    expect(store.state.terminalDockPosition).toBe('right');
     expect(store.state.terminalDrawerOpen).toBe(true);
     expect(store.ephemeral.focusedRegion).toBe('bottom');
   });

--- a/apps/emdash-desktop/src/core/features/tasks/api/browser/stores/task-chrome-store.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/api/browser/stores/task-chrome-store.ts
@@ -1,4 +1,4 @@
-import type { SidebarTab } from '@core/features/tasks/api/browser/types';
+import type { SidebarTab, TerminalDockPosition } from '@core/features/tasks/api/browser/types';
 import {
   taskChromeMemento,
   type TaskChromeState,
@@ -59,6 +59,9 @@ export const taskChromeStore = defineChromeStore({
         ephemeral: { focusedRegion: open ? ('bottom' as const) : ('main' as const) },
       };
     },
+    setTerminalDockPosition: ({ state }, position: TerminalDockPosition) => ({
+      state: { ...state, terminalDockPosition: position },
+    }),
     focusRegion: (_current, region: TaskFocusedRegion) => ({
       ephemeral: { focusedRegion: region },
     }),

--- a/apps/emdash-desktop/src/core/features/tasks/api/browser/types.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/api/browser/types.ts
@@ -1,1 +1,3 @@
 export type SidebarTab = 'conversations' | 'changes' | 'files';
+
+export type TerminalDockPosition = 'bottom' | 'right';

--- a/apps/emdash-desktop/src/core/features/tasks/browser/view/task-main-column.tsx
+++ b/apps/emdash-desktop/src/core/features/tasks/browser/view/task-main-column.tsx
@@ -40,6 +40,7 @@ type ActiveDrag =
 // Drag-to-close threshold, in percent of the active resize group. Keeping it below the old 15%
 // resize floor preserves every bottom-dock size that previous versions could persist.
 const TERMINAL_DRAWER_CLOSE_THRESHOLD = 10;
+const TERMINAL_DRAWER_MIN_WIDTH = '120px';
 
 export const TaskMainColumn = observer(function TaskMainColumn() {
   const taskView = useTaskComposition();
@@ -120,6 +121,9 @@ export const TaskMainColumn = observer(function TaskMainColumn() {
             <Resizable.Handle />
             <Resizable.Panel
               {...drawerBinding.collapsiblePanelProps}
+              minSize={terminalDockedRight ? TERMINAL_DRAWER_MIN_WIDTH : undefined}
+              collapsible={terminalDockedRight}
+              collapsedSize={terminalDockedRight ? '0%' : undefined}
               defaultSize={
                 drawerBinding.collapsiblePanelProps.defaultSize ??
                 (terminalDockedRight ? '40%' : '25%')

--- a/apps/emdash-desktop/src/core/features/tasks/browser/view/task-main-column.tsx
+++ b/apps/emdash-desktop/src/core/features/tasks/browser/view/task-main-column.tsx
@@ -37,16 +37,15 @@ type ActiveDrag =
   | { kind: 'tab'; tabId: string }
   | { kind: 'terminal'; terminal: TerminalDrawerDragData };
 
-// Drag-to-close threshold for the bottom drawer, in percent of the column.
-// Below ~10% only the drawer tab bar and a row or two of terminal remain
-// visible, so a drag settling there reads as intent to close rather than a
-// resize. Deliberately under the drawer's old 15% resize floor, so every
-// height the previous UI could persist stays a plain restore, never a close.
+// Drag-to-close threshold, in percent of the active resize group. Keeping it below the old 15%
+// resize floor preserves every bottom-dock size that previous versions could persist.
 const TERMINAL_DRAWER_CLOSE_THRESHOLD = 10;
 
 export const TaskMainColumn = observer(function TaskMainColumn() {
   const taskView = useTaskComposition();
   const { paneLayout } = taskView;
+  const terminalDockedRight = taskView.chrome.state.terminalDockPosition === 'right';
+  const terminalGroupId = terminalDockedRight ? 'task-main-horizontal' : 'task-main-vertical';
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
   const [activeDrag, setActiveDrag] = useState<ActiveDrag | null>(null);
 
@@ -57,7 +56,7 @@ export const TaskMainColumn = observer(function TaskMainColumn() {
     [taskView.space]
   );
   const drawerBinding = useCollapsiblePanelBinding({
-    storageKey: 'task-main-vertical',
+    storageKey: terminalGroupId,
     storage: layoutStorage,
     panelIds: ['task-main-content', 'task-terminal-drawer'],
     collapsiblePanelId: 'task-terminal-drawer',
@@ -103,7 +102,12 @@ export const TaskMainColumn = observer(function TaskMainColumn() {
       onDragEnd={handleDragEnd}
       onDragCancel={() => setActiveDrag(null)}
     >
-      <Resizable.Group orientation="vertical" id="task-main-vertical" {...drawerBinding.groupProps}>
+      <Resizable.Group
+        key={terminalGroupId}
+        orientation={terminalDockedRight ? 'horizontal' : 'vertical'}
+        id={terminalGroupId}
+        {...drawerBinding.groupProps}
+      >
         <Resizable.Panel id="task-main-content" minSize="30%">
           <SplitPaneLayout storage={layoutStorage} />
         </Resizable.Panel>
@@ -116,7 +120,10 @@ export const TaskMainColumn = observer(function TaskMainColumn() {
             <Resizable.Handle />
             <Resizable.Panel
               {...drawerBinding.collapsiblePanelProps}
-              defaultSize={drawerBinding.collapsiblePanelProps.defaultSize ?? '25%'}
+              defaultSize={
+                drawerBinding.collapsiblePanelProps.defaultSize ??
+                (terminalDockedRight ? '40%' : '25%')
+              }
             >
               <TerminalsPanel />
             </Resizable.Panel>

--- a/apps/emdash-desktop/src/core/features/tasks/contributions/mementos.test.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/contributions/mementos.test.ts
@@ -1,5 +1,34 @@
 import { describe, expect, it } from 'vitest';
-import { taskDiffSelectionSchema, taskPaneLayoutMemento, taskPaneLayoutSchema } from './mementos';
+import {
+  taskChromeMemento,
+  taskChromeSchema,
+  taskDiffSelectionSchema,
+  taskPaneLayoutMemento,
+  taskPaneLayoutSchema,
+} from './mementos';
+
+describe('task chrome memento', () => {
+  it('defaults and upgrades the terminal dock to the bottom', () => {
+    expect(taskChromeMemento.default.terminalDockPosition).toBe('bottom');
+    expect(
+      taskChromeSchema.safeParse({
+        version: '1',
+        sidebarTab: 'files',
+        sidebarCollapsed: false,
+        terminalDrawerOpen: true,
+      })
+    ).toEqual({
+      status: 'ok',
+      data: {
+        version: '2',
+        sidebarTab: 'files',
+        sidebarCollapsed: false,
+        terminalDrawerOpen: true,
+        terminalDockPosition: 'bottom',
+      },
+    });
+  });
+});
 
 describe('task pane layout memento', () => {
   it('uses a safe one-pane default', () => {

--- a/apps/emdash-desktop/src/core/features/tasks/contributions/mementos.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/contributions/mementos.ts
@@ -17,7 +17,22 @@ const taskChromeV1Schema = z.object({
   terminalDrawerOpen: z.boolean(),
 });
 
-export const taskChromeSchema = defineVersionedSchema().initial('1', taskChromeV1Schema).build();
+const taskChromeV2Schema = z.object({
+  version: z.literal('2'),
+  sidebarTab: z.enum(['conversations', 'changes', 'files']),
+  sidebarCollapsed: z.boolean(),
+  terminalDrawerOpen: z.boolean(),
+  terminalDockPosition: z.enum(['bottom', 'right']),
+});
+
+export const taskChromeSchema = defineVersionedSchema()
+  .initial('1', taskChromeV1Schema)
+  .version('2', taskChromeV2Schema, (value) => ({
+    ...value,
+    version: '2' as const,
+    terminalDockPosition: 'bottom' as const,
+  }))
+  .build();
 export type TaskChromeState = typeof taskChromeSchema.Type;
 
 export const taskChromeMemento = defineMemento({
@@ -25,10 +40,11 @@ export const taskChromeMemento = defineMemento({
   subject: taskSubject,
   schema: taskChromeSchema,
   default: {
-    version: '1' as const,
+    version: '2' as const,
     sidebarTab: 'conversations' as const,
     sidebarCollapsed: true,
     terminalDrawerOpen: false,
+    terminalDockPosition: 'bottom' as const,
   },
 });
 

--- a/apps/emdash-desktop/src/core/features/terminals/browser/task-terminal/terminal-drawer-tab-bar.tsx
+++ b/apps/emdash-desktop/src/core/features/terminals/browser/task-terminal/terminal-drawer-tab-bar.tsx
@@ -5,9 +5,21 @@ import type {
 } from '@emdash/core/primitives/terminal-shell/api';
 import { ScriptStatus, type ScriptStatusKind } from '@emdash/ui/react/components';
 import { Button, DropdownMenu, Tabs, Tooltip } from '@emdash/ui/react/primitives';
-import { ChevronDown, LoaderCircle, Pause, Play, Plus, RefreshCw, Terminal, X } from 'lucide-react';
+import {
+  ChevronDown,
+  LoaderCircle,
+  PanelBottom,
+  PanelRight,
+  Pause,
+  Play,
+  Plus,
+  RefreshCw,
+  Terminal,
+  X,
+} from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { useEffect, useRef, useState, type ReactNode } from 'react';
+import type { TerminalDockPosition } from '@core/features/tasks/api/browser/types';
 import {
   TERMINAL_DRAWER_DRAG_TYPE,
   type TerminalDrawerDragData,
@@ -49,6 +61,8 @@ interface TerminalDrawerTabBarProps {
   onHoverTerminal?: (id: string) => void;
   projectId: string;
   liveActionsDisabled: boolean;
+  dockPosition: TerminalDockPosition;
+  onDockPositionChange: (position: TerminalDockPosition) => void;
   className?: string;
 }
 
@@ -80,6 +94,8 @@ export const TerminalDrawerTabBar = observer(function TerminalDrawerTabBar({
   onHoverTerminal,
   projectId,
   liveActionsDisabled,
+  dockPosition,
+  onDockPositionChange,
   className,
 }: TerminalDrawerTabBarProps) {
   const scripts = lifecycleScriptsMgr?.tabs ?? [];
@@ -195,9 +211,46 @@ export const TerminalDrawerTabBar = observer(function TerminalDrawerTabBar({
           <Tabs.Tab value="scripts">Scripts</Tabs.Tab>
         </Tabs.List>
       </Tabs.Root>
+      <div className="mx-1 h-4 w-px shrink-0 bg-border" aria-hidden="true" />
+      <TerminalDockButton position={dockPosition} onPositionChange={onDockPositionChange} />
     </div>
   );
 });
+
+export function TerminalDockButton({
+  position,
+  onPositionChange,
+}: {
+  position: TerminalDockPosition;
+  onPositionChange: (position: TerminalDockPosition) => void;
+}) {
+  const nextPosition = position === 'bottom' ? 'right' : 'bottom';
+  const label = `Dock terminal ${nextPosition}`;
+
+  return (
+    <Tooltip.Root>
+      <Tooltip.Trigger
+        render={
+          <Button
+            variant="ghost"
+            size="xs"
+            icon
+            className="size-6 px-0"
+            aria-label={label}
+            onClick={() => onPositionChange(nextPosition)}
+          />
+        }
+      >
+        {nextPosition === 'right' ? (
+          <PanelRight className="size-3.5" />
+        ) : (
+          <PanelBottom className="size-3.5" />
+        )}
+      </Tooltip.Trigger>
+      <Tooltip.Content>{label}</Tooltip.Content>
+    </Tooltip.Root>
+  );
+}
 
 export function NewTerminalButton({
   disabled = false,

--- a/apps/emdash-desktop/src/core/features/terminals/browser/task-terminal/terminal-drawer-tab-bar.tsx
+++ b/apps/emdash-desktop/src/core/features/terminals/browser/task-terminal/terminal-drawer-tab-bar.tsx
@@ -49,7 +49,7 @@ interface TerminalDrawerTabBarProps {
   onSelectScript: (id: string) => void;
   onRunScript: (id: string) => void;
   onStopScript: (id: string) => void;
-  terminalTabView: TerminalTabViewStore;
+  terminalTabView: Pick<TerminalTabViewStore, 'tabs'>;
   activeTerminalId: string | undefined;
   shellMenuState: TerminalShellMenuState;
   onShellMenuOpen: () => void;
@@ -205,12 +205,14 @@ export const TerminalDrawerTabBar = observer(function TerminalDrawerTabBar({
         )}
       </div>
       <div className="mx-1 h-4 w-px shrink-0 bg-border" aria-hidden="true" />
-      <Tabs.Root value={mode} onValueChange={(value) => onModeChange(value as typeof mode)}>
-        <Tabs.List>
-          <Tabs.Tab value="terminals">Terminals</Tabs.Tab>
-          <Tabs.Tab value="scripts">Scripts</Tabs.Tab>
-        </Tabs.List>
-      </Tabs.Root>
+      <div className="min-w-0 overflow-x-auto">
+        <Tabs.Root value={mode} onValueChange={(value) => onModeChange(value as typeof mode)}>
+          <Tabs.List>
+            <Tabs.Tab value="terminals">Terminals</Tabs.Tab>
+            <Tabs.Tab value="scripts">Scripts</Tabs.Tab>
+          </Tabs.List>
+        </Tabs.Root>
+      </div>
       <div className="mx-1 h-4 w-px shrink-0 bg-border" aria-hidden="true" />
       <TerminalDockButton position={dockPosition} onPositionChange={onDockPositionChange} />
     </div>
@@ -235,7 +237,7 @@ export function TerminalDockButton({
             variant="ghost"
             size="xs"
             icon
-            className="size-6 px-0"
+            className="size-6 shrink-0 px-0"
             aria-label={label}
             onClick={() => onPositionChange(nextPosition)}
           />

--- a/apps/emdash-desktop/src/core/features/terminals/contributions/browser/task-terminal/terminal-panel.tsx
+++ b/apps/emdash-desktop/src/core/features/terminals/contributions/browser/task-terminal/terminal-panel.tsx
@@ -228,6 +228,8 @@ export const TerminalsPanel = observer(function TerminalsPanel() {
         <TerminalDrawerTabBar
           projectId={projectId}
           liveActionsDisabled={liveActionsDisabled}
+          dockPosition={taskView.chrome.state.terminalDockPosition}
+          onDockPositionChange={taskView.chrome.commands.setTerminalDockPosition}
           mode={mode}
           onModeChange={handleModeChange}
           lifecycleScriptsMgr={lifecycleScriptsMgr}

--- a/apps/emdash-desktop/src/renderer/tests/browser/terminal-shell-menu.test.tsx
+++ b/apps/emdash-desktop/src/renderer/tests/browser/terminal-shell-menu.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite
 import {
   NewTerminalButton,
   TerminalDockButton,
+  TerminalDrawerTabBar,
 } from '@core/features/terminals/browser/task-terminal/terminal-drawer-tab-bar';
 
 beforeAll(() => {
@@ -129,5 +130,45 @@ describe('terminal shell menu', () => {
       host.querySelector<HTMLButtonElement>(`[aria-label="Dock terminal ${target}"]`)!.click();
     });
     expect(onPositionChange).toHaveBeenCalledWith(target);
+  });
+
+  it('keeps the dock action visible at the minimum right-dock width', async () => {
+    host.style.width = '120px';
+    await act(async () => {
+      root.render(
+        <Tooltip.Provider>
+          <TerminalDrawerTabBar
+            mode="scripts"
+            onModeChange={() => {}}
+            lifecycleScriptsMgr={null}
+            activeScriptId={undefined}
+            onSelectScript={() => {}}
+            onRunScript={() => {}}
+            onStopScript={() => {}}
+            terminalTabView={{ tabs: [] }}
+            activeTerminalId={undefined}
+            shellMenuState={{ kind: 'ready', availability: [] }}
+            onShellMenuOpen={() => {}}
+            onRetryShellAvailability={() => {}}
+            onSelectTerminal={() => {}}
+            onAddTerminal={() => {}}
+            onRemoveTerminal={() => {}}
+            onRenameTerminal={() => {}}
+            projectId="project-1"
+            liveActionsDisabled={false}
+            dockPosition="right"
+            onDockPositionChange={() => {}}
+          />
+        </Tooltip.Provider>
+      );
+    });
+
+    const toolbar = host.firstElementChild!.getBoundingClientRect();
+    const dockAction = host
+      .querySelector<HTMLButtonElement>('[aria-label="Dock terminal bottom"]')!
+      .getBoundingClientRect();
+    expect(dockAction.width).toBeGreaterThan(0);
+    expect(dockAction.left).toBeGreaterThanOrEqual(toolbar.left);
+    expect(dockAction.right).toBeLessThanOrEqual(toolbar.right);
   });
 });

--- a/apps/emdash-desktop/src/renderer/tests/browser/terminal-shell-menu.test.tsx
+++ b/apps/emdash-desktop/src/renderer/tests/browser/terminal-shell-menu.test.tsx
@@ -2,7 +2,10 @@ import { Tooltip } from '@emdash/ui/react/primitives';
 import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { NewTerminalButton } from '@core/features/terminals/browser/task-terminal/terminal-drawer-tab-bar';
+import {
+  NewTerminalButton,
+  TerminalDockButton,
+} from '@core/features/terminals/browser/task-terminal/terminal-drawer-tab-bar';
 
 beforeAll(() => {
   (
@@ -107,5 +110,24 @@ describe('terminal shell menu', () => {
     await act(async () => trigger.click());
 
     expect(onOpen).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    ['bottom', 'right'],
+    ['right', 'bottom'],
+  ] as const)('moves the terminal from the %s dock to the %s dock', async (position, target) => {
+    const onPositionChange = vi.fn();
+    await act(async () => {
+      root.render(
+        <Tooltip.Provider>
+          <TerminalDockButton position={position} onPositionChange={onPositionChange} />
+        </Tooltip.Provider>
+      );
+    });
+
+    await act(async () => {
+      host.querySelector<HTMLButtonElement>(`[aria-label="Dock terminal ${target}"]`)!.click();
+    });
+    expect(onPositionChange).toHaveBeenCalledWith(target);
   });
 });


### PR DESCRIPTION
### Description

Add an accessible terminal toolbar action that switches the drawer between bottom and right placement.

- Persist the per-task position in task chrome state with an explicit v1-to-v2 migration; existing tasks remain bottom-docked.
- Reuse the existing resizable-panel layout with separate storage keys so each orientation restores its own size.
- Keep the change renderer-only with no new dependencies or changes to PTY, SSH, process spawning, paths, or credentials.

### Related issues

Related to #314.

### Testing

- `pnpm run format`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run typecheck`
- `EMDASH_TEST_SKIP_BROWSER=1 NX_DAEMON=false pnpm run test`
- Focused task chrome and memento tests: 23 passed
- Focused terminal browser tests: 6 passed, including the 120px right-dock layout regression
- Manually switched between both placements in Electron and confirmed the layout and accessible action label update
- The full browser project also reaches an unrelated existing failure in `workspace-settings-section.browser.test.tsx`: its fixture omits `workspaceOptions`. The changed terminal browser suite passes.

### Screenshot/Recording (if applicable)

https://videos.copperlane.ai/s/s2gn3j87pm88xcm

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>