### PR TITLE
fix(tabs): restore active tab surface hierarchy

### DIFF
--- a/apps/emdash-desktop/src/core/primitives/workbench-shell/browser/tabs/tab-bar/generic-tab-item.tsx
+++ b/apps/emdash-desktop/src/core/primitives/workbench-shell/browser/tabs/tab-bar/generic-tab-item.tsx
@@ -136,8 +136,8 @@ export const GenericTabItem = observer(function GenericTabItem({
           className={cn(
             'group relative flex h-full flex-col text-sm',
             tab.isActive
-              ? 'bg-(--em-surface-selected) text-foreground-muted'
-              : 'hover:bg-(--em-surface-hover)',
+              ? 'bg-(--em-surface) text-foreground-muted'
+              : 'bg-(--em-surface-hover) hover:bg-(--em-surface)',
             isFocusedPane && 'text-foreground'
           )}
         >


### PR DESCRIPTION
## Summary

- use the paper surface for the active task tab
- visually recess inactive tabs while preserving their hover state

Closes #3091

## Validation

- `git diff --check`
- repository CI