### PR TITLE
fix(acp): recover chat history after reconnect

### DIFF
--- a/agents/architecture/acp-runtime.md
+++ b/agents/architecture/acp-runtime.md
@@ -104,6 +104,9 @@ hook, and asks the `SessionRouter` to resolve the owning conversation. The cell 
 through the reducer; its handle republishes the resulting activation snapshot through the
 conversation-keyed projection.
 
+Renderer chat stores refresh authoritative history after prompt completion and Host recovery so
+reconnects recover turns whose live projection updates were missed.
+
 The public API describes user intent instead of exposing lifecycle choreography. Desktop resolves
 the authoritative conversation configuration and fresh provider environment, then `attach` creates
 or refreshes the handle and publishes its retained projection without spawning a provider.

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
@@ -110,6 +110,7 @@ export class AcpChatStore {
   private readonly _disposeHostReaction: () => void;
   private _acpClientPromise: Promise<ConversationsClient['acp']> | null = null;
   private _submissionSequence = 0;
+  private _pendingPromptBaselineSeq: number | null = null;
   private _historyRefreshRequested = false;
   private _historyRefreshTask: Promise<void> | null = null;
   private _disposed = false;
@@ -170,15 +171,13 @@ export class AcpChatStore {
     this._disposeHostReaction = reaction(
       () => this.hostAccess?.state.kind,
       (kind) => {
-        if (
-          kind === 'ready' &&
-          this._bootstrapped &&
-          !this.historyLoading &&
-          this.loadError?.kind === 'unavailable'
-        ) {
+        if (kind !== 'ready' || !this._bootstrapped || this.historyLoading) return;
+        if (this.loadError?.kind === 'unavailable') {
           this.historyLoading = true;
           this.loadError = null;
           void this._runBootstrap();
+        } else if (!this.loadError) {
+          this._requestHistoryRefresh();
         }
       }
     );
@@ -395,6 +394,8 @@ export class AcpChatStore {
     this.draftText = '';
     this.draftAttachments = [];
     if (!this.affordances.isWorking) {
+      const turns = this.chatState.transcript.state.committedTurns;
+      this._pendingPromptBaselineSeq = turns.at(-1)?.seq ?? -1;
       optimisticId = `optimistic:user:${Date.now()}`;
       this.chatState.session.setPendingPrompt({
         id: optimisticId,
@@ -408,11 +409,15 @@ export class AcpChatStore {
     }
 
     void this._submitPrompt(text, promptAttachments, hiddenContext).then((accepted) => {
-      if (accepted) return;
+      if (accepted) {
+        if (optimisticId) this._requestHistoryRefresh();
+        return;
+      }
       runInAction(() => {
         if (this._disposed || submissionSequence !== this._submissionSequence) return;
         if (optimisticId && this.chatState.session.state.pendingPrompt?.id === optimisticId) {
           this.chatState.session.setPendingPrompt(null);
+          this._pendingPromptBaselineSeq = null;
           this._syncMessageCount();
         }
         if (this.draftText !== '' || this.draftAttachments.length > 0) return;
@@ -854,8 +859,26 @@ export class AcpChatStore {
       if (this.chatState.transcript.state.activeTurnSnapshot !== null) return;
       runInAction(() => {
         const pendingPrompt = this.chatState.session.state.pendingPrompt;
+        const baselineSeq = this._pendingPromptBaselineSeq;
+        const pendingPromptCommitted =
+          pendingPrompt !== null &&
+          baselineSeq !== null &&
+          history.data.turns.some(
+            (turn) =>
+              turn.seq > baselineSeq &&
+              turn.initiator === 'user' &&
+              turn.items.some(
+                (item) =>
+                  item.kind === 'message' &&
+                  item.role === 'user' &&
+                  item.text === pendingPrompt.text
+              )
+          );
         this.chatState.transcript.history.seed(history.data.turns);
-        if (pendingPrompt && this.chatState.session.state.pendingPrompt === null) {
+        if (pendingPromptCommitted) {
+          this.chatState.session.setPendingPrompt(null);
+          this._pendingPromptBaselineSeq = null;
+        } else if (pendingPrompt && this.chatState.session.state.pendingPrompt === null) {
           this.chatState.session.setPendingPrompt(pendingPrompt);
         }
         this._syncMessageCount();

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
@@ -110,7 +110,7 @@ export class AcpChatStore {
   private readonly _disposeHostReaction: () => void;
   private _acpClientPromise: Promise<ConversationsClient['acp']> | null = null;
   private _submissionSequence = 0;
-  private _pendingPromptBaselineSeq: number | null = null;
+  private _optimisticPrompts: Array<{ id: string; text: string; baselineSeq: number }> = [];
   private _historyRefreshRequested = false;
   private _historyRefreshTask: Promise<void> | null = null;
   private _disposed = false;
@@ -395,8 +395,12 @@ export class AcpChatStore {
     this.draftAttachments = [];
     if (!this.affordances.isWorking) {
       const turns = this.chatState.transcript.state.committedTurns;
-      this._pendingPromptBaselineSeq = turns.at(-1)?.seq ?? -1;
-      optimisticId = `optimistic:user:${Date.now()}`;
+      optimisticId = `optimistic:user:${submissionSequence}`;
+      this._optimisticPrompts.push({
+        id: optimisticId,
+        text,
+        baselineSeq: turns.at(-1)?.seq ?? -1,
+      });
       this.chatState.session.setPendingPrompt({
         id: optimisticId,
         text,
@@ -414,10 +418,15 @@ export class AcpChatStore {
         return;
       }
       runInAction(() => {
-        if (this._disposed || submissionSequence !== this._submissionSequence) return;
+        if (this._disposed) return;
+        if (optimisticId) {
+          this._optimisticPrompts = this._optimisticPrompts.filter(
+            (prompt) => prompt.id !== optimisticId
+          );
+        }
+        if (submissionSequence !== this._submissionSequence) return;
         if (optimisticId && this.chatState.session.state.pendingPrompt?.id === optimisticId) {
           this.chatState.session.setPendingPrompt(null);
-          this._pendingPromptBaselineSeq = null;
           this._syncMessageCount();
         }
         if (this.draftText !== '' || this.draftAttachments.length > 0) return;
@@ -859,27 +868,30 @@ export class AcpChatStore {
       if (this.chatState.transcript.state.activeTurnSnapshot !== null) return;
       runInAction(() => {
         const pendingPrompt = this.chatState.session.state.pendingPrompt;
-        const baselineSeq = this._pendingPromptBaselineSeq;
-        const pendingPromptCommitted =
-          pendingPrompt !== null &&
-          baselineSeq !== null &&
-          history.data.turns.some(
-            (turn) =>
-              turn.seq > baselineSeq &&
-              turn.initiator === 'user' &&
-              turn.items.some(
+        const committedPromptIds = new Set<string>();
+        let afterSeq = -1;
+        for (const prompt of this._optimisticPrompts) {
+          const turn = history.data.turns.find(
+            (candidate) =>
+              candidate.seq > Math.max(prompt.baselineSeq, afterSeq) &&
+              candidate.initiator === 'user' &&
+              candidate.items.some(
                 (item) =>
-                  item.kind === 'message' &&
-                  item.role === 'user' &&
-                  item.text === pendingPrompt.text
+                  item.kind === 'message' && item.role === 'user' && item.text === prompt.text
               )
           );
+          if (!turn) break;
+          committedPromptIds.add(prompt.id);
+          afterSeq = turn.seq;
+        }
         this.chatState.transcript.history.seed(history.data.turns);
-        if (pendingPromptCommitted) {
+        if (pendingPrompt && committedPromptIds.has(pendingPrompt.id)) {
           this.chatState.session.setPendingPrompt(null);
-          this._pendingPromptBaselineSeq = null;
         } else if (pendingPrompt && this.chatState.session.state.pendingPrompt === null) {
           this.chatState.session.setPendingPrompt(pendingPrompt);
+        }
+        if (committedPromptIds.size === this._optimisticPrompts.length) {
+          this._optimisticPrompts = [];
         }
         this._syncMessageCount();
       });

--- a/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
@@ -1,4 +1,5 @@
 import type { HistoryPage, SessionState } from '@emdash/core/runtimes/acp/api/client';
+import { observable, runInAction } from 'mobx';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { installChatUiRuntime } from '@core/features/conversations/api/browser/chat/chat-ui-runtime';
 import {
@@ -6,6 +7,10 @@ import {
   type AcpPromptAttachment,
 } from '@core/features/conversations/browser/acp/acp-chat-store';
 import { AcpLiveSession } from '@core/features/conversations/browser/acp/acp-live-session';
+import type {
+  ProjectHostAccess,
+  ProjectHostAccessState,
+} from '@core/features/projects/api/browser/stores/project-context';
 
 type DraftState = {
   version: '1';
@@ -150,6 +155,52 @@ describe('AcpChatStore prompt submission', () => {
 
     await vi.waitFor(() => expect(sendPrompt).toHaveBeenCalledWith({ text: 'hello' }));
     expect(store.draftText).toBe('');
+  });
+
+  it('reconciles a prompt when authoritative history arrives without live turn updates', async () => {
+    let finishPrompt!: () => void;
+    const sendPrompt = vi.fn(
+      () =>
+        new Promise<{ success: true; data: { queued: false } }>((resolve) => {
+          finishPrompt = () => resolve({ success: true, data: { queued: false } });
+        })
+    );
+    const live = fakeLiveSession(idleState(), historyPage('before'), { sendPrompt });
+    const store = await bootstrapWithSession(live.session);
+    live.loadHistory.mockClear();
+    historySeed.mockClear();
+
+    store.submitPrompt('survived disconnect');
+    await vi.waitFor(() => expect(sendPrompt).toHaveBeenCalled());
+    expect(chatSessionTestState.pendingPrompt).toMatchObject({ text: 'survived disconnect' });
+
+    live.loadHistory.mockResolvedValueOnce({
+      success: true,
+      data: historyPageWithPrompt('completed', 1, 'survived disconnect'),
+    });
+    finishPrompt();
+
+    await vi.waitFor(() => expect(live.loadHistory).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(chatSessionTestState.pendingPrompt).toBeNull());
+    expect(historySeed).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 'completed', seq: 1 }),
+    ]);
+    store.dispose();
+  });
+
+  it('does not reconcile against an identical prompt from earlier history', async () => {
+    const text = 'continue';
+    const priorHistory = historyPageWithPrompt('prior', 0, text);
+    const live = fakeLiveSession(idleState(), priorHistory);
+    const store = await bootstrapWithSession(live.session);
+    live.loadHistory.mockClear();
+    live.loadHistory.mockResolvedValueOnce({ success: true, data: priorHistory });
+
+    store.submitPrompt(text);
+
+    await vi.waitFor(() => expect(live.loadHistory).toHaveBeenCalledTimes(1));
+    expect(chatSessionTestState.pendingPrompt).toMatchObject({ text });
+    store.dispose();
   });
 
   it('restores the persisted draft when the live session is unavailable', async () => {
@@ -533,6 +584,41 @@ describe('AcpChatStore prompt submission', () => {
     store.dispose();
   });
 
+  it('refreshes authoritative history when Host availability returns', async () => {
+    const hostState = observable.box<ProjectHostAccessState>({
+      kind: 'ready',
+      hostGeneration: 1,
+    });
+    const hostAccess = {
+      get state() {
+        return hostState.get();
+      },
+      get liveAction() {
+        const state = hostState.get();
+        return state.kind === 'ready'
+          ? ({ kind: 'enabled' } as const)
+          : ({ kind: 'disabled', state } as const);
+      },
+    } as ProjectHostAccess;
+    const live = fakeLiveSession(idleState(), historyPage('before'));
+    vi.spyOn(AcpLiveSession, 'create').mockResolvedValueOnce(live.session);
+    const store = new AcpChatStore('conversation-1', 'project-1', 'task-1', hostAccess);
+    store.bootstrap();
+    await vi.waitFor(() => expect(store.historyLoading).toBe(false));
+    live.loadHistory.mockClear();
+    historySeed.mockClear();
+    live.loadHistory.mockResolvedValueOnce({ success: true, data: historyPage('recovered') });
+
+    runInAction(() =>
+      hostState.set({ kind: 'degraded', situation: 'offline', recovery: 'automatic' })
+    );
+    runInAction(() => hostState.set({ kind: 'ready', hostGeneration: 2 }));
+
+    await vi.waitFor(() => expect(live.loadHistory).toHaveBeenCalledTimes(1));
+    expect(historySeed).toHaveBeenCalledWith([expect.objectContaining({ id: 'recovered' })]);
+    store.dispose();
+  });
+
   it('keeps rendered history when a suspension-driven refresh is unavailable', async () => {
     const live = fakeLiveSession(idleState(), historyPage('rendered'));
     const store = await bootstrapWithSession(live.session);
@@ -667,6 +753,20 @@ function historyPage(turnId: string): HistoryPage {
   };
 }
 
+function historyPageWithPrompt(turnId: string, seq: number, text: string): HistoryPage {
+  return {
+    turns: [
+      {
+        id: turnId,
+        seq,
+        initiator: 'user',
+        items: [{ kind: 'message', id: `${turnId}-user`, seq: 0, role: 'user', text }],
+      },
+    ],
+    nextCursor: null,
+  };
+}
+
 function unavailableHistory(): HistoryPage {
   return { turns: [], nextCursor: null, unavailable: true };
 }
@@ -680,6 +780,7 @@ function createStore(
   store.session = {
     sessionState: { current: () => state },
     sendPrompt,
+    loadHistory: vi.fn(async () => ({ success: true, data: unavailableHistory() })),
     dispose: vi.fn(),
     ...sessionOverrides,
   } as never;

--- a/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
@@ -203,6 +203,53 @@ describe('AcpChatStore prompt submission', () => {
     store.dispose();
   });
 
+  it('keeps a later identical prompt until its own turn is committed', async () => {
+    const text = 'continue';
+    let finishFirst!: () => void;
+    const sendPrompt = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ success: true; data: { queued: false } }>((resolve) => {
+            finishFirst = () => resolve({ success: true, data: { queued: false } });
+          })
+      )
+      .mockResolvedValueOnce({ success: true, data: { queued: true } });
+    const initialHistory = historyPage('before');
+    const firstHistory = {
+      turns: [...initialHistory.turns, ...historyPageWithPrompt('first', 1, text).turns],
+      nextCursor: null,
+    };
+    const completeHistory = {
+      turns: [...firstHistory.turns, ...historyPageWithPrompt('second', 2, text).turns],
+      nextCursor: null,
+    };
+    const live = fakeLiveSession(idleState(), initialHistory, { sendPrompt });
+    const store = await bootstrapWithSession(live.session);
+    live.loadHistory.mockClear();
+    live.loadHistory
+      .mockResolvedValueOnce({ success: true, data: initialHistory })
+      .mockResolvedValueOnce({ success: true, data: firstHistory })
+      .mockResolvedValueOnce({ success: true, data: completeHistory });
+
+    store.submitPrompt(text);
+    const firstId = chatSessionTestState.pendingPrompt?.id;
+    store.submitPrompt(text);
+    const secondId = chatSessionTestState.pendingPrompt?.id;
+
+    expect(secondId).not.toBe(firstId);
+    await vi.waitFor(() => expect(live.loadHistory).toHaveBeenCalledTimes(1));
+    finishFirst();
+    await vi.waitFor(() => expect(historySeed).toHaveBeenLastCalledWith(firstHistory.turns));
+    expect(chatSessionTestState.pendingPrompt?.id).toBe(secondId);
+    expect(store.messageCount).toBe(2);
+
+    connectSessionOptions?.onTurnCommitted?.();
+    await vi.waitFor(() => expect(historySeed).toHaveBeenLastCalledWith(completeHistory.turns));
+    expect(chatSessionTestState.pendingPrompt).toBeNull();
+    store.dispose();
+  });
+
   it('restores the persisted draft when the live session is unavailable', async () => {
     const store = createStore(idleState(), vi.fn());
     const attachment = promptAttachment('attachment-no-session', 'data:image/png;base64,AQ==');


### PR DESCRIPTION
### Description

Restore authoritative ACP chat history when live turn updates are missed during a disconnect.

- refresh history after an accepted prompt settles and whenever Host availability returns
- give optimistic submissions unique sequence IDs and reconcile them against distinct user turns in submission order
- preserve consecutive identical prompts until each prompt's authoritative turn exists

The change stays in the renderer projection layer; it does not alter the ACP protocol, runtime state machine, provider processes, or dependencies.

### Related issues

Complements #3062, which makes transient SSH/Wire disconnects publish the Host recovery edge used here.

### Testing

- focused ACP browser suite (26 tests)
- focused ACP store and live-session node tests (7 tests)
- `pnpm --filter @emdash/emdash-desktop format:check`
- `pnpm --filter @emdash/emdash-desktop lint`
- `pnpm --filter @emdash/emdash-desktop typecheck`
- full desktop suite: 3,617 tests passed and 1 skipped. Two unrelated browser tests failed: the untouched `workspace-settings-section.browser.test.tsx` fixture omits `workspaceOptions`, and an agent-selector hover test timed out under suite load but passed immediately in isolation (2 tests).

### Screenshot/Recording (if applicable)

Not applicable; this restores transcript state without changing layout or styling.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit message and PR title

</details>
