### PR TITLE
feat(editor): propagate git status to explorer folders

### DIFF
--- a/apps/emdash-desktop/src/core/features/editor/browser/file-tree/file-tree-git-decorations.test.ts
+++ b/apps/emdash-desktop/src/core/features/editor/browser/file-tree/file-tree-git-decorations.test.ts
@@ -1,0 +1,65 @@
+import type { GitChange } from '@emdash/core/runtimes/git/api';
+import { describe, expect, it } from 'vitest';
+import { portablePath } from '@core/primitives/desktop-runtime/api';
+import { buildFileTreeGitDecorations } from './file-tree-git-decorations';
+
+describe('buildFileTreeGitDecorations', () => {
+  it('keeps the exact Git status on changed files', () => {
+    const decorations = buildFileTreeGitDecorations([change('src/index.ts', 'added')]);
+
+    expect(decorations.fileStatusByPath.get('src/index.ts')).toBe('added');
+  });
+
+  it('propagates the Git status to every ancestor directory', () => {
+    const decorations = buildFileTreeGitDecorations([change('src/components/button.tsx', 'added')]);
+
+    expect(decorations).toHaveProperty(
+      'directoryStatusByPath',
+      new Map([
+        ['src', 'added'],
+        ['src/components', 'added'],
+      ])
+    );
+  });
+
+  it('does not propagate deleted-only changes, matching Cursor', () => {
+    const decorations = buildFileTreeGitDecorations([
+      change('src/components/legacy/button.tsx', 'deleted'),
+    ]);
+
+    expect(decorations).toHaveProperty('directoryStatusByPath', new Map());
+  });
+
+  it('uses the first path with a propagated status when a directory contains mixed changes', () => {
+    const decorations = buildFileTreeGitDecorations([
+      change('tooling/z-new.ts', 'added'),
+      change('tooling/a-existing.ts', 'modified'),
+    ]);
+
+    expect(decorations).toHaveProperty('directoryStatusByPath', new Map([['tooling', 'modified']]));
+  });
+
+  it('does not decorate a directory for a root-level change or a sibling change', () => {
+    const decorations = buildFileTreeGitDecorations([
+      change('README.md', 'modified'),
+      change('src/components/button.tsx', 'modified'),
+    ]);
+
+    expect(decorations).toHaveProperty(
+      'directoryStatusByPath',
+      new Map([
+        ['src', 'modified'],
+        ['src/components', 'modified'],
+      ])
+    );
+  });
+});
+
+function change(path: string, status: GitChange['status']): GitChange {
+  return {
+    path: portablePath(path),
+    status,
+    additions: status === 'deleted' ? 0 : 1,
+    deletions: status === 'deleted' ? 1 : 0,
+  };
+}

--- a/apps/emdash-desktop/src/core/features/editor/browser/file-tree/file-tree-git-decorations.ts
+++ b/apps/emdash-desktop/src/core/features/editor/browser/file-tree/file-tree-git-decorations.ts
@@ -1,0 +1,39 @@
+import type { GitChange, GitChangeStatus } from '@emdash/core/runtimes/git/api';
+import { normalizeFileTreePath } from '@core/features/editor/api/browser/file-tree/tree-utils';
+
+export interface FileTreeGitDecorations {
+  fileStatusByPath: ReadonlyMap<string, GitChangeStatus>;
+  directoryStatusByPath: ReadonlyMap<string, GitChangeStatus>;
+}
+
+export function buildFileTreeGitDecorations(changes: readonly GitChange[]): FileTreeGitDecorations {
+  const fileStatusByPath = new Map<string, GitChangeStatus>();
+  const directoryStatusByPath = new Map<string, GitChangeStatus>();
+  const propagatingChanges: Array<{ path: string; status: GitChangeStatus }> = [];
+
+  for (const change of changes) {
+    const path = normalizeFileTreePath(change.path);
+    fileStatusByPath.set(path, change.status);
+    if (change.status !== 'deleted') {
+      propagatingChanges.push({ path, status: change.status });
+    }
+  }
+
+  propagatingChanges.sort((left, right) => left.path.localeCompare(right.path));
+  for (const change of propagatingChanges) {
+    const { path } = change;
+    let separatorIndex = path.lastIndexOf('/');
+    while (separatorIndex > 0) {
+      const directoryPath = path.slice(0, separatorIndex);
+      if (!directoryStatusByPath.has(directoryPath)) {
+        directoryStatusByPath.set(directoryPath, change.status);
+      }
+      separatorIndex = directoryPath.lastIndexOf('/');
+    }
+  }
+
+  return {
+    fileStatusByPath,
+    directoryStatusByPath,
+  };
+}

