### PR TITLE
fix(ssh): allow streamlocal on compatible non-openssh servers

### DIFF
--- a/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.test.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.test.ts
@@ -146,6 +146,7 @@ describe('resolveSshConnectConfig', () => {
       username: 'deploy',
       agent: '/tmp/agent.sock',
       agentForward: true,
+      strictVendor: false,
     });
     expect(result.config.sock).toBeDefined();
     expect(spawned).toEqual(['cloudflared access ssh --hostname %h dev.internal:2222 deploy']);

--- a/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.ts
@@ -107,6 +107,7 @@ export async function resolveSshConnectConfig(
     keepaliveInterval: resolved?.serverAliveInterval ? resolved.serverAliveInterval * 1000 : 60_000,
     keepaliveCountMax: resolved?.serverAliveCountMax ?? 3,
     ...authResult.config,
+    strictVendor: false,
   };
 
   const forwardAgent = resolved?.forwardAgent ?? base.forwardAgent === true;

--- a/apps/emdash-desktop/src/core/services/ssh/node/operations/streamlocal.test.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/operations/streamlocal.test.ts
@@ -1,0 +1,60 @@
+import { generateKeyPairSync } from 'node:crypto';
+import { once } from 'node:events';
+import { Client, Server } from 'ssh2';
+import { describe, expect, it } from 'vitest';
+import type { SshConfig } from '@core/primitives/ssh/api';
+import { resolveSshConnectConfig } from '../connect/resolve-ssh-connect-config';
+import { forwardOutStreamLocalOnClient } from './streamlocal';
+
+const { privateKey: hostKey } = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  privateKeyEncoding: { type: 'pkcs1', format: 'pem' },
+  publicKeyEncoding: { type: 'pkcs1', format: 'pem' },
+});
+
+describe('forwardOutStreamLocalOnClient', () => {
+  it('opens streamlocal on a compatible server with a non-OpenSSH banner', async () => {
+    let observedSocketPath: string | undefined;
+    const server = new Server({ hostKeys: [hostKey], ident: 'Tailscale' });
+    server.on('connection', (connection) => {
+      connection.on('authentication', (context) => context.accept());
+      connection.on('ready', () => {
+        connection.on('openssh.streamlocal', (accept, _reject, info) => {
+          observedSocketPath = info.socketPath;
+          accept().end();
+        });
+      });
+    });
+    server.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Expected TCP server address');
+
+    const input = {
+      id: 'tailscale-test',
+      name: 'Tailscale test',
+      host: '127.0.0.1',
+      port: address.port,
+      username: 'alice',
+      authType: 'password',
+      useAgent: false,
+      password: 'secret',
+    } satisfies SshConfig & { password: string };
+    const resolved = await resolveSshConnectConfig({ kind: 'transient', config: input });
+    const client = new Client();
+
+    try {
+      client.connect(resolved.config);
+      await once(client, 'ready');
+
+      const channel = await forwardOutStreamLocalOnClient(client, '/tmp/workspace.sock');
+      channel.destroy();
+
+      expect(observedSocketPath).toBe('/tmp/workspace.sock');
+    } finally {
+      client.end();
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
- allow workspace-server unix socket forwarding through compatible ssh servers such as tailscale ssh
- rely on streamlocal capability negotiation instead of the advertised server vendor
- preserve server-side forwarding authorization and rejection behavior