### PR TITLE
chore(projects): rename new repository option to create repository

### DIFF
--- a/apps/emdash-desktop/src/core/features/projects/api/browser/stores/project-manager.ts
+++ b/apps/emdash-desktop/src/core/features/projects/api/browser/stores/project-manager.ts
@@ -436,7 +436,7 @@ export class ProjectManagerStore {
     const isSsh = projectType.type === 'ssh';
     const projectTelemetryType: 'local' | 'ssh' = isSsh ? 'ssh' : 'local';
     const projectTelemetryStrategy: 'open' | 'create' | 'clone' =
-      data.mode === 'clone' ? 'clone' : data.mode === 'new' ? 'create' : 'open';
+      data.mode === 'clone' ? 'clone' : data.mode === 'create' ? 'create' : 'open';
 
     let result: ProjectCreationCompletion;
     try {
@@ -495,7 +495,7 @@ export class ProjectManagerStore {
           break;
         }
 
-        case 'new': {
+        case 'create': {
           const repoResult = await (
             await getGithubClient()
           ).createRepository({
@@ -729,7 +729,7 @@ export class ProjectManagerStore {
   private async _createProjectFromRemote(opts: {
     projectId: string;
     host: { type: 'local' } | { type: 'ssh'; connectionId: string };
-    mode: 'clone' | 'new';
+    mode: 'clone' | 'create';
     repositoryUrl: string;
     targetPath: string;
     name: string;
@@ -785,7 +785,7 @@ export class ProjectManagerStore {
           opts.projectType.type === 'ssh'
             ? { type: 'ssh', connectionId: opts.projectType.connectionId }
             : { type: 'local' },
-        mode: 'new',
+        mode: 'create',
         repositoryUrl: opts.cloneUrl,
         targetPath: opts.targetPath,
         name: opts.name,
@@ -851,7 +851,7 @@ function initialCreationStage(mode: ModeData['mode']): ProjectCreationStage {
       return 'registering';
     case 'clone':
       return 'cloning';
-    case 'new':
+    case 'create':
       return 'creating-repo';
   }
 }

--- a/apps/emdash-desktop/src/core/features/projects/api/browser/stores/project.ts
+++ b/apps/emdash-desktop/src/core/features/projects/api/browser/stores/project.ts
@@ -13,7 +13,7 @@ export type CreationStatus =
     }
   | { kind: 'failed'; stage: ProjectCreationStage; message: string };
 
-export type ProjectMode = 'pick' | 'clone' | 'new';
+export type ProjectMode = 'pick' | 'clone' | 'create';
 
 /**
  * Container class — holds a stable reference in the ObservableMap across all

--- a/apps/emdash-desktop/src/core/features/projects/api/wire-contract.ts
+++ b/apps/emdash-desktop/src/core/features/projects/api/wire-contract.ts
@@ -83,7 +83,7 @@ export const projectHostParamsSchema = z.discriminatedUnion('type', [
 export const createProjectFromRemoteInputSchema = z.object({
   projectId: z.string(),
   host: projectHostParamsSchema,
-  mode: z.enum(['clone', 'new']),
+  mode: z.enum(['clone', 'create']),
   repositoryUrl: z.string().min(1),
   targetPath: z.string().min(1),
   name: z.string().min(1),

--- a/apps/emdash-desktop/src/core/features/projects/browser/components/add-project-modal/add-project-modal.tsx
+++ b/apps/emdash-desktop/src/core/features/projects/browser/components/add-project-modal/add-project-modal.tsx
@@ -26,14 +26,14 @@ import { defineModal } from '@core/primitives/modals/react';
 import { useNavigate } from '@core/primitives/navigation/browser/navigation-hooks';
 import { basenameFromAnyPath } from '@core/primitives/path-name/api';
 import type { SshConfig } from '@core/primitives/ssh/api';
-import { ClonePanel, CreateNewPanel, PickExistingPanel } from './content';
+import { ClonePanel, CreateRepositoryPanel, PickExistingPanel } from './content';
 import { LocationSelector } from './location-selector';
-import { extractRepoName, useCloneMode, useNewMode, usePickMode } from './modes';
+import { extractRepoName, useCloneMode, useCreateRepositoryMode, usePickMode } from './modes';
 import { useProjectName } from './use-project-name';
 
 export type Strategy = 'local' | 'ssh';
 
-export type Mode = 'pick' | 'new' | 'clone';
+export type Mode = 'pick' | 'create' | 'clone';
 type MachineOption = SshConfig & { id: string };
 
 export interface AddProjectModalProps {
@@ -130,21 +130,24 @@ export const AddProjectModal = observer(function AddProjectModal({
   const defaultGitHubAccountId = defaultGitHubAccountSelect.selectedAccountId;
 
   const pickState = usePickMode();
-  const newState = useNewMode(defaultPath, mode === 'new' ? selectedGitHubAccountId : null);
+  const createRepositoryState = useCreateRepositoryMode(
+    defaultPath,
+    mode === 'create' ? selectedGitHubAccountId : null
+  );
   const cloneState = useCloneMode(defaultPath);
   const generatedProjectName = useMemo(() => {
     switch (mode) {
       case 'pick':
         return basenameFromAnyPath(pickState.path);
-      case 'new':
-        return newState.repositoryName;
+      case 'create':
+        return createRepositoryState.repositoryName;
       case 'clone':
         return extractRepoName(cloneState.repositoryUrl);
     }
-  }, [cloneState.repositoryUrl, mode, newState.repositoryName, pickState.path]);
+  }, [cloneState.repositoryUrl, createRepositoryState.repositoryName, mode, pickState.path]);
   const projectName = useProjectName(generatedProjectName);
 
-  const activeMode = { pick: pickState, new: newState, clone: cloneState }[mode];
+  const activeMode = { pick: pickState, create: createRepositoryState, clone: cloneState }[mode];
   const shouldCheckPickPathStatus =
     mode === 'pick' &&
     pickState.path.trim().length > 0 &&
@@ -178,7 +181,7 @@ export const AddProjectModal = observer(function AddProjectModal({
     (strategy === 'local' || !!selectedConnectionId) &&
     !isCheckingPickPathStatus &&
     !pickPathInspectionError &&
-    (mode !== 'new' || !githubAccountsQuery.isPending) &&
+    (mode !== 'create' || !githubAccountsQuery.isPending) &&
     (mode !== 'pick' ||
       !requiresGitInitialization ||
       !pickState.initGitRepository ||
@@ -209,14 +212,14 @@ export const AddProjectModal = observer(function AddProjectModal({
             : undefined,
         };
         break;
-      case 'new':
+      case 'create':
         data = {
-          mode: 'new',
+          mode: 'create',
           name: projectName.effectiveName,
-          path: newState.path,
-          repositoryName: newState.repositoryName,
-          repositoryOwner: newState.repositoryOwner?.value ?? '',
-          repositoryVisibility: newState.repositoryVisibility,
+          path: createRepositoryState.path,
+          repositoryName: createRepositoryState.repositoryName,
+          repositoryOwner: createRepositoryState.repositoryOwner?.value ?? '',
+          repositoryVisibility: createRepositoryState.repositoryVisibility,
           githubAccountId: selectedGitHubAccountId ?? undefined,
         };
         break;
@@ -324,10 +327,10 @@ export const AddProjectModal = observer(function AddProjectModal({
               onSelect={setMode}
             />
             <ModeCard
-              mode="new"
-              selected={mode === 'new'}
+              mode="create"
+              selected={mode === 'create'}
               icon={<PlusIcon className="size-3" />}
-              label="New Repository"
+              label="Create Repository"
               onSelect={setMode}
             />
             <ModeCard
@@ -348,11 +351,11 @@ export const AddProjectModal = observer(function AddProjectModal({
               showInitializeGitPrompt={requiresGitInitialization}
             />
           )}
-          {mode === 'new' && (
-            <CreateNewPanel
+          {mode === 'create' && (
+            <CreateRepositoryPanel
               strategy={strategy}
               connectionId={selectedConnectionId}
-              state={newState}
+              state={createRepositoryState}
               getProjectsClient={getProjectsClient}
               accounts={githubAccountSelect.accounts}
               selectedAccount={githubAccountSelect.selectedAccount}
@@ -361,7 +364,7 @@ export const AddProjectModal = observer(function AddProjectModal({
               onConnectGithub={() => void openGithubConnectModal({})}
               ensureDefaultRoot={
                 defaultRepositoriesRootQuery.data !== undefined &&
-                newState.path === defaultRepositoriesRootQuery.data
+                createRepositoryState.path === defaultRepositoriesRootQuery.data
               }
             />
           )}

--- a/apps/emdash-desktop/src/core/features/projects/browser/components/add-project-modal/content.browser.test.tsx
+++ b/apps/emdash-desktop/src/core/features/projects/browser/components/add-project-modal/content.browser.test.tsx
@@ -2,11 +2,11 @@ import '@emdash/ui/style.css';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { CreateNewPanel } from './content';
-import type { NewModeState } from './modes';
+import { CreateRepositoryPanel } from './content';
+import type { CreateRepositoryModeState } from './modes';
 import type { ProjectDirectoryPickerClient } from './project-directory-picker';
 
-describe('CreateNewPanel layout', () => {
+describe('CreateRepositoryPanel layout', () => {
   let container: HTMLDivElement;
   let root: Root;
   let style: HTMLStyleElement;
@@ -45,7 +45,7 @@ describe('CreateNewPanel layout', () => {
 
   it('keeps the owner and repository name fields within the row', () => {
     const owner = { value: 'octocat', label: 'octocat', avatarUrl: '' };
-    const state: NewModeState = {
+    const state: CreateRepositoryModeState = {
       repositoryName: '',
       repositoryOwner: owner,
       repositoryVisibility: 'private',
@@ -62,7 +62,7 @@ describe('CreateNewPanel layout', () => {
 
     act(() => {
       root.render(
-        <CreateNewPanel
+        <CreateRepositoryPanel
           strategy="local"
           state={state}
           getProjectsClient={getProjectsClient}

--- a/apps/emdash-desktop/src/core/features/projects/browser/components/add-project-modal/content.tsx
+++ b/apps/emdash-desktop/src/core/features/projects/browser/components/add-project-modal/content.tsx
@@ -6,7 +6,7 @@ import type { GitHubAccountSummary } from '@core/primitives/github/api';
 import type { Resolved } from '@core/primitives/project-settings/api';
 import { type Strategy } from './add-project-modal';
 import { DirectoryField } from './local-directory-selector';
-import { type CloneModeState, type NewModeState, type PickModeState } from './modes';
+import { type CloneModeState, type CreateRepositoryModeState, type PickModeState } from './modes';
 import { OwnerSelector } from './owner-selector';
 import { type ProjectDirectoryPickerClient } from './project-directory-picker';
 
@@ -70,7 +70,7 @@ export function PickExistingPanel({
   );
 }
 
-export function CreateNewPanel({
+export function CreateRepositoryPanel({
   strategy,
   connectionId,
   state,
@@ -84,7 +84,7 @@ export function CreateNewPanel({
 }: {
   strategy: Strategy;
   connectionId?: string;
-  state: NewModeState;
+  state: CreateRepositoryModeState;
   getProjectsClient(): Promise<ProjectDirectoryPickerClient>;
   accounts: GitHubAccountSummary[];
   selectedAccount: GitHubAccountSummary | null;

--- a/apps/emdash-desktop/src/core/features/projects/browser/components/add-project-modal/modes.ts
+++ b/apps/emdash-desktop/src/core/features/projects/browser/components/add-project-modal/modes.ts
@@ -22,10 +22,10 @@ export function usePickMode() {
 }
 
 export type PickModeState = ReturnType<typeof usePickMode>;
-export type NewModeState = ReturnType<typeof useNewMode>;
+export type CreateRepositoryModeState = ReturnType<typeof useCreateRepositoryMode>;
 export type CloneModeState = ReturnType<typeof useCloneMode>;
 
-export function useNewMode(defaultPath: string, githubAccountId: string | null) {
+export function useCreateRepositoryMode(defaultPath: string, githubAccountId: string | null) {
   const [repositoryName, setRepositoryName] = useState('');
   const [repositoryVisibility, setRepositoryVisibility] = useState<'public' | 'private'>('private');
   const [pathOverride, setPathOverride] = useState<string | undefined>(undefined);

--- a/apps/emdash-desktop/src/core/features/projects/browser/components/main-panel/pending-project.tsx
+++ b/apps/emdash-desktop/src/core/features/projects/browser/components/main-panel/pending-project.tsx
@@ -8,6 +8,7 @@ import { observer } from 'mobx-react-lite';
 import type { ReactNode } from 'react';
 import {
   type ProjectCreationStage,
+  type ProjectMode,
   type UnregisteredProject,
 } from '@core/features/projects/api/browser/stores/project';
 import { getProjectManagerStore } from '@core/features/projects/api/browser/stores/project-selectors';
@@ -20,10 +21,10 @@ const STAGE_LABELS: Record<ProjectCreationStage, string> = {
   registering: 'Registering project',
 };
 
-const STAGES_BY_MODE: Record<'pick' | 'clone' | 'new', ProjectCreationStage[]> = {
+const STAGES_BY_MODE: Record<ProjectMode, ProjectCreationStage[]> = {
   pick: ['registering'],
   clone: ['cloning', 'registering'],
-  new: ['creating-repo', 'cloning', 'registering'],
+  create: ['creating-repo', 'cloning', 'registering'],
 };
 
 export const PendingProjectStatus = observer(function PendingProjectStatus({

--- a/apps/emdash-desktop/src/core/features/projects/browser/stores/project-creation-types.ts
+++ b/apps/emdash-desktop/src/core/features/projects/browser/stores/project-creation-types.ts
@@ -17,15 +17,15 @@ export interface CloneModeData extends BaseModeData {
   repositoryUrl: string;
 }
 
-export interface NewModeData extends BaseModeData {
-  mode: 'new';
+export interface CreateRepositoryModeData extends BaseModeData {
+  mode: 'create';
   repositoryName: string;
   repositoryOwner: string;
   repositoryVisibility: 'public' | 'private';
   githubAccountId?: string;
 }
 
-export type ModeData = PickModeData | CloneModeData | NewModeData;
+export type ModeData = PickModeData | CloneModeData | CreateRepositoryModeData;
 
 export type ProjectType = { type: 'local' } | { type: 'ssh'; connectionId: string };
 

--- a/apps/emdash-desktop/src/core/features/projects/browser/stores/project-manager.test.ts
+++ b/apps/emdash-desktop/src/core/features/projects/browser/stores/project-manager.test.ts
@@ -1008,13 +1008,13 @@ describe('ProjectManagerStore project creation', () => {
     expect(store.projects.has('optimistic-project')).toBe(false);
   });
 
-  it('inspects the final new-project path instead of the parent directory', async () => {
+  it('inspects the final repository-creation path instead of the parent directory', async () => {
     const store = new ProjectManagerStore();
 
     const result = await store.startProjectCreation(
       { type: 'local' },
       {
-        mode: 'new',
+        mode: 'create',
         name: 'child-project',
         path: '/parent',
         repositoryName: 'child-project',
@@ -1056,7 +1056,7 @@ describe('ProjectManagerStore project creation', () => {
     expect(store.projects.has('optimistic-project')).toBe(true);
   });
 
-  it('does not let a project registered at the new-project parent path short-circuit creation', async () => {
+  it('does not let a project at the repository-creation parent path short-circuit creation', async () => {
     const parentProject = localProject({ id: 'parent-project', path: '/parent' });
     mocks.inspectProjectPath.mockImplementation(async ({ path }: { path: string }) => ({
       isDirectory: true,
@@ -1068,7 +1068,7 @@ describe('ProjectManagerStore project creation', () => {
     const result = await store.startProjectCreation(
       { type: 'local' },
       {
-        mode: 'new',
+        mode: 'create',
         name: 'child-project',
         path: '/parent',
         repositoryName: 'child-project',
@@ -1083,13 +1083,13 @@ describe('ProjectManagerStore project creation', () => {
     expect(store.projects.has('optimistic-project')).toBe(true);
   });
 
-  it('persists the selected GitHub account after registering a new project', async () => {
+  it('persists the selected GitHub account after creating the project', async () => {
     const store = new ProjectManagerStore();
 
     const result = await store.startProjectCreation(
       { type: 'local' },
       {
-        mode: 'new',
+        mode: 'create',
         name: 'Project',
         path: '/parent',
         repositoryName: 'project',
@@ -1264,13 +1264,13 @@ describe('ProjectManagerStore project creation', () => {
     expect(mocks.updateProjectSettings).not.toHaveBeenCalled();
   });
 
-  it('uses the selected GitHub account when creating a repository for a new project', async () => {
+  it('uses the selected GitHub account when creating a repository for the project', async () => {
     const store = new ProjectManagerStore();
 
     const result = await store.startProjectCreation(
       { type: 'local' },
       {
-        mode: 'new',
+        mode: 'create',
         name: 'Project',
         path: '/parent',
         repositoryName: 'project',
@@ -1302,7 +1302,7 @@ describe('ProjectManagerStore project creation', () => {
     const result = await store.startProjectCreation(
       { type: 'local' },
       {
-        mode: 'new',
+        mode: 'create',
         name: 'Project',
         path: '/parent',
         repositoryName: 'project',
@@ -1333,7 +1333,7 @@ describe('ProjectManagerStore project creation', () => {
     const result = await store.startProjectCreation(
       { type: 'local' },
       {
-        mode: 'new',
+        mode: 'create',
         name: 'Project',
         path: '/parent',
         repositoryName: 'project',
@@ -1368,7 +1368,7 @@ describe('ProjectManagerStore project creation', () => {
     expect(mocks.createProject).not.toHaveBeenCalled();
   });
 
-  it('starts new-project cloning on the SSH host and rolls back GitHub if it fails', async () => {
+  it('starts repository-creation cloning on the SSH host and rolls back GitHub if it fails', async () => {
     mocks.projectWireResult = Promise.reject(
       new LiveJobFailedError({ type: 'clone-failed', message: 'Remote clone failed' })
     );
@@ -1377,7 +1377,7 @@ describe('ProjectManagerStore project creation', () => {
     const result = await store.startProjectCreation(
       { type: 'ssh', connectionId: 'ssh-1' },
       {
-        mode: 'new',
+        mode: 'create',
         name: 'Project',
         path: '/remote/parent',
         repositoryName: 'project',
@@ -1404,7 +1404,7 @@ describe('ProjectManagerStore project creation', () => {
     expect(mocks.projectWireCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         host: { type: 'ssh', connectionId: 'ssh-1' },
-        mode: 'new',
+        mode: 'create',
         repositoryUrl: 'https://github.com/acme/project.git',
         targetPath: '/remote/parent/Project',
       })
@@ -1426,7 +1426,7 @@ describe('ProjectManagerStore project creation', () => {
     const result = await store.startProjectCreation(
       { type: 'local' },
       {
-        mode: 'new',
+        mode: 'create',
         name: 'Project',
         path: '/parent',
         repositoryName: 'project',

--- a/apps/emdash-desktop/src/core/features/workbench/browser/home-view.tsx
+++ b/apps/emdash-desktop/src/core/features/workbench/browser/home-view.tsx
@@ -20,9 +20,9 @@ const PROJECT_ACTIONS = [
   },
   {
     label: 'Create repository',
-    description: 'Create a project by creating a new repository on GitHub',
+    description: 'Create a project and repository on GitHub',
     icon: Plus,
-    modalArgs: { strategy: 'local', mode: 'new' },
+    modalArgs: { strategy: 'local', mode: 'create' },
   },
   {
     label: 'Clone from GitHub',


### PR DESCRIPTION
- rename the project picker option from "new repository" to "create repository"
- replace the "new" creation mode with "create" across modal state, project stores and wire contracts
- rename useNewMode, NewModeState and CreateNewPanel to useCreateRepositoryMode, CreateRepositoryModeState and CreateRepositoryPanel