--- a/apps/emdash-desktop/src/core/features/editor/contributions/browser/editor-file-tree.browser.test.tsx
+++ b/apps/emdash-desktop/src/core/features/editor/contributions/browser/editor-file-tree.browser.test.tsx
@@ -1,8 +1,16 @@
-import type { FileTreeHeaderContext } from '@emdash/ui/react/components';
+import {
+  FileTree,
+  type FileTreeHeaderContext,
+  type FileTreeNode,
+} from '@emdash/ui/react/components';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { FileTreeHeaderBar } from './editor-file-tree';
+import {
+  FileTreeGitChangeIndicator,
+  FileTreeHeaderBar,
+  fileTreeGitStatusTone,
+} from './editor-file-tree';
 import '@emdash/ui/style.css';
 
 beforeAll(() => {
@@ -18,6 +26,7 @@ describe('FileTreeHeaderBar layout', () => {
   beforeEach(() => {
     host = document.createElement('div');
     host.style.width = '720px';
+    host.style.height = '240px';
     document.body.append(host);
     root = createRoot(host);
   });
@@ -90,5 +99,56 @@ describe('FileTreeHeaderBar layout', () => {
     expect(header).toHaveClass('h-[41px]', 'bg-background-secondary');
     expect(getComputedStyle(input!).height).toBe('24px');
     expect(input).toHaveClass('focus-visible:bg-transparent');
+  });
+});
+
+describe('FileTree Git decorations', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    host.style.width = '400px';
+    host.style.height = '240px';
+    document.body.append(host);
+    root = createRoot(host);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    host.remove();
+  });
+
+  it('uses the added color for both the parent folder name and bubble', async () => {
+    const tooling: FileTreeNode = {
+      id: 'tooling',
+      path: '/repo/tooling',
+      name: 'tooling',
+      parentId: null,
+      parentPath: '/repo',
+      depth: 0,
+      type: 'directory',
+      childrenLoaded: true,
+    };
+
+    await act(async () => {
+      root.render(
+        <FileTree
+          rootPath="/repo"
+          rootNodes={[tooling]}
+          childrenById={new Map([['tooling', []]])}
+          renderHeader={() => null}
+          getRowState={() => ({ tone: fileTreeGitStatusTone('added') })}
+          renderDecoration={() => <FileTreeGitChangeIndicator status="added" />}
+        />
+      );
+    });
+
+    const folderName = host.querySelector<HTMLElement>('[data-tone="success"]');
+    const bubble = host.querySelector<HTMLElement>('[aria-label="Contains emphasized items"]');
+    expect(folderName).not.toBeNull();
+    expect(bubble).not.toBeNull();
+    expect(bubble).toHaveStyle({ color: 'var(--em-foreground-success)' });
+    expect(getComputedStyle(folderName!).color).toBe(getComputedStyle(bubble!).color);
   });
 });

--- a/apps/emdash-desktop/src/core/features/editor/contributions/browser/editor-file-tree.tsx
+++ b/apps/emdash-desktop/src/core/features/editor/contributions/browser/editor-file-tree.tsx
@@ -1,6 +1,7 @@
 import { encodeResourceUri } from '@emdash/core/primitives/path/api';
 import { FILE_SEARCH_MAX_QUERY_LENGTH } from '@emdash/core/runtimes/file-search/api';
 import { copyNameForConflict, MAX_FILE_UPLOAD_BYTES } from '@emdash/core/runtimes/files/api';
