### PR TITLE
fix(workbench): keep left sidebar width across tasks

### DIFF
--- a/agents/conventions/renderer-patterns.md
+++ b/agents/conventions/renderer-patterns.md
@@ -102,7 +102,9 @@ Workbench layout follows a strict ownership model (see
 - **Pixel sizes belong to react-resizable-panels alone**, persisted via
   `useResizableDefaultLayout` with a memento-backed `LayoutStorage` facade
   (`createLayoutStorage` in `src/core/primitives/mementos/browser/`). Sizes are never
-  MobX observables and never persisted to localStorage.
+  MobX observables and never persisted to localStorage. The workspace outer layout is
+  app-scoped because it belongs to the workbench shell; task-internal panel layouts are
+  task-scoped.
 - **Persisted view state renders below a hydration gate.** The task view gates on
   `space.isHydrated`; the storage facade dev-asserts on reads before hydration.
 

--- a/apps/emdash-desktop/src/core/features/projects/api/browser/stores/project-context.ts
+++ b/apps/emdash-desktop/src/core/features/projects/api/browser/stores/project-context.ts
@@ -5,7 +5,6 @@ import type {
   ProjectRecoveryRequestError,
 } from '@core/features/projects/api';
 import { projectAttachmentIssueRecovery } from '@core/features/projects/api/browser/project-attachment-recovery';
-import type { createLayoutStorage, MementoLayoutStorage } from '@core/primitives/mementos/browser';
 import type { Project } from '@core/primitives/projects/api';
 import type { ScopedStoreToken, ScopedStoreValue } from '@core/primitives/scoped-stores/browser';
 import type { HostAvailabilityState } from '@core/services/hosts/api';
@@ -62,9 +61,6 @@ export interface ProjectContext {
   readonly project: Project;
   readonly host: ProjectHostAccess;
   get<Token extends ScopedStoreToken<unknown>>(token: Token): ScopedStoreValue<Token>;
-  createLayoutStorage(
-    definition: Parameters<typeof createLayoutStorage<'project'>>[1]
-  ): MementoLayoutStorage;
   dispose(): Promise<void>;
 }
 

--- a/apps/emdash-desktop/src/core/features/projects/browser/stores/project-context.ts
+++ b/apps/emdash-desktop/src/core/features/projects/browser/stores/project-context.ts
@@ -23,11 +23,7 @@ import type {
 } from '@core/features/projects/api/host-observation';
 import type { ProjectScopedStoreContext } from '@core/features/projects/contributions/project-stores';
 import { projectSubject } from '@core/features/projects/contributions/subject';
-import {
-  createLayoutStorage,
-  getMementoClient,
-  type SubjectSpace,
-} from '@core/primitives/mementos/browser';
+import { getMementoClient, type SubjectSpace } from '@core/primitives/mementos/browser';
 import { projectHostRef, projectSchema, type Project } from '@core/primitives/projects/api';
 import {
   ScopedStoreHost,
@@ -157,12 +153,6 @@ export class ProjectContext implements ProjectContextApi {
 
   get<Token extends ScopedStoreToken<unknown>>(token: Token): ScopedStoreValue<Token> {
     return this.stores.get(token);
-  }
-
-  createLayoutStorage(
-    definition: Parameters<typeof createLayoutStorage<'project'>>[1]
-  ): ReturnType<typeof createLayoutStorage<'project'>> {
-    return createLayoutStorage(this.space, definition);
   }
 
   static async hydrate(

--- a/apps/emdash-desktop/src/core/features/projects/contributions/mementos.ts
+++ b/apps/emdash-desktop/src/core/features/projects/contributions/mementos.ts
@@ -57,26 +57,3 @@ export const workspaceChromeMemento = defineMemento({
     zen: { active: false, restore: {} },
   },
 });
-
-const projectPanelLayoutsV1Schema = z.object({
-  version: z.literal('1'),
-  // Serialized panel layouts for workspace chrome surfaces, keyed by the
-  // react-resizable-panels internal storage key
-  // (`react-resizable-panels:${id}[:${panelIds}]`).
-  layouts: z.record(z.string(), z.string()),
-});
-
-export const projectPanelLayoutsSchema = defineVersionedSchema()
-  .initial('1', projectPanelLayoutsV1Schema)
-  .build();
-export type ProjectPanelLayoutsState = typeof projectPanelLayoutsSchema.Type;
-
-export const projectPanelLayoutsMemento = defineMemento({
-  id: 'projects.panel-layouts',
-  subject: projectSubject,
-  schema: projectPanelLayoutsSchema,
-  default: {
-    version: '1' as const,
-    layouts: {},
-  },
-});

--- a/apps/emdash-desktop/src/core/features/workbench/contributions/browser/layout-provider.tsx
+++ b/apps/emdash-desktop/src/core/features/workbench/contributions/browser/layout-provider.tsx
@@ -6,9 +6,12 @@ import {
   getProjectStore,
 } from '@core/features/projects/api/browser/stores/project-selectors';
 import type { WorkspaceChromeStore } from '@core/features/projects/api/browser/stores/workspace-chrome-store';
-import { projectPanelLayoutsMemento } from '@core/features/projects/contributions/mementos';
 import { workspaceChromeStoreToken } from '@core/features/projects/contributions/project-stores';
+import { workbenchPanelLayoutsMemento } from '@core/features/workbench/contributions/mementos';
+import { createLayoutStorage } from '@core/primitives/mementos/browser';
+import { useSubjectSpace } from '@core/primitives/mementos/react';
 import { getNavigation } from '@core/primitives/navigation/browser/navigation-selectors';
+import { appSubject } from '@core/primitives/subjects/api';
 import type { ViewRef } from '@core/primitives/views/api';
 
 export interface WorkspaceLayoutContextValue {
@@ -17,17 +20,10 @@ export interface WorkspaceLayoutContextValue {
   toggleLeftSidebar: () => void;
   toggleZenMode: () => void;
   /**
-   * Storage facade for the workspace outer layout, scoped to the active
-   * project's chrome subject (spec §Persistence model editorial call);
-   * ephemeral in-memory storage until a project chrome is hydrated.
+   * App-scoped storage facade for the workspace outer layout. The left
+   * sidebar is workbench chrome, so navigation never changes its size owner.
    */
   layoutStorage: LayoutStorage;
-  /**
-   * Remount key for the outer `Resizable.Group`: the library reads
-   * `defaultLayout` only at group mount, so the group must remount whenever
-   * the storage subject changes (project switch or hydration completing).
-   */
-  layoutKey: string;
 }
 
 const WorkspaceLayoutContext = createContext<WorkspaceLayoutContextValue | undefined>(undefined);
@@ -41,22 +37,11 @@ function projectIdFromRef(ref: ViewRef | undefined): string | undefined {
 /**
  * Workspace chrome for one project, readable only once its subject space has
  * hydrated. There is no render gate at the project boundary (the task-view
- * `isHydrated` gate covers only task subjects), so callers gate here: reading
- * chrome state or the layout facade pre-hydration is a loud dev error by
- * design, never a silent reset.
+ * `isHydrated` gate covers only task subjects), so callers gate here rather
+ * than reading project chrome before hydration.
  */
 function hydratedWorkspaceChrome(projectId: string): WorkspaceChromeStore | undefined {
   return asAvailableProject(getProjectStore(projectId))?.get(workspaceChromeStoreToken);
-}
-
-function createEphemeralLayoutStorage(): LayoutStorage {
-  const entries = new Map<string, string>();
-  return {
-    getItem: (key) => entries.get(key) ?? null,
-    setItem: (key, value) => {
-      entries.set(key, value);
-    },
-  };
 }
 
 export const WorkspaceLayoutContextProvider = observer(function WorkspaceLayoutContextProvider({
@@ -73,6 +58,9 @@ export const WorkspaceLayoutContextProvider = observer(function WorkspaceLayoutC
   // sidebar toggle still works on a fresh install's home view. Not a shadow
   // copy of store state — it feeds the view only while no chrome store exists.
   const [fallbackLeftOpen, setFallbackLeftOpen] = useState(true);
+  // The root app SubjectProvider hydrates before rendering this provider, so
+  // the layout facade is safe to read synchronously from the first paint.
+  const appSpace = useSubjectSpace(appSubject);
 
   useEffect(() => {
     return getNavigation().onDidNavigate.subscribe((event) => {
@@ -101,10 +89,9 @@ export const WorkspaceLayoutContextProvider = observer(function WorkspaceLayoutC
     : undefined;
   const chrome = context?.get(workspaceChromeStoreToken);
 
-  const ephemeralStorage = useMemo(() => createEphemeralLayoutStorage(), []);
   const layoutStorage = useMemo(
-    () => (context ? context.createLayoutStorage(projectPanelLayoutsMemento) : ephemeralStorage),
-    [context, ephemeralStorage]
+    () => createLayoutStorage(appSpace, workbenchPanelLayoutsMemento),
+    [appSpace]
   );
 
   const state = chrome ? chrome.state : undefined;
@@ -121,7 +108,6 @@ export const WorkspaceLayoutContextProvider = observer(function WorkspaceLayoutC
       else chrome.commands.enterZenMode();
     },
     layoutStorage,
-    layoutKey: context && activeProjectId ? `project:${activeProjectId}` : 'unscoped',
   };
 
   return (

--- a/apps/emdash-desktop/src/core/features/workbench/contributions/mementos.ts
+++ b/apps/emdash-desktop/src/core/features/workbench/contributions/mementos.ts
@@ -30,5 +30,25 @@ export const workbenchSidebarMemento = defineMemento({
   },
 });
 
+const workbenchPanelLayoutsV1Schema = z.object({
+  version: z.literal('1'),
+  layouts: z.record(z.string(), z.string()),
+});
+
+export const workbenchPanelLayoutsSchema = defineVersionedSchema()
+  .initial('1', workbenchPanelLayoutsV1Schema)
+  .build();
+export type WorkbenchPanelLayoutsState = typeof workbenchPanelLayoutsSchema.Type;
+
+export const workbenchPanelLayoutsMemento = defineMemento({
+  id: 'workbench.panel-layouts',
+  subject: appSubject,
+  schema: workbenchPanelLayoutsSchema,
+  default: {
+    version: '1' as const,
+    layouts: {},
+  },
+});
+
 // The navigation and history mementos moved into the navigation primitive:
 // @core/primitives/navigation/api/mementos.

--- a/apps/emdash-desktop/src/core/features/workbench/node/layout-contract.test.ts
+++ b/apps/emdash-desktop/src/core/features/workbench/node/layout-contract.test.ts
@@ -177,11 +177,28 @@ const sourceFiles = listSourceFiles(SRC_ROOT).map((file) => ({
   lines: readFileSync(file, 'utf8').split('\n'),
 }));
 
+function sourceText(relPath: string): string {
+  const source = sourceFiles.find((file) => file.relPath === relPath);
+  if (!source) throw new Error(`Missing source file: ${relPath}`);
+  return source.lines.join('\n');
+}
+
 describe('workbench layout contract', () => {
   it('scans a plausible source tree', () => {
     // Guard against the walker silently scanning nothing (e.g. after a move).
     expect(sourceFiles.length).toBeGreaterThan(500);
     expect(sourceFiles.some((file) => surfaceDirs(file.relPath))).toBe(true);
+  });
+
+  it('keeps the workspace outer layout app-scoped across navigation', () => {
+    const provider = sourceText(
+      'core/features/workbench/contributions/browser/layout-provider.tsx'
+    );
+    const workspaceLayout = sourceText('renderer/lib/layout/workspace-layout.tsx');
+
+    expect(provider).toContain('createLayoutStorage(appSpace, workbenchPanelLayoutsMemento)');
+    expect(provider).not.toMatch(/projectPanelLayoutsMemento|layoutKey/);
+    expect(workspaceLayout).not.toMatch(/key=\{layoutKey\}/);
   });
 
   for (const check of checks) {

--- a/apps/emdash-desktop/src/core/manifests/shared/memento-catalog.test.ts
+++ b/apps/emdash-desktop/src/core/manifests/shared/memento-catalog.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { acpDraftMemento } from '@core/features/conversations/contributions/mementos';
-import { projectPanelLayoutsMemento } from '@core/features/projects/contributions/mementos';
 import { taskPanelLayoutsMemento } from '@core/features/tasks/contributions/mementos';
+import { workbenchPanelLayoutsMemento } from '@core/features/workbench/contributions/mementos';
 import { mementoCatalog } from './memento-catalog';
 
 describe('mementoCatalog', () => {
@@ -11,16 +11,16 @@ describe('mementoCatalog', () => {
     expect(mementoCatalog).toContain(acpDraftMemento);
   });
 
-  it('registers the task- and project-scoped panel-layouts mementos', () => {
+  it('registers task-scoped and app-scoped panel-layouts mementos', () => {
     expect(taskPanelLayoutsMemento.id).toBe('tasks.panel-layouts');
     expect(taskPanelLayoutsMemento.subject.kind).toBe('task');
     expect(taskPanelLayoutsMemento.retention.tier).toBe('persisted');
-    expect(projectPanelLayoutsMemento.id).toBe('projects.panel-layouts');
-    expect(projectPanelLayoutsMemento.subject.kind).toBe('project');
-    expect(projectPanelLayoutsMemento.retention.tier).toBe('persisted');
+    expect(workbenchPanelLayoutsMemento.id).toBe('workbench.panel-layouts');
+    expect(workbenchPanelLayoutsMemento.subject.kind).toBe('app');
+    expect(workbenchPanelLayoutsMemento.retention.tier).toBe('persisted');
 
     expect(mementoCatalog).toContain(taskPanelLayoutsMemento);
-    expect(mementoCatalog).toContain(projectPanelLayoutsMemento);
+    expect(mementoCatalog).toContain(workbenchPanelLayoutsMemento);
   });
 
   it('round-trips panel-layouts values through their versioned schemas', () => {
@@ -28,7 +28,7 @@ describe('mementoCatalog', () => {
       version: '1' as const,
       layouts: { 'react-resizable-panels:task-sidebar-split': '{"sidebar":30,"main":70}' },
     };
-    for (const definition of [taskPanelLayoutsMemento, projectPanelLayoutsMemento]) {
+    for (const definition of [taskPanelLayoutsMemento, workbenchPanelLayoutsMemento]) {
       expect(definition.schema.parseJson(definition.schema.serialize(value))).toEqual(value);
       expect(definition.default).toEqual({ version: '1', layouts: {} });
     }

--- a/apps/emdash-desktop/src/core/manifests/shared/memento-catalog.ts
+++ b/apps/emdash-desktop/src/core/manifests/shared/memento-catalog.ts
@@ -3,7 +3,6 @@ import {
   providerPreferencesMemento,
 } from '@core/features/conversations/contributions/mementos';
 import {
-  projectPanelLayoutsMemento,
   projectViewMemento,
   workspaceChromeMemento,
 } from '@core/features/projects/contributions/mementos';
@@ -16,7 +15,10 @@ import {
   taskPanelLayoutsMemento,
   taskTerminalSelectionMemento,
 } from '@core/features/tasks/contributions/mementos';
-import { workbenchSidebarMemento } from '@core/features/workbench/contributions/mementos';
+import {
+  workbenchPanelLayoutsMemento,
+  workbenchSidebarMemento,
+} from '@core/features/workbench/contributions/mementos';
 import type { MementoCatalogEntry } from '@core/primitives/mementos/api';
 import { workbenchHistoryMemento } from '@core/primitives/navigation/api/mementos';
 
@@ -31,7 +33,6 @@ export const mementoCatalog: readonly MementoCatalogEntry[] = [
   acpDraftMemento,
   providerPreferencesMemento,
   projectViewMemento,
-  projectPanelLayoutsMemento,
   workspaceChromeMemento,
   taskChromeMemento,
   taskTerminalSelectionMemento,
@@ -40,6 +41,7 @@ export const mementoCatalog: readonly MementoCatalogEntry[] = [
   taskDiffSelectionMemento,
   taskPaneLayoutMemento,
   taskPanelLayoutsMemento,
+  workbenchPanelLayoutsMemento,
   workbenchSidebarMemento,
   workbenchHistoryMemento,
 ];

--- a/apps/emdash-desktop/src/core/primitives/mementos/browser/layout-storage.ts
+++ b/apps/emdash-desktop/src/core/primitives/mementos/browser/layout-storage.ts
@@ -6,7 +6,7 @@ import type { SubjectSpace } from './memento-client';
 
 /**
  * Value shape shared by every panel-layouts memento (`tasks.panel-layouts`,
- * `projects.panel-layouts`): one document per subject mapping the
+ * `workbench.panel-layouts`): one document per subject mapping the
  * react-resizable-panels internal storage key
  * (`react-resizable-panels:${id}[:${panelIds}]`) to its serialized layout.
  */

--- a/apps/emdash-desktop/src/core/services/mementos/node/layout-storage.test.ts
+++ b/apps/emdash-desktop/src/core/services/mementos/node/layout-storage.test.ts
@@ -20,7 +20,7 @@ const taskSubject = defineSubject({
 });
 
 // Mirrors the real panel-layouts memento shape (`tasks.panel-layouts` /
-// `projects.panel-layouts`); the catalog test in
+// `workbench.panel-layouts`); the catalog test in
 // src/core/manifests/shared/memento-catalog.test.ts covers the real
 // definitions, which module boundaries keep out of services tests.
 const panelLayoutsSchema = defineVersionedSchema()

--- a/apps/emdash-desktop/src/renderer/lib/layout/workspace-layout.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/layout/workspace-layout.tsx
@@ -25,7 +25,7 @@ interface WorkspaceLayoutProps {
 }
 
 export function WorkspaceLayout({ leftSidebar, mainContent }: WorkspaceLayoutProps) {
-  const { isLeftOpen, toggleLeftSidebar, layoutStorage, layoutKey } = useWorkspaceLayoutContext();
+  const { isLeftOpen, toggleLeftSidebar, layoutStorage } = useWorkspaceLayoutContext();
   const binding = useCollapsiblePanelBinding({
     storageKey: 'workspace-outer',
     storage: layoutStorage,
@@ -38,12 +38,7 @@ export function WorkspaceLayout({ leftSidebar, mainContent }: WorkspaceLayoutPro
   });
 
   return (
-    <Resizable.Group
-      key={layoutKey}
-      id="workspace-outer"
-      orientation="horizontal"
-      {...binding.groupProps}
-    >
+    <Resizable.Group id="workspace-outer" orientation="horizontal" {...binding.groupProps}>
       {/* Closed = panel AND handle unmounted (sync contract: never program
           the panels). */}
       {isLeftOpen && (


### PR DESCRIPTION
- scopes the workspace outer panel layout to app-level workbench state so resized width persists across task and project navigation
- removes the project-scoped panel layout memento and unused ProjectContext layout storage plumbing
- keeps react-resizable-panels as the size owner through createLayoutStorage and enforces stable app-scoped ownership with contract coverage