### PR TITLE
fix(ui): align elevated action card surfaces

### DIFF
--- a/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/action-card.tsx
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/action-card.tsx
@@ -1,4 +1,6 @@
+import { card } from '@emdash/ui/styles/recipes/card';
 import { type ReactNode } from 'react';
+import { cn } from '@core/primitives/styling/browser/cn';
 
 interface ActionCardProps {
   selectedCount: number;
@@ -9,7 +11,12 @@ interface ActionCardProps {
 export function ActionCard({ selectedCount, selectionActions, generalActions }: ActionCardProps) {
   const hasSelection = selectedCount > 0;
   return (
-    <div className="mx-2 flex shrink-0 items-center justify-between rounded-lg border border-border bg-background-1 py-1.5 pr-1.5 pl-2.5">
+    <div
+      className={cn(
+        card({ level: 'elevated-emphasis', radius: 'md', padding: 'sm' }),
+        'mx-2 flex shrink-0 items-center justify-between'
+      )}
+    >
       <span className="min-w-0 truncate text-xs text-foreground-muted">
         {hasSelection
           ? `${selectedCount} file${selectedCount !== 1 ? 's' : ''} selected`

--- a/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/commit-card.tsx
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/commit-card.tsx
@@ -1,4 +1,5 @@
 import { Input, SplitButton, Textarea, toast } from '@emdash/ui/react/primitives';
+import { card } from '@emdash/ui/styles/recipes/card';
 import { CheckCircle, Loader2 } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { useState } from 'react';
@@ -14,6 +15,7 @@ import {
   useWorkspaceId,
 } from '@core/features/workbench/api/browser/task-composition-context';
 import { useOpenModal } from '@core/manifests/browser/modal-api';
+import { cn } from '@core/primitives/styling/browser/cn';
 
 type CommitPhase =
   | 'idle'
@@ -156,7 +158,12 @@ export const CommitCard = observer(function CommitCard({ autoStage = false }: Co
       : diffView.effectiveCommitAction;
 
   return (
-    <div className="mx-2 mb-2 flex shrink-0 flex-col items-center justify-between gap-2 rounded-xl border border-border bg-background-1 p-2">
+    <div
+      className={cn(
+        card({ level: 'elevated-emphasis', radius: 'lg', padding: 'sm' }),
+        'mx-2 mb-2 flex shrink-0 flex-col items-center justify-between gap-2'
+      )}
+    >
       <Input
         placeholder="Commit message"
         className="w-full bg-background"

--- a/packages/ui/src/react/components/list-popover-card/list-popover-card.css.ts
+++ b/packages/ui/src/react/components/list-popover-card/list-popover-card.css.ts
@@ -1,4 +1,5 @@
 import { style } from '@vanilla-extract/css';
+import { vars } from '@theme/core/contract/contract.css';
 import { tokenVars } from '@theme/tokens.css';
 // Side-effect import so the @layer order declaration is emitted before these
 // rules; otherwise `recipes` gets registered first and loses to app layers.
@@ -26,6 +27,7 @@ export const inner = style({
       alignItems: 'center',
       gap: '0.5rem',
       fontSize: tokenVars.textSm,
+      boxShadow: vars.shadowSm,
     },
   },
 });

--- a/packages/ui/src/react/components/list-popover-card/list-popover-card.tsx
+++ b/packages/ui/src/react/components/list-popover-card/list-popover-card.tsx
@@ -21,7 +21,7 @@ function ListPopoverCard({ status, className, children, ...props }: ListPopoverC
       <div
         data-status={status}
         className={cx(
-          card({ level: 'elevated', radius: 'md', padding: 'sm', status }),
+          card({ level: 'elevated-emphasis', radius: 'md', padding: 'sm', status }),
           styles.inner,
           className
         )}

--- a/packages/ui/src/styles/recipes/card.css.ts
+++ b/packages/ui/src/styles/recipes/card.css.ts
@@ -13,7 +13,7 @@
  *   padding     — none | sm | md | lg (default: md)
  *   radius      — sm | md | lg (default: md)
  *   interactive — true | false: hover/selected state (default: false)
- *   level       — sunken | base | elevated | paper (default: base)
+ *   level       — sunken | base | elevated | elevated-emphasis | paper (default: base)
  *   status      — destructive | warning | info | success (optional)
  *
  * Status rooms are level-aware: when both `level` and `status` are set on the
@@ -48,7 +48,7 @@ export const card = recipe({
   base: {
     backgroundColor: vars.surface,
     color: vars.foreground,
-    border: `1px solid ${vars.surfaceBorder}`,
+    border: `1px solid ${vars.border}`,
     overflow: 'hidden',
   },
 
@@ -87,6 +87,18 @@ export const card = recipe({
           ...statusRebindings('elevated'),
         },
       },
+      'elevated-emphasis': {
+        vars: {
+          [vars.surface]: vars.surfaceElevatedEmphasis,
+          [vars.surfaceHover]: vars.surfaceElevatedEmphasisHover,
+          [vars.surfaceSelected]: vars.surfaceElevatedEmphasisSelected,
+          // Top of the elevation ladder — nested emphasis clamps here.
+          [vars.surfaceEmphasis]: vars.surfaceElevatedEmphasis,
+          [vars.surfaceEmphasisHover]: vars.surfaceElevatedEmphasisHover,
+          [vars.surfaceEmphasisSelected]: vars.surfaceElevatedEmphasisSelected,
+          ...statusRebindings('elevated-emphasis'),
+        },
+      },
       paper: {
         vars: {
           [vars.surface]: vars.surfacePaper,
@@ -102,6 +114,7 @@ export const card = recipe({
 
     status: {
       destructive: {
+        borderColor: vars.surfaceBorder,
         vars: {
           [vars.surface]: vars.surfaceDestructive,
           [vars.surfaceForeground]: vars.surfaceDestructiveForeground,
@@ -111,6 +124,7 @@ export const card = recipe({
         },
       },
       warning: {
+        borderColor: vars.surfaceBorder,
         vars: {
           [vars.surface]: vars.surfaceWarning,
           [vars.surfaceForeground]: vars.surfaceWarningForeground,
@@ -120,6 +134,7 @@ export const card = recipe({
         },
       },
       info: {
+        borderColor: vars.surfaceBorder,
         vars: {
           [vars.surface]: vars.surfaceInfo,
           [vars.surfaceForeground]: vars.surfaceInfoForeground,
@@ -129,6 +144,7 @@ export const card = recipe({
         },
       },
       success: {
+        borderColor: vars.surfaceBorder,
         vars: {
           [vars.surface]: vars.surfaceSuccess,
           [vars.surfaceForeground]: vars.surfaceSuccessForeground,


### PR DESCRIPTION
- add an elevated-emphasis level to the shared card recipe
- apply consistent background border radius and padding to ListPopoverCard and source-control action cards
- preserve status-aware colors and add subtle shadow elevation to floating list popovers
- keep floating and in-flow action card positioning behavior distinct