+import type { GitChangeStatus } from '@emdash/core/runtimes/git/api';
 import {
   EmptyState,
   FileTree,
@@ -21,6 +22,7 @@ import {
 import { SearchInput, toast } from '@emdash/ui/react/primitives';
 import {
   ClipboardPaste,
+  Circle,
   Copy,
   CopyMinus,
   FilePen,
@@ -37,6 +39,10 @@ import { observer } from 'mobx-react-lite';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import type { RenderableFileNode } from '@core/features/editor/api/browser/file-tree/tree-utils';
 import type { FileTabResource } from '@core/features/editor/api/browser/task-editor/stores/file-tab-resource';
+import {
+  buildFileTreeGitDecorations,
+  type FileTreeGitDecorations,
+} from '@core/features/editor/browser/file-tree/file-tree-git-decorations';
 import { FileContentSearchResults } from '@core/features/editor/browser/task-editor/file-content-search';
 import type { TreeMutationError } from '@core/features/editor/browser/task-editor/stores/files-store';
 import type { FilesStore } from '@core/features/editor/browser/task-editor/stores/files-store';
@@ -219,6 +225,7 @@ async function importLocalFiles(args: {
 
 export const EditorFileTree = observer(function EditorFileTree() {
   const workspace = useWorkspace();
+  const gitCheckout = workspace.get(gitCheckoutStoreToken);
   const workspaceId = useWorkspaceId();
   const taskView = useTaskComposition();
   const tabLayout = useTabLayout();
@@ -245,6 +252,8 @@ export const EditorFileTree = observer(function EditorFileTree() {
   const expandedPaths = editorView.expandedPaths;
   const activeFile = tabLayout.focusedPane.activeResourceOfKind<FileTabResource>('file');
   const openedPaths = useMemo(() => new Set(editorView.openFilePaths), [editorView.openFilePaths]);
+  const fileChanges = gitCheckout.fileChanges;
+  const gitDecorations = useMemo(() => buildFileTreeGitDecorations(fileChanges), [fileChanges]);
   const { rootNodes, childrenById } = useMemo(
     () => mapFileTreeData(files?.rootNodes ?? [], files?.childrenById ?? new Map()),
     [files?.childrenById, files?.rootNodes]
@@ -868,9 +877,16 @@ export const EditorFileTree = observer(function EditorFileTree() {
           if (node.type === 'symlink') return <Link2 size={12} />;
           return null;
         }}
+        renderDecoration={(node) => {
+          if (node.type !== 'directory') return null;
+          const status = gitDecorations.directoryStatusByPath.get(
+            relativeFileTreePath(workspace.path, node.path)
+          );
+          return status ? <FileTreeGitChangeIndicator status={status} /> : null;
+        }}
         getRowState={(node) =>
           mergeRowState(
-            rowStateForNode(node, workspace.path, workspace),
+            rowStateForNode(node, workspace.path, gitDecorations),
             clipboard?.mode === 'cut' && clipboard.paths.includes(node.path)
               ? { muted: true }
               : undefined
@@ -1111,27 +1127,65 @@ function toFileTreeNode(node: RenderableFileNode): FileTreeNode {
 function rowStateForNode(
   node: FileTreeNode,
   workspacePath: string,
-  workspace: ReturnType<typeof useWorkspace>
+  gitDecorations: FileTreeGitDecorations
 ): FileTreeRowState | undefined {
-  const relNodePath = relativeToWorkspace(workspacePath, node.path);
-  const fileStatus = workspace
-    .get(gitCheckoutStoreToken)
-    .fileChanges?.find((change) => change.path === relNodePath)?.status;
+  const relativePath = relativeFileTreePath(workspacePath, node.path);
+  const fileStatus =
+    gitDecorations.fileStatusByPath.get(relativePath) ??
+    (node.type === 'directory'
+      ? gitDecorations.directoryStatusByPath.get(relativePath)
+      : undefined);
   if (!fileStatus && !node.isHidden) return undefined;
   return {
     muted: node.isHidden || fileStatus === 'deleted',
     strikethrough: fileStatus === 'deleted',
-    tone:
-      fileStatus === 'added'
-        ? 'success'
-        : fileStatus === 'modified'
-          ? 'warning'
-          : fileStatus === 'deleted'
-            ? 'error'
-            : fileStatus === 'renamed'
-              ? 'info'
-              : undefined,
+    tone: fileStatus ? fileTreeGitStatusTone(fileStatus) : undefined,
   };
+}
+
+function relativeFileTreePath(workspacePath: string, nodePath: string): string {
+  return normalizeFileTreePath(relativeToWorkspace(workspacePath, nodePath));
+}
+
+export function FileTreeGitChangeIndicator({ status }: { status: GitChangeStatus }) {
+  return (
+    <span
+      className="flex size-4 items-center justify-center"
+      style={{ color: fileTreeGitStatusColor(status) }}
+      aria-label="Contains emphasized items"
+      title="Contains emphasized items"
+    >
+      <Circle aria-hidden className="size-2 fill-current opacity-40" strokeWidth={0} />
+    </span>
+  );
+}
+
+export function fileTreeGitStatusTone(status: GitChangeStatus): FileTreeRowState['tone'] {
+  switch (status) {
+    case 'added':
+      return 'success';
+    case 'modified':
+      return 'warning';
+    case 'deleted':
+    case 'conflicted':
+      return 'error';
+    case 'renamed':
+      return 'info';
+  }
+}
+
+function fileTreeGitStatusColor(status: GitChangeStatus): string {
+  switch (status) {
+    case 'added':
+      return 'var(--em-foreground-success)';
+    case 'modified':
+      return 'var(--em-foreground-warning)';
+    case 'deleted':
+    case 'conflicted':
+      return 'var(--em-foreground-error)';
+    case 'renamed':
+      return 'var(--em-foreground-diff-modified)';
+  }
 }
 
 function isPathWithin(path: string, deletedPath: string, closesDescendants: boolean) {


### PR DESCRIPTION
- propagate descendant git status to parent folders in the regular file explorer
- color folder names and indicators from the same git status
- match cursor ordering and exclude deleted-only changes from parent propagation
- keep parent decorations visible while folders are collapsed

closes #2337