### PR TITLE
fix(ssh): disable ssh2 strictVendor so non-OpenSSH servers can forward unix sockets

### DIFF
--- a/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.test.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.test.ts
@@ -808,4 +808,15 @@ describe('resolveSshConnectConfig', () => {
     expect(readFiles).toEqual([expect.stringContaining('/.ssh/corp_ed25519')]);
     expect(result.config.privateKey).toBe('ALIAS KEY');
   });
+
+  it('disables strictVendor so OpenSSH extensions work against non-OpenSSH servers', async () => {
+    const transient = await resolveSshConnectConfig(
+      { kind: 'transient', config: { ...baseConfig(), password: 'secret' } },
+      deps()
+    );
+    const persisted = await resolveSshConnectConfig({ kind: 'persisted', row: row() }, deps());
+
+    expect(transient.config.strictVendor).toBe(false);
+    expect(persisted.config.strictVendor).toBe(false);
+  });
 });

--- a/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.ts
@@ -98,6 +98,13 @@ export async function resolveSshConnectConfig(
     host,
     port,
     username,
+    // ssh2 gates the OpenSSH extensions we rely on (notably
+    // direct-streamlocal@openssh.com, used to reach the workspace-server unix socket)
+    // behind a version-string match on the server banner. Non-OpenSSH servers that do
+    // implement those extensions — Tailscale SSH announces itself as SSH-2.0-Tailscale —
+    // would otherwise be rejected client-side before a channel is ever opened. Let the
+    // server decide: an unsupported extension still fails, just with its own error.
+    strictVendor: false,
     readyTimeout:
       resolved?.connectTimeout !== undefined
         ? resolved.connectTimeout * 1000


### PR DESCRIPTION
### Description

`ssh2` gates its OpenSSH extension methods behind `strictVendor`, which defaults to `true` and
only lets a request through when the server's version banner matches
`/^OpenSSH_(?:(?![0-4])\d)|(?:\d{2,})/` (`ssh2/lib/client.js`). The desktop app reaches a remote
workspace server by forwarding its unix socket over SSH — `ssh-streamlocal-transport.ts` →
`proxy.forwardOutStreamLocal(...)` → `client.openssh_forwardOutStreamLocal(...)` — so on any
non-OpenSSH server that call failed client-side before a channel was ever opened.

Tailscale SSH announces itself as `SSH-2.0-Tailscale`, so remote hosts reached that way failed
every dial with `strictVendor enabled and server is not OpenSSH or compatible version`. Exec
sessions go through a normal `session` channel and were unaffected, which is why the SSH
connection showed as OK in Machines while the Workspace Runtime looped install → start → dial and
settled on a misleading `daemon-start-failed`, even with a healthy daemon on the host.

This sets `strictVendor: false` on the connect config so the server decides. A server that
genuinely does not implement `direct-streamlocal@openssh.com` still fails — just with its own
channel-open failure instead of a client-side guess from a version string.

`strictVendor` also guards `openssh_noMoreSessions`, `openssh_forwardInStreamLocal`,
`openssh_unforwardInStreamLocal`, and `hostKeysProve`; none of those are called from this app
today, so the blast radius is the streamlocal path.

### Related issues

Fixes #3064

### Testing

`pnpm run format`, `pnpm run lint`, `pnpm run typecheck` (all 9 projects), and the app's `node`
Vitest project (2954 passed, 1 skipped). Added a unit test asserting the flag is set for both
persisted and transient connections.

Verified end to end against a real Tailscale SSH host (Tailscale 1.102.3, banner confirmed as
`SSH-2.0-Tailscale`) by running an echo server on a remote unix socket and dialing it through the
production path — `resolveSshConnectConfig` → `SshConnectionManager` → `SshClientProxy.forwardOutStreamLocal`:

- Without the change: `strictVendor enabled and server is not OpenSSH or compatible version`,
  thrown at `streamlocal.ts:32` — the exact error from the issue.
- With the change: channel opens and data round-trips through the forwarded socket.

That also answers the open question in the issue: Tailscale SSH 1.102.3 does implement
`direct-streamlocal@openssh.com`.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [ ] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
