### PR TITLE
fix(exec): prefer PATHEXT shims over extensionless files on Windows

### DIFF
--- a/packages/core/src/primitives/exec/node/executable-launch.test.ts
+++ b/packages/core/src/primitives/exec/node/executable-launch.test.ts
@@ -60,6 +60,45 @@ describe('planExecutableLaunch', () => {
     });
   });
 
+  it('prefers the cmd shim over an extensionless sibling for a resolved npm bin path', () => {
+    const bare = 'C:\\Users\\dev\\AppData\\Roaming\\npm\\pi';
+    const shim = 'C:\\Users\\dev\\AppData\\Roaming\\npm\\pi.CMD';
+    const plan = planExecutableLaunch({
+      platform: 'win32',
+      command: bare,
+      args: ['--session', 'abc'],
+      cwd: 'C:\\work',
+      env: { PATHEXT: '.COM;.EXE;.BAT;.CMD', ComSpec: 'C:\\Windows\\System32\\cmd.exe' },
+      fileExists: (candidate) => candidate === bare || candidate === shim,
+    });
+
+    expect(plan).toMatchObject({
+      invocation: {
+        kind: 'windows-command-line',
+        executable: 'C:\\Windows\\System32\\cmd.exe',
+        rawArguments: expect.stringContaining(shim),
+      },
+      diagnostics: [],
+    });
+  });
+
+  it('falls back to a bare extensionless file when no PATHEXT sibling exists', () => {
+    const bare = 'C:\\Tools\\provider';
+    const plan = planExecutableLaunch({
+      platform: 'win32',
+      command: bare,
+      args: ['run'],
+      cwd: 'C:\\work',
+      env: { PATHEXT: '.COM;.EXE;.BAT;.CMD' },
+      fileExists: (candidate) => candidate === bare,
+    });
+
+    expect(plan).toMatchObject({
+      invocation: { kind: 'argv', executable: bare, argv: ['run'] },
+      diagnostics: [],
+    });
+  });
+
   it('searches PATH for commands that already have an extension', () => {
     const provider = 'C:\\Tools With Spaces\\provider.cmd';
     const plan = planExecutableLaunch({

--- a/packages/core/src/primitives/exec/node/executable-launch.ts
+++ b/packages/core/src/primitives/exec/node/executable-launch.ts
@@ -139,8 +139,10 @@ function resolveWindowsExecutable(
         path.win32.join(resolutionCwd, command),
         ...windowsPathDirs(env).map((dir) => path.win32.join(dir, command)),
       ];
+  // PATHEXT extensions come first: npm shim dirs hold an extensionless POSIX
+  // script next to the .cmd, and Windows cannot execute the bare file.
   const hasExtension = path.win32.extname(command).length > 0;
-  const extensions = hasExtension ? [''] : ['', ...windowsPathExtensions(env)];
+  const extensions = hasExtension ? [''] : [...windowsPathExtensions(env), ''];
 
   for (const base of pathCandidates) {
     for (const extension of extensions) {

--- a/packages/core/src/primitives/exec/node/executable-launch.ts
+++ b/packages/core/src/primitives/exec/node/executable-launch.ts
@@ -139,8 +139,6 @@ function resolveWindowsExecutable(
         path.win32.join(resolutionCwd, command),
         ...windowsPathDirs(env).map((dir) => path.win32.join(dir, command)),
       ];
-  // PATHEXT extensions come first: npm shim dirs hold an extensionless POSIX
-  // script next to the .cmd, and Windows cannot execute the bare file.
   const hasExtension = path.win32.extname(command).length > 0;
   const extensions = hasExtension ? [''] : [...windowsPathExtensions(env), ''];
 


### PR DESCRIPTION
Fixes #3066.

npm bin directories on Windows ship an extensionless POSIX script next to the `.cmd` shim, and executable resolution picked the bare file first, so npm-installed providers like Pi failed to spawn ("Failed to create conversation"). Try PATHEXT extensions before the bare file so the `.cmd` shim wins, keeping the extensionless file as a last resort.

Checks: `@emdash/core` test, typecheck, lint, format. Not verified on a Windows machine.