### PR TITLE
feat(codex): add plan mode to ACP chat

### DIFF
--- a/agents/integrations/providers.md
+++ b/agents/integrations/providers.md
@@ -72,6 +72,10 @@ host's `agent-config` runtime for both local and remote hosts.
   sources such as Nix should add new source and selection variants without changing runtime spawn
   injection.
 - Claude uses deterministic `--session-id` values for conversation isolation.
+- Codex ACP exposes collaboration mode separately from permission mode. The ACP runtime maps the
+  provider-owned `collaboration_mode` config category to the chat composer's Default/Plan selector
+  and persists that selection with the conversation; filesystem and approval controls remain in
+  the existing permission-mode selector.
 - Agents that cannot receive an automated initial prompt via argv or stdin declare `pty-only`
   prompt delivery. Their TUI opens without an initial prompt, and automation flows exclude them
   unless they also support ACP.

--- a/apps/emdash-desktop/src/core/features/conversations/api/node/utils.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/api/node/utils.ts
@@ -35,6 +35,7 @@ export function mapConversationRowToConversation(row: ConversationRow): Conversa
     model: config?.model,
     modeId: config?.type === 'acp' ? config.modeId : undefined,
     effort: config?.type === 'acp' ? config.effort : undefined,
+    collaborationMode: config?.type === 'acp' ? config.collaborationMode : undefined,
     initialQueue: initialQueueFromRow(row),
     lastInteractedAt: row.lastSessionActivityAt ?? null,
     isInitialConversation: row.isInitialConversation,

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-panel.tsx
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-panel.tsx
@@ -298,6 +298,13 @@ const ComposerForStore = observer(function ComposerForStore({
     [store]
   );
 
+  const handleCollaborationModeChange = useCallback(
+    (modeId: string) => {
+      store.setCollaborationMode(modeId);
+    },
+    [store]
+  );
+
   const handleEffortChange = useCallback(
     (effortId: string) => {
       store.setEffort(effortId);
@@ -605,6 +612,9 @@ const ComposerForStore = observer(function ComposerForStore({
           permissionModeOptions={store.permissionModeOptions}
           selectedPermissionMode={store.permissionMode ?? undefined}
           onPermissionModeChange={handleModeChange}
+          collaborationModeOptions={store.collaborationModeOptions}
+          selectedCollaborationMode={store.collaborationMode ?? undefined}
+          onCollaborationModeChange={handleCollaborationModeChange}
           mcpServers={store.mcpServers}
           agentOptions={agentOptions}
           selectedAgent={providerId ?? undefined}

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
@@ -11,6 +11,7 @@ import type {
 import { createScope, type Scope } from '@emdash/shared/concurrency';
 import type {
   CommandItem,
+  ComposerCollaborationModeOption,
   ComposerEffortOption,
   ComposerModelOption,
   ComposerPermissionModeOption,
@@ -142,6 +143,8 @@ export class AcpChatStore {
       modelOptions: computed,
       permissionMode: computed,
       permissionModeOptions: computed,
+      collaborationMode: computed,
+      collaborationModeOptions: computed,
       effort: computed,
       effortOptions: computed,
       commands: computed,
@@ -155,6 +158,7 @@ export class AcpChatStore {
       stop: action,
       setModel: action,
       setMode: action,
+      setCollaborationMode: action,
       setEffort: action,
       resolvePermission: action,
       editQueuedPrompt: action,
@@ -231,6 +235,21 @@ export class AcpChatStore {
 
   get permissionModeOptions(): Record<string, ComposerPermissionModeOption> | null {
     const options = this.session?.config.current().modeOptions;
+    if (!options) return null;
+    return Object.fromEntries(
+      options.available.map((option) => [
+        option.id,
+        { name: option.name, description: option.description },
+      ])
+    );
+  }
+
+  get collaborationMode(): string | null {
+    return this.session?.config.current().collaborationModeOptions?.selected ?? null;
+  }
+
+  get collaborationModeOptions(): Record<string, ComposerCollaborationModeOption> | null {
+    const options = this.session?.config.current().collaborationModeOptions;
     if (!options) return null;
     return Object.fromEntries(
       options.available.map((option) => [
@@ -479,6 +498,19 @@ export class AcpChatStore {
       .catch((error: unknown) => this._toastError('Failed to change session mode', error));
   }
 
+  setCollaborationMode(modeId: string): void {
+    void this.session
+      ?.setOption('collaborationMode', modeId)
+      .then((result) => {
+        if (!result.success) {
+          this._toastError('Failed to change collaboration mode', result.error);
+          return;
+        }
+        void this._rememberPreference({ collaborationMode: modeId });
+      })
+      .catch((error: unknown) => this._toastError('Failed to change collaboration mode', error));
+  }
+
   setEffort(effort: string): void {
     void this.session
       ?.setOption('effort', effort)
@@ -585,6 +617,7 @@ export class AcpChatStore {
             model?: null;
             modeId?: null;
             effort?: null;
+            collaborationMode?: null;
           }
         );
       }
@@ -805,6 +838,7 @@ export class AcpChatStore {
     model?: string | null;
     modeId?: string | null;
     effort?: string | null;
+    collaborationMode?: string | null;
   }): Promise<void> {
     const providerId = conversationRegistry.get(this.taskId)?.conversations.get(this.conversationId)
       ?.data.providerId;

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.ts
@@ -196,7 +196,10 @@ export class AcpLiveSession {
     return this.client.cancelTurn({ conversationId: this.conversationId });
   }
 
-  setOption(key: 'model' | 'mode' | 'effort', value: string): Promise<Result<void, unknown>> {
+  setOption(
+    key: 'model' | 'mode' | 'effort' | 'collaborationMode',
+    value: string
+  ): Promise<Result<void, unknown>> {
     return this.client.setOption({ conversationId: this.conversationId, key, value });
   }
 

--- a/apps/emdash-desktop/src/core/features/conversations/browser/create-conversation-modal.tsx
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/create-conversation-modal.tsx
@@ -130,6 +130,8 @@ export const CreateConversationModal = observer(function CreateConversationModal
         model: selectedModel ?? undefined,
         modeId: conversationType === 'acp' ? savedPreference?.modeId : undefined,
         effort: conversationType === 'acp' ? savedPreference?.effort : undefined,
+        collaborationMode:
+          conversationType === 'acp' ? savedPreference?.collaborationMode : undefined,
         type: conversationType,
       });
       try {
@@ -163,6 +165,7 @@ export const CreateConversationModal = observer(function CreateConversationModal
     host,
     savedPreference?.effort,
     savedPreference?.modeId,
+    savedPreference?.collaborationMode,
     setProviderPreferences,
   ]);
 

--- a/apps/emdash-desktop/src/core/features/conversations/contributions/mementos.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/contributions/mementos.test.ts
@@ -50,6 +50,7 @@ describe('provider preferences memento', () => {
             model: 'sonnet',
             modeId: 'agent-full-access',
             effort: 'high',
+            collaborationMode: 'plan',
           },
         },
       }).status

--- a/apps/emdash-desktop/src/core/features/conversations/contributions/mementos.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/contributions/mementos.ts
@@ -26,6 +26,7 @@ const providerPreferenceSchema = z.object({
   model: z.string().optional(),
   modeId: z.string().optional(),
   effort: z.string().optional(),
+  collaborationMode: z.string().optional(),
 });
 
 export const providerPreferencesSchema = defineVersionedSchema()

--- a/apps/emdash-desktop/src/core/features/conversations/node/createConversation.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/createConversation.test.ts
@@ -151,13 +151,14 @@ describe('createConversation', () => {
     expect(db.inserted[0]).toMatchObject({ cwd: '/work/repo', workspacePath: '/work/repo' });
   });
 
-  it('stores provider-native ACP model, mode, and effort defaults', async () => {
+  it('stores provider-native ACP configuration defaults', async () => {
     await createConversation(
       {
         ...baseParams,
         model: 'sonnet',
         modeId: 'agent-full-access',
         effort: 'high',
+        collaborationMode: 'plan',
       },
       dependencies()
     );
@@ -168,6 +169,7 @@ describe('createConversation', () => {
           model: 'sonnet',
           modeId: 'agent-full-access',
           effort: 'high',
+          collaborationMode: 'plan',
         }),
       })
     );

--- a/apps/emdash-desktop/src/core/features/conversations/node/createConversation.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/createConversation.ts
@@ -99,6 +99,7 @@ export async function createConversation(
           ...(params.model && { model: params.model }),
           ...(params.modeId && { modeId: params.modeId }),
           ...(params.effort && { effort: params.effort }),
+          ...(params.collaborationMode && { collaborationMode: params.collaborationMode }),
           ...(initialQueue?.length && { initialQueue }),
         }
       : {

--- a/apps/emdash-desktop/src/core/features/conversations/node/set-acp-config-option.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/set-acp-config-option.test.ts
@@ -4,7 +4,7 @@ import type { HostConversationMutationDeps } from './host-mutation';
 import { setConversationAcpConfigOption } from './set-acp-config-option';
 
 describe('setConversationAcpConfigOption', () => {
-  it('persists model and effort and can clear an unsupported stored selection', async () => {
+  it('persists ACP selections and can clear an unsupported stored selection', async () => {
     const { deps, hostCalls } = fakeDeps({
       version: '1',
       type: 'acp',
@@ -16,6 +16,11 @@ describe('setConversationAcpConfigOption', () => {
       setConversationAcpConfigOption(deps, 'conversation-1', 'effort', 'high')
     ).resolves.toMatchObject({ success: true, data: { changed: true } });
     expect(hostCalls.at(-1)?.config).toMatchObject({ effort: 'high' });
+
+    await expect(
+      setConversationAcpConfigOption(deps, 'conversation-1', 'collaborationMode', 'plan')
+    ).resolves.toMatchObject({ success: true, data: { changed: true } });
+    expect(hostCalls.at(-1)?.config).toMatchObject({ collaborationMode: 'plan' });
 
     const clearing = fakeDeps({
       version: '1',

--- a/apps/emdash-desktop/src/core/features/conversations/node/set-acp-config-option.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/set-acp-config-option.ts
@@ -4,7 +4,7 @@ import type { ConversationConfig, ConversationConfigAcp } from '@core/primitives
 import type { HostConversationMutationDeps } from './host-mutation';
 import { resolveConversationHostClient } from './host-mutation';
 
-export type AcpPersistedConfigKey = 'model' | 'modeId' | 'effort';
+export type AcpPersistedConfigKey = 'model' | 'modeId' | 'effort' | 'collaborationMode';
 
 export type SetAcpConfigOptionError = BaseError<
   'empty-value' | 'conversation-not-found' | 'not-acp-conversation' | 'host-rejected'

--- a/apps/emdash-desktop/src/core/features/conversations/node/wire-controller.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/wire-controller.test.ts
@@ -35,6 +35,7 @@ const target = {
   model: null,
   modeId: null,
   effort: null,
+  collaborationMode: null,
   workspacePath: '/repo',
   host: LOCAL_HOST_REF,
   acpInput: {
@@ -44,6 +45,7 @@ const target = {
     sessionId: null,
     model: null,
     modeId: null,
+    collaborationMode: null,
   },
 } as const;
 type TestRuntimeTarget = typeof target;
@@ -96,7 +98,7 @@ describe('createConversationsWireController', () => {
       ok({
         turns: [],
         nextCursor: null,
-        clearedConfiguration: ['model', 'modeId'] as const,
+        clearedConfiguration: ['model', 'modeId', 'collaborationMode'] as const,
       })
     );
     const persistAcpConfigOption = vi.fn(async () => {});
@@ -113,6 +115,7 @@ describe('createConversationsWireController', () => {
     expect(persistAcpConfigOption.mock.calls).toEqual([
       [target, 'model', null],
       [target, 'modeId', null],
+      [target, 'collaborationMode', null],
     ]);
   });
 
@@ -351,7 +354,7 @@ function setupController(options: {
   hooks?: Partial<{
     persistAcpConfigOption: (
       target: TestRuntimeTarget,
-      key: 'model' | 'modeId' | 'effort',
+      key: 'model' | 'modeId' | 'effort' | 'collaborationMode',
       value: string | null
     ) => Promise<void>;
     recordTuiInput: (target: TestRuntimeTarget) => Promise<void>;

--- a/apps/emdash-desktop/src/core/features/conversations/node/wire-controller.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/wire-controller.ts
@@ -48,6 +48,7 @@ type ConversationRuntimeTarget = Readonly<{
   model: string | null;
   modeId: string | null;
   effort: string | null;
+  collaborationMode: string | null;
   workspacePath?: string;
   host: HostRef;
   acpInput?: ConversationsAcpStartInput;
@@ -396,6 +397,7 @@ async function resolveConversationRuntimeTarget(
           model: acpConfig?.model ?? null,
           modeId: acpConfig?.modeId ?? null,
           effort: acpConfig?.effort ?? null,
+          collaborationMode: acpConfig?.collaborationMode ?? null,
           ...(initialQueue && { initialQueue }),
           ...(providerEnv && { env: providerEnv }),
         }
@@ -411,6 +413,7 @@ async function resolveConversationRuntimeTarget(
     model: acpConfig?.model ?? null,
     modeId: acpConfig?.modeId ?? null,
     effort: acpConfig?.effort ?? null,
+    collaborationMode: acpConfig?.collaborationMode ?? null,
     workspacePath,
     host: identity?.host ?? LOCAL_HOST_REF,
     acpInput,
@@ -440,7 +443,12 @@ function callOptions(meta: CallMeta): { signal?: AbortSignal } {
 async function persistClearedConfiguration(
   hooks: ConversationRuntimeHooks,
   target: ConversationRuntimeTarget,
-  result: Result<{ clearedConfiguration?: Array<'model' | 'modeId' | 'effort'> }, unknown>,
+  result: Result<
+    {
+      clearedConfiguration?: Array<'model' | 'modeId' | 'effort' | 'collaborationMode'>;
+    },
+    unknown
+  >,
   logger: Logger
 ): Promise<void> {
   if (!result.success) return;

--- a/apps/emdash-desktop/src/core/primitives/conversations/api/conversation-config.test.ts
+++ b/apps/emdash-desktop/src/core/primitives/conversations/api/conversation-config.test.ts
@@ -112,6 +112,21 @@ describe('conversation-config v1 schema', () => {
     }
   });
 
+  it('round-trips collaboration mode on a v1 acp config', () => {
+    const config = conversationConfig.safeParse({
+      version: '1',
+      type: 'acp',
+      collaborationMode: 'plan',
+    });
+    expect(config.status).toBe('ok');
+    if (config.status === 'ok') {
+      expect(config.data.type === 'acp' && config.data.collaborationMode).toBe('plan');
+      expect(conversationConfig.parseJson(conversationConfig.serialize(config.data))).toEqual(
+        config.data
+      );
+    }
+  });
+
   it('returns invalid for non-object input', () => {
     expect(conversationConfig.safeParse('not-json')).toMatchObject({ status: 'invalid' });
     expect(conversationConfig.safeParse(null)).toMatchObject({ status: 'invalid' });

--- a/apps/emdash-desktop/src/core/primitives/conversations/api/conversation-config.ts
+++ b/apps/emdash-desktop/src/core/primitives/conversations/api/conversation-config.ts
@@ -39,6 +39,8 @@ const acpConfigV1 = z.object({
   modeId: z.string().optional(),
   /** Last user-selected provider reasoning/effort id, re-applied on session start. */
   effort: z.string().optional(),
+  /** Last user-selected provider collaboration mode, such as Codex Default or Plan. */
+  collaborationMode: z.string().optional(),
 });
 
 export const conversationConfig = defineVersionedSchema()

--- a/apps/emdash-desktop/src/core/primitives/conversations/api/conversations.ts
+++ b/apps/emdash-desktop/src/core/primitives/conversations/api/conversations.ts
@@ -33,6 +33,8 @@ export type Conversation = {
   modeId?: string;
   /** Last user-selected ACP reasoning/effort id, re-applied on session start. */
   effort?: string;
+  /** Last user-selected ACP collaboration mode, re-applied on session start. */
+  collaborationMode?: string;
   /** Initial queued prompts to deliver on first ACP spawn. Only present before sessionId is set. */
   initialQueue?: InitialQueuePrompt[];
   isInitialConversation: boolean | null;
@@ -51,7 +53,13 @@ export type ConversationEvent =
       changes: Partial<
         Pick<
           Conversation,
-          'lastInteractedAt' | 'title' | 'sessionId' | 'model' | 'modeId' | 'effort'
+          | 'lastInteractedAt'
+          | 'title'
+          | 'sessionId'
+          | 'model'
+          | 'modeId'
+          | 'effort'
+          | 'collaborationMode'
         >
       >;
     }
@@ -114,6 +122,8 @@ export type CreateConversationParams = {
   modeId?: string;
   /** Provider-native ACP reasoning/effort id to apply on first activation. */
   effort?: string;
+  /** Provider-native ACP collaboration mode to apply on first activation. */
+  collaborationMode?: string;
   isInitialConversation?: boolean;
   initialSize?: { cols: number; rows: number };
   initialPrompt?: string;

--- a/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
@@ -518,6 +518,25 @@ describe('AcpChatStore prompt submission', () => {
     store.dispose();
   });
 
+  it('remembers a successful collaboration-mode change', async () => {
+    const setOption = vi.fn(async () => ({ success: true as const, data: undefined }));
+    const store = createStore(idleState(), vi.fn(), { setOption });
+    const rememberPreference = vi
+      .spyOn(
+        store as unknown as {
+          _rememberPreference(patch: { collaborationMode: string }): Promise<void>;
+        },
+        '_rememberPreference'
+      )
+      .mockResolvedValue();
+
+    store.setCollaborationMode('plan');
+
+    await vi.waitFor(() => expect(setOption).toHaveBeenCalledWith('collaborationMode', 'plan'));
+    expect(rememberPreference).toHaveBeenCalledWith({ collaborationMode: 'plan' });
+    store.dispose();
+  });
+
   it('keeps the ordinary active-turn completion history refresh', async () => {
     const live = fakeLiveSession(idleState(), historyPage('initial'));
     const store = await bootstrapWithSession(live.session);

--- a/packages/core/src/runtimes/acp/api/contract.ts
+++ b/packages/core/src/runtimes/acp/api/contract.ts
@@ -60,7 +60,9 @@ import {
 
 const launchResultSchema = z.object({
   sessionId: z.string(),
-  clearedConfiguration: z.array(z.enum(['model', 'modeId', 'effort'])).optional(),
+  clearedConfiguration: z
+    .array(z.enum(['model', 'modeId', 'effort', 'collaborationMode']))
+    .optional(),
 });
 const sessionKeySchema = z.object({ conversationId: z.string() });
 const terminalOutputKeySchema = z.object({ terminalId: z.string() });

--- a/packages/core/src/runtimes/acp/api/models/config.ts
+++ b/packages/core/src/runtimes/acp/api/models/config.ts
@@ -75,6 +75,16 @@ export const sessionConfigStateSchema = z.object({
       available: z.array(modeOptionSchema),
     })
     .nullable(),
+  /** Collaboration style selector state (for example Codex Default / Plan). */
+  collaborationModeOptions: z
+    .object({
+      /** Provider-owned ACP config option id used when sending config updates. */
+      configId: z.string(),
+      selected: z.string().nullable(),
+      available: z.array(modeOptionSchema),
+    })
+    .nullable()
+    .optional(),
   /** Slash commands currently advertised by the active ACP session. */
   availableCommands: z.array(sessionCommandSchema),
 });
@@ -84,6 +94,7 @@ export const initialSessionConfigState: SessionConfigState = {
   modelOptions: null,
   efforts: null,
   modeOptions: null,
+  collaborationModeOptions: null,
   availableCommands: [],
 };
 

--- a/packages/core/src/runtimes/acp/api/models/models.test.ts
+++ b/packages/core/src/runtimes/acp/api/models/models.test.ts
@@ -25,6 +25,16 @@ function buildParserOutput(): AcpTranscriptParser {
         currentValue: 'sonnet',
         options: [{ value: 'sonnet', name: 'Sonnet' }],
       },
+      {
+        id: 'collaboration_mode',
+        category: 'collaboration_mode',
+        type: 'select',
+        currentValue: 'plan',
+        options: [
+          { value: 'default', name: 'Default' },
+          { value: 'plan', name: 'Plan', description: 'Plan before making changes' },
+        ],
+      },
     ],
   } as unknown as SessionUpdate);
   parser.push({
@@ -84,6 +94,14 @@ describe('ACP zod models', () => {
       parser.activeTurn === null ? null : transcriptTurnSchema.parse(parser.activeTurn)
     ).not.toThrow();
     expect(() => sessionConfigStateSchema.parse(parser.config)).not.toThrow();
+    expect(parser.config.collaborationModeOptions).toEqual({
+      configId: 'collaboration_mode',
+      selected: 'plan',
+      available: [
+        { id: 'default', name: 'Default' },
+        { id: 'plan', name: 'Plan', description: 'Plan before making changes' },
+      ],
+    });
     expect(() =>
       parser.usage === null ? null : sessionUsageSchema.parse(parser.usage)
     ).not.toThrow();

--- a/packages/core/src/runtimes/acp/api/reducer/config-derive.ts
+++ b/packages/core/src/runtimes/acp/api/reducer/config-derive.ts
@@ -41,13 +41,13 @@ function selectOptions(opt: SessionConfigOption): RawOption[] {
 }
 
 /**
- * Map a raw `SessionConfigOption[]` to the three typed groups of
- * SessionConfigState: modelOptions, efforts, modeOptions.
+ * Map a raw `SessionConfigOption[]` to the typed groups of SessionConfigState.
  *
  * Category mapping:
  *   'model'         → modelOptions   (model selector)
  *   'thought_level' → efforts        (Claude effort / Codex reasoning effort)
  *   'mode'          → modeOptions    (permission mode)
+ *   'collaboration_mode' → collaborationModeOptions (provider workflow mode)
  *
  * `configId` preserves the provider-owned ACP config option id, `selected` is taken from
  * `currentValue`, and `available` is the full options list.
@@ -56,10 +56,14 @@ function selectOptions(opt: SessionConfigOption): RawOption[] {
  */
 export function deriveConfigGroups(
   options: ReadonlyArray<SessionConfigOption>
-): Pick<SessionConfigState, 'modelOptions' | 'efforts' | 'modeOptions'> {
+): Pick<
+  SessionConfigState,
+  'modelOptions' | 'efforts' | 'modeOptions' | 'collaborationModeOptions'
+> {
   let modelOptions: SessionConfigState['modelOptions'] = null;
   let efforts: SessionConfigState['efforts'] = null;
   let modeOptions: SessionConfigState['modeOptions'] = null;
+  let collaborationModeOptions: SessionConfigState['collaborationModeOptions'] = null;
 
   for (const opt of options) {
     if (opt.type !== 'select') continue;
@@ -88,9 +92,16 @@ export function deriveConfigGroups(
           available: rawOptions.map(toModeOption),
         };
         break;
+      case 'collaboration_mode':
+        collaborationModeOptions = {
+          configId: opt.id,
+          selected: rawSelected,
+          available: rawOptions.map(toModeOption),
+        };
+        break;
       // Unknown categories (e.g. 'model_config') are ignored — extension point.
     }
   }
 
-  return { modelOptions, efforts, modeOptions };
+  return { modelOptions, efforts, modeOptions, collaborationModeOptions };
 }

--- a/packages/core/src/runtimes/acp/api/reducer/parser.ts
+++ b/packages/core/src/runtimes/acp/api/reducer/parser.ts
@@ -3,7 +3,7 @@
  *
  * A single push() call folds one raw ACP SessionUpdate into all slices:
  *   - transcript (committed turns + active turn)
- *   - config     (modelOptions / efforts / modeOptions / availableCommands)
+ *   - config     (model / effort / permission / collaboration options + commands)
  *   - usage      (contextUsed / contextSize / cost)
  *   - title      (session info title)
  *

--- a/packages/core/src/runtimes/acp/api/schemas.ts
+++ b/packages/core/src/runtimes/acp/api/schemas.ts
@@ -12,6 +12,7 @@ export const acpStartInputSchema = z.object({
   model: z.string().nullable(),
   modeId: z.string().nullable().optional(),
   effort: z.string().nullable().optional(),
+  collaborationMode: z.string().nullable().optional(),
   initialQueue: z.array(promptInputSchema).optional(),
   env: z.record(z.string(), z.string()).optional(),
 });
@@ -44,7 +45,7 @@ export const changeQueuePromptOrderCommandSchema = z.object({
 export const cancelTurnCommandSchema = z.object({ conversationId: z.string() });
 export const setOptionCommandSchema = z.object({
   conversationId: z.string(),
-  key: z.enum(['model', 'mode', 'effort']),
+  key: z.enum(['model', 'mode', 'effort', 'collaborationMode']),
   value: z.string(),
 });
 export const resolvePermissionCommandSchema = permissionDecisionSchema.extend({
@@ -83,7 +84,9 @@ export const historyPageSchema = z.object({
 export type HistoryPage = z.infer<typeof historyPageSchema>;
 
 export const loadHistoryResultSchema = historyPageSchema.extend({
-  clearedConfiguration: z.array(z.enum(['model', 'modeId', 'effort'])).optional(),
+  clearedConfiguration: z
+    .array(z.enum(['model', 'modeId', 'effort', 'collaborationMode']))
+    .optional(),
 });
 export type LoadHistoryResult = z.infer<typeof loadHistoryResultSchema>;
 

--- a/packages/core/src/runtimes/acp/node/api/procedures.ts
+++ b/packages/core/src/runtimes/acp/node/api/procedures.ts
@@ -74,7 +74,7 @@ export function createAcpProcedures(runtime: AcpRuntime) {
     },
     async setOption(input: {
       conversationId: string;
-      key: 'model' | 'mode' | 'effort';
+      key: 'model' | 'mode' | 'effort' | 'collaborationMode';
       value: string;
     }): Promise<Result<void, AcpSetOptionError>> {
       const result = await runtime.setOption(input.conversationId, input.key, input.value);

--- a/packages/core/src/runtimes/acp/node/runtime/conversation-handle.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/conversation-handle.ts
@@ -331,7 +331,14 @@ export class ConversationHandle {
   updateConfig(dimension: ConfigDimension, value: string): void {
     this.configOverrides = { ...this.configOverrides, [dimension]: value };
     this.updateConfigured({ [dimension]: value });
-    this.updateDescriptor(dimension === 'model' ? { model: value } : { effort: value }, true);
+    this.updateDescriptor(
+      dimension === 'model'
+        ? { model: value }
+        : dimension === 'effort'
+          ? { effort: value }
+          : { collaborationMode: value },
+      true
+    );
   }
 
   clearMode(): void {
@@ -343,7 +350,14 @@ export class ConversationHandle {
     const { [dimension]: _removed, ...remaining } = this.configOverrides;
     this.configOverrides = remaining;
     this.updateConfigured({ [dimension]: null });
-    this.updateDescriptor(dimension === 'model' ? { model: null } : { effort: null }, true);
+    this.updateDescriptor(
+      dimension === 'model'
+        ? { model: null }
+        : dimension === 'effort'
+          ? { effort: null }
+          : { collaborationMode: null },
+      true
+    );
   }
 
   refreshDescriptor(descriptor: AcpStartInput): void {
@@ -360,6 +374,7 @@ export class ConversationHandle {
     this.configOverrides = {
       ...(descriptor.model ? { model: descriptor.model } : {}),
       ...(descriptor.effort ? { effort: descriptor.effort } : {}),
+      ...(descriptor.collaborationMode ? { collaborationMode: descriptor.collaborationMode } : {}),
     };
     this.updateConfigured(configuredFromDescriptor(descriptor));
   }
@@ -528,6 +543,7 @@ function configuredFromDescriptor(descriptor: AcpStartInput): RetainedPresentati
     model: descriptor.model ?? null,
     modeId: descriptor.modeId ?? null,
     effort: descriptor.effort ?? null,
+    collaborationMode: descriptor.collaborationMode ?? null,
   };
 }
 
@@ -548,6 +564,8 @@ function mergeCapabilities(
     modelOptions: current.modelOptions ?? retained.modelOptions,
     efforts: current.efforts ?? retained.efforts,
     modeOptions: current.modeOptions ?? retained.modeOptions,
+    collaborationModeOptions:
+      current.collaborationModeOptions ?? retained.collaborationModeOptions ?? null,
     availableCommands:
       preservePendingCommands && current.availableCommands.length === 0
         ? retained.availableCommands

--- a/packages/core/src/runtimes/acp/node/runtime/conversation-types.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/conversation-types.ts
@@ -3,7 +3,7 @@ import type { SessionCell } from '#runtimes/acp/node/session/cell';
 import type { ConversationHandle } from './conversation-handle';
 import type { AcpStartInput } from './types';
 
-export type ConfigDimension = 'model' | 'effort';
+export type ConfigDimension = 'model' | 'effort' | 'collaborationMode';
 export type ConfigOverrides = Partial<Record<ConfigDimension, string>>;
 export type ActivationStartError = AcpStartError | ConversationNotFoundError;
 
@@ -16,7 +16,7 @@ export interface SessionRecord {
   epoch: number;
   input: AcpStartInput;
   resumeOutcome: 'loaded' | 'replaced-by-new' | null;
-  clearedConfiguration: Array<'model' | 'modeId' | 'effort'>;
+  clearedConfiguration: Array<'model' | 'modeId' | 'effort' | 'collaborationMode'>;
   processKey: string;
   processGeneration: number;
   connectionLeaseState: ConnectionLeaseState;

--- a/packages/core/src/runtimes/acp/node/runtime/runtime.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/runtime.ts
@@ -134,7 +134,7 @@ export class AcpRuntime {
 
   setOption(
     conversationId: string,
-    key: 'model' | 'mode' | 'effort',
+    key: 'model' | 'mode' | 'effort' | 'collaborationMode',
     value: string
   ): Promise<Result<void, AcpSetOptionError | AcpWakeFailure>> {
     return key === 'mode'

--- a/packages/core/src/runtimes/acp/node/runtime/session-intent-schemas.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/session-intent-schemas.ts
@@ -10,6 +10,7 @@ const retainedConfiguredSchema = z.object({
   model: z.string().nullable(),
   modeId: z.string().nullable(),
   effort: z.string().nullable(),
+  collaborationMode: z.string().nullable().optional(),
 });
 
 const retainedPresentationSchema = z.object({
@@ -35,6 +36,7 @@ export const legacyRetainedIntentSchema = acpStartInputSchema.extend({
     .object({
       model: z.string().optional(),
       effort: z.string().optional(),
+      collaborationMode: z.string().optional(),
     })
     .optional(),
 });

--- a/packages/core/src/runtimes/acp/node/runtime/session-manager.test.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/session-manager.test.ts
@@ -250,7 +250,11 @@ describe('AcpRuntime session manager', () => {
     });
     h.agent.newSession.mockResolvedValueOnce({
       sessionId: 'session-1',
-      configOptions: [modeConfigOption('agent'), effortConfigOption('low')],
+      configOptions: [
+        modeConfigOption('agent'),
+        effortConfigOption('low'),
+        collaborationModeConfigOption('default'),
+      ],
     });
     const rt = new AcpRuntime(h.deps);
     const input = makeStartInput({ conversationId: 'conv-dormant-settings' });
@@ -265,20 +269,28 @@ describe('AcpRuntime session manager', () => {
       ok()
     );
     await expect(rt.setOption(input.conversationId, 'effort', 'high')).resolves.toEqual(ok());
+    await expect(rt.setOption(input.conversationId, 'collaborationMode', 'plan')).resolves.toEqual(
+      ok()
+    );
 
     expect(h.agent.loadSession).not.toHaveBeenCalled();
     expect(h.agent.newSession).not.toHaveBeenCalled();
     expect(h.agent.setSessionConfigOption).not.toHaveBeenCalled();
     expect(intents.snapshot()[0]?.payload).toMatchObject({
-      configured: { modeId: 'agent-full-access', effort: 'high' },
+      configured: { modeId: 'agent-full-access', effort: 'high', collaborationMode: 'plan' },
     });
     expect(peek(rt.sessionLiveModels(input.conversationId)!.states.config)).toMatchObject({
       modeOptions: { selected: 'agent-full-access' },
       efforts: { selected: 'high' },
+      collaborationModeOptions: { selected: 'plan' },
     });
 
     h.agent.loadSession.mockResolvedValueOnce({
-      configOptions: [modeConfigOption('agent'), effortConfigOption('low')],
+      configOptions: [
+        modeConfigOption('agent'),
+        effortConfigOption('low'),
+        collaborationModeConfigOption('default'),
+      ],
     });
     await rt.sendPrompt(input.conversationId, { text: 'wake once' });
 
@@ -292,6 +304,11 @@ describe('AcpRuntime session manager', () => {
       sessionId: 'session-1',
       configId: 'reasoning_effort',
       value: 'high',
+    });
+    expect(h.agent.setSessionConfigOption).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      configId: 'collaboration_mode',
+      value: 'plan',
     });
     expect(h.agent.prompt).toHaveBeenCalledTimes(1);
   });
@@ -1425,6 +1442,20 @@ function effortConfigOption(currentValue: string) {
     options: [
       { value: 'low', name: 'Low' },
       { value: 'high', name: 'High' },
+    ],
+  };
+}
+
+function collaborationModeConfigOption(currentValue: string) {
+  return {
+    id: 'collaboration_mode',
+    name: 'Collaboration mode',
+    category: 'collaboration_mode',
+    type: 'select',
+    currentValue,
+    options: [
+      { value: 'default', name: 'Default' },
+      { value: 'plan', name: 'Plan' },
     ],
   };
 }

--- a/packages/core/src/runtimes/acp/node/runtime/session-manager.test.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/session-manager.test.ts
@@ -55,12 +55,16 @@ describe('AcpRuntime session manager', () => {
     const rt = new AcpRuntime(h.deps);
 
     const result = await rt.launchSession(
-      makeStartInput({ conversationId: 'conv-unsupported-model', model: 'removed-model' })
+      makeStartInput({
+        conversationId: 'conv-unsupported-model',
+        model: 'removed-model',
+        collaborationMode: 'plan',
+      })
     );
 
     expect(result).toMatchObject({
       success: true,
-      data: { clearedConfiguration: ['model'] },
+      data: { clearedConfiguration: ['model', 'collaborationMode'] },
     });
     expect(h.agent.setSessionConfigOption).not.toHaveBeenCalled();
 
@@ -68,7 +72,11 @@ describe('AcpRuntime session manager', () => {
     missingCatalogHarness.agent.newSession.mockResolvedValueOnce({ sessionId: 'session-2' });
     const missingCatalogRuntime = new AcpRuntime(missingCatalogHarness.deps);
     const missingCatalogResult = await missingCatalogRuntime.launchSession(
-      makeStartInput({ conversationId: 'conv-missing-catalog', model: 'keep-me' })
+      makeStartInput({
+        conversationId: 'conv-missing-catalog',
+        model: 'keep-me',
+        collaborationMode: 'plan',
+      })
     );
     expect(missingCatalogResult).toMatchObject({ success: true, data: { sessionId: 'session-2' } });
     if (missingCatalogResult.success) {

--- a/packages/core/src/runtimes/acp/node/runtime/session-manager.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/session-manager.ts
@@ -201,11 +201,12 @@ export class SessionManager {
     return ok();
   }
 
-  async ensureActivation(
-    conversationId: string
-  ): Promise<
+  async ensureActivation(conversationId: string): Promise<
     Result<
-      { sessionId: string; clearedConfiguration?: Array<'model' | 'modeId' | 'effort'> },
+      {
+        sessionId: string;
+        clearedConfiguration?: Array<'model' | 'modeId' | 'effort' | 'collaborationMode'>;
+      },
       AcpStartError
     >
   > {
@@ -214,11 +215,12 @@ export class SessionManager {
     return this.activateEntry(entry, false);
   }
 
-  async launch(
-    input: AcpStartInput
-  ): Promise<
+  async launch(input: AcpStartInput): Promise<
     Result<
-      { sessionId: string; clearedConfiguration?: Array<'model' | 'modeId' | 'effort'> },
+      {
+        sessionId: string;
+        clearedConfiguration?: Array<'model' | 'modeId' | 'effort' | 'collaborationMode'>;
+      },
       AcpStartError
     >
   > {
@@ -237,7 +239,10 @@ export class SessionManager {
     removeOnInitialFailure: boolean
   ): Promise<
     Result<
-      { sessionId: string; clearedConfiguration?: Array<'model' | 'modeId' | 'effort'> },
+      {
+        sessionId: string;
+        clearedConfiguration?: Array<'model' | 'modeId' | 'effort' | 'collaborationMode'>;
+      },
       AcpStartError
     >
   > {
@@ -729,6 +734,7 @@ export class SessionManager {
         ({
           ...(input.model ? { model: input.model } : {}),
           ...(input.effort ? { effort: input.effort } : {}),
+          ...(input.collaborationMode ? { collaborationMode: input.collaborationMode } : {}),
         } satisfies ConfigOverrides),
       options.consumed ?? false,
       options.everMaterialized ?? options.suspended,
@@ -755,6 +761,7 @@ export class SessionManager {
         model: configured.model,
         modeId: configured.modeId,
         effort: configured.effort,
+        collaborationMode: configured.collaborationMode ?? null,
       };
       configOverrides = configuredOverrides(configured);
       retained = { ...parsedV1.data.presentation, configured };
@@ -766,6 +773,7 @@ export class SessionManager {
         model: legacyOverrides?.model ?? legacy.model ?? null,
         modeId: legacy.modeId ?? null,
         effort: legacyOverrides?.effort ?? legacy.effort ?? null,
+        collaborationMode: legacyOverrides?.collaborationMode ?? legacy.collaborationMode ?? null,
       };
       descriptor = {
         conversationId: intent.conversationId,
@@ -775,6 +783,7 @@ export class SessionManager {
         model: configured.model,
         modeId: configured.modeId,
         effort: configured.effort,
+        collaborationMode: configured.collaborationMode,
       };
       configOverrides = configuredOverrides(configured);
       retained = emptyRetainedPresentation(configured);
@@ -942,6 +951,7 @@ function configuredOverrides(configured: RetainedPresentation['configured']): Co
   return {
     ...(configured.model ? { model: configured.model } : {}),
     ...(configured.effort ? { effort: configured.effort } : {}),
+    ...(configured.collaborationMode ? { collaborationMode: configured.collaborationMode } : {}),
   };
 }
 

--- a/packages/core/src/runtimes/acp/node/runtime/session-materializer.test.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/session-materializer.test.ts
@@ -13,9 +13,9 @@ describe('SessionMaterializer', () => {
     h.agent.loadSession.mockRejectedValueOnce(new Error('session file is gone'));
     h.agent.newSession.mockResolvedValueOnce({
       sessionId: 'replacement',
-      configOptions: [effortConfigOption('low')],
+      configOptions: [effortConfigOption('low'), collaborationModeConfigOption('default')],
     });
-    const setup = materializerHarness(h, { effort: 'high' });
+    const setup = materializerHarness(h, { effort: 'high', collaborationMode: 'plan' });
 
     const result = await setup.materializer.materialize(
       setup.entry,
@@ -35,6 +35,11 @@ describe('SessionMaterializer', () => {
       sessionId: 'replacement',
       configId: 'reasoning_effort',
       value: 'high',
+    });
+    expect(h.agent.setSessionConfigOption).toHaveBeenCalledWith({
+      sessionId: 'replacement',
+      configId: 'collaboration_mode',
+      value: 'plan',
     });
     expect(setup.discarded).toHaveLength(1);
 
@@ -283,6 +288,20 @@ function effortConfigOption(currentValue: string) {
     options: [
       { value: 'low', name: 'Low' },
       { value: 'high', name: 'High' },
+    ],
+  };
+}
+
+function collaborationModeConfigOption(currentValue: string) {
+  return {
+    id: 'collaboration_mode',
+    name: 'Collaboration mode',
+    category: 'collaboration_mode',
+    type: 'select',
+    currentValue,
+    options: [
+      { value: 'default', name: 'Default' },
+      { value: 'plan', name: 'Plan' },
     ],
   };
 }

--- a/packages/core/src/runtimes/acp/node/runtime/session-materializer.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/session-materializer.ts
@@ -305,13 +305,17 @@ export class SessionMaterializer {
   private async applyConfigOverrides(
     record: SessionRecord,
     entry: ConversationHandle
-  ): Promise<Array<'model' | 'effort'>> {
-    const cleared: Array<'model' | 'effort'> = [];
-    for (const dimension of ['model', 'effort'] as const) {
+  ): Promise<Array<'model' | 'effort' | 'collaborationMode'>> {
+    const cleared: Array<'model' | 'effort' | 'collaborationMode'> = [];
+    for (const dimension of ['model', 'effort', 'collaborationMode'] as const) {
       const value = entry.configOverrides[dimension];
       if (!value) continue;
       const catalog =
-        dimension === 'model' ? record.cell.config.modelOptions : record.cell.config.efforts;
+        dimension === 'model'
+          ? record.cell.config.modelOptions
+          : dimension === 'effort'
+            ? record.cell.config.efforts
+            : record.cell.config.collaborationModeOptions;
       if (catalog && !catalog.available.some((option) => option.id === value)) {
         entry.clearConfig(dimension);
         cleared.push(dimension);

--- a/packages/core/src/runtimes/acp/node/runtime/session-materializer.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/session-materializer.ts
@@ -125,7 +125,7 @@ export class SessionMaterializer {
             modes: response.modes,
             configOptions: response.configOptions,
           });
-          await this.applyDesiredConfiguration(record, entry);
+          await this.applyDesiredConfiguration(record, entry, response.configOptions !== undefined);
           const queueResult = this.queueInitialPrompts(record, input);
           if (!queueResult.success) return queueResult;
           record.cell.endReplay();
@@ -180,7 +180,7 @@ export class SessionMaterializer {
           modes: response.modes,
           configOptions: response.configOptions,
         });
-        await this.applyDesiredConfiguration(record, entry);
+        await this.applyDesiredConfiguration(record, entry, response.configOptions !== undefined);
         const queueResult = this.queueInitialPrompts(record, input);
         if (!queueResult.success) return queueResult;
         record.cell.applySessionReady();
@@ -304,7 +304,8 @@ export class SessionMaterializer {
 
   private async applyConfigOverrides(
     record: SessionRecord,
-    entry: ConversationHandle
+    entry: ConversationHandle,
+    hasAuthoritativeCatalog: boolean
   ): Promise<Array<'model' | 'effort' | 'collaborationMode'>> {
     const cleared: Array<'model' | 'effort' | 'collaborationMode'> = [];
     for (const dimension of ['model', 'effort', 'collaborationMode'] as const) {
@@ -316,7 +317,10 @@ export class SessionMaterializer {
           : dimension === 'effort'
             ? record.cell.config.efforts
             : record.cell.config.collaborationModeOptions;
-      if (catalog && !catalog.available.some((option) => option.id === value)) {
+      if (
+        (!catalog && hasAuthoritativeCatalog) ||
+        (catalog && !catalog.available.some((option) => option.id === value))
+      ) {
         entry.clearConfig(dimension);
         cleared.push(dimension);
         continue;
@@ -336,12 +340,13 @@ export class SessionMaterializer {
 
   private async applyDesiredConfiguration(
     record: SessionRecord,
-    entry: ConversationHandle
+    entry: ConversationHandle,
+    hasAuthoritativeCatalog: boolean
   ): Promise<void> {
     let revision: number;
     do {
       revision = entry.desiredRevision;
-      const cleared = await this.applyConfigOverrides(record, entry);
+      const cleared = await this.applyConfigOverrides(record, entry, hasAuthoritativeCatalog);
       const clearedMode = await this.applyInitialMode(record, entry);
       for (const key of [...cleared, ...(clearedMode ? [clearedMode] : [])]) {
         if (!record.clearedConfiguration.includes(key)) record.clearedConfiguration.push(key);

--- a/packages/core/src/runtimes/acp/node/session/cell.test.ts
+++ b/packages/core/src/runtimes/acp/node/session/cell.test.ts
@@ -258,6 +258,66 @@ describe('SessionCell config options', () => {
     });
     expect(cell.config.efforts?.selected).toBe('high');
   });
+
+  it('sets collaboration mode independently from permission mode', async () => {
+    const { cell, agent } = makeCell();
+    cell.applySessionMeta({
+      configOptions: [
+        {
+          id: 'mode',
+          name: 'Permissions',
+          category: 'mode',
+          type: 'select',
+          currentValue: 'agent',
+          options: [{ value: 'agent', name: 'Agent' }],
+        },
+        {
+          id: 'collaboration_mode',
+          name: 'Collaboration mode',
+          category: 'collaboration_mode',
+          type: 'select',
+          currentValue: 'default',
+          options: [
+            { value: 'default', name: 'Default' },
+            { value: 'plan', name: 'Plan' },
+          ],
+        },
+      ],
+    });
+    agent.setSessionConfigOption = vi.fn().mockResolvedValue({
+      configOptions: [
+        {
+          id: 'mode',
+          name: 'Permissions',
+          category: 'mode',
+          type: 'select',
+          currentValue: 'agent',
+          options: [{ value: 'agent', name: 'Agent' }],
+        },
+        {
+          id: 'collaboration_mode',
+          category: 'collaboration_mode',
+          type: 'select',
+          currentValue: 'plan',
+          options: [
+            { value: 'default', name: 'Default' },
+            { value: 'plan', name: 'Plan' },
+          ],
+        },
+      ],
+    });
+
+    const result = await cell.setConfigOption('collaborationMode', 'plan');
+
+    expect(isOk(result)).toBe(true);
+    expect(agent.setSessionConfigOption).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      configId: 'collaboration_mode',
+      value: 'plan',
+    });
+    expect(cell.config.collaborationModeOptions?.selected).toBe('plan');
+    expect(cell.config.modeOptions?.selected).toBe('agent');
+  });
 });
 
 describe('SessionCell idle turns and queue commands', () => {

--- a/packages/core/src/runtimes/acp/node/session/cell.ts
+++ b/packages/core/src/runtimes/acp/node/session/cell.ts
@@ -51,7 +51,7 @@ export interface AcpChatHistory {
   active: TranscriptTurn | null;
 }
 
-type ConfigDimension = 'model' | 'effort';
+type ConfigDimension = 'model' | 'effort' | 'collaborationMode';
 
 export class SessionCell {
   readonly machine: SessionMachine;
@@ -614,6 +614,9 @@ export class SessionCell {
           ? [this.transcript.config.modelOptions.configId]
           : []),
         ...(this.transcript.config.efforts ? [this.transcript.config.efforts.configId] : []),
+        ...(this.transcript.config.collaborationModeOptions
+          ? [this.transcript.config.collaborationModeOptions.configId]
+          : []),
       ],
     };
   }
@@ -624,6 +627,8 @@ export class SessionCell {
         return this.transcript.config.modelOptions?.configId ?? null;
       case 'effort':
         return this.transcript.config.efforts?.configId ?? null;
+      case 'collaborationMode':
+        return this.transcript.config.collaborationModeOptions?.configId ?? null;
     }
   }
 

--- a/packages/core/src/runtimes/acp/node/state/live-models.ts
+++ b/packages/core/src/runtimes/acp/node/state/live-models.ts
@@ -65,6 +65,7 @@ export type RetainedConfiguredState = {
   model: string | null;
   modeId: string | null;
   effort: string | null;
+  collaborationMode?: string | null;
 };
 
 export type RetainedPresentation = {
@@ -256,6 +257,10 @@ export function retainedConfig(retained: RetainedPresentation): SessionConfigSta
     modelOptions: selected(lastKnownCapabilities.modelOptions, configured.model),
     efforts: selected(lastKnownCapabilities.efforts, configured.effort),
     modeOptions: selected(lastKnownCapabilities.modeOptions, configured.modeId),
+    collaborationModeOptions: selected(
+      lastKnownCapabilities.collaborationModeOptions ?? null,
+      configured.collaborationMode ?? null
+    ),
   };
 }
 

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@agentclientprotocol/claude-agent-acp": "^0.54.1",
-    "@agentclientprotocol/codex-acp": "^1.0.2",
+    "@agentclientprotocol/codex-acp": "^1.7.0",
     "@typescript/native-preview": "7.0.0-dev.20260609.1",
     "oxfmt": "^0.51.0",
     "oxlint": "^1.69.0",

--- a/packages/plugins/src/agents/impl/codex/__snapshots__/acp-fixture.test.ts.snap
+++ b/packages/plugins/src/agents/impl/codex/__snapshots__/acp-fixture.test.ts.snap
@@ -115,6 +115,7 @@ exports[`Codex ACP fixture parsing > config 1`] = `
       "source": "provider-command",
     },
   ],
+  "collaborationModeOptions": null,
   "efforts": {
     "available": [
       {

--- a/packages/ui/src/react/components/chat-composer/chat-composer.stories.tsx
+++ b/packages/ui/src/react/components/chat-composer/chat-composer.stories.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/react/primitives/button';
 import { ChatComposer } from '.';
 import type {
   ComposerAgentOption,
+  ComposerCollaborationModeOption,
   ComposerEffortOption,
   ComposerModelOption,
   ComposerMcpServer,
@@ -215,8 +216,13 @@ const MOCK_PERMISSION_MODES: Record<string, ComposerPermissionModeOption> = {
     name: 'Accept edits',
     description: 'Auto-allow file edits, prompt for shell commands.',
   },
-  plan: { name: 'Plan only', description: 'Agent proposes changes but never writes files.' },
+  readOnly: { name: 'Read only', description: 'Allow inspection without writing files.' },
   bypass: { name: 'Bypass all', description: 'Auto-approve everything — use with caution.' },
+};
+
+const MOCK_COLLABORATION_MODES: Record<string, ComposerCollaborationModeOption> = {
+  default: { name: 'Default', description: 'Work directly on the task.' },
+  plan: { name: 'Plan', description: 'Create a plan before making changes.' },
 };
 
 // ── Mock permission requests ──────────────────────────────────────────────────
@@ -342,6 +348,7 @@ interface PlaygroundArgs {
   noticeTitle: string;
   noticeMessage: string;
   showPermissionModeSelector: boolean;
+  showCollaborationModeSelector: boolean;
   showPermissionRequest: boolean;
   showQueuedPrompts: boolean;
 }
@@ -360,6 +367,7 @@ function ComposerPlayground(args: PlaygroundArgs) {
     noticeTitle,
     noticeMessage,
     showPermissionModeSelector,
+    showCollaborationModeSelector,
     showPermissionRequest,
     showQueuedPrompts,
   } = args;
@@ -368,6 +376,7 @@ function ComposerPlayground(args: PlaygroundArgs) {
   const [selectedModel, setSelectedModel] = useState('claude-sonnet-4-5');
   const [dismissed, setDismissed] = useState(false);
   const [selectedPermissionMode, setSelectedPermissionMode] = useState('default');
+  const [selectedCollaborationMode, setSelectedCollaborationMode] = useState('default');
   const [permissionQueue, setPermissionQueue] = useState<ComposerPermissionRequest[]>([]);
   const [queuedPrompts, setQueuedPrompts] = useState<ComposerQueuedPrompt[]>([]);
 
@@ -431,6 +440,9 @@ function ComposerPlayground(args: PlaygroundArgs) {
         permissionModeOptions={showPermissionModeSelector ? MOCK_PERMISSION_MODES : null}
         selectedPermissionMode={selectedPermissionMode}
         onPermissionModeChange={setSelectedPermissionMode}
+        collaborationModeOptions={showCollaborationModeSelector ? MOCK_COLLABORATION_MODES : null}
+        selectedCollaborationMode={selectedCollaborationMode}
+        onCollaborationModeChange={setSelectedCollaborationMode}
         permissionRequest={permissionQueue[0] ?? null}
         permissionQueueCount={permissionQueue.length}
         onResolvePermission={() => setPermissionQueue((q) => q.slice(1))}
@@ -505,6 +517,10 @@ const meta: Meta<PlaygroundArgs> = {
       control: 'boolean',
       description: 'Render the approval-policy (Permissions…) selector in the toolbar.',
     },
+    showCollaborationModeSelector: {
+      control: 'boolean',
+      description: 'Render the workflow (Default / Plan) selector in the toolbar.',
+    },
     showPermissionRequest: {
       control: 'boolean',
       description:
@@ -529,6 +545,7 @@ const meta: Meta<PlaygroundArgs> = {
     noticeMessage:
       'The agent hit the maximum number of turn requests. Send a new message to continue.',
     showPermissionModeSelector: true,
+    showCollaborationModeSelector: true,
     showPermissionRequest: false,
     showQueuedPrompts: false,
   },

--- a/packages/ui/src/react/components/chat-composer/chat-composer.test.tsx
+++ b/packages/ui/src/react/components/chat-composer/chat-composer.test.tsx
@@ -1,14 +1,16 @@
 /**
  * @vitest-environment jsdom
  */
-import { fireEvent, render, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../prompt-editor/prompt-editor', () => ({
   PromptEditor: () => <div data-testid="prompt-editor" />,
 }));
 
 import { ChatComposer } from './index';
+
+afterEach(cleanup);
 
 describe('ChatComposer', () => {
   it('caps the permission-mode popup at its compact width', async () => {
@@ -42,5 +44,46 @@ describe('ChatComposer', () => {
       expect(popup!.style.minWidth).toBe('0px');
       expect(popup!.style.maxWidth).toBe('18rem');
     });
+  });
+
+  it('exposes collaboration mode separately from permission mode', async () => {
+    const onCollaborationModeChange = vi.fn();
+    render(
+      <ChatComposer
+        collaborationModeOptions={{
+          default: { name: 'Default' },
+          plan: { name: 'Plan', description: 'Plan before making changes' },
+        }}
+        selectedCollaborationMode="default"
+        onCollaborationModeChange={onCollaborationModeChange}
+        permissionModeOptions={{ agent: { name: 'Agent' } }}
+        selectedPermissionMode="agent"
+        onPermissionModeChange={() => {}}
+        onSubmit={() => {}}
+      />
+    );
+
+    const collaborationTrigger = document.body.querySelector<HTMLElement>(
+      '[aria-label="Collaboration mode"]'
+    );
+    const triggers = document.body.querySelectorAll<HTMLElement>('[data-slot="select-trigger"]');
+    expect(collaborationTrigger).not.toBeNull();
+    expect(Array.from(triggers).map((trigger) => trigger.textContent)).toEqual([
+      'Default',
+      'Agent',
+    ]);
+
+    fireEvent.click(collaborationTrigger!);
+    await waitFor(() => {
+      expect(document.body.querySelectorAll('[data-slot="select-item"]')).toHaveLength(2);
+    });
+    const planItem = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[data-slot="select-item"]')
+    ).find((item) => item.textContent?.includes('Plan'));
+    expect(planItem).toBeDefined();
+    fireEvent.pointerDown(planItem!, { pointerType: 'mouse', button: 0 });
+    fireEvent.click(planItem!, { detail: 1 });
+
+    await waitFor(() => expect(onCollaborationModeChange).toHaveBeenCalledWith('plan'));
   });
 });

--- a/packages/ui/src/react/components/chat-composer/index.tsx
+++ b/packages/ui/src/react/components/chat-composer/index.tsx
@@ -1,6 +1,14 @@
 import { Button } from '@react/primitives/button';
 import { cx } from '@styles/utilities/cx';
-import { ArrowUp, ChevronRight, CircleAlert, Paperclip, ShieldCheck, X } from 'lucide-react';
+import {
+  ArrowUp,
+  ChevronRight,
+  CircleAlert,
+  ListTodo,
+  Paperclip,
+  ShieldCheck,
+  X,
+} from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 import { Combobox } from '@/react/primitives/combobox/combobox';
 import { DropdownMenu } from '@/react/primitives/dropdown-menu';
@@ -149,6 +157,12 @@ export interface ComposerPermissionModeOption {
   description?: string;
 }
 
+/** Minimal collaboration-mode descriptor, such as Codex Default / Plan. */
+export interface ComposerCollaborationModeOption {
+  name: string;
+  description?: string;
+}
+
 export interface ComposerMcpServer {
   name: string;
   transport: string;
@@ -204,6 +218,10 @@ export interface ChatComposerProps {
   permissionModeOptions?: Record<string, ComposerPermissionModeOption> | null;
   selectedPermissionMode?: string;
   onPermissionModeChange?: (modeId: string) => void;
+
+  collaborationModeOptions?: Record<string, ComposerCollaborationModeOption> | null;
+  selectedCollaborationMode?: string;
+  onCollaborationModeChange?: (modeId: string) => void;
   mcpServers?: ComposerMcpServer[];
 
   onSubmit: (text: string) => void;
@@ -528,6 +546,105 @@ function ComposerAgentSelector({
   );
 }
 
+interface ComposerModeItem {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+interface ComposerModeSelectProps {
+  items: ComposerModeItem[];
+  selectedId?: string;
+  onChange?: (id: string) => void;
+  disabled: boolean;
+  isFirst: boolean;
+  ariaLabel: string;
+  placeholder: string;
+  icon: React.ReactNode;
+}
+
+function ComposerModeSelect({
+  items,
+  selectedId,
+  onChange,
+  disabled,
+  isFirst,
+  ariaLabel,
+  placeholder,
+  icon,
+}: ComposerModeSelectProps) {
+  const selected = selectedId ? (items.find((item) => item.id === selectedId) ?? null) : null;
+
+  return (
+    <Select.Root
+      value={selectedId}
+      onValueChange={(id) => {
+        if (id) onChange?.(id);
+      }}
+      disabled={disabled}
+    >
+      <Select.Trigger
+        aria-label={ariaLabel}
+        className={isFirst ? styles.permissionModeTrigger : undefined}
+      >
+        <span
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: '0.25rem',
+            color: selected ? 'var(--em-foreground)' : 'var(--em-foreground-muted)',
+            fontSize: 'var(--em-text-xs)',
+            lineHeight: 1.25,
+          }}
+        >
+          {icon}
+          {selected?.name ?? placeholder}
+        </span>
+      </Select.Trigger>
+      <Select.Content
+        align="start"
+        width="trigger"
+        className={composerThemeScope}
+        style={{
+          width: 'min(18rem, var(--available-width, 18rem))',
+          minWidth: 0,
+          maxWidth: '18rem',
+        }}
+      >
+        {items.map((item) => (
+          <Select.Item key={item.id} value={item.id}>
+            <span style={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+              <span
+                style={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  fontSize: 'var(--em-text-sm)',
+                }}
+              >
+                {item.name}
+              </span>
+              {item.description && (
+                <span
+                  style={{
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    fontSize: 'var(--em-text-xs)',
+                    color: 'var(--em-foreground-muted)',
+                  }}
+                >
+                  {item.description}
+                </span>
+              )}
+            </span>
+          </Select.Item>
+        ))}
+      </Select.Content>
+    </Select.Root>
+  );
+}
+
 // ── Main component ────────────────────────────────────────────────────────────
 
 export function ChatComposer({
@@ -549,6 +666,9 @@ export function ChatComposer({
   permissionModeOptions,
   selectedPermissionMode,
   onPermissionModeChange,
+  collaborationModeOptions,
+  selectedCollaborationMode,
+  onCollaborationModeChange,
   mcpServers = [],
   onSubmit,
   onInputChange,
@@ -717,19 +837,15 @@ export function ChatComposer({
 
   // ── Permission mode items ────────────────────────────────────────────────────
 
-  interface PermissionModeItem {
-    id: string;
-    name: string;
-    description?: string;
-  }
-
-  const permissionModeItems: PermissionModeItem[] = permissionModeOptions
+  const permissionModeItems: ComposerModeItem[] = permissionModeOptions
     ? Object.entries(permissionModeOptions).map(([id, opt]) => ({ id, ...opt }))
     : [];
-  const selectedPermissionModeItem = selectedPermissionMode
-    ? (permissionModeItems.find((item) => item.id === selectedPermissionMode) ?? null)
-    : null;
-  const permissionModeIsFirst = modelItems.length === 0 && !agentOptions?.length;
+  const collaborationModeItems: ComposerModeItem[] = collaborationModeOptions
+    ? Object.entries(collaborationModeOptions).map(([id, opt]) => ({ id, ...opt }))
+    : [];
+  const collaborationModeIsFirst = modelItems.length === 0 && !agentOptions?.length;
+  const permissionModeIsFirst =
+    collaborationModeItems.length === 0 && modelItems.length === 0 && !agentOptions?.length;
 
   const canShowQueuedPrompts =
     queuedPrompts.length > 0 &&
@@ -952,74 +1068,31 @@ export function ChatComposer({
                 }
               />
             )}
-            {permissionModeItems.length > 0 && (
-              <Select.Root
-                value={selectedPermissionMode ?? undefined}
-                onValueChange={(id) => {
-                  if (id) onPermissionModeChange?.(id);
-                }}
+            {collaborationModeItems.length > 0 && (
+              <ComposerModeSelect
+                items={collaborationModeItems}
+                selectedId={selectedCollaborationMode}
+                onChange={onCollaborationModeChange}
                 disabled={disabled}
-              >
-                <Select.Trigger
-                  className={permissionModeIsFirst ? styles.permissionModeTrigger : undefined}
-                >
-                  <span
-                    style={{
-                      display: 'inline-flex',
-                      alignItems: 'center',
-                      gap: '0.25rem',
-                      color: selectedPermissionModeItem
-                        ? 'var(--em-foreground)'
-                        : 'var(--em-foreground-muted)',
-                      fontSize: 'var(--em-text-xs)',
-                      lineHeight: 1.25,
-                    }}
-                  >
-                    <ShieldCheck style={{ width: '0.75rem', height: '0.75rem', flexShrink: 0 }} />
-                    {selectedPermissionModeItem?.name ?? 'Permissions…'}
-                  </span>
-                </Select.Trigger>
-                <Select.Content
-                  align="start"
-                  width="trigger"
-                  className={composerThemeScope}
-                  style={{
-                    width: 'min(18rem, var(--available-width, 18rem))',
-                    minWidth: 0,
-                    maxWidth: '18rem',
-                  }}
-                >
-                  {permissionModeItems.map((item) => (
-                    <Select.Item key={item.id} value={item.id}>
-                      <span style={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>
-                        <span
-                          style={{
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            whiteSpace: 'nowrap',
-                            fontSize: 'var(--em-text-sm)',
-                          }}
-                        >
-                          {item.name}
-                        </span>
-                        {item.description && (
-                          <span
-                            style={{
-                              overflow: 'hidden',
-                              textOverflow: 'ellipsis',
-                              whiteSpace: 'nowrap',
-                              fontSize: 'var(--em-text-xs)',
-                              color: 'var(--em-foreground-muted)',
-                            }}
-                          >
-                            {item.description}
-                          </span>
-                        )}
-                      </span>
-                    </Select.Item>
-                  ))}
-                </Select.Content>
-              </Select.Root>
+                isFirst={collaborationModeIsFirst}
+                ariaLabel="Collaboration mode"
+                placeholder="Collaboration…"
+                icon={<ListTodo style={{ width: '0.75rem', height: '0.75rem', flexShrink: 0 }} />}
+              />
+            )}
+            {permissionModeItems.length > 0 && (
+              <ComposerModeSelect
+                items={permissionModeItems}
+                selectedId={selectedPermissionMode}
+                onChange={onPermissionModeChange}
+                disabled={disabled}
+                isFirst={permissionModeIsFirst}
+                ariaLabel="Permission mode"
+                placeholder="Permissions…"
+                icon={
+                  <ShieldCheck style={{ width: '0.75rem', height: '0.75rem', flexShrink: 0 }} />
+                }
+              />
             )}
             {mcpServers.length > 0 && (
               <Popover.Root>

--- a/packages/ui/src/react/components/index.ts
+++ b/packages/ui/src/react/components/index.ts
@@ -3,6 +3,7 @@ export type {
   ChatComposerProps,
   ComposerAttachment,
   ComposerAgentOption,
+  ComposerCollaborationModeOption,
   ComposerModelOption,
   ComposerEffortOption,
   ComposerPermissionModeOption,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -584,8 +584,8 @@ importers:
         specifier: ^0.54.1
         version: 0.54.1(@anthropic-ai/sdk@0.106.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
       '@agentclientprotocol/codex-acp':
-        specifier: ^1.0.2
-        version: 1.0.2
+        specifier: ^1.7.0
+        version: 1.7.0
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260609.1
         version: 7.0.0-dev.20260609.1
@@ -868,12 +868,17 @@ packages:
     engines: {node: '>=22'}
     hasBin: true
 
-  '@agentclientprotocol/codex-acp@1.0.2':
-    resolution: {integrity: sha512-4CxkkqyeX62TBzv4RW5N3TI/4oy7QaWWzOBnwH5VGWa2UdhIg7qwvudyKFv0aOdJfWHcRSNZ3y8c0idaUquZfQ==}
+  '@agentclientprotocol/codex-acp@1.7.0':
+    resolution: {integrity: sha512-+nUhAJyunx8Zc7r3jjLPoMPPUkkk02TmBIosln4l+ugRNUOdNQAMm6toZo7xb+mF1yM5zxJB83qvy/bPmOTaaw==}
     hasBin: true
 
   '@agentclientprotocol/sdk@1.1.0':
     resolution: {integrity: sha512-NT2KqphUJ3w6EksUL51ZhJgIYgq/ZLGcBPkyMKgRSO5PMVwe9DnKKX+Htnvk6KHh6dUuh34UHK4gKp+4te1Mdg==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
+  '@agentclientprotocol/sdk@1.4.0':
+    resolution: {integrity: sha512-/eufudw+aFY1LKLolT6yFE6UMmYRl7fMJ/DEONSIyR6wI3slHWITBsANRGqXEY8FRzqUxwh7QEaGiZHcJPVThg==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
@@ -2258,8 +2263,8 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@openai/codex@0.142.4':
-    resolution: {integrity: sha512-BW9+3Cs7tChgkc0QhUsZIDm6XgpSDSeJkljRSHhJZqDwlaxDnNVhRP/sZwhgrTn3f2jPn3jc4WTKfLOTk+g5pA==}
+  '@openai/codex@0.148.0':
+    resolution: {integrity: sha512-bh5kH9+BMrFaHGmLeoSansPdfRksvr4UXzjQInns/KRO7r8VJ+6AAW+SqUsE8XcG3+OW/mI4EEy8Gpo9UDXGvQ==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -4985,6 +4990,10 @@ packages:
     resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
     engines: {node: '>=18'}
 
+  default-browser@5.5.1:
+    resolution: {integrity: sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==}
+    engines: {node: '>=18'}
+
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
 
@@ -5043,8 +5052,8 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  diff@8.0.4:
-    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
 
   dir-compare@4.2.0:
@@ -7091,8 +7100,8 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
-  open@11.0.0:
-    resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
+  open@11.0.2:
+    resolution: {integrity: sha512-RWqF+pBSkqecEvCKOn8QYhaNdRMJDZRIrlS/7rTDdLHaPcfXGCZ/h8zb413NfvdeAV0MR7T1yJcA34/q+CSm1Q==}
     engines: {node: '>=20'}
 
   open@8.4.2:
@@ -7311,6 +7320,10 @@ packages:
 
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
+    engines: {node: '>=20'}
+
+  powershell-utils@0.2.1:
+    resolution: {integrity: sha512-C+y9x90UElAddDZmV4qOx9W53B61PO7cIqWz2dQsWlwswuq4mr8NEwytdGKboYbQlGZ3awrkTeNvcZiZNHnQ8A==}
     engines: {node: '>=20'}
 
   prebuild-install@7.1.3:
@@ -8720,8 +8733,8 @@ packages:
       jsdom:
         optional: true
 
-  vscode-jsonrpc@8.2.1:
-    resolution: {integrity: sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==}
+  vscode-jsonrpc@9.0.2:
+    resolution: {integrity: sha512-SbQSV9yRemARxeXw6LU5sS6Zq0e9/DgCCX5yelH263ZQWukbTk8EF8fjTrr1dziasf4GwlJbvTwFnTrnQFWZXQ==}
     engines: {node: '>=14.0.0'}
 
   vscode-uri@3.1.0:
@@ -8844,8 +8857,8 @@ packages:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
 
-  wsl-utils@0.3.1:
-    resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
+  wsl-utils@1.0.0:
+    resolution: {integrity: sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA==}
     engines: {node: '>=20'}
 
   xcase@2.0.1:
@@ -8939,16 +8952,20 @@ snapshots:
       - '@anthropic-ai/sdk'
       - '@modelcontextprotocol/sdk'
 
-  '@agentclientprotocol/codex-acp@1.0.2':
+  '@agentclientprotocol/codex-acp@1.7.0':
     dependencies:
-      '@agentclientprotocol/sdk': 1.1.0(zod@4.4.3)
-      '@openai/codex': 0.142.4
-      diff: 8.0.4
-      open: 11.0.0
-      vscode-jsonrpc: 8.2.1
+      '@agentclientprotocol/sdk': 1.4.0(zod@4.4.3)
+      '@openai/codex': 0.148.0
+      diff: 9.0.0
+      open: 11.0.2
+      vscode-jsonrpc: 9.0.2
       zod: 4.4.3
 
   '@agentclientprotocol/sdk@1.1.0(zod@4.4.3)':
+    dependencies:
+      zod: 4.4.3
+
+  '@agentclientprotocol/sdk@1.4.0(zod@4.4.3)':
     dependencies:
       zod: 4.4.3
 
@@ -10265,7 +10282,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@openai/codex@0.142.4': {}
+  '@openai/codex@0.148.0': {}
 
   '@oxc-parser/binding-android-arm-eabi@0.127.0':
     optional: true
@@ -12874,6 +12891,11 @@ snapshots:
       bundle-name: 4.1.0
       default-browser-id: 5.0.1
 
+  default-browser@5.5.1:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
   defaults@1.0.4:
     dependencies:
       clone: 1.0.4
@@ -12921,7 +12943,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  diff@8.0.4: {}
+  diff@9.0.0: {}
 
   dir-compare@4.2.0:
     dependencies:
@@ -15363,14 +15385,14 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
-  open@11.0.0:
+  open@11.0.2:
     dependencies:
-      default-browser: 5.5.0
+      default-browser: 5.5.1
       define-lazy-prop: 3.0.0
       is-in-ssh: 1.0.0
       is-inside-container: 1.0.0
-      powershell-utils: 0.1.0
-      wsl-utils: 0.3.1
+      powershell-utils: 0.2.1
+      wsl-utils: 1.0.0
 
   open@8.4.2:
     dependencies:
@@ -15665,6 +15687,8 @@ snapshots:
     optional: true
 
   powershell-utils@0.1.0: {}
+
+  powershell-utils@0.2.1: {}
 
   prebuild-install@7.1.3:
     dependencies:
@@ -17250,7 +17274,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vscode-jsonrpc@8.2.1: {}
+  vscode-jsonrpc@9.0.2: {}
 
   vscode-uri@3.1.0: {}
 
@@ -17395,7 +17419,7 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
 
-  wsl-utils@0.3.1:
+  wsl-utils@1.0.0:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0


### PR DESCRIPTION
### Description

Adds Codex Plan mode to ACP chat as a collaboration control separate from filesystem and approval permissions.

- maps the provider-owned `collaboration_mode` ACP category to a Default / Plan composer selector
- carries the selection through typed Wire contracts, live models, dormant sessions, and replacement sessions
- persists the selection on the conversation and as the provider preference for new chats
- clears stored selections when a provider no longer advertises them
- updates `@agentclientprotocol/codex-acp` from 1.0.2 to 1.7.0, the version that advertises Codex collaboration modes

The dependency update adds no install scripts or native builds. A lockfile audit found no advisory path through `@agentclientprotocol/codex-acp` or its updated transitive dependencies.

### Related issues

None.

### Testing

- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run build`
- 143 focused Core, desktop, plugin, UI, and browser tests
- `pnpm run test`: 3,618 passed, 1 skipped, and 1 unrelated failure in `workspace-settings-section.browser.test.tsx`; the same failure reproduces on an untouched `origin/main` worktree because the test mock does not define `workspaceOptions`
- `pnpm audit --audit-level high`: reports existing repository advisories; none are introduced through the upgraded Codex ACP dependency

### Screenshot/Recording (if applicable)

Not attached from this environment. The composer interaction test verifies that Default / Plan renders separately from the permission selector and that choosing Plan invokes only the collaboration-mode handler.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>