### PR TITLE
fix(pty): preserve raw windows command lines

### DIFF
--- a/packages/core/src/primitives/exec/api/index.ts
+++ b/packages/core/src/primitives/exec/api/index.ts
@@ -5,3 +5,4 @@ export type {
   ExecStreamingResult,
   IExecutionContext,
 } from './execution-context';
+export type { NativeInvocation } from './native-invocation';

--- a/packages/core/src/primitives/exec/api/native-invocation.ts
+++ b/packages/core/src/primitives/exec/api/native-invocation.ts
@@ -1,0 +1,12 @@
+export type NativeInvocation =
+  | {
+      kind: 'argv';
+      executable: string;
+      argv: readonly string[];
+    }
+  | {
+      kind: 'windows-command-line';
+      executable: string;
+      /** Preformatted arguments only, excluding the executable. Treat as opaque after creation. */
+      rawArguments: string;
+    };

--- a/packages/core/src/primitives/exec/node/executable-launch.test.ts
+++ b/packages/core/src/primitives/exec/node/executable-launch.test.ts
@@ -11,12 +11,9 @@ describe('planExecutableLaunch', () => {
         cwd: '/workspace',
       })
     ).toEqual({
-      executable: 'provider',
-      args: ['', 'hello world'],
+      invocation: { kind: 'argv', executable: 'provider', argv: ['', 'hello world'] },
       cwd: '/workspace',
-      kind: 'direct',
       diagnostics: [],
-      windowsVerbatimArguments: false,
     });
   });
 
@@ -52,17 +49,14 @@ describe('planExecutableLaunch', () => {
     });
 
     expect(plan).toEqual({
-      executable: 'C:\\Windows\\System32\\cmd.exe',
-      args: [
-        '/d',
-        '/s',
-        '/c',
-        '""C:\\Program Files\\npm shims\\provider.CMD" "" "hello world" "embedded^"quote" "%%TOKEN%%" "bang^^!" "caret^^" "ampersand^&" "pipe^|" "less^<" "greater^>" "^(parentheses^)" "space trailing\\" ユニコード /c "x ^& echo injected""',
-      ],
+      invocation: {
+        kind: 'windows-command-line',
+        executable: 'C:\\Windows\\System32\\cmd.exe',
+        rawArguments:
+          '/d /s /c ""C:\\Program Files\\npm shims\\provider.CMD" "" "hello world" "embedded^"quote" "%%TOKEN%%" "bang^^!" "caret^^" "ampersand^&" "pipe^|" "less^<" "greater^>" "^(parentheses^)" "space trailing\\" ユニコード /c "x ^& echo injected""',
+      },
       cwd: 'C:\\Work Space',
-      kind: 'windows-cmd',
       diagnostics: [],
-      windowsVerbatimArguments: true,
     });
   });
 
@@ -77,8 +71,11 @@ describe('planExecutableLaunch', () => {
       fileExists: (candidate) => candidate === provider,
     });
 
-    expect(plan.executable).toBe('C:\\Windows\\cmd.exe');
-    expect(plan.args[3]).toContain(provider);
+    expect(plan.invocation).toMatchObject({
+      kind: 'windows-command-line',
+      executable: 'C:\\Windows\\cmd.exe',
+      rawArguments: expect.stringContaining(provider),
+    });
     expect(plan.diagnostics).toEqual([]);
   });
 
@@ -93,7 +90,10 @@ describe('planExecutableLaunch', () => {
       fileExists: (candidate) => candidate === provider,
     });
 
-    expect(plan).toMatchObject({ executable: provider, kind: 'direct', diagnostics: [] });
+    expect(plan).toMatchObject({
+      invocation: { kind: 'argv', executable: provider },
+      diagnostics: [],
+    });
   });
 
   it('runs native executables directly with exact argv', () => {
@@ -123,10 +123,11 @@ describe('planExecutableLaunch', () => {
     });
 
     expect(plan).toMatchObject({
-      executable: 'C:\\Program Files\\Provider\\provider.exe',
-      args,
-      kind: 'direct',
-      windowsVerbatimArguments: false,
+      invocation: {
+        kind: 'argv',
+        executable: 'C:\\Program Files\\Provider\\provider.exe',
+        argv: args,
+      },
     });
   });
 
@@ -141,7 +142,10 @@ describe('planExecutableLaunch', () => {
       fileExists: (candidate) => candidate === executable,
     });
 
-    expect(plan).toMatchObject({ executable, args: ['run'], kind: 'direct', diagnostics: [] });
+    expect(plan).toMatchObject({
+      invocation: { kind: 'argv', executable, argv: ['run'] },
+      diagnostics: [],
+    });
   });
 
   it('uses the selected PowerShell profile for ps1 files', () => {
@@ -172,16 +176,18 @@ describe('planExecutableLaunch', () => {
     });
 
     expect(plan).toMatchObject({
-      executable: 'C:\\Program Files\\PowerShell\\pwsh.exe',
-      args: [
-        '-NoLogo',
-        '-ExecutionPolicy',
-        'Bypass',
-        '-File',
-        'C:\\Scripts\\provider.ps1',
-        ...args,
-      ],
-      kind: 'powershell',
+      invocation: {
+        kind: 'argv',
+        executable: 'C:\\Program Files\\PowerShell\\pwsh.exe',
+        argv: [
+          '-NoLogo',
+          '-ExecutionPolicy',
+          'Bypass',
+          '-File',
+          'C:\\Scripts\\provider.ps1',
+          ...args,
+        ],
+      },
     });
   });
 
@@ -198,9 +204,11 @@ describe('planExecutableLaunch', () => {
     });
 
     expect(plan).toMatchObject({
-      executable: powershell,
-      args: ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', script, 'run'],
-      kind: 'powershell',
+      invocation: {
+        kind: 'argv',
+        executable: powershell,
+        argv: ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', script, 'run'],
+      },
       diagnostics: [],
     });
   });
