### PR TITLE
fix(remote): recover stale workspace connections

### DIFF
--- a/agents/architecture/workspace-server.md
+++ b/agents/architecture/workspace-server.md
@@ -8,8 +8,10 @@ broker asks `HostService` (`core/services/hosts/`) for a runtime client. It coor
 existing `SshConnectionManager`, workspace-server provisioning, and `WireConnectionManager`.
 `WireConnectionManager` owns dial/initialize, reconnecting transports, and one pinned Wire client
 per target until lifecycle invalidation or shutdown. The broker only resolves clients and does not
-own connection lifetime. Ordinary SSH disconnects preserve the pinned connection; terminal Wire
-failures, exhausted SSH reconnects, and machine edits invalidate it.
+own connection lifetime. Ordinary SSH or Wire disconnects demote Host availability while preserving
+the pinned connection and retrying with capped backoff. A health heartbeat cycles silent half-open
+remote Wire transports. Authentication, protocol, configuration, and machine changes still
+invalidate the affected connection.
 
 Managed Linux installations use `~/.emdash/workspace-server/` with immutable version directories,
 an atomic `current` symlink, staging and install-lock paths, and an explicitly selected socket under

--- a/apps/emdash-desktop/src/core/features/machines/browser/components/machine-connection-card.browser.test.tsx
+++ b/apps/emdash-desktop/src/core/features/machines/browser/components/machine-connection-card.browser.test.tsx
@@ -1,0 +1,61 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SshConfig } from '@core/primitives/ssh/api';
+import { MachineConnectionRow } from './machine-connection-card';
+
+const machine: SshConfig = {
+  id: 'ssh-1',
+  name: 'Orion',
+  host: 'orion.example.com',
+  port: 22,
+  username: 'alice',
+  authType: 'agent',
+  useAgent: true,
+};
+
+beforeAll(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+describe('MachineConnectionRow', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    host.remove();
+  });
+
+  it('offers reconnect when the workspace server is down despite live SSH', async () => {
+    const onRetry = vi.fn();
+    await act(async () => {
+      root.render(
+        <MachineConnectionRow
+          machine={machine}
+          state="connected"
+          availability={{ kind: 'unavailable', recovery: 'eligible' }}
+          onEdit={vi.fn()}
+          onConnect={vi.fn()}
+          onRetry={onRetry}
+          onDisconnect={vi.fn()}
+        />
+      );
+    });
+    const reconnect = [...host.querySelectorAll('button')].find(
+      (button) => button.textContent?.trim() === 'Reconnect'
+    );
+
+    await act(async () => reconnect?.click());
+    expect(reconnect).toBeDefined();
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/emdash-desktop/src/core/features/machines/browser/components/machine-connection-card.tsx
+++ b/apps/emdash-desktop/src/core/features/machines/browser/components/machine-connection-card.tsx
@@ -27,7 +27,22 @@ export function MachineConnectionRow({
     state === 'connected' || state === 'connecting' || state === 'reconnecting';
   const preparing = availability?.kind === 'preparing';
   const ready = availability?.kind === 'ready';
-  const retry = availability?.kind === 'unavailable' && availability.issue !== undefined;
+  const reconnectNow = preparing || state === 'connecting' || state === 'reconnecting';
+  const reconnect =
+    (ready && state !== 'connected') ||
+    (state === 'connected' && availability?.kind === 'unavailable');
+  const retry =
+    reconnectNow ||
+    reconnect ||
+    state === 'error' ||
+    (availability?.kind === 'unavailable' && availability.issue !== undefined);
+  const connectionActionLabel = reconnectNow
+    ? 'Reconnect now'
+    : reconnect
+      ? 'Reconnect'
+      : retry
+        ? 'Retry'
+        : 'Connect';
 
   return (
     <SettingsRow
@@ -46,10 +61,10 @@ export function MachineConnectionRow({
       }
       control={
         <span className="flex items-center gap-2">
-          {availability && !ready && !preparing ? (
+          {availability && (!ready || state !== 'connected') ? (
             <Button type="button" variant="primary" size="xs" onClick={retry ? onRetry : onConnect}>
               <PlugIcon />
-              {retry ? 'Retry' : 'Connect'}
+              {connectionActionLabel}
             </Button>
           ) : null}
           {transportActive || preparing ? (

--- a/apps/emdash-desktop/src/core/features/projects/browser/components/project-availability-banner.browser.test.tsx
+++ b/apps/emdash-desktop/src/core/features/projects/browser/components/project-availability-banner.browser.test.tsx
@@ -125,9 +125,9 @@ describe('ProjectAvailabilityBanner', () => {
   });
 
   it.each([
-    ['connecting', 'Connecting to Orion', 'Open Machines'],
-    ['provisioning', 'Preparing Orion', 'Open Machines'],
-    ['handshaking', 'Preparing Orion', 'Open Machines'],
+    ['connecting', 'Connecting to Orion', 'Reconnect now'],
+    ['provisioning', 'Preparing Orion', 'Reconnect now'],
+    ['handshaking', 'Preparing Orion', 'Reconnect now'],
     ['attaching', 'Opening Project on Orion', null],
   ] as const)('announces %s progress politely', async (state, title, actionLabel) => {
     await render(sshProject, {

--- a/apps/emdash-desktop/src/core/features/projects/browser/project-availability-presentation.test.ts
+++ b/apps/emdash-desktop/src/core/features/projects/browser/project-availability-presentation.test.ts
@@ -124,19 +124,19 @@ describe('classifyProjectAvailability', () => {
       'connecting',
       { kind: 'degraded', situation: 'connecting', recovery: 'automatic' },
       'Connecting to Orion',
-      ['Open Machines'],
+      ['Reconnect now', 'Open Machines'],
     ],
     [
       'provisioning',
       { kind: 'degraded', situation: 'provisioning', recovery: 'automatic' },
       'Preparing Orion',
-      ['Open Machines'],
+      ['Reconnect now', 'Open Machines'],
     ],
     [
       'handshaking',
       { kind: 'degraded', situation: 'handshaking', recovery: 'automatic' },
       'Preparing Orion',
-      ['Open Machines'],
+      ['Reconnect now', 'Open Machines'],
     ],
     [
       'attaching',

--- a/apps/emdash-desktop/src/core/features/projects/browser/project-availability-presentation.ts
+++ b/apps/emdash-desktop/src/core/features/projects/browser/project-availability-presentation.ts
@@ -77,6 +77,10 @@ export function classifyProjectAvailability({
 }): ProjectAvailabilityPresentation | null {
   if (state.kind === 'ready') return null;
   const machineName = host.kind === 'ssh' ? host.machineName?.trim() || 'Machine' : undefined;
+  const preparingActions =
+    host.kind === 'ssh'
+      ? [action('retry', 'Reconnect now'), action('diagnostics', 'Open Machines')]
+      : [];
 
   switch (state.situation) {
     case 'suspended':
@@ -91,7 +95,7 @@ export function classifyProjectAvailability({
             ? 'The Project stays open while local services start.'
             : 'The Project stays open while the SSH connection is established.',
         progress: true,
-        actions: host.kind === 'ssh' ? [action('diagnostics', 'Open Machines')] : [],
+        actions: preparingActions,
       };
     case 'provisioning':
     case 'handshaking':
@@ -104,7 +108,7 @@ export function classifyProjectAvailability({
             ? 'The Project stays open while local services start.'
             : 'SSH is connected. The workspace server is starting.',
         progress: true,
-        actions: host.kind === 'ssh' ? [action('diagnostics', 'Open Machines')] : [],
+        actions: preparingActions,
       };
     case 'attaching':
       return {

--- a/apps/emdash-desktop/src/core/features/tasks/browser/task-titlebar.tsx
+++ b/apps/emdash-desktop/src/core/features/tasks/browser/task-titlebar.tsx
@@ -140,6 +140,13 @@ const ActiveTaskTitlebar = observer(function ActiveTaskTitlebar({
   if (!taskStore || !taskPayload) return null;
 
   const isRemoteProject = projectContext?.project.type === 'ssh';
+  const hostState = projectContext?.host.state;
+  const connectionState =
+    workspace.connectionState !== 'connected' || hostState?.kind === 'ready'
+      ? workspace.connectionState
+      : hostState?.recovery === 'automatic'
+        ? 'reconnecting'
+        : 'disconnected';
   return (
     <Titlebar
       leftSlot={
@@ -159,7 +166,7 @@ const ActiveTaskTitlebar = observer(function ActiveTaskTitlebar({
                   <Popover.Trigger className="flex items-center gap-1 text-sm text-foreground-muted hover:text-foreground">
                     <span className="flex min-w-0 items-center gap-1.5">
                       <span className="max-w-56 truncate">{taskDisplayName(taskStore)}</span>
-                      <ConnectionStatusDot state={workspace.connectionState} />
+                      <ConnectionStatusDot state={connectionState} />
                     </span>
                     <ChevronDown className="size-3.5 shrink-0" />
                   </Popover.Trigger>

--- a/apps/emdash-desktop/src/core/features/tasks/browser/task-titlebar.tsx
+++ b/apps/emdash-desktop/src/core/features/tasks/browser/task-titlebar.tsx
@@ -142,9 +142,12 @@ const ActiveTaskTitlebar = observer(function ActiveTaskTitlebar({
   const isRemoteProject = projectContext?.project.type === 'ssh';
   const hostState = projectContext?.host.state;
   const connectionState =
-    workspace.connectionState !== 'connected' || hostState?.kind === 'ready'
+    workspace.connectionState !== 'connected' ||
+    !isRemoteProject ||
+    !hostState ||
+    hostState.kind === 'ready'
       ? workspace.connectionState
-      : hostState?.recovery === 'automatic'
+      : hostState.recovery === 'automatic'
         ? 'reconnecting'
         : 'disconnected';
   return (

--- a/apps/emdash-desktop/src/core/services/hosts/node/host-service.test.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/host-service.test.ts
@@ -1,4 +1,5 @@
 import { createScope } from '@emdash/shared/concurrency';
+import { deferred } from '@emdash/shared/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SshConnectionManagerEvent } from '@core/primitives/ssh/api/node/ssh-connection-manager';
 import type { SshWorkspaceServerTarget } from '../api/targets';
@@ -15,6 +16,9 @@ const mocks = vi.hoisted(() => ({
   connectionLostListener: undefined as
     | ((target: SshWorkspaceServerTarget, error: unknown) => void)
     | undefined,
+  connectionStateListener: undefined as
+    | ((target: SshWorkspaceServerTarget, state: 'connected' | 'reconnecting') => void)
+    | undefined,
 }));
 
 vi.mock('./workspace-server/connect/wire-connection-manager', () => ({
@@ -26,6 +30,14 @@ vi.mock('./workspace-server/connect/wire-connection-manager', () => ({
       mocks.connectionLostListener = listener;
       return () => {
         mocks.connectionLostListener = undefined;
+      };
+    },
+    onConnectionStateChanged(
+      listener: (target: SshWorkspaceServerTarget, state: 'connected' | 'reconnecting') => void
+    ) {
+      mocks.connectionStateListener = listener;
+      return () => {
+        mocks.connectionStateListener = undefined;
       };
     },
     dispose: vi.fn(async () => {}),
@@ -53,12 +65,19 @@ const target: SshWorkspaceServerTarget = {
 };
 
 function connection(): WorkspaceServerConnection {
-  return { target, client: {} } as WorkspaceServerConnection;
+  return {
+    target,
+    client: {},
+    connection: {},
+    ready: vi.fn(async () => ({})),
+    currentHandshake: () => undefined,
+  } as unknown as WorkspaceServerConnection;
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.connectionLostListener = undefined;
+  mocks.connectionStateListener = undefined;
   mocks.ensure.mockResolvedValue(target);
   mocks.client.mockResolvedValue(connection());
 });
@@ -92,6 +111,27 @@ describe('HostService', () => {
       expect(mocks.ensure).toHaveBeenCalledWith('ssh-1');
       expect(mocks.client).toHaveBeenCalledWith(target);
       expect(onPhase.mock.calls).toEqual([['connecting'], ['provisioning'], ['handshaking']]);
+    } finally {
+      await fixture.dispose();
+    }
+  });
+
+  it('waits for a pinned Wire client to reconnect before reporting it ready', async () => {
+    const fixture = createFixture();
+    const ready = deferred<void>();
+    const wireConnection = connection();
+    wireConnection.ready = vi.fn(async () => {
+      await ready.promise;
+      return {} as never;
+    });
+    mocks.client.mockResolvedValue(wireConnection);
+
+    try {
+      const pending = fixture.service.client('ssh-1');
+      await vi.waitFor(() => expect(wireConnection.ready).toHaveBeenCalledOnce());
+
+      ready.resolve();
+      await expect(pending).resolves.toBe(wireConnection);
     } finally {
       await fixture.dispose();
     }
@@ -192,6 +232,30 @@ describe('HostService', () => {
     }
   });
 
+  it('reports SSH and workspace-server connectivity edges', async () => {
+    const fixture = createFixture();
+
+    try {
+      fixture.sshEventListener?.({ type: 'disconnected', connectionId: 'ssh-1' });
+      mocks.connectionStateListener?.(target, 'reconnecting');
+      fixture.sshEventListener?.({
+        type: 'reconnected',
+        connectionId: 'ssh-1',
+        proxy: {} as never,
+      });
+      mocks.connectionStateListener?.(target, 'connected');
+
+      expect(fixture.connectivity).toEqual([
+        { connectionId: 'ssh-1', state: 'disconnected' },
+        { connectionId: 'ssh-1', state: 'disconnected' },
+        { connectionId: 'ssh-1', state: 'connected' },
+        { connectionId: 'ssh-1', state: 'connected' },
+      ]);
+    } finally {
+      await fixture.dispose();
+    }
+  });
+
   it('continues notifying observers when one observer throws', async () => {
     const fixture = createFixture();
     fixture.service.onInvalidate(() => {
@@ -239,12 +303,15 @@ function createFixture() {
     },
   });
   const invalidations: unknown[] = [];
+  const connectivity: unknown[] = [];
   service.onInvalidate((event) => invalidations.push(event));
+  service.onConnectivityChange((event) => connectivity.push(event));
 
   return {
     service,
     ensureConnected,
     invalidations,
+    connectivity,
     get sshEventListener() {
       return sshEventListener;
     },

--- a/apps/emdash-desktop/src/core/services/hosts/node/host-service.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/host-service.ts
@@ -43,6 +43,11 @@ export type HostClientOptions = {
   onPhase(phase: HostPreparingPhase): void;
 };
 
+export type HostConnectivityEvent = {
+  connectionId: string;
+  state: 'connected' | 'disconnected';
+};
+
 /**
  * Orchestrates transport, provisioning, and lifecycle for remote runtime clients.
  * Machine persistence and CRUD remain owned by the feature-level MachinesService.
@@ -57,6 +62,7 @@ export interface HostService {
   restartServer(connectionId: string): Promise<void>;
   updateServer(connectionId: string): Promise<void>;
   onInvalidate(listener: (event: HostInvalidation) => void): () => void;
+  onConnectivityChange(listener: (event: HostConnectivityEvent) => void): () => void;
   dispose(): Promise<void>;
 }
 
@@ -93,8 +99,14 @@ export function createHostService(deps: CreateHostServiceDeps): HostService {
     provision: provisioner,
   });
   const invalidationListeners = new Set<(event: HostInvalidation) => void>();
+  const connectivityListeners = new Set<(event: HostConnectivityEvent) => void>();
 
   const handleSshEvent = (event: SshConnectionManagerEvent) => {
+    if (event.type === 'connected' || event.type === 'reconnected') {
+      notifyConnectivity({ connectionId: event.connectionId, state: 'connected' });
+    } else if (event.type === 'disconnected') {
+      notifyConnectivity({ connectionId: event.connectionId, state: 'disconnected' });
+    }
     if (event.type !== 'reconnect-failed') return;
     host.drop(event.connectionId);
     provisioner.drop(event.connectionId);
@@ -122,6 +134,15 @@ export function createHostService(deps: CreateHostServiceDeps): HostService {
     })
   );
   scope.add(
+    wire.onConnectionStateChanged((target, state) => {
+      if (target.kind !== 'ssh') return;
+      notifyConnectivity({
+        connectionId: target.sshConnectionId,
+        state: state === 'connected' ? 'connected' : 'disconnected',
+      });
+    })
+  );
+  scope.add(
     wire.onConnectionLost((target, error) => {
       if (target.kind !== 'ssh') return;
       provisioner.drop(target.sshConnectionId);
@@ -134,7 +155,10 @@ export function createHostService(deps: CreateHostServiceDeps): HostService {
       });
     })
   );
-  scope.add(() => invalidationListeners.clear());
+  scope.add(() => {
+    invalidationListeners.clear();
+    connectivityListeners.clear();
+  });
 
   let disposePromise: Promise<void> | undefined;
   return {
@@ -156,9 +180,13 @@ export function createHostService(deps: CreateHostServiceDeps): HostService {
         : await provisioner.ensure(connectionId);
       if (options) {
         options.onPhase('handshaking');
-        return await waitWithSignal(wire.client(target), options.signal);
+        const connection = await waitWithSignal(wire.client(target), options.signal);
+        await waitWithSignal(connection.ready(), options.signal);
+        return connection;
       }
-      return wire.client(target);
+      const connection = await wire.client(target);
+      await connection.ready();
+      return connection;
     },
     refreshServerState: (connectionId, options) => serverOperations.refresh(connectionId, options),
     installServer: (connectionId) => serverOperations.install(connectionId),
@@ -169,6 +197,10 @@ export function createHostService(deps: CreateHostServiceDeps): HostService {
     onInvalidate(listener) {
       invalidationListeners.add(listener);
       return () => invalidationListeners.delete(listener);
+    },
+    onConnectivityChange(listener) {
+      connectivityListeners.add(listener);
+      return () => connectivityListeners.delete(listener);
     },
     dispose() {
       disposePromise ??= scope.dispose();
@@ -183,6 +215,14 @@ export function createHostService(deps: CreateHostServiceDeps): HostService {
       } catch {
         // One observer must not prevent lifecycle cleanup or remaining listeners.
       }
+    }
+  }
+
+  function notifyConnectivity(event: HostConnectivityEvent): void {
+    for (const listener of connectivityListeners) {
+      try {
+        listener(event);
+      } catch {}
     }
   }
 }

--- a/apps/emdash-desktop/src/core/services/hosts/node/index.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/index.ts
@@ -9,6 +9,7 @@ export {
   createHostService,
   type CreateHostServiceDeps,
   type HostClientOptions,
+  type HostConnectivityEvent,
   type HostService,
 } from './host-service';
 export { translateHostPreparationError } from './runtime-resolution';

--- a/apps/emdash-desktop/src/core/services/hosts/node/workspace-server/connect/wire-connection-manager.test.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/workspace-server/connect/wire-connection-manager.test.ts
@@ -53,7 +53,6 @@ describe('WireConnectionManager', () => {
       idleTtlMs: 0,
       retrySchedule: retrySchedules.sequence([5], { repeatLast: true }),
     });
-
     try {
       const [first, second] = await Promise.all([manager.client(target), manager.client(target)]);
       expect(first).toBe(second);
@@ -246,14 +245,70 @@ describe('WireConnectionManager', () => {
     }
   });
 
-  it('keeps retrying beyond the SSH manager backoff window before becoming terminal', () => {
+  it('replaces a silent half-open transport when its heartbeat times out', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'emdash-workspace-heartbeat-'));
+    const target = {
+      kind: 'ssh',
+      sshConnectionId: 'ssh-1',
+      socketPath: join(directory, 'workspace.sock'),
+    } as const;
+    const server = await serveSocket(createTestWorkspaceWireController(), {
+      socketPath: target.socketPath,
+    });
+    const clock = createManualClock();
+    let openCount = 0;
+    let droppedHealthCalls = 0;
+    const states: string[] = [];
+    const manager = createWireConnectionManager({
+      clock,
+      heartbeatIntervalMs: 100,
+      heartbeatTimeoutMs: 20,
+      retrySchedule: retrySchedules.sequence([1], { repeatLast: true }),
+      openTransport: async (nextTarget) => {
+        const inner = await openLocalWorkspaceServerTransport(localTarget(nextTarget.socketPath));
+        openCount += 1;
+        if (openCount > 1) return inner;
+        return {
+          ...inner,
+          post(message) {
+            if (message.kind === 'call' && message.path === 'health') {
+              droppedHealthCalls += 1;
+            } else {
+              inner.post(message);
+            }
+          },
+          close: () => inner.close?.(),
+        };
+      },
+    });
+    manager.onConnectionStateChanged((_target, state) => states.push(state));
+
+    try {
+      const connection = await manager.client(target);
+      await clock.advanceBy(100);
+      await waitFor(() => droppedHealthCalls === 1);
+      await clock.advanceBy(20);
+      await waitFor(() => openCount === 2);
+
+      await expect(connection.ready()).resolves.toBeDefined();
+      expect(states).toEqual(['connected', 'reconnecting', 'connected']);
+      await expect(manager.client(target)).resolves.toBe(connection);
+    } finally {
+      await manager.dispose();
+      await server.dispose();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps retrying beyond the SSH manager backoff window', () => {
     const delays = Array.from({ length: 9 }, (_, index) =>
       workspaceServerReconnectSchedule.delayFor(index)
     );
     const total = delays.reduce<number>((sum, delay) => sum + (delay ?? 0), 0);
 
     expect(total).toBeGreaterThanOrEqual(90_000);
-    expect(workspaceServerReconnectSchedule.delayFor(9)).toBeUndefined();
+    expect(workspaceServerReconnectSchedule.delayFor(9)).toBe(30_000);
+    expect(workspaceServerReconnectSchedule.delayFor(100)).toBe(30_000);
   });
 
   it('dials once, handshakes, and closes the probe transport', async () => {

--- a/apps/emdash-desktop/src/core/services/hosts/node/workspace-server/connect/wire-connection-manager.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/workspace-server/connect/wire-connection-manager.ts
@@ -4,6 +4,7 @@ import { createResourceCache, createScope, type Scope } from '@emdash/shared/con
 import {
   retrySchedules,
   runWithTimeout,
+  systemClock,
   waitWithSignal,
   type Clock,
   type RetrySchedule,
@@ -32,6 +33,8 @@ export type WorkspaceServerConnection = {
   currentHandshake(): WireInitializeResult | undefined;
 };
 
+export type WorkspaceServerConnectionState = 'connected' | 'reconnecting';
+
 export interface WireConnectionManager {
   client(target: WorkspaceServerTarget): Promise<WorkspaceServerConnection>;
   dialOnce(
@@ -40,6 +43,9 @@ export interface WireConnectionManager {
   ): Promise<WireInitializeResult>;
   invalidateConnection(connectionId: string): Promise<void>;
   onConnectionLost(listener: (target: WorkspaceServerTarget, error: unknown) => void): () => void;
+  onConnectionStateChanged(
+    listener: (target: WorkspaceServerTarget, state: WorkspaceServerConnectionState) => void
+  ): () => void;
   dispose(): Promise<void>;
 }
 
@@ -50,6 +56,8 @@ export type CreateWireConnectionManagerOptions = {
   retrySchedule?: RetrySchedule;
   protocolVersion?: string;
   client?: { id: string; appVersion: string };
+  heartbeatIntervalMs?: number;
+  heartbeatTimeoutMs?: number;
   ssh?: WorkspaceServerSshPort;
   openTransport?: (target: WorkspaceServerTarget) => Promise<WireTransport>;
 };
@@ -67,11 +75,14 @@ export class WorkspaceServerConfigurationError extends Error {
   readonly name = 'WorkspaceServerConfigurationError';
 }
 
-export const workspaceServerReconnectSchedule = retrySchedules.sequence([
-  500, 1_000, 2_000, 5_000, 10_000, 15_000, 20_000, 30_000, 30_000,
-]);
+export const workspaceServerReconnectSchedule = retrySchedules.sequence(
+  [500, 1_000, 2_000, 5_000, 10_000, 15_000, 20_000, 30_000],
+  { repeatLast: true }
+);
 
 const DEFAULT_DIAL_TIMEOUT_MS = 5_000;
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 15_000;
+const DEFAULT_HEARTBEAT_TIMEOUT_MS = 8_000;
 
 export function createWireConnectionManager(
   options: CreateWireConnectionManagerOptions = {}
@@ -85,6 +96,9 @@ export function createWireConnectionManager(
   const connectionLostListeners = new Set<
     (target: WorkspaceServerTarget, error: unknown) => void
   >();
+  const connectionStateListeners = new Set<
+    (target: WorkspaceServerTarget, state: WorkspaceServerConnectionState) => void
+  >();
   const cache = createResourceCache<WorkspaceServerTarget, WorkspaceServerConnection>({
     key: workspaceServerTargetKey,
     scope,
@@ -93,10 +107,18 @@ export function createWireConnectionManager(
     idleTtlMs: options.idleTtlMs ?? 30_000,
     create: (target, connectionScope) => {
       trackTarget(target, connectionScope);
-      return createWorkspaceServerConnection(target, connectionScope, options, (error) => {
-        if (connectionScope.disposed) return;
-        void handleConnectionLost(target, error).catch(() => {});
-      });
+      return createWorkspaceServerConnection(
+        target,
+        connectionScope,
+        options,
+        (error) => {
+          if (connectionScope.disposed) return;
+          void handleConnectionLost(target, error).catch(() => {});
+        },
+        (state) => {
+          if (!connectionScope.disposed) notifyConnectionStateChanged(target, state);
+        }
+      );
     },
   });
 
@@ -105,6 +127,7 @@ export function createWireConnectionManager(
     targetsByKey.clear();
     targetKeysByConnection.clear();
     connectionLostListeners.clear();
+    connectionStateListeners.clear();
   });
 
   let disposePromise: Promise<void> | undefined;
@@ -140,6 +163,10 @@ export function createWireConnectionManager(
       return () => {
         connectionLostListeners.delete(listener);
       };
+    },
+    onConnectionStateChanged(listener) {
+      connectionStateListeners.add(listener);
+      return () => connectionStateListeners.delete(listener);
     },
     dispose() {
       disposePromise ??= scope.dispose();
@@ -193,6 +220,17 @@ export function createWireConnectionManager(
     }
   }
 
+  function notifyConnectionStateChanged(
+    target: WorkspaceServerTarget,
+    state: WorkspaceServerConnectionState
+  ): void {
+    for (const listener of connectionStateListeners) {
+      try {
+        listener(target, state);
+      } catch {}
+    }
+  }
+
   async function releasePinnedConnections(connectionId?: string): Promise<void> {
     const releases: Promise<void>[] = [];
     for (const [key, pinned] of pinnedConnections) {
@@ -213,7 +251,8 @@ async function createWorkspaceServerConnection(
   target: WorkspaceServerTarget,
   scope: Scope,
   options: CreateWireConnectionManagerOptions,
-  onConnectionLost: (error: unknown) => void
+  onConnectionLost: (error: unknown) => void,
+  onConnectionStateChanged: (state: WorkspaceServerConnectionState) => void
 ): Promise<WorkspaceServerConnection> {
   let handshake: WireInitializeResult | undefined;
   const openTransport =
@@ -240,10 +279,12 @@ async function createWorkspaceServerConnection(
   );
   scope.add(() => transport.close());
 
-  const connection = connect(transport);
+  const connection = connect(transport, options.clock ? { clock: options.clock } : {});
   scope.add(() => connection.dispose());
+  scope.add(transport.onReconnect(() => onConnectionStateChanged('connected')));
   scope.add(
     connection.onDisconnect(() => {
+      onConnectionStateChanged('reconnecting');
       void transport.ready().catch(onConnectionLost);
     })
   );
@@ -256,6 +297,7 @@ async function createWorkspaceServerConnection(
     throw error;
   }
   requireHandshake(handshake);
+  if (target.kind === 'ssh') startHeartbeat(scope, transport, client, options);
 
   return {
     target,
@@ -264,6 +306,32 @@ async function createWorkspaceServerConnection(
     ready: () => readyHandshake(transport, () => handshake),
     currentHandshake: () => handshake,
   };
+}
+
+function startHeartbeat(
+  scope: Scope,
+  transport: ReconnectingTransport,
+  client: ContractClient<typeof workspaceWireContract>,
+  options: CreateWireConnectionManagerOptions
+): void {
+  const intervalMs = options.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+  if (intervalMs <= 0) return;
+  const timeoutMs = options.heartbeatTimeoutMs ?? DEFAULT_HEARTBEAT_TIMEOUT_MS;
+  const clock = options.clock ?? systemClock;
+
+  scope.run('workspace-server-heartbeat', async (signal) => {
+    while (!signal.aborted) {
+      await clock.sleep(intervalMs, { signal, unref: true });
+      if (signal.aborted) return;
+      try {
+        await client.health(undefined, { signal, timeoutMs });
+      } catch {
+        if (signal.aborted) return;
+        transport.forceReconnect();
+        await waitWithSignal(transport.ready(), signal);
+      }
+    }
+  });
 }
 
 export function openWorkspaceServerTransport(

--- a/apps/emdash-desktop/src/core/services/ssh/node/lifecycle/ssh-connection-manager.test.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/lifecycle/ssh-connection-manager.test.ts
@@ -340,6 +340,61 @@ describe('SshConnectionManager', () => {
     }
   });
 
+  it('keeps retrying a prolonged outage on the same proxy', async () => {
+    vi.useFakeTimers();
+    try {
+      const { SshConnectionManager } = await import('./ssh-connection-manager');
+      class ScriptedClient extends PassThrough {
+        constructor(private readonly succeeds: boolean) {
+          super();
+        }
+        connect() {
+          queueMicrotask(() =>
+            this.succeeds
+              ? this.emit('ready')
+              : this.emit('error', new Error('network unavailable'))
+          );
+        }
+        end() {
+          this.emit('close');
+          return this;
+        }
+      }
+      const clients: ScriptedClient[] = [];
+      let recover = false;
+      const manager = new SshConnectionManager({
+        createClient: () => {
+          const client = new ScriptedClient(clients.length === 0 || recover);
+          clients.push(client);
+          return client as unknown as Client;
+        },
+      });
+      const resolve = async () => ({
+        config: { sock: new PassThrough(), username: 'alice' },
+        cleanup: () => {},
+        debugLogs: [],
+      });
+
+      const proxy = await manager.createConnection('ssh-1', resolve);
+      clients[0]!.emit('error', new Error('transport failed'));
+      clients[0]!.emit('close');
+
+      for (const delayMs of [1_000, 2_000, 5_000, 10_000, 20_000, 20_000]) {
+        await vi.advanceTimersByTimeAsync(delayMs);
+      }
+      expect(manager.getConnectionState('ssh-1')).toBe('reconnecting');
+      expect(manager.getProxy('ssh-1')).toBe(proxy);
+
+      recover = true;
+      await vi.advanceTimersByTimeAsync(20_000);
+      expect(proxy.isConnected).toBe(true);
+      expect(manager.getConnectionState('ssh-1')).toBe('connected');
+      await manager.dropConnection('ssh-1');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does not re-enter reconnecting after dropping an in-flight reconnect', async () => {
     vi.useFakeTimers();
     try {

--- a/apps/emdash-desktop/src/core/services/ssh/node/lifecycle/ssh-connection-manager.test.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/lifecycle/ssh-connection-manager.test.ts
@@ -526,47 +526,56 @@ describe('SshConnectionManager', () => {
     ).rejects.toBeInstanceOf(SshTimeoutError);
   });
 
-  it('stops reconnecting immediately after an auth failure during reconnect', async () => {
-    vi.useFakeTimers();
-    try {
-      const { SshAuthError, SshConnectionManager } = await import('./ssh-connection-manager');
-      class FakeReadyClient extends PassThrough {
-        connect() {
-          queueMicrotask(() => this.emit('ready'));
+  it.each(['authentication', 'resolution'] as const)(
+    'stops reconnecting immediately after a permanent %s failure',
+    async (failure) => {
+      vi.useFakeTimers();
+      try {
+        const { SshAuthError, SshConnectionManager } = await import('./ssh-connection-manager');
+        class FakeReadyClient extends PassThrough {
+          connect() {
+            queueMicrotask(() => this.emit('ready'));
+          }
+          end() {
+            this.emit('close');
+            return this;
+          }
         }
-        end() {
-          this.emit('close');
-          return this;
-        }
-      }
-      const client = new FakeReadyClient();
-      const events: string[] = [];
-      let resolveCalls = 0;
-      const resolve = async () => {
-        resolveCalls += 1;
-        if (resolveCalls > 1) throw new SshAuthError('auth failed');
-        return {
-          config: { sock: new PassThrough(), username: 'alice' },
-          cleanup: () => {},
-          debugLogs: [],
+        const client = new FakeReadyClient();
+        const events: string[] = [];
+        let resolveCalls = 0;
+        const resolve = async () => {
+          resolveCalls += 1;
+          if (resolveCalls > 1) {
+            throw failure === 'authentication'
+              ? new SshAuthError('auth failed')
+              : new Error('SSH agent socket not found');
+          }
+          return {
+            config: { sock: new PassThrough(), username: 'alice' },
+            cleanup: () => {},
+            debugLogs: [],
+          };
         };
-      };
-      const manager = new SshConnectionManager({
-        createClient: () => client as unknown as Client,
-      });
-      manager.on('connection-event', (event) => events.push(event.type));
+        const manager = new SshConnectionManager({
+          createClient: () => client as unknown as Client,
+        });
+        manager.on('connection-event', (event) => events.push(event.type));
 
-      await manager.createConnection('ssh-1', resolve);
-      client.emit('error', new Error('transport failed'));
-      client.emit('close');
-      await vi.advanceTimersByTimeAsync(1_000);
+        await manager.createConnection('ssh-1', resolve);
+        client.emit('error', new Error('transport failed'));
+        client.emit('close');
+        await vi.advanceTimersByTimeAsync(1_000);
 
-      expect(events).toContain('reconnect-failed');
-      expect(manager.getConnectionState('ssh-1')).toBe('disconnected');
-    } finally {
-      vi.useRealTimers();
+        expect(events).toContain('reconnect-failed');
+        expect(manager.getConnectionState('ssh-1')).toBe('disconnected');
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect(resolveCalls).toBe(2);
+      } finally {
+        vi.useRealTimers();
+      }
     }
-  });
+  );
 
   it('suppresses ephemeral events, snapshots, and automatic reconnects', async () => {
     vi.useFakeTimers();

--- a/apps/emdash-desktop/src/core/services/ssh/node/lifecycle/ssh-connection-manager.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/lifecycle/ssh-connection-manager.ts
@@ -36,10 +36,11 @@ export class SshConnectionError extends Error {
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-/** Delays between successive reconnect attempts; exhausting the sequence gives up. */
-const RECONNECT_SCHEDULE: RetrySchedule = retrySchedules.sequence([
-  1_000, 2_000, 5_000, 10_000, 20_000,
-]);
+/** Delays between successive reconnect attempts. */
+const RECONNECT_SCHEDULE: RetrySchedule = retrySchedules.sequence(
+  [1_000, 2_000, 5_000, 10_000, 20_000],
+  { repeatLast: true }
+);
 
 interface ReconnectState {
   attempt: number;

--- a/apps/emdash-desktop/src/core/services/ssh/node/lifecycle/ssh-connection-manager.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/lifecycle/ssh-connection-manager.ts
@@ -470,6 +470,7 @@ export class SshConnectionManager extends EventEmitter implements SshConnectionM
 
       void this.connect(id, () =>
         resolve().catch((error: unknown) => {
+          if (error instanceof SshAuthError) throw error;
           throw new SshResolutionError(error);
         })
       ).catch((error: unknown) => {

--- a/apps/emdash-desktop/src/core/services/ssh/node/lifecycle/ssh-connection-manager.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/lifecycle/ssh-connection-manager.ts
@@ -34,6 +34,13 @@ export class SshConnectionError extends Error {
   }
 }
 
+class SshResolutionError extends Error {
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause), { cause });
+    this.name = 'SshResolutionError';
+  }
+}
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 /** Delays between successive reconnect attempts. */
@@ -129,6 +136,13 @@ export class SshConnectionManager extends EventEmitter implements SshConnectionM
       this.ephemeralConnections.delete(id);
     }
 
+    return await this.connect(id, resolve);
+  }
+
+  private async connect(
+    id: string,
+    resolve: () => Promise<SshConnectResult>
+  ): Promise<SshClientProxy> {
     const existing = this.proxies.get(id);
     if (existing?.isConnected) return existing;
 
@@ -427,14 +441,7 @@ export class SshConnectionManager extends EventEmitter implements SshConnectionM
 
     const delayMs = RECONNECT_SCHEDULE.delayFor(attempt - 1);
     if (delayMs === undefined) {
-      this.deps.log.error('SshConnectionManager: max reconnect attempts reached', {
-        connectionId: id,
-      });
-      this.reconnecting.delete(id);
-      this.emitConnectionEvent(
-        { type: 'reconnect-failed', connectionId: id },
-        { type: 'reconnect-failed', connectionId: id }
-      );
+      this.failReconnect(id, 'retry-exhausted');
       return;
     }
 
@@ -461,17 +468,13 @@ export class SshConnectionManager extends EventEmitter implements SshConnectionM
         return;
       }
 
-      void this.createConnection(id, resolve).catch((error: unknown) => {
-        // Auth failures won't resolve with retries — stop immediately.
-        if (error instanceof SshAuthError) {
-          this.deps.log.error('SshConnectionManager: reconnect stopped — auth failure', {
-            connectionId: id,
-          });
-          this.reconnecting.delete(id);
-          this.emitConnectionEvent(
-            { type: 'reconnect-failed', connectionId: id },
-            { type: 'reconnect-failed', connectionId: id }
-          );
+      void this.connect(id, () =>
+        resolve().catch((error: unknown) => {
+          throw new SshResolutionError(error);
+        })
+      ).catch((error: unknown) => {
+        if (error instanceof SshAuthError || error instanceof SshResolutionError) {
+          this.failReconnect(id, error instanceof SshAuthError ? 'authentication' : 'resolution');
         } else if (this.intentionalDisconnects.has(id)) {
           this.reconnecting.delete(id);
         } else {
@@ -481,6 +484,15 @@ export class SshConnectionManager extends EventEmitter implements SshConnectionM
     }, delayMs);
 
     this.reconnecting.set(id, { attempt, timer });
+  }
+
+  private failReconnect(id: string, reason: string): void {
+    this.deps.log.error('SshConnectionManager: reconnect stopped', { connectionId: id, reason });
+    this.reconnecting.delete(id);
+    this.emitConnectionEvent(
+      { type: 'reconnect-failed', connectionId: id },
+      { type: 'reconnect-failed', connectionId: id }
+    );
   }
 
   private cancelReconnect(id: string): void {

--- a/apps/emdash-desktop/src/core/services/ssh/node/operations/streamlocal.test.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/operations/streamlocal.test.ts
@@ -1,0 +1,30 @@
+import { EventEmitter } from 'node:events';
+import type { Client, ClientCallback, ClientChannel } from 'ssh2';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { forwardOutStreamLocalOnClient } from './streamlocal';
+
+afterEach(() => vi.useRealTimers());
+
+describe('forwardOutStreamLocalOnClient', () => {
+  it('times out a hung channel open and destroys a late channel', async () => {
+    vi.useFakeTimers();
+    let callback: ClientCallback | undefined;
+    const events = new EventEmitter();
+    const client = Object.assign(events, {
+      openssh_forwardOutStreamLocal(_path: string, next: ClientCallback) {
+        callback = next;
+        return client;
+      },
+    }) as unknown as Client;
+    const pending = forwardOutStreamLocalOnClient(client, '/run/emdash.sock', { timeoutMs: 25 });
+    const rejected = expect(pending).rejects.toThrow('Timed out after 25ms');
+
+    await vi.advanceTimersByTimeAsync(25);
+    await rejected;
+
+    const channel = { destroy: vi.fn() } as unknown as ClientChannel;
+    callback?.(undefined, channel);
+    expect(channel.destroy).toHaveBeenCalledOnce();
+    expect(events.eventNames()).toEqual([]);
+  });
+});

--- a/apps/emdash-desktop/src/core/services/ssh/node/operations/streamlocal.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/operations/streamlocal.ts
@@ -1,12 +1,22 @@
 import type { Client, ClientChannel } from 'ssh2';
 
+const DEFAULT_OPEN_TIMEOUT_MS = 10_000;
+
 export function forwardOutStreamLocalOnClient(
   client: Client,
-  socketPath: string
+  socketPath: string,
+  options: { timeoutMs?: number } = {}
 ): Promise<ClientChannel> {
   return new Promise((resolve, reject) => {
     let settled = false;
+    const timeoutMs = options.timeoutMs ?? DEFAULT_OPEN_TIMEOUT_MS;
+    const timeout = setTimeout(
+      () => fail(new Error(`Timed out after ${timeoutMs}ms opening SSH streamlocal channel`)),
+      timeoutMs
+    );
+    timeout.unref();
     const cleanup = () => {
+      clearTimeout(timeout);
       client.off('close', handleClose);
       client.off('end', handleClose);
       client.off('error', handleError);

--- a/apps/emdash-desktop/src/main/bootstrap/boot/phases/runtimes.ts
+++ b/apps/emdash-desktop/src/main/bootstrap/boot/phases/runtimes.ts
@@ -36,7 +36,6 @@ export async function bootRuntimes(
       hosts: infrastructure.hosts,
       runtimes: broker,
       connectSsh: (connectionId) => infrastructure.ssh.ssh.connect(connectionId),
-      sshEvents: infrastructure.ssh.manager,
       localReady: () => runtimeWorkers.runtimeReady(),
     });
     runMementosOrphanPruning(database, runtimeWorkers.clients.mementos);

--- a/apps/emdash-desktop/src/main/gateway/host-availability.test.ts
+++ b/apps/emdash-desktop/src/main/gateway/host-availability.test.ts
@@ -3,12 +3,8 @@ import type { RuntimeUnavailableReason } from '@emdash/core/primitives/runtime-r
 import { createScope } from '@emdash/shared/concurrency';
 import { deferred } from '@emdash/shared/testing';
 import { describe, expect, it, vi } from 'vitest';
-import type {
-  SshConnectionManager,
-  SshConnectionManagerListener,
-} from '@core/primitives/ssh/api/node/ssh-connection-manager';
 import type { HostInvalidation } from '@core/services/hosts/api';
-import type { HostService } from '@core/services/hosts/node';
+import type { HostConnectivityEvent, HostService } from '@core/services/hosts/node';
 import {
   WorkspaceServerProtocolError,
   WorkspaceServerProvisionError,
@@ -19,65 +15,66 @@ import {
 } from './host-availability';
 
 function createDesktopHostAvailability(
-  options: Omit<CreateDesktopHostAvailabilityOptions, 'connectSsh' | 'sshEvents' | 'runtimes'> & {
+  options: Omit<CreateDesktopHostAvailabilityOptions, 'connectSsh' | 'runtimes'> & {
     connectSsh?: CreateDesktopHostAvailabilityOptions['connectSsh'];
     runtimes?: CreateDesktopHostAvailabilityOptions['runtimes'];
-    sshEvents?: CreateDesktopHostAvailabilityOptions['sshEvents'];
   }
 ) {
   return createProductionHostAvailability({
     ...options,
+    hosts: {
+      ...options.hosts,
+      onConnectivityChange: options.hosts.onConnectivityChange ?? (() => () => {}),
+    } as HostService,
     connectSsh: options.connectSsh ?? (async () => 'connected'),
     runtimes: options.runtimes ?? { rebind: vi.fn() },
-    sshEvents:
-      options.sshEvents ??
-      ({
-        on: () => {},
-        off: () => {},
-      } as unknown as CreateDesktopHostAvailabilityOptions['sshEvents']),
   });
 }
 
+function createConnectivityFixture() {
+  const scope = createScope({ label: 'desktop-host-availability-test' });
+  let listener: ((event: HostConnectivityEvent) => void) | undefined;
+  const availability = createDesktopHostAvailability({
+    scope,
+    hosts: {
+      client: vi.fn(async () => ({})),
+      onInvalidate: () => () => {},
+      onConnectivityChange(next: (event: HostConnectivityEvent) => void) {
+        listener = next;
+        return () => {
+          listener = undefined;
+        };
+      },
+    } as unknown as HostService,
+    localReady: async () => {},
+  });
+  return { scope, availability, emit: (event: HostConnectivityEvent) => listener?.(event) };
+}
+
 describe('desktop Host availability', () => {
-  it.each(['connected', 'reconnected'] as const)(
-    'forwards an SSH %s edge to demanded Host recovery',
-    async (type) => {
-      const scope = createScope({ label: 'desktop-host-availability-test' });
-      let listener: SshConnectionManagerListener | undefined;
-      const off = vi.fn();
-      const sshEvents = {
-        on(_event: 'connection-event', nextListener: SshConnectionManagerListener) {
-          listener = nextListener;
-          return this;
-        },
-        off(_event: 'connection-event', nextListener: SshConnectionManagerListener) {
-          if (listener === nextListener) listener = undefined;
-          off();
-          return this;
-        },
-      } as Pick<SshConnectionManager, 'on' | 'off'>;
-      const availability = createDesktopHostAvailability({
-        scope,
-        hosts: {
-          client: vi.fn(async () => ({})),
-          onInvalidate: () => () => {},
-        } as unknown as HostService,
-        sshEvents,
-        localReady: async () => {},
-      });
-      const wake = vi.spyOn(availability, 'wake');
+  it('wakes demanded recovery when Host connectivity returns', async () => {
+    const { scope, availability, emit } = createConnectivityFixture();
+    const wake = vi.spyOn(availability, 'wake');
 
-      listener?.({
-        type,
-        connectionId: 'ssh-1',
-        proxy: {},
-      } as Parameters<SshConnectionManagerListener>[0]);
+    emit({ connectionId: 'ssh-1', state: 'connected' });
 
-      expect(wake).toHaveBeenCalledWith(hostRef('remote', 'ssh-1'), 'ssh-edge');
-      await scope.dispose();
-      expect(off).toHaveBeenCalledOnce();
-    }
-  );
+    expect(wake).toHaveBeenCalledWith(hostRef('remote', 'ssh-1'), 'ssh-edge');
+    await scope.dispose();
+  });
+
+  it('invalidates ready Host state on a transport disconnect', async () => {
+    const { scope, availability, emit } = createConnectivityFixture();
+    const host = hostRef('remote', 'ssh-1');
+    await availability.ensureReady(host, 'demand');
+
+    emit({ connectionId: 'ssh-1', state: 'disconnected' });
+
+    expect(availability.stateFor(host)).toEqual({
+      kind: 'unavailable',
+      recovery: 'eligible',
+    });
+    await scope.dispose();
+  });
 
   it.each(['connect', 'retry'] as const)(
     'records explicit SSH connection intent before %s prepares runtime readiness',

--- a/apps/emdash-desktop/src/main/gateway/host-availability.ts
+++ b/apps/emdash-desktop/src/main/gateway/host-availability.ts
@@ -14,10 +14,6 @@ import { err, ok, type Result } from '@emdash/shared';
 import type { Scope } from '@emdash/shared/concurrency';
 import { waitWithSignal } from '@emdash/shared/scheduling';
 import type { ConnectionState } from '@core/primitives/ssh/api';
-import type {
-  SshConnectionManager,
-  SshConnectionManagerListener,
-} from '@core/primitives/ssh/api/node/ssh-connection-manager';
 import {
   createHostAvailability,
   type HostAvailabilityService,
@@ -31,7 +27,6 @@ export type CreateDesktopHostAvailabilityOptions = {
   hosts: HostService;
   runtimes: Pick<RuntimeBroker, 'rebind'>;
   connectSsh(connectionId: string): Promise<ConnectionState>;
-  sshEvents: Pick<SshConnectionManager, 'on' | 'off'>;
   localReady(): Promise<void>;
 };
 
@@ -49,14 +44,13 @@ export function createDesktopHostAvailability(
       availability.markUnavailable(hostRef('remote', connectionId));
     })
   );
-  const handleSshEvent: SshConnectionManagerListener = (event) => {
-    if (event.type !== 'connected' && event.type !== 'reconnected') return;
-    availability.wake(hostRef('remote', event.connectionId), 'ssh-edge');
-  };
-  options.sshEvents.on('connection-event', handleSshEvent);
-  options.scope.add(() => {
-    options.sshEvents.off('connection-event', handleSshEvent);
-  });
+  options.scope.add(
+    options.hosts.onConnectivityChange(({ connectionId, state }) => {
+      const host = hostRef('remote', connectionId);
+      if (state === 'connected') availability.wake(host, 'ssh-edge');
+      else availability.invalidate(host);
+    })
+  );
   return availability;
 }
 

--- a/packages/wire/src/api/transports/reconnecting.test.ts
+++ b/packages/wire/src/api/transports/reconnecting.test.ts
@@ -92,6 +92,24 @@ describe('reconnectingTransport', () => {
     transport.close();
   });
 
+  it('replaces a silent half-open connection on demand', async () => {
+    const first = new FakeTransport();
+    const second = new FakeTransport();
+    let attempts = 0;
+    const transport = reconnectingTransport(() =>
+      Promise.resolve(attempts++ === 0 ? first : second)
+    );
+
+    await transport.ready();
+    transport.forceReconnect();
+
+    expect(first.isClosed).toBe(true);
+    await transport.ready();
+    transport.post({ kind: 'detach', topic: 'after-watchdog' });
+    expect(second.sent).toEqual([{ kind: 'detach', topic: 'after-watchdog' }]);
+    transport.close();
+  });
+
   it('returns readiness for the replacement connection after disconnect', async () => {
     const firstReady = deferred<WireTransport>();
     const secondReady = deferred<WireTransport>();
@@ -274,6 +292,10 @@ class FakeTransport implements WireTransport {
 
   get disconnectSubscriberCount(): number {
     return this.disconnectListeners.size;
+  }
+
+  get isClosed(): boolean {
+    return this.closed;
   }
 
   post(message: WireMessage): void {

--- a/packages/wire/src/api/transports/reconnecting.ts
+++ b/packages/wire/src/api/transports/reconnecting.ts
@@ -26,6 +26,8 @@ export type ReconnectFailureContext = {
 export type ReconnectingTransport = WireTransport & {
   /** Resolves when the current physical connection has passed connectOnce readiness. */
   ready(): Promise<void>;
+  /** Replaces the current physical connection. */
+  forceReconnect(): void;
   onReconnect(cb: () => void): Unsubscribe;
   onTerminalFailure(cb: (error: unknown) => void): Unsubscribe;
   close(): void;
@@ -150,13 +152,24 @@ export function reconnectingTransport(
     );
     cleanupInner.push(
       next.onDisconnect(() => {
-        if (inner !== next) return;
-        inner = null;
-        resetReadiness();
-        for (const listener of disconnectListeners) listener();
-        if (!closed) void reconnect();
+        disconnectInner(next);
       })
     );
+  }
+
+  function disconnectInner(current: WireTransport, closeCurrent = false): void {
+    if (inner !== current) return;
+    inner = null;
+    for (const cleanup of cleanupInner) cleanup();
+    cleanupInner = [];
+    resetReadiness();
+    for (const listener of disconnectListeners) listener();
+    if (closeCurrent) {
+      try {
+        current.close?.();
+      } catch {}
+    }
+    if (!closed) void reconnect();
   }
 
   function notifyReconnect(): void {
@@ -191,12 +204,7 @@ export function reconnectingTransport(
       try {
         current.post(message);
       } catch (error) {
-        if (inner === current) {
-          inner = null;
-          resetReadiness();
-          for (const listener of disconnectListeners) listener();
-          if (!closed) void reconnect();
-        }
+        disconnectInner(current, true);
         throw error;
       }
     },
@@ -207,6 +215,11 @@ export function reconnectingTransport(
     onDisconnect(cb): Unsubscribe {
       disconnectListeners.add(cb);
       return () => disconnectListeners.delete(cb);
+    },
+    forceReconnect() {
+      if (closed || terminal) return;
+      if (inner) disconnectInner(inner, true);
+      else void reconnect();
     },
     onReconnect(cb): Unsubscribe {
       reconnectListeners.add(cb);
@@ -227,8 +240,9 @@ export function reconnectingTransport(
       const closeError = new Error('Reconnecting transport closed');
       void scope.dispose(closeError);
       for (const cleanup of cleanupInner.splice(0)) cleanup();
-      inner?.close?.();
+      const current = inner;
       inner = null;
+      current?.close?.();
       readiness.reject(closeError);
       for (const listener of terminalFailureListeners) listener(closeError);
       messageListeners.clear();


### PR DESCRIPTION
### Description

Recover remote workspaces after silent or prolonged disconnects without discarding the pinned runtime connection.

- heartbeat SSH-backed workspace-server connections and replace half-open Wire transports
- retry transient SSH and Wire outages indefinitely with capped delays, while stopping on authentication, configuration, and protocol failures
- demote stale Host availability immediately and expose direct reconnect controls instead of a green connected state

This touches SSH/Wire lifecycle code, but does not change credentials, command construction, shell escaping, environment forwarding, or dependencies.

### Related issues

None.

### Testing

- `pnpm --filter @emdash/wire test` (308 tests)
- focused desktop node tests (122 tests)
- focused desktop browser tests (13 tests)
- `pnpm --filter @emdash/emdash-desktop format:check`
- `pnpm --filter @emdash/wire format:check`
- `pnpm --filter @emdash/emdash-desktop lint`
- `pnpm --filter @emdash/emdash-desktop typecheck`
- `pnpm run check` completed format, lint, and typecheck; 3,625 of 3,627 desktop tests passed. The sole failure is an untouched upstream browser fixture in `workspace-settings-section.browser.test.tsx` that omits `workspaceOptions`; it reproduces in isolation.

### Screenshot/Recording (if applicable)

Not attached; the state-driven reconnect controls and stale-status behavior are covered by browser tests.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit message and PR title

</details>
