### PR TITLE
fix(tui): recover restored sessions after restart

### DIFF
--- a/apps/emdash-desktop/src/core/features/conversations/api/browser/conversation-manager.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/api/browser/conversation-manager.ts
@@ -24,6 +24,7 @@ import {
   type ConversationEvent,
   type CreateConversationParams,
 } from '@core/primitives/conversations/api';
+import { log } from '@core/primitives/logging/browser/logger';
 import { makePtySessionId } from '@core/primitives/pty/api';
 import { getConversationsClient } from './client';
 
@@ -569,7 +570,22 @@ function createTuiAgentsConnector(conversationId: string): FrontendPtyConnector 
       };
     },
     sendInput(data: string) {
-      void client().then((runtime) => runtime.tui.sendInput({ conversationId, data }));
+      void client()
+        .then(async (runtime) => {
+          const result = await runtime.tui.sendInput({ conversationId, data });
+          if (!result.success) {
+            log.warn('ConversationManagerStore: TUI input failed', {
+              conversationId,
+              error: result.error,
+            });
+          }
+        })
+        .catch((error) => {
+          log.warn('ConversationManagerStore: failed to send TUI input', {
+            conversationId,
+            error,
+          });
+        });
     },
     resize(cols: number, rows: number) {
       void client().then((runtime) => runtime.tui.resize({ conversationId, cols, rows }));

--- a/apps/emdash-desktop/src/core/features/conversations/browser/conversation-tab-resource.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/conversation-tab-resource.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ConversationStore } from '@core/features/conversations/api/browser/conversation-manager';
+import { ConversationTabResource } from './conversation-tab-resource';
+
+const registryGet = vi.hoisted(() => vi.fn());
+const setTelemetryConversationScope = vi.hoisted(() => vi.fn());
+const retryHydration = vi.hoisted(() => vi.fn());
+
+vi.mock('@core/features/conversations/api/browser/stores/conversation-registry', () => ({
+  conversationRegistry: { get: registryGet },
+}));
+
+vi.mock('@core/primitives/telemetry/browser/telemetry-scope', () => ({
+  setTelemetryConversationScope,
+}));
+
+vi.mock('@core/features/conversations/browser/stores/conversation-session-manager', () => ({
+  getConversationSessionManager: () => ({ retryHydration }),
+}));
+
+describe('ConversationTabResource activation', () => {
+  const isSessionActive = vi.fn();
+
+  beforeEach(() => {
+    registryGet.mockReset();
+    setTelemetryConversationScope.mockReset();
+    retryHydration.mockReset();
+    isSessionActive.mockReset();
+    registryGet.mockReturnValue({
+      conversations: new Map([['conversation-1', {}]]),
+      isSessionActive,
+    });
+  });
+
+  it('rehydrates an inactive TUI conversation when its tab is selected', () => {
+    isSessionActive.mockReturnValue(false);
+    const resource = new ConversationTabResource(tuiStore(), 'task-1', tabHandle());
+
+    resource.onActivate();
+
+    expect(retryHydration).toHaveBeenCalledWith('conversation-1');
+    resource.dispose();
+  });
+
+  it('does not rehydrate an already active TUI conversation', () => {
+    isSessionActive.mockReturnValue(true);
+    const resource = new ConversationTabResource(tuiStore(), 'task-1', tabHandle());
+
+    resource.onActivate();
+
+    expect(retryHydration).not.toHaveBeenCalled();
+    resource.dispose();
+  });
+
+  it('leaves ACP conversation recovery to the ACP store', () => {
+    isSessionActive.mockReturnValue(false);
+    const resource = new ConversationTabResource(acpStore(), 'task-1', tabHandle());
+
+    resource.onActivate();
+
+    expect(retryHydration).not.toHaveBeenCalled();
+    resource.dispose();
+  });
+});
+
+function tuiStore(): ConversationStore {
+  return {
+    data: { id: 'conversation-1', type: 'pty' },
+    seen: true,
+    markSeen: vi.fn(),
+  } as unknown as ConversationStore;
+}
+
+function acpStore(): ConversationStore {
+  return {
+    data: { id: 'conversation-1', type: 'acp' },
+    seen: true,
+    markSeen: vi.fn(),
+  } as unknown as ConversationStore;
+}
+
+function tabHandle() {
+  return { close: vi.fn() } as never;
+}