@@ -216,9 +224,7 @@ describe('planExecutableLaunch', () => {
     });
 
     expect(plan).toMatchObject({
-      executable: 'missing-provider',
-      args: ['run'],
-      kind: 'direct',
+      invocation: { kind: 'argv', executable: 'missing-provider', argv: ['run'] },
       diagnostics: [{ type: 'command-not-found', command: 'missing-provider' }],
     });
   });
@@ -233,6 +239,6 @@ describe('planExecutableLaunch', () => {
       fileExists: () => true,
     });
 
-    expect(plan.executable).toBe('C:\\Windows\\System32\\cmd.exe');
+    expect(plan.invocation.executable).toBe('C:\\Windows\\System32\\cmd.exe');
   });
 });

--- a/packages/core/src/primitives/exec/node/executable-launch.ts
+++ b/packages/core/src/primitives/exec/node/executable-launch.ts
@@ -1,9 +1,7 @@
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { getWindowsEnvValue } from '#primitives/agent-env/api';
-import { formatCommandLine } from '#primitives/exec/api';
-
-export type ExecutableLaunchKind = 'direct' | 'windows-cmd' | 'powershell';
+import { formatCommandLine, type NativeInvocation } from '#primitives/exec/api';
 
 export type ExecutableLaunchDiagnostic = {
   type: 'command-not-found';
@@ -16,11 +14,14 @@ export type ExecutableShellProfile = {
 };
 
 export type ExecutableLaunchPlan = {
+  invocation: NativeInvocation;
+  cwd: string | undefined;
+  diagnostics: ExecutableLaunchDiagnostic[];
+};
+
+export type ChildProcessLaunch = {
   executable: string;
   args: string[];
-  cwd: string | undefined;
-  kind: ExecutableLaunchKind;
-  diagnostics: ExecutableLaunchDiagnostic[];
   windowsVerbatimArguments: boolean;
 };
 
@@ -57,31 +58,34 @@ export function planExecutableLaunch({
   if (extension === '.cmd' || extension === '.bat') {
     const commandLine = formatCommandLine({ command: executable, args: [...args] }, 'windows-cmd');
     return {
-      executable: resolveCmdExecutable(env),
-      args: ['/d', '/s', '/c', wrapCmdExeCommandLine(commandLine)],
+      invocation: {
+        kind: 'windows-command-line',
+        executable: resolveCmdExecutable(env),
+        rawArguments: `/d /s /c ${wrapCmdExeCommandLine(commandLine)}`,
+      },
       cwd,
-      kind: 'windows-cmd',
       diagnostics,
-      windowsVerbatimArguments: true,
     };
   }
 
   if (extension === '.ps1') {
     const selectedPowerShell = shellProfile?.family === 'powershell' ? shellProfile : undefined;
     return {
-      executable: selectedPowerShell?.executable ?? resolveWindowsPowerShell(env, cwd, fileExists),
-      args: [
-        selectedPowerShell ? '-NoLogo' : '-NoProfile',
-        '-ExecutionPolicy',
-        'Bypass',
-        '-File',
-        executable,
-        ...args,
-      ],
+      invocation: {
+        kind: 'argv',
+        executable:
+          selectedPowerShell?.executable ?? resolveWindowsPowerShell(env, cwd, fileExists),
+        argv: [
+          selectedPowerShell ? '-NoLogo' : '-NoProfile',
+          '-ExecutionPolicy',
+          'Bypass',
+          '-File',
+          executable,
+          ...args,
+        ],
+      },
       cwd,
-      kind: 'powershell',
       diagnostics,
-      windowsVerbatimArguments: false,
     };
   }
 
@@ -97,13 +101,27 @@ function directPlan(
   cwd: string | undefined
 ): ExecutableLaunchPlan {
   return {
-    executable,
-    args: [...args],
+    invocation: { kind: 'argv', executable, argv: [...args] },
     cwd,
-    kind: 'direct',
     diagnostics: [],
-    windowsVerbatimArguments: false,
   };
+}
+
+export function toChildProcessLaunch(invocation: NativeInvocation): ChildProcessLaunch {
+  switch (invocation.kind) {
+    case 'argv':
+      return {
+        executable: invocation.executable,
+        args: [...invocation.argv],
+        windowsVerbatimArguments: false,
+      };
+    case 'windows-command-line':
+      return {
+        executable: invocation.executable,
+        args: [invocation.rawArguments],
+        windowsVerbatimArguments: true,
+      };
+  }
 }
 
 function resolveWindowsExecutable(

--- a/packages/core/src/primitives/exec/node/index.ts
+++ b/packages/core/src/primitives/exec/node/index.ts
@@ -1,7 +1,8 @@
 export {
   planExecutableLaunch,
+  toChildProcessLaunch,
+  type ChildProcessLaunch,
   type ExecutableLaunchDiagnostic,
-  type ExecutableLaunchKind,
   type ExecutableLaunchPlan,
   type ExecutableShellProfile,
   type FileExists,

--- a/packages/core/src/runtimes/acp/node/node/child-process-host.test.ts
+++ b/packages/core/src/runtimes/acp/node/node/child-process-host.test.ts
@@ -31,8 +31,8 @@ describe('ChildAcpProcessHost', () => {
 
     const [executable, args, options] = spawnMock.mock.calls[0]!;
     expect(executable).toBe('C:\\Windows\\System32\\cmd.exe');
-    expect(args.slice(0, 3)).toEqual(['/d', '/s', '/c']);
-    expect(args[3].toLowerCase()).toContain(shim.toLowerCase());
+    expect(args).toHaveLength(1);
+    expect(args[0].toLowerCase()).toContain(`/d /s /c ""${shim.toLowerCase()}"`);
     expect(options).toMatchObject({ windowsVerbatimArguments: true });
     expect(options).not.toHaveProperty('shell');
   });
@@ -50,7 +50,7 @@ describe('ChildAcpProcessHost', () => {
 
     expect(spawnMock).toHaveBeenCalledWith(
       'C:\\Windows\\System32\\cmd.exe',
-      ['/d', '/s', '/c', expect.stringContaining(shim)],
+      [expect.stringContaining(`/d /s /c ""${shim}`)],
       expect.objectContaining({ windowsVerbatimArguments: true })
     );
     expect(spawnMock.mock.calls[0]?.[2]).not.toHaveProperty('shell');

--- a/packages/core/src/runtimes/acp/node/node/child-process-host.ts
+++ b/packages/core/src/runtimes/acp/node/node/child-process-host.ts
@@ -5,6 +5,7 @@ import { recordSpawn } from '@emdash/shared/perf';
 import {
   createChildProcessTreeTerminator,
   planExecutableLaunch,
+  toChildProcessLaunch,
   type FileExists,
   type ProcessTreeTerminator,
 } from '#primitives/exec/node';
@@ -137,13 +138,14 @@ export class ChildAcpProcessHost implements AcpRuntimeProcessHost {
       env: spec.env,
       fileExists: this.options.fileExists,
     });
-    recordSpawn('agent', plan.executable);
-    const child = spawn(plan.executable, plan.args, {
+    const launch = toChildProcessLaunch(plan.invocation);
+    recordSpawn('agent', launch.executable);
+    const child = spawn(launch.executable, launch.args, {
       cwd: plan.cwd,
       detached: platform !== 'win32',
       env: spec.env,
       stdio: ['pipe', 'pipe', 'pipe'],
-      windowsVerbatimArguments: plan.windowsVerbatimArguments,
+      windowsVerbatimArguments: launch.windowsVerbatimArguments,
     });
     if (!child.stdin || !child.stdout) {
       throw new Error('ChildAcpProcessHost: failed to spawn process - no stdio streams');
@@ -166,13 +168,14 @@ export class ChildAcpProcessHost implements AcpRuntimeProcessHost {
       env: spec.env,
       fileExists: this.options.fileExists,
     });
-    recordSpawn('agent', plan.executable);
-    const child = spawn(plan.executable, plan.args, {
+    const launch = toChildProcessLaunch(plan.invocation);
+    recordSpawn('agent', launch.executable);
+    const child = spawn(launch.executable, launch.args, {
       cwd: plan.cwd,
       detached: platform !== 'win32',
       env: spec.env,
       stdio: ['ignore', 'pipe', 'pipe'],
-      windowsVerbatimArguments: plan.windowsVerbatimArguments,
+      windowsVerbatimArguments: launch.windowsVerbatimArguments,
     });
     if (!child.stdout) {
       throw new Error('ChildAcpProcessHost: failed to spawn terminal - no stdout stream');

--- a/packages/core/src/runtimes/agent-config/node/runtime/auth.ts
+++ b/packages/core/src/runtimes/agent-config/node/runtime/auth.ts
@@ -220,8 +220,7 @@ export class AgentAuthManager {
     const pty = await this.ptys.create(
       providerId,
       {
-        command: spawn.command,
-        args: spawn.args,
+        invocation: spawn.invocation,
         cwd: this.deps.agentHost.homeDir,
         env,
         cols: dimensions?.cols ?? DEFAULT_COLS,

--- a/packages/core/src/runtimes/agent-config/node/runtime/runtime.test.ts
+++ b/packages/core/src/runtimes/agent-config/node/runtime/runtime.test.ts
@@ -170,8 +170,7 @@ describe('AgentConfigRuntime', () => {
     expect(started).toEqual(ok(undefined));
     expect(ptySpawner.processes).toHaveLength(1);
     expect(ptySpawner.specs[0]).toMatchObject({
-      command: '/opt/fake-agent',
-      args: [],
+      invocation: { kind: 'argv', executable: '/opt/fake-agent', argv: [] },
       cwd: '/home/ada',
       cols: 120,
       rows: 30,
@@ -207,8 +206,11 @@ describe('AgentConfigRuntime', () => {
 
     expect(started).toEqual(ok(undefined));
     expect(ptySpawner.specs[0]).toMatchObject({
-      command: 'C:\\Windows\\System32\\cmd.exe',
-      args: ['/d', '/s', '/c', expect.stringContaining(providerPath)],
+      invocation: {
+        kind: 'windows-command-line',
+        executable: 'C:\\Windows\\System32\\cmd.exe',
+        rawArguments: expect.stringContaining(providerPath),
+      },
       cwd: '/home/ada',
     });
     await runtime.dispose();
@@ -233,7 +235,7 @@ describe('AgentConfigRuntime', () => {
     });
     const authCheckStatus = vi.fn(async (ctx: AgentAuthContext) => {
       const result = await ctx.exec(ctx.cli, ['status', 'hello world']);
-      expect(result.stdout).toContain('/d\n/s\n/c\n');
+      expect(result.stdout).toContain('/d /s /c');
       expect(result.stdout).toContain('fake-agent.cmd');
       expect(result.stdout).toContain('hello world');
       expect(ctx.env).not.toHaveProperty('UNSAFE_ENV');

--- a/packages/core/src/runtimes/scripts/node/api/contract.test.ts
+++ b/packages/core/src/runtimes/scripts/node/api/contract.test.ts
@@ -83,7 +83,9 @@ describe('scripts runtime contract', () => {
     expect(started.success && started.data.status).toBe('running');
 
     const spec = spawner.specs[0]!;
-    expect(spec.args?.slice(-1)[0]).toBe('pnpm install');
+    expect(spec.invocation.kind === 'argv' ? spec.invocation.argv.at(-1) : null).toBe(
+      'pnpm install'
+    );
     expect(spec.cwd).toBe(WORKSPACE);
     expect(spec.env).toMatchObject({
       EMDASH_TASK_ID: 'ws-1',
@@ -212,7 +214,8 @@ describe('scripts runtime contract', () => {
   it('executes the supplied command', async () => {
     const result = await start('setup', { command: 'echo personal setup' });
     expect(result.success).toBe(true);
-    expect(spawner.specs[0]!.args?.slice(-1)[0]).toBe('echo personal setup');
+    const { invocation } = spawner.specs[0]!;
+    expect(invocation.kind === 'argv' ? invocation.argv.at(-1) : null).toBe('echo personal setup');
   });
 
   it('stop and wait on a workspace with no runs return not-found', async () => {
@@ -263,7 +266,8 @@ describe('scripts runtime contract', () => {
         command: 'echo supplied command',
         shellSetup: 'source /supplied/profile',
       });
-      expect(spawner.specs[0]!.args?.slice(-1)[0]).toBe(
+      const { invocation } = spawner.specs[0]!;
+      expect(invocation.kind === 'argv' ? invocation.argv.at(-1) : null).toBe(
         'source /supplied/profile && echo supplied command'
       );
       expect(readFile).not.toHaveBeenCalled();
@@ -294,8 +298,11 @@ describe('scripts runtime contract', () => {
 
       expect(result.success).toBe(true);
       expect(windowsSpawner.specs[0]).toMatchObject({
-        command: 'C:\\Windows\\System32\\cmd.exe',
-        args: ['/d', '/s', '/c', 'set READY=1 && pnpm install'],
+        invocation: {
+          kind: 'windows-command-line',
+          executable: 'C:\\Windows\\System32\\cmd.exe',
+          rawArguments: '/d /s /c set READY=1 && pnpm install',
+        },
       });
     } finally {
       windowsRuntime.dispose();

--- a/packages/core/src/runtimes/scripts/node/runtime.ts
+++ b/packages/core/src/runtimes/scripts/node/runtime.ts
@@ -479,8 +479,7 @@ function spawnSpec(input: {
   });
   logLocalPtySpawnWarnings('ScriptsRuntime', resolved.warnings, { cwd: input.cwd }, input.logger);
   return {
-    command: resolved.command,
-    args: resolved.args,
+    invocation: resolved.invocation,
     cwd: input.cwd,
     env: input.env,
     cols: input.cols,

--- a/packages/core/src/runtimes/scripts/node/script-test-support.ts
+++ b/packages/core/src/runtimes/scripts/node/script-test-support.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { toChildProcessLaunch } from '#primitives/exec/node';
 import {
   normalizeSignal,
   type PtyExitInfo,
@@ -14,10 +15,12 @@ import {
  */
 export class ChildProcessPtySpawner implements PtySpawner {
   spawn(spec: PtySpawnSpec): PtyProcess {
-    const child = spawn(spec.command, spec.args, {
+    const launch = toChildProcessLaunch(spec.invocation);
+    const child = spawn(launch.executable, launch.args, {
       cwd: spec.cwd,
       env: spec.env,
       stdio: ['ignore', 'pipe', 'pipe'],
+      windowsVerbatimArguments: launch.windowsVerbatimArguments,
     });
     const dataHandlers: Array<(data: string) => void> = [];
     const exitHandlers: Array<(info: PtyExitInfo) => void> = [];

--- a/packages/core/src/runtimes/terminals/node/runtime/runtime.test.ts
+++ b/packages/core/src/runtimes/terminals/node/runtime/runtime.test.ts
@@ -435,8 +435,11 @@ describe('TerminalsRuntime', () => {
     });
 
     expect(shellResolver.resolveCalls).toEqual(['zsh']);
-    expect(spawner.specs[0]!.command).toBe('/opt/homebrew/bin/zsh');
-    expect(spawner.specs[0]!.args).toEqual(['-il']);
+    expect(spawner.specs[0]!.invocation).toEqual({
+      kind: 'argv',
+      executable: '/opt/homebrew/bin/zsh',
+      argv: ['-il'],
+    });
     await scope.dispose();
   });
 

--- a/packages/core/src/runtimes/terminals/node/runtime/runtime.ts
+++ b/packages/core/src/runtimes/terminals/node/runtime/runtime.ts
@@ -343,8 +343,7 @@ export class TerminalsRuntime {
     return await this.registry.create(
       sessionKey,
       {
-        command: resolved.command,
-        args: resolved.args,
+        invocation: resolved.invocation,
         cwd: resolved.cwd,
         env,
         cols: spec.cols ?? DEFAULT_COLS,

--- a/packages/core/src/runtimes/tui-agents/node/runtime/runtime.test.ts
+++ b/packages/core/src/runtimes/tui-agents/node/runtime/runtime.test.ts
@@ -117,8 +117,11 @@ describe('TuiAgentsRuntime', () => {
 
     expect(spawner.specs).toEqual([
       {
-        command: 'agent',
-        args: ['run', 'hello world'],
+        invocation: {
+          kind: 'argv',
+          executable: 'agent',
+          argv: ['run', 'hello world'],
+        },
         cwd: '/workspace',
         env: {
           TERM: 'xterm-256color',
@@ -163,8 +166,11 @@ describe('TuiAgentsRuntime', () => {
     await runtime.startSession(startInput({ cwd: 'C:\\workspace' }));
 
     expect(spawner.specs[0]).toMatchObject({
-      command: 'C:\\Windows\\System32\\cmd.exe',
-      args: ['/d', '/s', '/c', expect.stringContaining(command)],
+      invocation: {
+        kind: 'windows-command-line',
+        executable: 'C:\\Windows\\System32\\cmd.exe',
+        rawArguments: expect.stringContaining(command),
+      },
       cwd: 'C:\\workspace',
     });
   });
@@ -233,11 +239,14 @@ describe('TuiAgentsRuntime', () => {
       })
     );
 
-    expect(spawner.specs[0]!.command).toBe('/bin/bash');
-    expect(spawner.specs[0]!.args[0]).toBe('-lc');
-    expect(spawner.specs[0]!.args[1]).toContain('tmux -u attach-session');
-    expect(spawner.specs[0]!.args[1]).toContain('emdash-test');
-    expect(spawner.specs[0]!.args[1]).toContain("source ~/.profile && agent run 'hello world'");
+    const { invocation } = spawner.specs[0]!;
+    expect(invocation.kind).toBe('argv');
+    if (invocation.kind !== 'argv') throw new Error('Expected argv invocation');
+    expect(invocation.executable).toBe('/bin/bash');
+    expect(invocation.argv[0]).toBe('-lc');
+    expect(invocation.argv[1]).toContain('tmux -u attach-session');
+    expect(invocation.argv[1]).toContain('emdash-test');
+    expect(invocation.argv[1]).toContain("source ~/.profile && agent run 'hello world'");
   });
 
   it('resolves the Windows default shell, applies setup, and removes tmux intent', async () => {
@@ -252,10 +261,16 @@ describe('TuiAgentsRuntime', () => {
     );
 
     expect(spawner.specs[0]).toMatchObject({
-      command: 'C:\\Windows\\System32\\cmd.exe',
-      args: ['/d', '/s', '/c', expect.stringContaining('set READY=1 &&')],
+      invocation: {
+        kind: 'windows-command-line',
+        executable: 'C:\\Windows\\System32\\cmd.exe',
+        rawArguments: expect.stringContaining('/d /s /c set READY=1 &&'),
+      },
     });
-    expect(spawner.specs[0]!.args.join(' ')).not.toContain('tmux');
+    const windowsInvocation = spawner.specs[0]!.invocation;
+    expect(
+      windowsInvocation.kind === 'windows-command-line' ? windowsInvocation.rawArguments : ''
+    ).not.toContain('tmux');
     await runtime.reconcile();
     await runtime.dispose();
     expect(exec.exec).not.toHaveBeenCalled();

--- a/packages/core/src/runtimes/tui-agents/node/runtime/runtime.ts
+++ b/packages/core/src/runtimes/tui-agents/node/runtime/runtime.ts
@@ -523,8 +523,7 @@ export class TuiAgentsRuntime {
       pty = await this.registry.create(
         config.input.conversationId,
         {
-          command: spawnSpec.command,
-          args: spawnSpec.args,
+          invocation: spawnSpec.invocation,
           cwd: config.input.cwd,
           env,
           cols: config.input.cols,
@@ -909,7 +908,7 @@ export class TuiAgentsRuntime {
     command: AgentCommand,
     input: TuiAgentStartInput,
     env: Record<string, string>
-  ): Promise<Pick<PtySpawnSpec, 'command' | 'args'>> {
+  ): Promise<Pick<PtySpawnSpec, 'invocation'>> {
     const platform = this.deps.platform ?? process.platform;
     const shellProfile = await resolveTerminalShell({
       intent: 'system',
@@ -934,7 +933,7 @@ export class TuiAgentsRuntime {
       { conversationId: input.conversationId },
       this.deps.logger
     );
-    return { command: resolved.command, args: resolved.args };
+    return { invocation: resolved.invocation };
   }
 
   private maybeRespawnAfterUnexpectedExit(

--- a/packages/core/src/services/exec/api/bound-exec.test.ts
+++ b/packages/core/src/services/exec/api/bound-exec.test.ts
@@ -106,7 +106,7 @@ describe('BoundExec', () => {
       fileExists: (candidate) => candidate === provider,
     }).exec(['hello world']);
 
-    expect(result.stdout).toContain('/d\n/s\n/c\n');
+    expect(result.stdout).toContain('/d /s /c');
     expect(result.stdout).toContain('provider.cmd');
     expect(result.stdout).toContain('hello world');
   });

--- a/packages/core/src/services/exec/api/bound-exec.ts
+++ b/packages/core/src/services/exec/api/bound-exec.ts
@@ -5,6 +5,7 @@ import type { EnvSource } from '#primitives/exec/api';
 import {
   createChildProcessTreeTerminator,
   planExecutableLaunch,
+  toChildProcessLaunch,
   type FileExists,
 } from '#primitives/exec/node';
 import {
@@ -84,13 +85,14 @@ class ProcessBoundExec implements BoundExec {
       env: composedEnv,
       fileExists: this.fileExists,
     });
-    recordSpawn(classifySpawnPurpose(this.file, args), plan.executable);
-    return spawnProcess(plan.executable, plan.args, {
+    const launch = toChildProcessLaunch(plan.invocation);
+    recordSpawn(classifySpawnPurpose(this.file, args), launch.executable);
+    return spawnProcess(launch.executable, launch.args, {
       cwd: plan.cwd,
       env: composedEnv,
       signal: options.signal,
       stdio: ['pipe', 'pipe', 'pipe'],
-      windowsVerbatimArguments: plan.windowsVerbatimArguments,
+      windowsVerbatimArguments: launch.windowsVerbatimArguments,
     });
   }
 
@@ -114,14 +116,15 @@ class ProcessBoundExec implements BoundExec {
         env: composedEnv,
         fileExists: this.fileExists,
       });
+      const launch = toChildProcessLaunch(plan.invocation);
       const spawnOptions: SpawnOptionsWithoutStdio = {
         cwd: plan.cwd,
         env: composedEnv,
         detached: this.platform !== 'win32',
-        windowsVerbatimArguments: plan.windowsVerbatimArguments,
+        windowsVerbatimArguments: launch.windowsVerbatimArguments,
       };
-      recordSpawn(classifySpawnPurpose(this.file, args), plan.executable);
-      const child = spawnProcess(plan.executable, plan.args, spawnOptions);
+      recordSpawn(classifySpawnPurpose(this.file, args), launch.executable);
+      const child = spawnProcess(launch.executable, launch.args, spawnOptions);
       const terminator = createChildProcessTreeTerminator(child, {
         platform: this.platform,
         processGroup: this.platform !== 'win32',

--- a/packages/core/src/services/exec/api/index.ts
+++ b/packages/core/src/services/exec/api/index.ts
@@ -2,7 +2,6 @@ export { createBoundExec, type CreateBoundExecOptions } from './bound-exec';
 export {
   planExecutableLaunch,
   type ExecutableLaunchDiagnostic,
-  type ExecutableLaunchKind,
   type ExecutableLaunchPlan,
   type ExecutableShellProfile,
   type FileExists,

--- a/packages/core/src/services/exec/api/node-execution-context.test.ts
+++ b/packages/core/src/services/exec/api/node-execution-context.test.ts
@@ -102,7 +102,7 @@ describe('NodeExecutionContext', () => {
       return true;
     });
 
-    expect(buffered.stdout).toContain('/d\n/s\n/c\n');
+    expect(buffered.stdout).toContain('/d /s /c');
     expect(buffered.stdout).toContain('provider.cmd');
     expect(buffered.stdout).toContain('hello world');
     expect(streaming).toEqual({ exitCode: 0 });

--- a/packages/core/src/services/exec/api/node-execution-context.ts
+++ b/packages/core/src/services/exec/api/node-execution-context.ts
@@ -4,6 +4,7 @@ import type { EnvSource } from '#primitives/exec/api';
 import {
   createChildProcessTreeTerminator,
   planExecutableLaunch,
+  toChildProcessLaunch,
   type FileExists,
 } from '#primitives/exec/node';
 import { createBoundExec } from './bound-exec';
@@ -77,6 +78,7 @@ export class NodeExecutionContext implements IExecutionContext {
       env,
       fileExists: this.fileExists,
     });
+    const launch = toChildProcessLaunch(plan.invocation);
     return new Promise((resolve, reject) => {
       const signal = this.signal(opts.signal);
       if (signal.aborted) {
@@ -84,12 +86,12 @@ export class NodeExecutionContext implements IExecutionContext {
         return;
       }
 
-      recordSpawn(classifySpawnPurpose(command, args), plan.executable);
-      const child = spawn(plan.executable, plan.args, {
+      recordSpawn(classifySpawnPurpose(command, args), launch.executable);
+      const child = spawn(launch.executable, launch.args, {
         cwd: plan.cwd,
         detached: this.platform !== 'win32',
         env,
-        windowsVerbatimArguments: plan.windowsVerbatimArguments,
+        windowsVerbatimArguments: launch.windowsVerbatimArguments,
       });
       const terminator = createChildProcessTreeTerminator(child, {
         platform: this.platform,

--- a/packages/core/src/services/pty/api/index.ts
+++ b/packages/core/src/services/pty/api/index.ts
@@ -41,5 +41,4 @@ export {
   TMUX_SESSION_PREFIX,
 } from './tmux';
 export { buildTerminalEnv } from './terminal-env';
-export type { NativeInvocation } from '#primitives/exec/api';
 export type { PtyDimensions, PtyExitInfo, PtyProcess, PtySpawner, PtySpawnSpec } from './types';

--- a/packages/core/src/services/pty/api/index.ts
+++ b/packages/core/src/services/pty/api/index.ts
@@ -41,4 +41,5 @@ export {
   TMUX_SESSION_PREFIX,
 } from './tmux';
 export { buildTerminalEnv } from './terminal-env';
+export type { NativeInvocation } from '#primitives/exec/api';
 export type { PtyDimensions, PtyExitInfo, PtyProcess, PtySpawner, PtySpawnSpec } from './types';

--- a/packages/core/src/services/pty/api/local-spawn.test.ts
+++ b/packages/core/src/services/pty/api/local-spawn.test.ts
@@ -25,8 +25,11 @@ describe('resolveLocalPtySpawn', () => {
         },
       })
     ).toEqual({
-      command: '/opt/provider',
-      args: ['run', 'hello world'],
+      invocation: {
+        kind: 'argv',
+        executable: '/opt/provider',
+        argv: ['run', 'hello world'],
+      },
       cwd: '/workspace',
       warnings: [],
     });
@@ -51,8 +54,11 @@ describe('resolveLocalPtySpawn', () => {
     });
 
     expect(resolved).toMatchObject({
-      command: 'C:\\Windows\\System32\\cmd.exe',
-      args: ['/d', '/s', '/c', expect.stringMatching(/provider\.cmd/i)],
+      invocation: {
+        kind: 'windows-command-line',
+        executable: 'C:\\Windows\\System32\\cmd.exe',
+        rawArguments: expect.stringMatching(/^\/d \/s \/c .*provider\.cmd/i),
+      },
       warnings: [],
     });
   });
@@ -72,8 +78,11 @@ describe('resolveLocalPtySpawn', () => {
     });
 
     expect(resolved).toMatchObject({
-      command: powershellProfile.executable,
-      args: ['-NoLogo', '-ExecutionPolicy', 'Bypass', '-File', script, 'run'],
+      invocation: {
+        kind: 'argv',
+        executable: powershellProfile.executable,
+        argv: ['-NoLogo', '-ExecutionPolicy', 'Bypass', '-File', script, 'run'],
+      },
     });
   });
 
@@ -91,12 +100,15 @@ describe('resolveLocalPtySpawn', () => {
     });
 
     expect(resolved).toEqual({
-      command: powershellProfile.executable,
-      args: [
-        '-NoLogo',
-        '-Command',
-        '$env:COREPACK_HOME = "C:\\Corepack"\nif ($?) {\npnpm install\n}',
-      ],
+      invocation: {
+        kind: 'argv',
+        executable: powershellProfile.executable,
+        argv: [
+          '-NoLogo',
+          '-Command',
+          '$env:COREPACK_HOME = "C:\\Corepack"\nif ($?) {\npnpm install\n}',
+        ],
+      },
       cwd: 'C:\\workspace',
       warnings: [],
     });
@@ -165,7 +177,13 @@ describe('resolveLocalPtySpawn', () => {
       },
     });
 
-    expect(resolved.command).toBe(entry.executable);
-    expect(resolved.args.slice(0, entry.commandArgs.length)).toEqual(entry.commandArgs);
+    expect(resolved.invocation.executable).toBe(entry.executable);
+    if (resolved.invocation.kind === 'windows-command-line') {
+      expect(resolved.invocation.rawArguments).toBe(`${entry.commandArgs.join(' ')} echo ready`);
+    } else {
+      expect(resolved.invocation.argv.slice(0, entry.commandArgs.length)).toEqual(
+        entry.commandArgs
+      );
+    }
   });
 });

--- a/packages/core/src/services/pty/api/local-spawn.ts
+++ b/packages/core/src/services/pty/api/local-spawn.ts
@@ -1,5 +1,5 @@
 import { getWindowsEnvValue } from '#primitives/agent-env/api';
-import { formatCommandLine, quoteArg } from '#primitives/exec/api';
+import { formatCommandLine, quoteArg, type NativeInvocation } from '#primitives/exec/api';
 import { planExecutableLaunch, type FileExists } from '#primitives/exec/node';
 import { buildTmuxShellLine } from './tmux';
 
@@ -41,11 +41,26 @@ export type PtySpawnIntent =
 export type LocalPtySpawnWarning = 'tmux_unsupported_on_windows';
 
 export type ResolvedLocalPtySpawn = {
-  command: string;
-  args: string[];
+  invocation: NativeInvocation;
   cwd: string;
   warnings: LocalPtySpawnWarning[];
 };
+
+function argvInvocation(executable: string, argv: readonly string[]): NativeInvocation {
+  return { kind: 'argv', executable, argv: [...argv] };
+}
+
+function windowsCommandLineInvocation(
+  executable: string,
+  argumentPrefix: readonly string[],
+  commandLine: string
+): NativeInvocation {
+  return {
+    kind: 'windows-command-line',
+    executable,
+    rawArguments: [...argumentPrefix, wrapCmdExeCommandLine(commandLine)].join(' '),
+  };
+}
 
 function getPosixShell(env: NodeJS.ProcessEnv): string {
   return env.SHELL || '/bin/sh';
@@ -121,11 +136,10 @@ function windowsShellLineSpawn({
   const shell = shellProfile?.executable ?? getWindowsShell(env);
   const commandArgs = shellProfile?.commandArgs ?? ['/d', '/s', '/c'];
   return {
-    command: shell,
-    args:
+    invocation:
       shellProfile?.family === 'powershell' || shellProfile?.family === 'wsl'
-        ? [...commandArgs, commandLine]
-        : [...commandArgs, wrapCmdExeCommandLine(commandLine)],
+        ? argvInvocation(shell, [...commandArgs, commandLine])
+        : windowsCommandLineInvocation(shell, commandArgs, commandLine),
     cwd,
     warnings,
   };
@@ -144,16 +158,14 @@ function resolveWindowsSpawn(
       const family = intent.shellProfile?.family ?? 'windows-cmd';
       if (family === 'windows-cmd') {
         return {
-          command: shell,
-          args: ['/d', '/s', '/k', wrapCmdExeCommandLine(intent.shellSetup)],
+          invocation: windowsCommandLineInvocation(shell, ['/d', '/s', '/k'], intent.shellSetup),
           cwd: intent.cwd,
           warnings,
         };
       }
       if (family === 'powershell') {
         return {
-          command: shell,
-          args: ['-NoExit', '-Command', intent.shellSetup],
+          invocation: argvInvocation(shell, ['-NoExit', '-Command', intent.shellSetup]),
           cwd: intent.cwd,
           warnings,
         };
@@ -172,8 +184,7 @@ function resolveWindowsSpawn(
       });
     }
     return {
-      command: shell,
-      args: intent.shellProfile?.interactiveArgs ?? [],
+      invocation: argvInvocation(shell, intent.shellProfile?.interactiveArgs ?? []),
       cwd: intent.cwd,
       warnings,
     };
@@ -224,7 +235,7 @@ function resolveWindowsSpawn(
     shellProfile: intent.shellProfile,
     fileExists,
   });
-  return { command: plan.executable, args: plan.args, cwd: intent.cwd, warnings };
+  return { invocation: plan.invocation, cwd: intent.cwd, warnings };
 }
 
 function resolvePosixSpawn(
@@ -243,11 +254,10 @@ function resolvePosixSpawn(
         ? `${intent.shellSetup} && exec ${quoteArg(shell, 'posix')} ${interactiveArgs.join(' ')}`
         : `exec ${quoteArg(shell, 'posix')} ${interactiveArgs.join(' ')}`;
       return {
-        command: shell,
-        args: [
+        invocation: argvInvocation(shell, [
           ...(intent.shellSetup ? setupWrapperArgs : commandArgs),
           buildTmuxShellLine(intent.tmuxSessionName, commandLine),
-        ],
+        ]),
         cwd: intent.cwd,
         warnings: [],
       };
@@ -255,17 +265,20 @@ function resolvePosixSpawn(
 
     if (intent.shellSetup) {
       return {
-        command: shell,
-        args: [
+        invocation: argvInvocation(shell, [
           ...setupWrapperArgs,
           `${intent.shellSetup} && exec ${quoteArg(shell, 'posix')} ${interactiveArgs.join(' ')}`,
-        ],
+        ]),
         cwd: intent.cwd,
         warnings: [],
       };
     }
 
-    return { command: shell, args: interactiveArgs, cwd: intent.cwd, warnings: [] };
+    return {
+      invocation: argvInvocation(shell, interactiveArgs),
+      cwd: intent.cwd,
+      warnings: [],
+    };
   }
 
   if (
@@ -286,7 +299,7 @@ function resolvePosixSpawn(
       cwd: intent.cwd,
       env,
     });
-    return { command: plan.executable, args: plan.args, cwd: intent.cwd, warnings: [] };
+    return { invocation: plan.invocation, cwd: intent.cwd, warnings: [] };
   }
 
   const commandLine =
@@ -299,16 +312,17 @@ function resolvePosixSpawn(
 
   if (intent.tmuxSessionName) {
     return {
-      command: shell,
-      args: [...commandArgs, buildTmuxShellLine(intent.tmuxSessionName, fullCommandLine)],
+      invocation: argvInvocation(shell, [
+        ...commandArgs,
+        buildTmuxShellLine(intent.tmuxSessionName, fullCommandLine),
+      ]),
       cwd: intent.cwd,
       warnings: [],
     };
   }
 
   return {
-    command: shell,
-    args: [...commandArgs, fullCommandLine],
+    invocation: argvInvocation(shell, [...commandArgs, fullCommandLine]),
     cwd: intent.cwd,
     warnings: [],
   };

--- a/packages/core/src/services/pty/api/node/node-pty-spawner.test.ts
+++ b/packages/core/src/services/pty/api/node/node-pty-spawner.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { resolveLocalPtySpawn } from '#services/pty/api';
 import { NodePtySpawner } from './node-pty-spawner';
 
 const { spawnMock } = vi.hoisted(() => ({
@@ -22,8 +23,7 @@ describe('NodePtySpawner', () => {
     spawnMock.mockReturnValue(proc);
 
     const spawned = await new NodePtySpawner().spawn({
-      command: 'agent',
-      args: ['--login'],
+      invocation: { kind: 'argv', executable: 'agent', argv: ['--login'] },
       cwd: '/tmp',
       env: { PATH: '/usr/bin' },
       cols: 80,
@@ -41,6 +41,51 @@ describe('NodePtySpawner', () => {
     spawned.resize(100, 30);
     expect(proc.write).toHaveBeenCalledWith('input');
     expect(proc.resize).toHaveBeenCalledWith(100, 30);
+  });
+
+  it('passes a preformatted Windows command line to node-pty without argv serialization', async () => {
+    const proc = {
+      pid: 123,
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      onData: vi.fn(),
+      onExit: vi.fn(),
+    };
+    spawnMock.mockReturnValue(proc);
+    const shim = 'C:\\Program Files\\npm\\pi.cmd';
+    const resolved = resolveLocalPtySpawn({
+      platform: 'win32',
+      env: {
+        PATH: 'C:\\Program Files\\npm',
+        PATHEXT: '.EXE;.cmd',
+        ComSpec: 'C:\\Windows\\System32\\cmd.exe',
+      },
+      intent: {
+        kind: 'run-command',
+        cwd: 'C:\\workspace',
+        command: {
+          kind: 'argv',
+          command: 'pi',
+          args: ['hello world', 'embedded"quote'],
+        },
+      },
+      fileExists: (candidate) => candidate.toLowerCase() === shim.toLowerCase(),
+    });
+
+    await new NodePtySpawner({ platform: 'win32' }).spawn({
+      invocation: resolved.invocation,
+      cwd: 'C:\\workspace',
+      env: { PATH: 'C:\\Windows\\System32' },
+      cols: 80,
+      rows: 24,
+    });
+
+    expect(spawnMock).toHaveBeenLastCalledWith(
+      'C:\\Windows\\System32\\cmd.exe',
+      '/d /s /c ""C:\\Program Files\\npm\\pi.cmd" "hello world" "embedded^"quote""',
+      expect.objectContaining({ cwd: 'C:\\workspace' })
+    );
   });
 
   it('terminates Windows PTY descendants with taskkill tree semantics', async () => {
@@ -62,8 +107,7 @@ describe('NodePtySpawner', () => {
       exitHandler?.({ exitCode: null, signal: 'SIGTERM' });
     });
     const spawned = await new NodePtySpawner({ platform: 'win32', taskkill }).spawn({
-      command: 'agent.cmd',
-      args: [],
+      invocation: { kind: 'argv', executable: 'agent.cmd', argv: [] },
       cwd: 'C:\\workspace',
       env: { PATH: 'C:\\Windows\\System32' },
       cols: 80,

--- a/packages/core/src/services/pty/api/node/node-pty-spawner.ts
+++ b/packages/core/src/services/pty/api/node/node-pty-spawner.ts
@@ -35,8 +35,10 @@ export class NodePtySpawner implements PtySpawner {
 
   async spawn(spec: PtySpawnSpec): Promise<PtyProcess> {
     try {
-      recordSpawn('pty', spec.command);
-      const proc = nodePty.spawn(spec.command, spec.args, {
+      const { invocation } = spec;
+      recordSpawn('pty', invocation.executable);
+      const args = invocation.kind === 'argv' ? [...invocation.argv] : invocation.rawArguments;
+      const proc = nodePty.spawn(invocation.executable, args, {
         name: 'xterm-256color',
         cols: spec.cols,
         rows: spec.rows,

--- a/packages/core/src/services/pty/api/pty-registry.test.ts
+++ b/packages/core/src/services/pty/api/pty-registry.test.ts
@@ -4,8 +4,7 @@ import { PtyRegistry } from './pty-registry';
 import type { PtySpawnSpec } from './types';
 
 const spec: PtySpawnSpec = {
-  command: 'claude',
-  args: ['auth', 'login'],
+  invocation: { kind: 'argv', executable: 'claude', argv: ['auth', 'login'] },
   cwd: '/tmp',
   env: { PATH: '/bin' },
   cols: 120,
@@ -57,10 +56,17 @@ describe('PtyRegistry', () => {
     const registry = new PtyRegistry(spawner);
 
     await registry.create('auth:claude', spec);
-    await registry.create('auth:claude', { ...spec, args: [] });
+    await registry.create('auth:claude', {
+      ...spec,
+      invocation: { kind: 'argv', executable: 'claude', argv: [] },
+    });
 
     expect(spawner.processes[0]!.killCount).toBeGreaterThan(0);
     expect(spawner.processes).toHaveLength(2);
-    expect(registry.get('auth:claude')?.spec.args).toEqual([]);
+    expect(registry.get('auth:claude')?.spec.invocation).toEqual({
+      kind: 'argv',
+      executable: 'claude',
+      argv: [],
+    });
   });
 });

--- a/packages/core/src/services/pty/api/types.ts
+++ b/packages/core/src/services/pty/api/types.ts
@@ -1,3 +1,4 @@
+import type { NativeInvocation } from '#primitives/exec/api';
 import type { PtySignal } from './exit-signals';
 
 export interface PtyDimensions {
@@ -20,8 +21,7 @@ export interface PtyProcess {
 }
 
 export interface PtySpawnSpec extends PtyDimensions {
-  command: string;
-  args: string[];
+  invocation: NativeInvocation;
   cwd: string;
   env: Record<string, string>;
 }


### PR DESCRIPTION
- carries typed native invocations through executable planning and pty spawning
- sends preformatted .cmd and .bat argument strings directly to node-pty to prevent double escaping
- derives child-process verbatim behavior at the adapter boundary and updates pty consumers