### PR TITLE
perf(workspace-registry): coalesce scans and publish record diffs

### DIFF
--- a/packages/core/src/runtimes/workspace-registry/node/api/contract.test.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/api/contract.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { createScope } from '@emdash/shared/concurrency';
 import { ManualClock } from '@emdash/shared/testing';
+import type { LiveUpdate } from '@emdash/wire/rpc';
 import { pin, remote, snapshot } from '@emdash/wire/state';
 import { createTestWire, type TestWire } from '@emdash/wire/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -149,6 +150,34 @@ describe('workspace registry contract', () => {
 
     const records = await listRecords();
     expect(Object.keys(records)).toEqual(['ws-repo']);
+  });
+
+  it('publishes record changes as structural patches instead of whole-map replacements', async () => {
+    const directoryPath = path.join(root, 'diff-published-directory');
+    await fs.mkdir(directoryPath);
+    const lease = runtime.recordsHost.acquireState(undefined, 'list');
+    const source = await lease.ready();
+    const updates: LiveUpdate[] = [];
+    const unsubscribe = await source.subscribe((update) => updates.push(update));
+
+    try {
+      await wire.client.createWorkspace({ workspaceId: 'ws-diff', path: directoryPath });
+
+      expect(updates).toHaveLength(1);
+      expect(updates[0]).toMatchObject({
+        delta: [expect.objectContaining({ op: 'add', path: ['ws-diff'] })],
+      });
+      expect(
+        updates.every(
+          (update) =>
+            Array.isArray(update.delta) &&
+            !update.delta.some((patch) => Array.isArray(patch.path) && patch.path.length === 0)
+        )
+      ).toBe(true);
+    } finally {
+      unsubscribe();
+      await lease.release();
+    }
   });
 
   it('createWorkspace detects a plain directory (including subdirectories of a repo)', async () => {
@@ -1215,7 +1244,7 @@ describe('workspace registry contract', () => {
       pollIntervalMs: 60 * 60_000,
     });
     runtime.setOnRecordsChanged(() => scheduler.syncWatches());
-    scheduler.start();
+    await scheduler.start();
     try {
       await fs.writeFile(path.join(repoPath, 'untracked.txt'), 'a\nb\n');
       await eventually(async () => {

--- a/packages/core/src/runtimes/workspace-registry/node/component.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/component.ts
@@ -104,7 +104,12 @@ export const workspaceRegistryComponent = defineWireComponent({
     runtime.setOnRecordsChanged(() => scheduler.syncWatches());
     // Self-suppression: background steps mute their own watch events while writing.
     runtime.setScanMuter((id) => scheduler.mute(id));
-    scheduler.start();
+    void scheduler
+      .start()
+      .then(() => (scope.disposed ? undefined : runtime.scanHost()))
+      .catch((error) => {
+        logger.warn?.(`initial workspace registry scan failed: ${String(error)}`);
+      });
     scope.add(() => scheduler.dispose());
 
     // The autonomous ref-follow loop (spec: pr-workspace-model staleness): slow,
@@ -115,11 +120,6 @@ export const workspaceRegistryComponent = defineWireComponent({
     });
     refFollow.start();
     scope.add(() => refFollow.dispose());
-
-    // Boot reconciliation: catch up with whatever changed while the daemon was down.
-    void runtime.scanHost().catch((error) => {
-      logger.warn?.(`initial workspace registry scan failed: ${String(error)}`);
-    });
 
     return instance({
       scope,

--- a/packages/core/src/runtimes/workspace-registry/node/runtime.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/runtime.ts
@@ -364,9 +364,11 @@ export class WorkspaceRegistryRuntime {
       }
     }
     this.recordsCell = cell<WorkspaceRecords>(initial, { name: 'workspace-records' });
-    this.recordsHost = expose(workspaceRegistryContract.records, {
-      list: () => this.recordsCell,
-    });
+    this.recordsHost = expose(
+      workspaceRegistryContract.records,
+      { list: () => this.recordsCell },
+      { publish: { list: 'diff' } }
+    );
     this.bootConfigHydration = Promise.resolve().then(() => this.hydrateBootConfigs());
     this.projectConfigs = family(
       (key, scope) =>

--- a/packages/core/src/runtimes/workspace-registry/node/scan/scanner.test.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/scan/scanner.test.ts
@@ -92,6 +92,26 @@ describe('RegistryScanner', () => {
     expect(log.events).toEqual([`config:${target.id}`, `observation:${target.id}`]);
   });
 
+  it('observes surviving worktrees when a repository request finds their parent missing', async () => {
+    const repository = record({
+      id: 'repo-missing',
+      kind: 'repository',
+      path: path.join(root, 'missing-repository'),
+    });
+    const worktree = await standaloneRecord('wt-survives');
+    worktree.parentId = repository.id;
+    const { landing, log } = fakeLanding([repository, worktree]);
+    const scanner = new RegistryScanner(landing, {
+      git: createRegistryGitContext(),
+      observe: { full: async () => null, refs: async () => null },
+    });
+
+    await scanner.executeScanRequest({ kind: 'repository', id: repository.id });
+
+    expect(log.vanished).toEqual([repository.id]);
+    expect(log.events).toEqual([`config:${worktree.id}`, `observation:${worktree.id}`]);
+  });
+
   it('serializes scans on one lane — the second observation starts after the first lands', async () => {
     const first = await standaloneRecord('ws-first');
     const second = await standaloneRecord('ws-second');

--- a/packages/core/src/runtimes/workspace-registry/node/scan/scanner.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/scan/scanner.ts
@@ -116,7 +116,7 @@ export class RegistryScanner {
       const record = this.landing.get(request.id);
       if (!record) return;
       if (request.kind === 'repository') {
-        await this.scanRepository(record, this.landing.list());
+        await this.scanRepositoryGroup(record);
         return;
       }
       if (request.mode === 'refs') {
@@ -192,18 +192,29 @@ export class RegistryScanner {
 
   private async scanRecordPass(record: DurableWorkspaceRecord): Promise<void> {
     if (record.kind === 'repository') {
-      await this.scanRepository(record, this.landing.list());
+      await this.scanRepositoryGroup(record);
       return;
     }
     if (record.kind === 'worktree' && record.parentId !== null) {
       const parent = this.landing.get(record.parentId);
       if (parent && (await isDirectory(parent.path))) {
         // Reconcile through the owning repository so relinks and locked/prunable land.
-        await this.scanRepository(parent, this.landing.list());
+        await this.scanRepositoryGroup(parent);
         return;
       }
     }
     await this.scanStandalone(record);
+  }
+
+  private async scanRepositoryGroup(repository: DurableWorkspaceRecord): Promise<void> {
+    const records = this.landing.list();
+    const settled = await this.scanRepository(repository, records);
+    for (const child of records) {
+      if (child.kind !== 'worktree' || child.parentId !== repository.id || settled.has(child.id)) {
+        continue;
+      }
+      await this.scanStandalone(child);
+    }
   }
 
   /**

--- a/packages/core/src/runtimes/workspace-registry/node/scan/scheduler.test.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/scan/scheduler.test.ts
@@ -153,11 +153,45 @@ function createHarness(
     activeDebounceMs: options.activeDebounceMs ?? 5,
     pollIntervalMs: options.pollIntervalMs ?? 60 * 60_000,
   });
-  scheduler.start();
+  void scheduler.start();
   return { watcher, requests, scheduler };
 }
 
 describe('WorkspaceScanScheduler', () => {
+  it('reports initial readiness only after every startup watch has settled', async () => {
+    const repo = repoTarget('repo-1', '/repos/main');
+    const watcher = new FakeWatchService();
+    const requests: ScanRequest[] = [];
+    const scheduler = new WorkspaceScanScheduler({
+      watcher,
+      execute: async (request) => {
+        requests.push(request);
+      },
+      listTargets: () => [repo],
+      isActive: () => false,
+      pollIntervalMs: 60 * 60_000,
+    });
+
+    try {
+      const ready = scheduler.start();
+      let settled = false;
+      void ready.then(() => {
+        settled = true;
+      });
+
+      watcher.resolveReady('/repos/main');
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(settled).toBe(false);
+
+      watcher.resolveReady(path.join('/repos/main', '.git'));
+      await ready;
+      expect(settled).toBe(true);
+      expect(requests).toEqual([]);
+    } finally {
+      await scheduler.dispose();
+    }
+  });
+
   it('rescans a target when its watcher becomes ready', async () => {
     const directory: ScanTarget = {
       id: 'dir-1',
@@ -168,13 +202,72 @@ describe('WorkspaceScanScheduler', () => {
       observedStatus: 'present',
       lastObservedAt: 0,
     };
-    const { watcher, requests, scheduler } = createHarness([directory], { debounceMs: 1 });
+    const targets: ScanTarget[] = [];
+    const { watcher, requests, scheduler } = createHarness(targets, { debounceMs: 1 });
     try {
+      targets.push(directory);
+      scheduler.syncWatches();
       expect(requests).toHaveLength(0);
       watcher.resolveReady('/plain');
 
       await eventually(() => {
         expect(requests).toEqual([{ kind: 'workspace', id: 'dir-1', mode: 'full' }]);
+      });
+    } finally {
+      await scheduler.dispose();
+    }
+  });
+
+  it('coalesces repository and worktree watcher readiness into one repository scan', async () => {
+    const repo = repoTarget('repo-1', '/repos/main');
+    const wtA = worktreeTarget('wt-a', '/worktrees/a', repo.id);
+    const wtB = worktreeTarget('wt-b', '/worktrees/b', repo.id);
+    const targets: ScanTarget[] = [];
+    const { watcher, requests, scheduler } = createHarness(targets, { debounceMs: 5 });
+    try {
+      targets.push(repo, wtA, wtB);
+      scheduler.syncWatches();
+      watcher.resolveReady('/repos/main');
+      watcher.resolveReady(path.join('/repos/main', '.git'));
+      watcher.resolveReady('/worktrees/a');
+      watcher.resolveReady('/worktrees/b');
+
+      await eventually(() => {
+        expect(requests).toEqual([{ kind: 'repository', id: repo.id }]);
+      });
+    } finally {
+      await scheduler.dispose();
+    }
+  });
+
+  it('falls back to a standalone scan when a watched worktree loses its parent record', async () => {
+    const repo = repoTarget('repo-1', '/repos/main');
+    const worktree = worktreeTarget('wt-1', '/worktrees/wt', repo.id);
+    const targets = [repo, worktree];
+    const { watcher, requests, scheduler } = createHarness(targets, { debounceMs: 5 });
+    try {
+      targets.splice(0, 1);
+      scheduler.syncWatches();
+      watcher.emit(worktree.path, [{ kind: 'update', path: path.join(worktree.path, 'file.txt') }]);
+
+      await eventually(() => {
+        expect(requests).toEqual([{ kind: 'workspace', id: worktree.id, mode: 'full' }]);
+      });
+    } finally {
+      await scheduler.dispose();
+    }
+  });
+
+  it('falls back to a standalone scan when a worktree parent is missing', async () => {
+    const repo = repoTarget('repo-1', '/repos/main');
+    repo.observedStatus = 'missing';
+    const worktree = worktreeTarget('wt-1', '/worktrees/wt', repo.id);
+    const { watcher, requests, scheduler } = createHarness([repo, worktree], { debounceMs: 5 });
+    try {
+      watcher.emit(worktree.path, [{ kind: 'update', path: path.join(worktree.path, 'file.txt') }]);
+
+      await eventually(() => {
+        expect(requests).toEqual([{ kind: 'workspace', id: worktree.id, mode: 'full' }]);
       });
     } finally {
       await scheduler.dispose();
@@ -324,6 +417,29 @@ describe('WorkspaceScanScheduler', () => {
         expect(requests).toContainEqual({ kind: 'workspace', id: 'dir-1', mode: 'full' });
       });
     } finally {
+      await scheduler.dispose();
+    }
+  });
+
+  it('polls a stale repository and all of its worktrees as one repository scan', async () => {
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const repo = repoTarget('repo-1', '/repos/main');
+    const wtA = worktreeTarget('wt-a', '/worktrees/a', repo.id);
+    const wtB = worktreeTarget('wt-b', '/worktrees/b', repo.id);
+    const { requests, scheduler } = createHarness([repo, wtA, wtB], {
+      debounceMs: 1,
+      pollIntervalMs: 25,
+      block: () => gate,
+    });
+    try {
+      await eventually(() => {
+        expect(requests).toEqual([{ kind: 'repository', id: repo.id }]);
+      });
+    } finally {
+      release();
       await scheduler.dispose();
     }
   });

--- a/packages/core/src/runtimes/workspace-registry/node/scan/scheduler.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/scan/scheduler.ts
@@ -75,6 +75,7 @@ export class WorkspaceScanScheduler {
   private readonly muted = new Map<string, number>();
   private readonly inFlight = new Map<string, Promise<void>>();
   private readonly rerunAfterFlight = new Map<string, ScanRequest>();
+  private targetsById = new Map<string, ScanTarget>();
   private pollTimer: ReturnType<typeof setInterval> | null = null;
   private disposed = false;
 
@@ -90,17 +91,26 @@ export class WorkspaceScanScheduler {
     this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
   }
 
-  start(): void {
-    this.syncWatches();
+  start(): Promise<void> {
+    const ready = this.reconcileWatches(false);
     this.pollTimer = setInterval(() => this.pollFloor(), this.pollIntervalMs);
     this.pollTimer.unref?.();
+    return ready;
   }
 
   /** Called by the runtime after every records change: reconciles watches with targets. */
   syncWatches(): void {
-    if (this.disposed || this.watcher === null) return;
+    void this.reconcileWatches(true);
+  }
+
+  private reconcileWatches(reconcileOnReady: boolean): Promise<void> {
+    if (this.disposed) return Promise.resolve();
+    const targets = this.listTargets();
+    this.targetsById = new Map(targets.map((target) => [target.id, target]));
+    if (this.watcher === null) return Promise.resolve();
     const desired = new Map<string, { target: ScanTarget; gitDir: boolean }>();
-    for (const target of this.listTargets()) {
+    const readiness: Promise<void>[] = [];
+    for (const target of targets) {
       if (target.observedStatus !== 'present') continue;
       desired.set(workingTreeWatchKey(target.path), { target, gitDir: false });
       if (target.kind === 'repository') {
@@ -133,29 +143,26 @@ export class WorkspaceScanScheduler {
               onResync: () => this.request({ kind: 'repository', id: target.id }),
             }
           )
-        : this.watcher.watch(
-            target.path,
-            () => this.request({ kind: 'workspace', id: target.id, mode: 'full' }),
-            {
-              ignore: ['.git/**'],
-              onError,
-              onResync: () => this.request({ kind: 'workspace', id: target.id, mode: 'full' }),
-            }
-          );
+        : this.watcher.watch(target.path, () => this.requestFullScan(target.id), {
+            ignore: ['.git/**'],
+            onError,
+            onResync: () => this.requestFullScan(target.id),
+          });
       handleRef.current = handle;
       this.watches.set(key, handle);
-      void handle.ready().then((attached) => {
+      const ready = handle.ready().then((attached) => {
         if (!attached.success || this.disposed || this.watches.get(key) !== handle) return;
+        if (!reconcileOnReady) return;
 
         // Changes can land after the last scan but before the asynchronous watcher attaches.
-        // Reconcile once at readiness so that startup gap cannot leave observations stale.
-        this.request(
-          gitDir
-            ? { kind: 'repository', id: target.id }
-            : { kind: 'workspace', id: target.id, mode: 'full' }
-        );
+        // Dynamic watches reconcile once at readiness so their attach gap cannot leave
+        // observations stale. Startup instead waits for all watches, then scans the host once.
+        if (gitDir) this.request({ kind: 'repository', id: target.id });
+        else this.requestFullScan(target.id);
       });
+      readiness.push(ready);
     }
+    return Promise.all(readiness).then(() => undefined);
   }
 
   /**
@@ -294,6 +301,13 @@ export class WorkspaceScanScheduler {
     this.pending.set(key, { request, timer });
   }
 
+  private requestFullScan(targetId: string): void {
+    const target = this.targetsById.get(targetId);
+    if (!target) return;
+    if (this.muted.has(target.id)) return;
+    this.request(fullScanRequest(target, this.targetsById));
+  }
+
   private fire(key: string): void {
     const pending = this.pending.get(key);
     if (!pending || this.disposed) return;
@@ -316,15 +330,25 @@ export class WorkspaceScanScheduler {
   private pollFloor(): void {
     this.syncWatches();
     const cutoff = this.clock.now() - this.pollIntervalMs;
-    for (const target of this.listTargets()) {
+    for (const target of this.targetsById.values()) {
       if (target.lastObservedAt > cutoff) continue;
-      this.request(
-        target.kind === 'repository'
-          ? { kind: 'repository', id: target.id }
-          : { kind: 'workspace', id: target.id, mode: 'full' }
-      );
+      if (target.kind === 'repository') this.request({ kind: 'repository', id: target.id });
+      else this.requestFullScan(target.id);
     }
   }
+}
+
+function fullScanRequest(
+  target: ScanTarget,
+  targetsById: ReadonlyMap<string, ScanTarget>
+): ScanRequest {
+  if (target.kind === 'worktree' && target.parentId !== null) {
+    const parent = targetsById.get(target.parentId);
+    if (parent?.kind === 'repository' && parent.observedStatus === 'present') {
+      return { kind: 'repository', id: parent.id };
+    }
+  }
+  return { kind: 'workspace', id: target.id, mode: 'full' };
 }
 
 /** Full scans subsume ref scans; repository reconciliation subsumes both. */


### PR DESCRIPTION
- coalesces repository and worktree scan requests by physical repository to prevent duplicate git observation work
- waits for startup watchers before running one host reconciliation and preserves standalone fallback for missing parents
- publishes workspace record changes as structural wire diffs instead of replacing the full record map
- reduces large-registry startup traffic from over 100 mb to about 41 kb and reaches a quiet state in roughly 20–25 seconds