--- a/apps/emdash-desktop/src/core/features/conversations/browser/conversation-tab-resource.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/conversation-tab-resource.ts
@@ -1,6 +1,7 @@
 import { reaction } from 'mobx';
 import type { ConversationStore } from '@core/features/conversations/api/browser/conversation-manager';
 import { conversationRegistry } from '@core/features/conversations/api/browser/stores/conversation-registry';
+import { getConversationSessionManager } from '@core/features/conversations/browser/stores/conversation-session-manager';
 import { setTelemetryConversationScope } from '@core/primitives/telemetry/browser/telemetry-scope';
 import type {
   TabHandle,
@@ -49,6 +50,11 @@ export class ConversationTabResource implements TabResource {
     if (!this.store.seen) {
       this.store.markSeen();
     }
+    if (this.store.data.type === 'acp') return;
+
+    const conversations = conversationRegistry.get(this._taskId);
+    if (!conversations || conversations.isSessionActive(this.store.data.id)) return;
+    getConversationSessionManager(this._taskId).retryHydration(this.store.data.id);
   }
 
   rename(name: string): void {

--- a/apps/emdash-desktop/src/core/features/conversations/browser/stores/conversation-hydration-reconciler.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/stores/conversation-hydration-reconciler.test.ts
@@ -135,6 +135,20 @@ describe('ConversationHydrationReconciler', () => {
     expect(dehydrateConversation).not.toHaveBeenCalled();
   });
 
+  it('retries a failed desired hydration when requested', async () => {
+    const { reconciler, hydrateConversation } = makeHarness();
+    hydrateConversation.mockRejectedValueOnce(new Error('hydrate failed'));
+
+    reconciler.sync(['conversation-1']);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    reconciler.retry('conversation-1');
+    await Promise.resolve();
+
+    expect(hydrateConversation).toHaveBeenCalledTimes(2);
+  });
+
   it('stops hydrated conversations on dispose', async () => {
     const { reconciler, dehydrateConversation } = makeHarness();
 

--- a/apps/emdash-desktop/src/core/features/conversations/browser/stores/conversation-hydration-reconciler.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/stores/conversation-hydration-reconciler.ts
@@ -57,6 +57,13 @@ export class ConversationHydrationReconciler implements Disposable {
     }
   }
 
+  retry(conversationId: string): void {
+    if (this.disposed) return;
+    const entry = this.entries.get(conversationId);
+    if (!entry?.desired) return;
+    this.reconcile(conversationId, entry);
+  }
+
   dispose(): void {
     this.disposed = true;
     for (const [id, entry] of this.entries) {

--- a/apps/emdash-desktop/src/core/features/conversations/browser/stores/conversation-session-manager.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/stores/conversation-session-manager.ts
@@ -62,6 +62,10 @@ export class ConversationSessionManager {
     this.sync();
   }
 
+  retryHydration(conversationId: string): void {
+    this._reconciler.retry(conversationId);
+  }
+
   dispose(): void {
     this._disposeHostReaction();
     this._reconciler.dispose();

--- a/packages/core/src/primitives/kv/node/index.test.ts
+++ b/packages/core/src/primitives/kv/node/index.test.ts
@@ -1,0 +1,35 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Serializable } from '@emdash/shared';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createJsonFileKeyValueStore } from './index';
+
+describe('createJsonFileKeyValueStore', () => {
+  let directory: string | undefined;
+
+  afterEach(async () => {
+    if (directory) await rm(directory, { recursive: true, force: true });
+  });
+
+  it('returns the JSON-normalized value after writing', async () => {
+    directory = await mkdtemp(join(tmpdir(), 'emdash-json-kv-'));
+    const path = join(directory, 'store.json');
+    const store = createJsonFileKeyValueStore({ path });
+    const value = {
+      status: 'active',
+      payload: { providerId: 'test', optional: undefined },
+    } as unknown as Serializable;
+
+    await expect(store.set('session', value)).resolves.toEqual({ success: true, data: undefined });
+
+    const loaded = await store.get('session');
+    expect(loaded).toEqual({
+      success: true,
+      data: { status: 'active', payload: { providerId: 'test' } },
+    });
+    expect(JSON.parse(await readFile(path, 'utf8'))).toEqual(
+      loaded.success ? { session: loaded.data } : undefined
+    );
+  });
+});

--- a/packages/core/src/primitives/kv/node/index.ts
+++ b/packages/core/src/primitives/kv/node/index.ts
@@ -32,9 +32,16 @@ export function createJsonFileKeyValueStore(options: JsonFileKeyValueStoreOption
     const data = loaded ?? {};
     const tmpPath = `${options.path}.${process.pid}.tmp`;
     try {
+      const serialized = JSON.stringify(data, null, 2);
+      if (serialized === undefined) {
+        throw new TypeError('KV state could not be serialized');
+      }
       await mkdir(dirname(options.path), { recursive: true });
-      await writeFile(tmpPath, JSON.stringify(data, null, 2), 'utf8');
+      await writeFile(tmpPath, serialized, 'utf8');
       await rename(tmpPath, options.path);
+      // Match persistent KV stores: subsequent reads observe the JSON value that was
+      // actually written, not pre-serialization properties such as nested `undefined`.
+      loaded = JSON.parse(serialized) as Record<string, Serializable>;
       return ok();
     } catch (error) {
       return { success: false, error: keyValueIoError(error, 'Failed to write KV file') };

--- a/packages/core/src/services/pty/api/tmux.test.ts
+++ b/packages/core/src/services/pty/api/tmux.test.ts
@@ -46,6 +46,17 @@ describe('listTmuxSessionActivity', () => {
     await expect(listTmuxSessionActivity(stubExecContext(exec))).resolves.toEqual(new Map());
   });
 
+  it('returns an empty map for the macOS missing-socket error', async () => {
+    const exec = vi.fn(async () => {
+      throw {
+        exitCode: 1,
+        stderr: 'error connecting to /private/tmp/tmux-501/default (No such file or directory)',
+      };
+    });
+
+    await expect(listTmuxSessionActivity(stubExecContext(exec))).resolves.toEqual(new Map());
+  });
+
   it('returns an empty map when tmux is not installed (spawn failure)', async () => {
     const exec = vi.fn(async () => {
       throw Object.assign(new Error('spawn tmux ENOENT'), { code: 'ENOENT' });

--- a/packages/core/src/services/pty/api/tmux.ts
+++ b/packages/core/src/services/pty/api/tmux.ts
@@ -81,7 +81,9 @@ function isExpectedTmuxListFailure(error: unknown): boolean {
   if (failure.spawnFailed) return true;
   if (
     failure.exitCode === 1 &&
-    /no server running|failed to connect to server/i.test(failure.stderr)
+    /no server running|failed to connect to server|error connecting to .*\(no such file or directory\)/i.test(
+      failure.stderr
+    )
   ) {
     return true;
   }


### PR DESCRIPTION
## Summary

- retry failed TUI hydration when an inactive restored tab becomes active
- normalize file-backed KV values after serialization so optional fields cannot poison later validation
- recognize the macOS tmux missing-socket response as an expected empty-server state
- log failed TUI input delivery instead of silently discarding it
- add regression coverage for restore retry, persistence normalization, tab activation, and tmux detection

## Validation

- formatting applied to changed files before the final lifecycle edit
- git diff whitespace checks pass
- full repository checks deferred to GitHub CI because the required Node runtime is not installed locally

Closes #3093