### PR TITLE
fix(fs-watch): harden native watcher lifecycle

### DIFF
--- a/packages/core/src/services/fs-watch/impl/backend.ts
+++ b/packages/core/src/services/fs-watch/impl/backend.ts
@@ -13,14 +13,9 @@ export type WatchSink = {
 
 export type WatchOnError = (context: string, error: unknown) => void;
 
-export type WatchBackendStart = {
-  /** Cancels only the wait for a backend-owned startup slot. */
-  signal: AbortSignal;
-  /** Marks the point at which the active startup deadline begins. */
-  onStart: () => void;
-};
-
 export interface WatchBackend {
-  subscribe(key: WatchKey, sink: WatchSink, scope: Scope, start: WatchBackendStart): Promise<void>;
+  /** Aborts when backend-wide state is poisoned and the owning service must be replaced. */
+  readonly failureSignal?: AbortSignal;
+  subscribe(key: WatchKey, sink: WatchSink, scope: Scope): Promise<void>;
   dispose?(): Promise<void> | void;
 }

--- a/packages/core/src/services/fs-watch/impl/backend.ts
+++ b/packages/core/src/services/fs-watch/impl/backend.ts
@@ -14,6 +14,6 @@ export type WatchSink = {
 export type WatchOnError = (context: string, error: unknown) => void;
 
 export interface WatchBackend {
-  subscribe(key: WatchKey, sink: WatchSink, scope: Scope): Promise<void>;
+  subscribe(key: WatchKey, sink: WatchSink, scope: Scope, onStart: () => void): Promise<void>;
   dispose?(): Promise<void> | void;
 }

--- a/packages/core/src/services/fs-watch/impl/backend.ts
+++ b/packages/core/src/services/fs-watch/impl/backend.ts
@@ -13,7 +13,14 @@ export type WatchSink = {
 
 export type WatchOnError = (context: string, error: unknown) => void;
 
+export type WatchBackendStart = {
+  /** Cancels only the wait for a backend-owned startup slot. */
+  signal: AbortSignal;
+  /** Marks the point at which the active startup deadline begins. */
+  onStart: () => void;
+};
+
 export interface WatchBackend {
-  subscribe(key: WatchKey, sink: WatchSink, scope: Scope, onStart: () => void): Promise<void>;
+  subscribe(key: WatchKey, sink: WatchSink, scope: Scope, start: WatchBackendStart): Promise<void>;
   dispose?(): Promise<void> | void;
 }

--- a/packages/core/src/services/fs-watch/impl/controller.ts
+++ b/packages/core/src/services/fs-watch/impl/controller.ts
@@ -6,23 +6,15 @@ import { createEventStreamHost } from '@emdash/wire/live';
 import { createController, type Controller } from '@emdash/wire/rpc';
 import { fsWatchContract, requireWatchReady, type FsWatchKey } from '#services/fs-watch/api';
 import type { IWatchService } from '#services/fs-watch/api';
-import { nativeWatchBackend } from './native-backend';
-import { createWatchService } from './watch-service';
 
 export type CreateFsWatchControllerOptions = {
   scope: Scope;
+  service: IWatchService;
   onError?: (context: string, error: unknown) => void;
-  service?: IWatchService;
 };
 
 export function createFsWatchController(options: CreateFsWatchControllerOptions): Controller {
-  const service =
-    options.service ??
-    createWatchService({
-      backend: nativeWatchBackend({ onError: options.onError }),
-      scope: options.scope,
-      onError: options.onError,
-    });
+  const service = options.service;
   const events = createEventStreamHost(fsWatchContract.events, {
     activate: async (key, signal) => {
       const handle = service.watch(

--- a/packages/core/src/services/fs-watch/impl/controller.ts
+++ b/packages/core/src/services/fs-watch/impl/controller.ts
@@ -1,4 +1,6 @@
+import { once } from '@emdash/shared';
 import type { Scope } from '@emdash/shared/concurrency';
+import { abortableWait } from '@emdash/shared/scheduling';
 import { stableStringify } from '@emdash/shared/util';
 import { createEventStreamHost } from '@emdash/wire/live';
 import { createController, type Controller } from '@emdash/wire/rpc';
@@ -22,7 +24,7 @@ export function createFsWatchController(options: CreateFsWatchControllerOptions)
       onError: options.onError,
     });
   const events = createEventStreamHost(fsWatchContract.events, {
-    activate: async (key) => {
+    activate: async (key, signal) => {
       const handle = service.watch(
         key.root,
         (batch) => events.emit(key, { kind: 'events', events: batch }),
@@ -31,21 +33,22 @@ export function createFsWatchController(options: CreateFsWatchControllerOptions)
           onResync: () => events.emit(key, { kind: 'resync' }),
         }
       );
+      const release = once(() => handle.release());
       try {
-        await requireWatchReady(handle);
+        await abortableWait<void>({ signal }, (settle) => {
+          requireWatchReady(handle).then(settle.resolve, settle.reject);
+        });
       } catch (error) {
         try {
-          await handle.release();
+          await release();
         } catch (releaseError) {
           options.onError?.(`release failed watch ${keyId(key)}`, releaseError);
         }
-        options.onError?.(`watch ${keyId(key)}`, error);
+        if (!signal.aborted) options.onError?.(`watch ${keyId(key)}`, error);
         throw error;
       }
       return () => {
-        void handle
-          .release()
-          .catch((error) => options.onError?.(`release watch ${keyId(key)}`, error));
+        void release().catch((error) => options.onError?.(`release watch ${keyId(key)}`, error));
       };
     },
   });

--- a/packages/core/src/services/fs-watch/impl/native-backend.ts
+++ b/packages/core/src/services/fs-watch/impl/native-backend.ts
@@ -1,30 +1,63 @@
+import { createConcurrencyLimiter } from '@emdash/shared/concurrency';
+import parcelWatcher from '@parcel/watcher';
 import type { WatchBackend, WatchOnError } from './backend';
 import { NativeWatch, type ParcelSubscribeFn } from './native-watch';
+
+const DEFAULT_MAX_CONCURRENT_STARTS = 1;
 
 export type NativeWatchBackendOptions = {
   onError?: WatchOnError;
   subscribe?: ParcelSubscribeFn;
+  maxConcurrentStarts?: number;
 };
 
 export function nativeWatchBackend(options: NativeWatchBackendOptions = {}): WatchBackend {
   const onError = options.onError ?? (() => {});
+  const reportError = (context: string, error: unknown): void => {
+    try {
+      onError(context, error);
+    } catch {
+      // Error observers are best-effort and must not turn cleanup into an unhandled rejection.
+    }
+  };
+  const subscribe = options.subscribe ?? parcelWatcher.subscribe;
+  const startLimiter = createConcurrencyLimiter(
+    options.maxConcurrentStarts ?? DEFAULT_MAX_CONCURRENT_STARTS
+  );
 
   return {
-    async subscribe(key, sink, scope) {
-      const native = new NativeWatch(
-        key.root,
-        key.ignore,
-        sink.events,
-        sink.resync,
-        onError,
-        options.subscribe
-      );
-      scope.add(() => {
-        // A Parcel subscribe can remain pending after the channel startup timeout. Start cleanup
-        // without making scope disposal wait for that promise; NativeWatch disposes a late result.
-        void native.dispose();
+    async subscribe(key, sink, scope, onStart) {
+      await startLimiter.run(scope.signal, async () => {
+        onStart();
+        let initialSubscribe = true;
+        const scheduledSubscribe: ParcelSubscribeFn = (...args) => {
+          if (initialSubscribe) {
+            initialSubscribe = false;
+            return subscribe(...args);
+          }
+          return startLimiter.run(scope.signal, () => subscribe(...args));
+        };
+        const native = new NativeWatch(
+          key.root,
+          key.ignore,
+          sink.events,
+          sink.resync,
+          reportError,
+          scheduledSubscribe
+        );
+        let ready = false;
+        scope.add(() => {
+          const disposal = native
+            .dispose()
+            .catch((error) => reportError(`dispose watch ${key.root}`, error));
+          if (ready) return disposal;
+          // A Parcel subscribe can remain pending after the channel startup timeout. Start cleanup
+          // without making scope disposal wait for that promise; NativeWatch disposes a late result.
+          void disposal;
+        });
+        await native.ready();
+        ready = true;
       });
-      await native.ready();
     },
   };
 }

--- a/packages/core/src/services/fs-watch/impl/native-backend.ts
+++ b/packages/core/src/services/fs-watch/impl/native-backend.ts
@@ -1,17 +1,42 @@
-import { createConcurrencyLimiter } from '@emdash/shared/concurrency';
+import { createConcurrencyLimiter, type Scope } from '@emdash/shared/concurrency';
+import {
+  abortableWait,
+  abortReason,
+  runWithTimeout,
+  TimeoutError,
+} from '@emdash/shared/scheduling';
 import parcelWatcher from '@parcel/watcher';
-import type { WatchBackend, WatchOnError } from './backend';
+import type { WatchBackend, WatchKey, WatchOnError } from './backend';
 import { NativeWatch, type ParcelSubscribeFn } from './native-watch';
 
-const DEFAULT_MAX_CONCURRENT_STARTS = 1;
+// Parcel exposes neither cancellation nor a failure signal for a subscribe call that never
+// settles. This is the single time-based failure detector for that native process boundary.
+const NATIVE_STARTUP_WATCHDOG_MS = 10_000;
 
 export type NativeWatchBackendOptions = {
   onError?: WatchOnError;
   subscribe?: ParcelSubscribeFn;
-  maxConcurrentStarts?: number;
 };
 
-export function nativeWatchBackend(options: NativeWatchBackendOptions = {}): WatchBackend {
+export type NativeWatchBackend = WatchBackend & {
+  readonly failureSignal: AbortSignal;
+};
+
+class NativeWatchStartupTimeoutError extends Error {
+  constructor(root: string, cause: TimeoutError) {
+    super(`Native watcher startup timed out for ${root}`, { cause });
+    this.name = 'NativeWatchStartupTimeoutError';
+  }
+}
+
+class NativeWatchStartupCancelledError extends Error {
+  constructor(root: string, cause: unknown) {
+    super(`Native watcher startup was cancelled for ${root}`, { cause });
+    this.name = 'NativeWatchStartupCancelledError';
+  }
+}
+
+export function nativeWatchBackend(options: NativeWatchBackendOptions = {}): NativeWatchBackend {
   const onError = options.onError ?? (() => {});
   const reportError = (context: string, error: unknown): void => {
     try {
@@ -21,22 +46,76 @@ export function nativeWatchBackend(options: NativeWatchBackendOptions = {}): Wat
     }
   };
   const subscribe = options.subscribe ?? parcelWatcher.subscribe;
-  const startLimiter = createConcurrencyLimiter(
-    options.maxConcurrentStarts ?? DEFAULT_MAX_CONCURRENT_STARTS
-  );
+  const startLimiter = createConcurrencyLimiter(1);
+  const failureController = new AbortController();
+  let poisoned: Error | undefined;
+
+  const poison = (error: Error): Error => {
+    if (poisoned) return poisoned;
+    poisoned = error;
+    failureController.abort(error);
+    return error;
+  };
+
+  const disposeLateSubscription = (
+    key: WatchKey,
+    pending: Promise<parcelWatcher.AsyncSubscription>
+  ): void => {
+    void pending.then(
+      (subscription) =>
+        subscription
+          .unsubscribe()
+          .catch((error) => reportError(`unsubscribe late watch ${key.root}`, error)),
+      () => {}
+    );
+  };
+
+  const startNativeSubscription = async (
+    key: WatchKey,
+    scope: Scope,
+    start: () => Promise<parcelWatcher.AsyncSubscription>
+  ): Promise<parcelWatcher.AsyncSubscription> => {
+    if (poisoned) throw poisoned;
+    if (scope.signal.aborted) throw abortReason(scope.signal, 'Native watcher startup cancelled');
+    const pending = start();
+    try {
+      return await runWithTimeout(
+        (timeoutSignal) =>
+          abortableWait<parcelWatcher.AsyncSubscription>(
+            { signal: AbortSignal.any([scope.signal, timeoutSignal]) },
+            (settle) => {
+              pending.then(settle.resolve, settle.reject);
+            }
+          ),
+        { timeoutMs: NATIVE_STARTUP_WATCHDOG_MS }
+      );
+    } catch (error) {
+      if (error instanceof TimeoutError) {
+        disposeLateSubscription(key, pending);
+        throw poison(new NativeWatchStartupTimeoutError(key.root, error));
+      }
+      if (scope.signal.aborted) {
+        disposeLateSubscription(key, pending);
+        throw poison(new NativeWatchStartupCancelledError(key.root, error));
+      }
+      throw error;
+    }
+  };
 
   return {
-    async subscribe(key, sink, scope, start) {
-      const startSignal = AbortSignal.any([scope.signal, start.signal]);
-      await startLimiter.run(startSignal, async () => {
-        start.onStart();
+    failureSignal: failureController.signal,
+    async subscribe(key, sink, scope) {
+      if (poisoned) throw poisoned;
+      await startLimiter.run(scope.signal, async () => {
+        if (poisoned) throw poisoned;
         let initialSubscribe = true;
         const scheduledSubscribe: ParcelSubscribeFn = (...args) => {
+          const start = () => subscribe(...args);
           if (initialSubscribe) {
             initialSubscribe = false;
-            return subscribe(...args);
+            return startNativeSubscription(key, scope, start);
           }
-          return startLimiter.run(scope.signal, () => subscribe(...args));
+          return startLimiter.run(scope.signal, () => startNativeSubscription(key, scope, start));
         };
         const native = new NativeWatch(
           key.root,
@@ -52,8 +131,8 @@ export function nativeWatchBackend(options: NativeWatchBackendOptions = {}): Wat
             .dispose()
             .catch((error) => reportError(`dispose watch ${key.root}`, error));
           if (ready) return disposal;
-          // A Parcel subscribe can remain pending after the channel startup timeout. Start cleanup
-          // without making scope disposal wait for that promise; NativeWatch disposes a late result.
+          // Parcel startup cannot be cancelled. A poisoned backend is replaced at the process
+          // boundary, while the guarded subscription disposes a late native result.
           void disposal;
         });
         await native.ready();

--- a/packages/core/src/services/fs-watch/impl/native-backend.ts
+++ b/packages/core/src/services/fs-watch/impl/native-backend.ts
@@ -78,25 +78,31 @@ export function nativeWatchBackend(options: NativeWatchBackendOptions = {}): Nat
     if (poisoned) throw poisoned;
     if (scope.signal.aborted) throw abortReason(scope.signal, 'Native watcher startup cancelled');
     const pending = start();
+    let disposalScheduled = false;
+    const scheduleDisposal = (): void => {
+      if (disposalScheduled) return;
+      disposalScheduled = true;
+      disposeLateSubscription(key, pending);
+    };
+    const supervised = runWithTimeout(() => pending, {
+      timeoutMs: NATIVE_STARTUP_WATCHDOG_MS,
+    }).catch((error: unknown) => {
+      if (!(error instanceof TimeoutError)) throw error;
+      scheduleDisposal();
+      throw poison(new NativeWatchStartupTimeoutError(key.root, error));
+    });
+    void supervised.catch(() => {});
     try {
-      return await runWithTimeout(
-        (timeoutSignal) =>
-          abortableWait<parcelWatcher.AsyncSubscription>(
-            { signal: AbortSignal.any([scope.signal, timeoutSignal]) },
-            (settle) => {
-              pending.then(settle.resolve, settle.reject);
-            }
-          ),
-        { timeoutMs: NATIVE_STARTUP_WATCHDOG_MS }
+      return await abortableWait<parcelWatcher.AsyncSubscription>(
+        { signal: scope.signal },
+        (settle) => {
+          supervised.then(settle.resolve, settle.reject);
+        }
       );
     } catch (error) {
-      if (error instanceof TimeoutError) {
-        disposeLateSubscription(key, pending);
-        throw poison(new NativeWatchStartupTimeoutError(key.root, error));
-      }
       if (scope.signal.aborted) {
-        disposeLateSubscription(key, pending);
-        throw poison(new NativeWatchStartupCancelledError(key.root, error));
+        scheduleDisposal();
+        throw new NativeWatchStartupCancelledError(key.root, error);
       }
       throw error;
     }

--- a/packages/core/src/services/fs-watch/impl/native-backend.ts
+++ b/packages/core/src/services/fs-watch/impl/native-backend.ts
@@ -26,9 +26,10 @@ export function nativeWatchBackend(options: NativeWatchBackendOptions = {}): Wat
   );
 
   return {
-    async subscribe(key, sink, scope, onStart) {
-      await startLimiter.run(scope.signal, async () => {
-        onStart();
+    async subscribe(key, sink, scope, start) {
+      const startSignal = AbortSignal.any([scope.signal, start.signal]);
+      await startLimiter.run(startSignal, async () => {
+        start.onStart();
         let initialSubscribe = true;
         const scheduledSubscribe: ParcelSubscribeFn = (...args) => {
           if (initialSubscribe) {

--- a/packages/core/src/services/fs-watch/impl/native-watch.test.ts
+++ b/packages/core/src/services/fs-watch/impl/native-watch.test.ts
@@ -205,6 +205,14 @@ describe('NativeWatch', () => {
     expect(resync).not.toHaveBeenCalled();
   });
 
+  it('does not enter the native subscriber when disposed during preflight', async () => {
+    const watch = new NativeWatch(root, [], vi.fn(), vi.fn(), vi.fn(), subscribe);
+
+    await watch.dispose();
+
+    expect(subscribe).not.toHaveBeenCalled();
+  });
+
   it('disposes a replacement that finishes subscribing during disposal', async () => {
     const replacement = deferred<parcelWatcher.AsyncSubscription>();
     const replacementUnsubscribe = vi.fn(async () => {});
@@ -223,5 +231,18 @@ describe('NativeWatch', () => {
     expect(replacementUnsubscribe).toHaveBeenCalledOnce();
     expect(subscribe).toHaveBeenCalledTimes(2);
     expect(resync).not.toHaveBeenCalled();
+  });
+
+  it('contains final unsubscribe failures and reports them', async () => {
+    const failure = new Error('Unable to remove watcher');
+    const unsubscribe = vi.fn().mockRejectedValue(failure);
+    queueSubscription({ unsubscribe });
+    const onError = vi.fn();
+    const watch = await openWatch(vi.fn(), onError);
+
+    await expect(watch.dispose()).resolves.toBeUndefined();
+
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(onError).toHaveBeenCalledWith(`unsubscribe ${root}`, failure);
   });
 });

--- a/packages/core/src/services/fs-watch/impl/native-watch.ts
+++ b/packages/core/src/services/fs-watch/impl/native-watch.ts
@@ -66,11 +66,16 @@ export class NativeWatch implements Disposable {
     await this.restartPromise;
     const subscription = await this.subscription?.catch(() => null);
     this.subscription = null;
-    await subscription?.unsubscribe();
+    try {
+      await subscription?.unsubscribe();
+    } catch (error) {
+      this.reportError(`unsubscribe ${this.root}`, error);
+    }
   }
 
   private async subscribe(): Promise<parcelWatcher.AsyncSubscription> {
     await fs.stat(this.root);
+    if (this.disposed) throw new Error(`Watcher was disposed before subscribing for ${this.root}`);
     const generation = ++this.generation;
     this.activeGeneration = generation;
     return this.subscribeFn(
@@ -78,7 +83,7 @@ export class NativeWatch implements Disposable {
       (err, events) => {
         if (this.disposed || generation !== this.activeGeneration) return;
         if (err) {
-          this.onError(`watch ${this.root}`, err);
+          this.reportError(`watch ${this.root}`, err);
           if (requiresResync(err)) {
             this.scheduleResync();
             return;
@@ -110,7 +115,7 @@ export class NativeWatch implements Disposable {
     try {
       this.resync();
     } catch (error) {
-      this.onError(`resync ${this.root}`, error);
+      this.reportError(`resync ${this.root}`, error);
     }
   }
 
@@ -150,7 +155,7 @@ export class NativeWatch implements Disposable {
     try {
       await previous?.unsubscribe();
     } catch (error) {
-      this.onError(`unsubscribe ${this.root}`, error);
+      this.reportError(`unsubscribe ${this.root}`, error);
       if (!this.disposed && this.subscription === previousPromise) {
         this.activeGeneration = previousGeneration;
         this.scheduleResync();
@@ -165,13 +170,21 @@ export class NativeWatch implements Disposable {
     try {
       await next;
     } catch (error) {
-      this.onError(`resubscribe ${this.root}`, error);
+      this.reportError(`resubscribe ${this.root}`, error);
       return true;
     }
     this.retryAttempts = 0;
     if (this.disposed) return false;
     this.signalResync();
     return false;
+  }
+
+  private reportError(context: string, error: unknown): void {
+    try {
+      this.onError(context, error);
+    } catch {
+      // Error observers are best-effort and must never escape a native watcher callback or cleanup path
+    }
   }
 }
 

--- a/packages/core/src/services/fs-watch/impl/process-backend.test.ts
+++ b/packages/core/src/services/fs-watch/impl/process-backend.test.ts
@@ -227,7 +227,6 @@ function createProcessWatchService({
       client: () => worker.ready(),
     }),
     scope,
-    graceMs: 2_500,
   });
 }
 

--- a/packages/core/src/services/fs-watch/impl/process-backend.test.ts
+++ b/packages/core/src/services/fs-watch/impl/process-backend.test.ts
@@ -177,6 +177,29 @@ describe('processWatchBackend', () => {
     wire.dispose();
     await scope.dispose();
   });
+
+  it('releases a child watcher when the final lease disappears during startup', async () => {
+    const childService = new FakeWatchService();
+    const scope = createScope({ label: 'test' });
+    const controller = createFsWatchController({ scope, service: childService });
+    const wire = createTestWire(fsWatchContract, controller);
+    const service = createWatchService({
+      backend: processWatchBackend({ client: wire.client }),
+      scope,
+    });
+    const handle = service.watch('/tmp/project', () => {});
+    const ready = handle.ready();
+
+    await waitFor(() => childService.watches.length === 1);
+    await handle.release();
+
+    await waitFor(() => childService.latest().released);
+    const readyResult = await ready;
+    expect(readyResult.success).toBe(false);
+
+    wire.dispose();
+    await scope.dispose();
+  });
 });
 
 function createProcessWatchService({

--- a/packages/core/src/services/fs-watch/impl/process-backend.ts
+++ b/packages/core/src/services/fs-watch/impl/process-backend.ts
@@ -16,8 +16,7 @@ export function processWatchBackend(options: ProcessWatchBackendOptions): WatchB
   const onError = options.onError ?? (() => {});
 
   return {
-    async subscribe(key, sink, scope, start) {
-      start.onStart();
+    async subscribe(key, sink, scope) {
       await options.ready?.();
       const client = await getClient(options.client);
       const detach = await client.events.handle(key).attach(

--- a/packages/core/src/services/fs-watch/impl/process-backend.ts
+++ b/packages/core/src/services/fs-watch/impl/process-backend.ts
@@ -16,7 +16,8 @@ export function processWatchBackend(options: ProcessWatchBackendOptions): WatchB
   const onError = options.onError ?? (() => {});
 
   return {
-    async subscribe(key, sink, scope) {
+    async subscribe(key, sink, scope, onStart) {
+      onStart();
       await options.ready?.();
       const client = await getClient(options.client);
       const detach = await client.events.handle(key).attach(
@@ -32,6 +33,7 @@ export function processWatchBackend(options: ProcessWatchBackendOptions): WatchB
           }
         },
         {
+          signal: scope.signal,
           onReattach: () => sink.resync(),
           onReattachError: (error, context) => {
             const mode = context.retrying ? 'retrying' : 'terminal';

--- a/packages/core/src/services/fs-watch/impl/process-backend.ts
+++ b/packages/core/src/services/fs-watch/impl/process-backend.ts
@@ -16,8 +16,8 @@ export function processWatchBackend(options: ProcessWatchBackendOptions): WatchB
   const onError = options.onError ?? (() => {});
 
   return {
-    async subscribe(key, sink, scope, onStart) {
-      onStart();
+    async subscribe(key, sink, scope, start) {
+      start.onStart();
       await options.ready?.();
       const client = await getClient(options.client);
       const detach = await client.events.handle(key).attach(

--- a/packages/core/src/services/fs-watch/impl/watch-service.test.ts
+++ b/packages/core/src/services/fs-watch/impl/watch-service.test.ts
@@ -6,8 +6,9 @@ import type { Scope } from '@emdash/shared/concurrency';
 import type parcelWatcher from '@parcel/watcher';
 import { describe, expect, it, vi } from 'vitest';
 import { requireWatchReady, type WatchEvent } from '#services/fs-watch/api';
-import type { WatchBackend, WatchBackendStart, WatchKey, WatchSink } from './backend';
+import type { WatchBackend, WatchKey, WatchSink } from './backend';
 import { nativeWatchBackend } from './native-backend';
+import type { ParcelSubscribeFn } from './native-watch';
 import { realpathOrResolve } from './paths';
 import { createWatchService } from './watch-service';
 
@@ -279,88 +280,70 @@ describe('createWatchService', () => {
     }
   });
 
-  it('evicts a timed-out startup so the next watch makes a fresh attempt', async () => {
-    vi.useFakeTimers();
-    const root = await mkdtemp(path.join(tmpdir(), 'emdash-watch-timeout-'));
+  it('evicts a failed startup so the next watch makes a fresh attempt', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'emdash-watch-retry-'));
     const backend = new DeferredWatchBackend();
-    const service = createWatchService({ backend, startupTimeoutMs: 25 });
+    const service = createWatchService({ backend });
+    const failure = new Error('watch attach failed');
 
     try {
       const first = service.watch(root, () => {});
       const firstReady = first.ready();
-      await vi.advanceTimersByTimeAsync(25);
-      const firstResult = await firstReady;
-      expect(firstResult.success).toBe(false);
-      if (firstResult.success) throw new Error('Expected watch startup to fail');
-      expect(firstResult.error).toMatchObject({ message: 'Operation timed out after 25ms' });
+      const firstAttempt = await eventually(() => backend.attempts[0]);
+      firstAttempt.ready.reject(failure);
+      await expect(firstReady).resolves.toEqual(err(failure));
       await first.release();
       expect(backend.attempts).toHaveLength(1);
       expect(backend.attempts[0]?.disposed).toBe(true);
 
       const second = service.watch(root, () => {});
       const secondReady = second.ready();
-      await vi.advanceTimersByTimeAsync(0);
-      expect(backend.attempts).toHaveLength(2);
+      await eventually(() => backend.attempts[1]);
       backend.attempts[1]?.ready.resolve(undefined);
       await expect(secondReady).resolves.toEqual(ok(undefined));
 
-      backend.attempts[0]?.ready.resolve(undefined);
-      await vi.advanceTimersByTimeAsync(0);
-      expect(backend.attempts[0]?.disposed).toBe(true);
       await second.release();
     } finally {
-      vi.useRealTimers();
       await service.dispose();
     }
   });
 
-  it('retries a timed-out native startup and disposes its late subscription', async () => {
-    vi.useFakeTimers();
-    const root = await mkdtemp(path.join(tmpdir(), 'emdash-native-watch-timeout-'));
+  it('poisons the native backend when an active startup is cancelled', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'emdash-native-watch-cancel-'));
     const firstSubscription = deferred<parcelWatcher.AsyncSubscription>();
-    const secondSubscription = deferred<parcelWatcher.AsyncSubscription>();
     const firstUnsubscribe = vi.fn(async () => {});
-    const secondUnsubscribe = vi.fn(async () => {});
-    const subscribe = vi
-      .fn()
-      .mockReturnValueOnce(firstSubscription.promise)
-      .mockReturnValueOnce(secondSubscription.promise);
+    const subscribe = vi.fn().mockReturnValueOnce(firstSubscription.promise);
+    const backend = nativeWatchBackend({ subscribe });
     const service = createWatchService({
-      backend: nativeWatchBackend({ subscribe }),
-      startupTimeoutMs: 1_000,
+      backend,
     });
 
     try {
       const first = service.watch(root, () => {});
       const firstReady = first.ready();
       await vi.waitFor(() => expect(subscribe).toHaveBeenCalledOnce());
-      await vi.advanceTimersByTimeAsync(1_000);
+      await first.release();
       const firstResult = await firstReady;
       expect(firstResult.success).toBe(false);
       if (firstResult.success) throw new Error('Expected watch startup to fail');
-      expect(firstResult.error).toMatchObject({ message: 'Operation timed out after 1000ms' });
-      await first.release();
+      expect(backend.failureSignal.aborted).toBe(true);
+      const failure = backend.failureSignal.reason;
+      expect(failure).toMatchObject({
+        name: 'NativeWatchStartupCancelledError',
+      });
 
-      const second = service.watch(root, () => {});
-      const secondReady = second.ready();
+      expect(() => service.watch(root, () => {})).toThrow(failure);
       expect(subscribe).toHaveBeenCalledOnce();
-      firstSubscription.resolve({ unsubscribe: firstUnsubscribe });
-      await vi.waitFor(() => expect(subscribe).toHaveBeenCalledTimes(2));
-      secondSubscription.resolve({ unsubscribe: secondUnsubscribe });
-      await expect(secondReady).resolves.toEqual(ok(undefined));
 
-      await vi.advanceTimersByTimeAsync(0);
-      expect(firstUnsubscribe).toHaveBeenCalledOnce();
-      await second.release();
-      expect(secondUnsubscribe).toHaveBeenCalledOnce();
+      firstSubscription.resolve({ unsubscribe: firstUnsubscribe });
+      await vi.waitFor(() => expect(firstUnsubscribe).toHaveBeenCalledOnce());
     } finally {
-      vi.useRealTimers();
+      firstSubscription.resolve({ unsubscribe: firstUnsubscribe });
       await service.dispose();
     }
   });
 
-  it('starts native subscriptions FIFO without timing out queued roots', async () => {
-    vi.useFakeTimers();
+  it('starts native subscriptions FIFO', async () => {
     const firstRoot = await mkdtemp(path.join(tmpdir(), 'emdash-native-queue-first-'));
     const secondRoot = await mkdtemp(path.join(tmpdir(), 'emdash-native-queue-second-'));
     const firstSubscription = deferred<parcelWatcher.AsyncSubscription>();
@@ -372,8 +355,7 @@ describe('createWatchService', () => {
       .mockReturnValueOnce(firstSubscription.promise)
       .mockReturnValueOnce(secondSubscription.promise);
     const service = createWatchService({
-      backend: nativeWatchBackend({ subscribe, maxConcurrentStarts: 1 }),
-      startupTimeoutMs: 1_000,
+      backend: nativeWatchBackend({ subscribe }),
     });
 
     try {
@@ -387,17 +369,10 @@ describe('createWatchService', () => {
 
       await vi.waitFor(() => expect(subscribe).toHaveBeenCalledOnce());
       expect(subscribe.mock.calls[0]?.[0]).toBe(realpathOrResolve(firstRoot));
-
-      await vi.advanceTimersByTimeAsync(1_000);
-      const firstResult = await firstReady;
-      expect(firstResult.success).toBe(false);
-      expect(subscribe).toHaveBeenCalledOnce();
-
-      await vi.advanceTimersByTimeAsync(5_000);
       expect(secondSettled).toBe(false);
-      expect(subscribe).toHaveBeenCalledOnce();
 
       firstSubscription.resolve({ unsubscribe: firstUnsubscribe });
+      await expect(firstReady).resolves.toEqual(ok(undefined));
       await vi.waitFor(() => expect(subscribe).toHaveBeenCalledTimes(2));
       expect(subscribe.mock.calls[1]?.[0]).toBe(realpathOrResolve(secondRoot));
       secondSubscription.resolve({ unsubscribe: secondUnsubscribe });
@@ -408,27 +383,20 @@ describe('createWatchService', () => {
       expect(firstUnsubscribe).toHaveBeenCalledOnce();
       expect(secondUnsubscribe).toHaveBeenCalledOnce();
     } finally {
-      vi.useRealTimers();
       await service.dispose();
     }
   });
 
-  it('bounds queue wait while a timed-out native startup still holds the slot', async () => {
+  it('poisons queued native starts when the active startup exceeds its watchdog', async () => {
     vi.useFakeTimers();
     const firstRoot = await mkdtemp(path.join(tmpdir(), 'emdash-native-stuck-first-'));
     const secondRoot = await mkdtemp(path.join(tmpdir(), 'emdash-native-stuck-second-'));
     const firstSubscription = deferred<parcelWatcher.AsyncSubscription>();
-    const retrySubscription = deferred<parcelWatcher.AsyncSubscription>();
     const firstUnsubscribe = vi.fn(async () => {});
-    const retryUnsubscribe = vi.fn(async () => {});
-    const subscribe = vi
-      .fn()
-      .mockReturnValueOnce(firstSubscription.promise)
-      .mockReturnValueOnce(retrySubscription.promise);
+    const subscribe = vi.fn().mockReturnValueOnce(firstSubscription.promise);
+    const backend = nativeWatchBackend({ subscribe });
     const service = createWatchService({
-      backend: nativeWatchBackend({ subscribe, maxConcurrentStarts: 1 }),
-      startupTimeoutMs: 1_000,
-      startupQueueTimeoutMs: 2_000,
+      backend,
     });
 
     try {
@@ -441,33 +409,81 @@ describe('createWatchService', () => {
       });
 
       await vi.waitFor(() => expect(subscribe).toHaveBeenCalledOnce());
-      await vi.advanceTimersByTimeAsync(1_000);
-      await expect(firstReady).resolves.toEqual(
-        err(expect.objectContaining({ message: 'Operation timed out after 1000ms' }))
-      );
+      await vi.advanceTimersByTimeAsync(9_000);
+      expect(secondSettled).toBe(false);
+      expect(backend.failureSignal.aborted).toBe(false);
 
       await vi.advanceTimersByTimeAsync(1_000);
+      const firstResult = await firstReady;
+      expect(firstResult.success).toBe(false);
+      if (firstResult.success) throw new Error('Expected watch startup to fail');
+      expect(firstResult.error).toMatchObject({
+        name: 'NativeWatchStartupTimeoutError',
+        message: expect.stringContaining(realpathOrResolve(firstRoot)),
+      });
       expect(secondSettled).toBe(true);
-      await expect(secondReady).resolves.toEqual(
-        err(expect.objectContaining({ message: 'Operation timed out after 2000ms' }))
-      );
+      await expect(secondReady).resolves.toEqual(err(firstResult.error));
+      expect(backend.failureSignal.aborted).toBe(true);
+      expect(backend.failureSignal.reason).toBe(firstResult.error);
+      expect(subscribe).toHaveBeenCalledOnce();
+
+      expect(() => service.watch(secondRoot, () => {})).toThrow(firstResult.error);
       expect(subscribe).toHaveBeenCalledOnce();
 
       firstSubscription.resolve({ unsubscribe: firstUnsubscribe });
       await vi.waitFor(() => expect(firstUnsubscribe).toHaveBeenCalledOnce());
       await first.release();
       await second.release();
-
-      expect(subscribe).toHaveBeenCalledOnce();
-      const retry = service.watch(secondRoot, () => {});
-      const retryReady = retry.ready();
-      await vi.waitFor(() => expect(subscribe).toHaveBeenCalledTimes(2));
-      retrySubscription.resolve({ unsubscribe: retryUnsubscribe });
-      await expect(retryReady).resolves.toEqual(ok(undefined));
-      await retry.release();
-      expect(retryUnsubscribe).toHaveBeenCalledOnce();
     } finally {
       firstSubscription.resolve({ unsubscribe: firstUnsubscribe });
+      vi.useRealTimers();
+      await service.dispose();
+    }
+  });
+
+  it('applies the native startup watchdog to replacement subscriptions', async () => {
+    vi.useFakeTimers();
+    const root = await mkdtemp(path.join(tmpdir(), 'emdash-native-stuck-replacement-'));
+    const replacement = deferred<parcelWatcher.AsyncSubscription>();
+    const firstUnsubscribe = vi.fn(async () => {});
+    const replacementUnsubscribe = vi.fn(async () => {});
+    let firstCallback: Parameters<ParcelSubscribeFn>[1] | undefined;
+    const subscribe = vi
+      .fn<ParcelSubscribeFn>()
+      .mockImplementationOnce((_root, callback) => {
+        firstCallback = callback;
+        return Promise.resolve({ unsubscribe: firstUnsubscribe });
+      })
+      .mockReturnValueOnce(replacement.promise);
+    const backend = nativeWatchBackend({ subscribe });
+    const service = createWatchService({
+      backend,
+    });
+
+    try {
+      const handle = service.watch(root, () => {});
+      await expect(handle.ready()).resolves.toEqual(ok(undefined));
+
+      firstCallback?.(new Error('native watcher failed'), []);
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.waitFor(() => expect(subscribe).toHaveBeenCalledTimes(2));
+      expect(firstUnsubscribe).toHaveBeenCalledOnce();
+
+      await vi.advanceTimersByTimeAsync(9_000);
+      expect(backend.failureSignal.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(backend.failureSignal.aborted).toBe(true);
+      const failure = backend.failureSignal.reason;
+      expect(failure).toMatchObject({ name: 'NativeWatchStartupTimeoutError' });
+
+      expect(() => service.watch(root, () => {})).toThrow(failure);
+      expect(subscribe).toHaveBeenCalledTimes(2);
+
+      replacement.resolve({ unsubscribe: replacementUnsubscribe });
+      await vi.waitFor(() => expect(replacementUnsubscribe).toHaveBeenCalledOnce());
+      await handle.release();
+    } finally {
+      replacement.resolve({ unsubscribe: replacementUnsubscribe });
       vi.useRealTimers();
       await service.dispose();
     }
@@ -480,7 +496,7 @@ describe('createWatchService', () => {
     const firstUnsubscribe = vi.fn(async () => {});
     const subscribe = vi.fn().mockReturnValueOnce(firstSubscription.promise);
     const service = createWatchService({
-      backend: nativeWatchBackend({ subscribe, maxConcurrentStarts: 1 }),
+      backend: nativeWatchBackend({ subscribe }),
     });
 
     try {
@@ -589,13 +605,7 @@ class FakeWatchBackend implements WatchBackend {
     return this.sinks.size;
   }
 
-  async subscribe(
-    key: WatchKey,
-    sink: WatchSink,
-    scope: Scope,
-    start: WatchBackendStart
-  ): Promise<void> {
-    start.onStart();
+  async subscribe(key: WatchKey, sink: WatchSink, scope: Scope): Promise<void> {
     this.subscribeCount += 1;
     const keyId = keyOf(key);
     this.sinks.set(keyId, sink);
@@ -619,13 +629,7 @@ class DeferredWatchBackend implements WatchBackend {
     disposed: boolean;
   }> = [];
 
-  async subscribe(
-    _key: WatchKey,
-    _sink: WatchSink,
-    scope: Scope,
-    start: WatchBackendStart
-  ): Promise<void> {
-    start.onStart();
+  async subscribe(_key: WatchKey, _sink: WatchSink, scope: Scope): Promise<void> {
     const attempt = { ready: deferred(), disposed: false };
     this.attempts.push(attempt);
     scope.add(() => {

--- a/packages/core/src/services/fs-watch/impl/watch-service.test.ts
+++ b/packages/core/src/services/fs-watch/impl/watch-service.test.ts
@@ -308,37 +308,93 @@ describe('createWatchService', () => {
     }
   });
 
-  it('poisons the native backend when an active startup is cancelled', async () => {
-    const root = await mkdtemp(path.join(tmpdir(), 'emdash-native-watch-cancel-'));
-    const firstSubscription = deferred<parcelWatcher.AsyncSubscription>();
-    const firstUnsubscribe = vi.fn(async () => {});
-    const subscribe = vi.fn().mockReturnValueOnce(firstSubscription.promise);
+  it('keeps the native backend healthy when an active startup is cancelled', async () => {
+    const activeRoot = await mkdtemp(path.join(tmpdir(), 'emdash-native-watch-active-'));
+    const cancelledRoot = await mkdtemp(path.join(tmpdir(), 'emdash-native-watch-cancelled-'));
+    const nextRoot = await mkdtemp(path.join(tmpdir(), 'emdash-native-watch-next-'));
+    const cancelledSubscription = deferred<parcelWatcher.AsyncSubscription>();
+    const activeUnsubscribe = vi.fn(async () => {});
+    const cancelledUnsubscribe = vi.fn(async () => {});
+    const nextUnsubscribe = vi.fn(async () => {});
+    let activeCallback: Parameters<ParcelSubscribeFn>[1] | undefined;
+    const subscribe = vi
+      .fn<ParcelSubscribeFn>()
+      .mockImplementationOnce((_root, callback) => {
+        activeCallback = callback;
+        return Promise.resolve({ unsubscribe: activeUnsubscribe });
+      })
+      .mockReturnValueOnce(cancelledSubscription.promise)
+      .mockResolvedValueOnce({ unsubscribe: nextUnsubscribe });
     const backend = nativeWatchBackend({ subscribe });
     const service = createWatchService({
       backend,
     });
+    const activeEvents: WatchEvent[] = [];
 
     try {
-      const first = service.watch(root, () => {});
-      const firstReady = first.ready();
+      const active = service.watch(activeRoot, (events) => activeEvents.push(...events));
+      await expect(active.ready()).resolves.toEqual(ok(undefined));
+
+      const cancelled = service.watch(cancelledRoot, () => {});
+      const cancelledReady = cancelled.ready();
+      await vi.waitFor(() => expect(subscribe).toHaveBeenCalledTimes(2));
+      await cancelled.release();
+      const cancelledResult = await cancelledReady;
+      expect(cancelledResult.success).toBe(false);
+      if (cancelledResult.success) throw new Error('Expected watch startup to be cancelled');
+      expect(backend.failureSignal.aborted).toBe(false);
+
+      activeCallback?.(null, [{ type: 'update', path: path.join(activeRoot, 'still-watched') }]);
+      expect(activeEvents).toEqual([
+        { kind: 'update', path: path.join(activeRoot, 'still-watched') },
+      ]);
+
+      const next = service.watch(nextRoot, () => {});
+      await expect(next.ready()).resolves.toEqual(ok(undefined));
+      expect(subscribe).toHaveBeenCalledTimes(3);
+
+      cancelledSubscription.resolve({ unsubscribe: cancelledUnsubscribe });
+      await vi.waitFor(() => expect(cancelledUnsubscribe).toHaveBeenCalledOnce());
+
+      await active.release();
+      await next.release();
+      expect(activeUnsubscribe).toHaveBeenCalledOnce();
+      expect(nextUnsubscribe).toHaveBeenCalledOnce();
+    } finally {
+      cancelledSubscription.resolve({ unsubscribe: cancelledUnsubscribe });
+      await service.dispose();
+    }
+  });
+
+  it('poisons the native backend when a cancelled startup exceeds its watchdog', async () => {
+    vi.useFakeTimers();
+    const root = await mkdtemp(path.join(tmpdir(), 'emdash-native-watch-cancelled-stuck-'));
+    const subscription = deferred<parcelWatcher.AsyncSubscription>();
+    const unsubscribe = vi.fn(async () => {});
+    const subscribe = vi.fn().mockReturnValueOnce(subscription.promise);
+    const backend = nativeWatchBackend({ subscribe });
+    const service = createWatchService({ backend });
+
+    try {
+      const handle = service.watch(root, () => {});
+      const ready = handle.ready();
       await vi.waitFor(() => expect(subscribe).toHaveBeenCalledOnce());
-      await first.release();
-      const firstResult = await firstReady;
-      expect(firstResult.success).toBe(false);
-      if (firstResult.success) throw new Error('Expected watch startup to fail');
-      expect(backend.failureSignal.aborted).toBe(true);
-      const failure = backend.failureSignal.reason;
-      expect(failure).toMatchObject({
-        name: 'NativeWatchStartupCancelledError',
+      await handle.release();
+      await expect(ready).resolves.toMatchObject({ success: false });
+
+      await vi.advanceTimersByTimeAsync(9_000);
+      expect(backend.failureSignal.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(backend.failureSignal.reason).toMatchObject({
+        name: 'NativeWatchStartupTimeoutError',
+        message: expect.stringContaining(realpathOrResolve(root)),
       });
 
-      expect(() => service.watch(root, () => {})).toThrow(failure);
-      expect(subscribe).toHaveBeenCalledOnce();
-
-      firstSubscription.resolve({ unsubscribe: firstUnsubscribe });
-      await vi.waitFor(() => expect(firstUnsubscribe).toHaveBeenCalledOnce());
+      subscription.resolve({ unsubscribe });
+      await vi.waitFor(() => expect(unsubscribe).toHaveBeenCalledOnce());
     } finally {
-      firstSubscription.resolve({ unsubscribe: firstUnsubscribe });
+      subscription.resolve({ unsubscribe });
+      vi.useRealTimers();
       await service.dispose();
     }
   });

--- a/packages/core/src/services/fs-watch/impl/watch-service.test.ts
+++ b/packages/core/src/services/fs-watch/impl/watch-service.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { err, ok } from '@emdash/shared';
@@ -249,7 +249,8 @@ describe('createWatchService', () => {
       await handle.release();
       attempt.ready.reject(failure);
 
-      await expect(handle.ready()).resolves.toEqual(err(failure));
+      const result = await handle.ready();
+      expect(result.success).toBe(false);
       expect(onError).not.toHaveBeenCalled();
     } finally {
       await service.dispose();
@@ -332,6 +333,7 @@ describe('createWatchService', () => {
     try {
       const first = service.watch(root, () => {});
       const firstReady = first.ready();
+      await vi.waitFor(() => expect(subscribe).toHaveBeenCalledOnce());
       await vi.advanceTimersByTimeAsync(1_000);
       const firstResult = await firstReady;
       expect(firstResult.success).toBe(false);
@@ -340,12 +342,13 @@ describe('createWatchService', () => {
       await first.release();
 
       const second = service.watch(root, () => {});
-      const secondReady = expect(second.ready()).resolves.toEqual(ok(undefined));
+      const secondReady = second.ready();
+      expect(subscribe).toHaveBeenCalledOnce();
+      firstSubscription.resolve({ unsubscribe: firstUnsubscribe });
       await vi.waitFor(() => expect(subscribe).toHaveBeenCalledTimes(2));
       secondSubscription.resolve({ unsubscribe: secondUnsubscribe });
-      await secondReady;
+      await expect(secondReady).resolves.toEqual(ok(undefined));
 
-      firstSubscription.resolve({ unsubscribe: firstUnsubscribe });
       await vi.advanceTimersByTimeAsync(0);
       expect(firstUnsubscribe).toHaveBeenCalledOnce();
       await second.release();
@@ -355,6 +358,157 @@ describe('createWatchService', () => {
       await service.dispose();
     }
   });
+
+  it('starts native subscriptions FIFO without timing out queued roots', async () => {
+    vi.useFakeTimers();
+    const firstRoot = await mkdtemp(path.join(tmpdir(), 'emdash-native-queue-first-'));
+    const secondRoot = await mkdtemp(path.join(tmpdir(), 'emdash-native-queue-second-'));
+    const firstSubscription = deferred<parcelWatcher.AsyncSubscription>();
+    const secondSubscription = deferred<parcelWatcher.AsyncSubscription>();
+    const firstUnsubscribe = vi.fn(async () => {});
+    const secondUnsubscribe = vi.fn(async () => {});
+    const subscribe = vi
+      .fn()
+      .mockReturnValueOnce(firstSubscription.promise)
+      .mockReturnValueOnce(secondSubscription.promise);
+    const service = createWatchService({
+      backend: nativeWatchBackend({ subscribe, maxConcurrentStarts: 1 }),
+      startupTimeoutMs: 1_000,
+    });
+
+    try {
+      const first = service.watch(firstRoot, () => {});
+      const second = service.watch(secondRoot, () => {});
+      const firstReady = first.ready();
+      let secondSettled = false;
+      const secondReady = second.ready().finally(() => {
+        secondSettled = true;
+      });
+
+      await vi.waitFor(() => expect(subscribe).toHaveBeenCalledOnce());
+      expect(subscribe.mock.calls[0]?.[0]).toBe(realpathOrResolve(firstRoot));
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      const firstResult = await firstReady;
+      expect(firstResult.success).toBe(false);
+      expect(subscribe).toHaveBeenCalledOnce();
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(secondSettled).toBe(false);
+      expect(subscribe).toHaveBeenCalledOnce();
+
+      firstSubscription.resolve({ unsubscribe: firstUnsubscribe });
+      await vi.waitFor(() => expect(subscribe).toHaveBeenCalledTimes(2));
+      expect(subscribe.mock.calls[1]?.[0]).toBe(realpathOrResolve(secondRoot));
+      secondSubscription.resolve({ unsubscribe: secondUnsubscribe });
+      await expect(secondReady).resolves.toEqual(ok(undefined));
+
+      await first.release();
+      await second.release();
+      expect(firstUnsubscribe).toHaveBeenCalledOnce();
+      expect(secondUnsubscribe).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+      await service.dispose();
+    }
+  });
+
+  it('cancels a queued native subscription when its final lease is released', async () => {
+    const firstRoot = await mkdtemp(path.join(tmpdir(), 'emdash-native-cancel-first-'));
+    const secondRoot = await mkdtemp(path.join(tmpdir(), 'emdash-native-cancel-second-'));
+    const firstSubscription = deferred<parcelWatcher.AsyncSubscription>();
+    const firstUnsubscribe = vi.fn(async () => {});
+    const subscribe = vi.fn().mockReturnValueOnce(firstSubscription.promise);
+    const service = createWatchService({
+      backend: nativeWatchBackend({ subscribe, maxConcurrentStarts: 1 }),
+    });
+
+    try {
+      const first = service.watch(firstRoot, () => {});
+      const second = service.watch(secondRoot, () => {});
+      const secondReady = second.ready();
+      await vi.waitFor(() => expect(subscribe).toHaveBeenCalledOnce());
+
+      await second.release();
+      const secondResult = await secondReady;
+      expect(secondResult.success).toBe(false);
+
+      firstSubscription.resolve({ unsubscribe: firstUnsubscribe });
+      await expect(first.ready()).resolves.toEqual(ok(undefined));
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(subscribe).toHaveBeenCalledOnce();
+
+      await first.release();
+      expect(firstUnsubscribe).toHaveBeenCalledOnce();
+    } finally {
+      await service.dispose();
+    }
+  });
+
+  it('survives native unsubscribe failure and accepts a later root', async () => {
+    const firstRoot = await mkdtemp(path.join(tmpdir(), 'emdash-native-release-first-'));
+    const secondRoot = await mkdtemp(path.join(tmpdir(), 'emdash-native-release-second-'));
+    const failure = new Error('Unable to remove watcher');
+    const firstUnsubscribe = vi.fn().mockRejectedValue(failure);
+    const secondUnsubscribe = vi.fn(async () => {});
+    const subscribe = vi
+      .fn()
+      .mockResolvedValueOnce({ unsubscribe: firstUnsubscribe })
+      .mockResolvedValueOnce({ unsubscribe: secondUnsubscribe });
+    const onError = vi.fn();
+    const unhandled = vi.fn();
+    process.on('unhandledRejection', unhandled);
+    const service = createWatchService({
+      backend: nativeWatchBackend({ subscribe, onError }),
+    });
+
+    try {
+      const first = service.watch(firstRoot, () => {});
+      await expect(first.ready()).resolves.toEqual(ok(undefined));
+      await first.release();
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(onError).toHaveBeenCalledWith(`unsubscribe ${realpathOrResolve(firstRoot)}`, failure);
+      expect(unhandled).not.toHaveBeenCalled();
+
+      const second = service.watch(secondRoot, () => {});
+      await expect(second.ready()).resolves.toEqual(ok(undefined));
+      await second.release();
+      expect(secondUnsubscribe).toHaveBeenCalledOnce();
+    } finally {
+      process.off('unhandledRejection', unhandled);
+      await service.dispose();
+    }
+  });
+
+  it('releases every native subscription after repeated many-root churn', async () => {
+    const parent = await mkdtemp(path.join(tmpdir(), 'emdash-native-churn-'));
+    const roots = Array.from({ length: 8 }, (_, index) => path.join(parent, `root-${index}`));
+    await Promise.all(roots.map((root) => mkdir(root)));
+    const service = createNativeWatchService();
+
+    try {
+      for (let cycle = 0; cycle < 4; cycle += 1) {
+        const handles = roots.map((root) => service.watch(root, () => {}));
+        await expect(Promise.all(handles.map((handle) => handle.ready()))).resolves.toEqual(
+          roots.map(() => ok(undefined))
+        );
+        await Promise.all(handles.map((handle) => handle.release()));
+      }
+
+      const events: WatchEvent[] = [];
+      const final = service.watch(roots[0]!, (batch) => events.push(...batch));
+      await expect(final.ready()).resolves.toEqual(ok(undefined));
+      await writeFile(path.join(roots[0]!, 'after-churn.txt'), 'still alive\n', 'utf8');
+      await eventually(() =>
+        events.some((event) => path.basename(event.path) === 'after-churn.txt') ? true : undefined
+      );
+      await final.release();
+    } finally {
+      await service.dispose();
+      await rm(parent, { recursive: true, force: true });
+    }
+  }, 15_000);
 
   it('disposes active handles by releasing their shared native subscription', async () => {
     const root = await mkdtemp(path.join(tmpdir(), 'emdash-shared-watch-dispose-'));
@@ -375,7 +529,13 @@ class FakeWatchBackend implements WatchBackend {
     return this.sinks.size;
   }
 
-  async subscribe(key: WatchKey, sink: WatchSink, scope: Scope): Promise<void> {
+  async subscribe(
+    key: WatchKey,
+    sink: WatchSink,
+    scope: Scope,
+    onStart: () => void
+  ): Promise<void> {
+    onStart();
     this.subscribeCount += 1;
     const keyId = keyOf(key);
     this.sinks.set(keyId, sink);
@@ -399,7 +559,13 @@ class DeferredWatchBackend implements WatchBackend {
     disposed: boolean;
   }> = [];
 
-  async subscribe(_key: WatchKey, _sink: WatchSink, scope: Scope): Promise<void> {
+  async subscribe(
+    _key: WatchKey,
+    _sink: WatchSink,
+    scope: Scope,
+    onStart: () => void
+  ): Promise<void> {
+    onStart();
     const attempt = { ready: deferred(), disposed: false };
     this.attempts.push(attempt);
     scope.add(() => {

--- a/packages/core/src/services/fs-watch/impl/watch-service.test.ts
+++ b/packages/core/src/services/fs-watch/impl/watch-service.test.ts
@@ -6,7 +6,7 @@ import type { Scope } from '@emdash/shared/concurrency';
 import type parcelWatcher from '@parcel/watcher';
 import { describe, expect, it, vi } from 'vitest';
 import { requireWatchReady, type WatchEvent } from '#services/fs-watch/api';
-import type { WatchBackend, WatchKey, WatchSink } from './backend';
+import type { WatchBackend, WatchBackendStart, WatchKey, WatchSink } from './backend';
 import { nativeWatchBackend } from './native-backend';
 import { realpathOrResolve } from './paths';
 import { createWatchService } from './watch-service';
@@ -413,6 +413,66 @@ describe('createWatchService', () => {
     }
   });
 
+  it('bounds queue wait while a timed-out native startup still holds the slot', async () => {
+    vi.useFakeTimers();
+    const firstRoot = await mkdtemp(path.join(tmpdir(), 'emdash-native-stuck-first-'));
+    const secondRoot = await mkdtemp(path.join(tmpdir(), 'emdash-native-stuck-second-'));
+    const firstSubscription = deferred<parcelWatcher.AsyncSubscription>();
+    const retrySubscription = deferred<parcelWatcher.AsyncSubscription>();
+    const firstUnsubscribe = vi.fn(async () => {});
+    const retryUnsubscribe = vi.fn(async () => {});
+    const subscribe = vi
+      .fn()
+      .mockReturnValueOnce(firstSubscription.promise)
+      .mockReturnValueOnce(retrySubscription.promise);
+    const service = createWatchService({
+      backend: nativeWatchBackend({ subscribe, maxConcurrentStarts: 1 }),
+      startupTimeoutMs: 1_000,
+      startupQueueTimeoutMs: 2_000,
+    });
+
+    try {
+      const first = service.watch(firstRoot, () => {});
+      const second = service.watch(secondRoot, () => {});
+      const firstReady = first.ready();
+      let secondSettled = false;
+      const secondReady = second.ready().finally(() => {
+        secondSettled = true;
+      });
+
+      await vi.waitFor(() => expect(subscribe).toHaveBeenCalledOnce());
+      await vi.advanceTimersByTimeAsync(1_000);
+      await expect(firstReady).resolves.toEqual(
+        err(expect.objectContaining({ message: 'Operation timed out after 1000ms' }))
+      );
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(secondSettled).toBe(true);
+      await expect(secondReady).resolves.toEqual(
+        err(expect.objectContaining({ message: 'Operation timed out after 2000ms' }))
+      );
+      expect(subscribe).toHaveBeenCalledOnce();
+
+      firstSubscription.resolve({ unsubscribe: firstUnsubscribe });
+      await vi.waitFor(() => expect(firstUnsubscribe).toHaveBeenCalledOnce());
+      await first.release();
+      await second.release();
+
+      expect(subscribe).toHaveBeenCalledOnce();
+      const retry = service.watch(secondRoot, () => {});
+      const retryReady = retry.ready();
+      await vi.waitFor(() => expect(subscribe).toHaveBeenCalledTimes(2));
+      retrySubscription.resolve({ unsubscribe: retryUnsubscribe });
+      await expect(retryReady).resolves.toEqual(ok(undefined));
+      await retry.release();
+      expect(retryUnsubscribe).toHaveBeenCalledOnce();
+    } finally {
+      firstSubscription.resolve({ unsubscribe: firstUnsubscribe });
+      vi.useRealTimers();
+      await service.dispose();
+    }
+  });
+
   it('cancels a queued native subscription when its final lease is released', async () => {
     const firstRoot = await mkdtemp(path.join(tmpdir(), 'emdash-native-cancel-first-'));
     const secondRoot = await mkdtemp(path.join(tmpdir(), 'emdash-native-cancel-second-'));
@@ -533,9 +593,9 @@ class FakeWatchBackend implements WatchBackend {
     key: WatchKey,
     sink: WatchSink,
     scope: Scope,
-    onStart: () => void
+    start: WatchBackendStart
   ): Promise<void> {
-    onStart();
+    start.onStart();
     this.subscribeCount += 1;
     const keyId = keyOf(key);
     this.sinks.set(keyId, sink);
@@ -563,9 +623,9 @@ class DeferredWatchBackend implements WatchBackend {
     _key: WatchKey,
     _sink: WatchSink,
     scope: Scope,
-    onStart: () => void
+    start: WatchBackendStart
   ): Promise<void> {
-    onStart();
+    start.onStart();
     const attempt = { ready: deferred(), disposed: false };
     this.attempts.push(attempt);
     scope.add(() => {

--- a/packages/core/src/services/fs-watch/impl/watch-service.ts
+++ b/packages/core/src/services/fs-watch/impl/watch-service.ts
@@ -32,6 +32,7 @@ export function createWatchService(options: CreateWatchServiceOptions): IWatchSe
     scope: serviceScope,
     label: 'channels',
     idleTtlMs: options.graceMs ?? 0,
+    cancelPendingOnRelease: true,
     onError: (error, key) => options.onError?.(`watch ${key}`, error),
     create: async (key, scope) => {
       const events = createEmitter<WatchEvent[]>();
@@ -40,21 +41,24 @@ export function createWatchService(options: CreateWatchServiceOptions): IWatchSe
         events.clear();
         resync.clear();
       });
-      await runWithTimeout(
-        () =>
-          options.backend.subscribe(
-            key,
-            {
-              events: (batch) => events.emit(batch),
-              resync: () => resync.emit(),
-            },
-            scope
-          ),
+      let markStarted: () => void = () => {};
+      const started = new Promise<void>((resolve) => {
+        markStarted = resolve;
+      });
+      const subscription = options.backend.subscribe(
+        key,
         {
-          timeoutMs: options.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS,
-          signal: scope.signal,
-        }
+          events: (batch) => events.emit(batch),
+          resync: () => resync.emit(),
+        },
+        scope,
+        markStarted
       );
+      await Promise.race([started, subscription]);
+      await runWithTimeout(() => subscription, {
+        timeoutMs: options.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS,
+        signal: scope.signal,
+      });
       return { events, resync };
     },
   });

--- a/packages/core/src/services/fs-watch/impl/watch-service.ts
+++ b/packages/core/src/services/fs-watch/impl/watch-service.ts
@@ -1,6 +1,6 @@
 import { createEmitter, err, ok, type Emitter } from '@emdash/shared';
 import { createResourceCache, createScope, type Scope } from '@emdash/shared/concurrency';
-import { runWithTimeout } from '@emdash/shared/scheduling';
+import { abortableWait } from '@emdash/shared/scheduling';
 import type { IWatchService, WatchEvent } from '#services/fs-watch/api';
 import type { WatchBackend, WatchKey, WatchOnError } from './backend';
 import { realpathOrResolve } from './paths';
@@ -8,14 +8,8 @@ import { realpathOrResolve } from './paths';
 export type CreateWatchServiceOptions = {
   backend: WatchBackend;
   scope?: Scope;
-  graceMs?: number;
-  startupTimeoutMs?: number;
-  startupQueueTimeoutMs?: number;
   onError?: WatchOnError;
 };
-
-const DEFAULT_STARTUP_TIMEOUT_MS = 10_000;
-const DEFAULT_STARTUP_QUEUE_TIMEOUT_MS = 30_000;
 
 type WatchChannel = {
   events: Emitter<WatchEvent[]>;
@@ -28,12 +22,12 @@ export function createWatchService(options: CreateWatchServiceOptions): IWatchSe
     : createScope({ label: 'fs-watch-service' });
   const consumers = new Set<Scope>();
   let disposed = false;
+  let terminalError: unknown;
 
   const channels = createResourceCache<WatchKey, WatchChannel>({
     key: watchKey,
     scope: serviceScope,
     label: 'channels',
-    idleTtlMs: options.graceMs ?? 0,
     cancelPendingOnRelease: true,
     onError: (error, key) => options.onError?.(`watch ${key}`, error),
     create: async (key, scope) => {
@@ -43,39 +37,36 @@ export function createWatchService(options: CreateWatchServiceOptions): IWatchSe
         events.clear();
         resync.clear();
       });
-      let markStarted: () => void = () => {};
-      const started = new Promise<void>((resolve) => {
-        markStarted = resolve;
-      });
-      let subscription!: Promise<void>;
-      await runWithTimeout(
-        (signal) => {
-          subscription = options.backend.subscribe(
+      await abortableWait<void>({ signal: scope.signal }, (settle) => {
+        options.backend
+          .subscribe(
             key,
             {
               events: (batch) => events.emit(batch),
               resync: () => resync.emit(),
             },
-            scope,
-            { signal, onStart: markStarted }
-          );
-          return Promise.race([started, subscription]);
-        },
-        {
-          timeoutMs: options.startupQueueTimeoutMs ?? DEFAULT_STARTUP_QUEUE_TIMEOUT_MS,
-          signal: scope.signal,
-        }
-      );
-      await runWithTimeout(() => subscription, {
-        timeoutMs: options.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS,
-        signal: scope.signal,
+            scope
+          )
+          .then(settle.resolve, settle.reject);
       });
       return { events, resync };
     },
   });
 
+  const backendFailureSignal = options.backend.failureSignal;
+  if (backendFailureSignal) {
+    const onBackendFailure = (): void => {
+      terminalError = backendFailureSignal.reason ?? new Error('Watch backend failed');
+      void serviceScope.dispose(terminalError);
+    };
+    backendFailureSignal.addEventListener('abort', onBackendFailure, { once: true });
+    serviceScope.add(() => backendFailureSignal.removeEventListener('abort', onBackendFailure));
+    if (backendFailureSignal.aborted) onBackendFailure();
+  }
+
   return {
     watch(root, onEvents, watchOptions = {}) {
+      if (terminalError) throw terminalError;
       if (disposed || serviceScope.disposed) throw new Error('FsWatchService disposed');
 
       const key = normalizeWatchKey(root, watchOptions.ignore);

--- a/packages/core/src/services/fs-watch/impl/watch-service.ts
+++ b/packages/core/src/services/fs-watch/impl/watch-service.ts
@@ -10,10 +10,12 @@ export type CreateWatchServiceOptions = {
   scope?: Scope;
   graceMs?: number;
   startupTimeoutMs?: number;
+  startupQueueTimeoutMs?: number;
   onError?: WatchOnError;
 };
 
 const DEFAULT_STARTUP_TIMEOUT_MS = 10_000;
+const DEFAULT_STARTUP_QUEUE_TIMEOUT_MS = 30_000;
 
 type WatchChannel = {
   events: Emitter<WatchEvent[]>;
@@ -45,16 +47,25 @@ export function createWatchService(options: CreateWatchServiceOptions): IWatchSe
       const started = new Promise<void>((resolve) => {
         markStarted = resolve;
       });
-      const subscription = options.backend.subscribe(
-        key,
-        {
-          events: (batch) => events.emit(batch),
-          resync: () => resync.emit(),
+      let subscription!: Promise<void>;
+      await runWithTimeout(
+        (signal) => {
+          subscription = options.backend.subscribe(
+            key,
+            {
+              events: (batch) => events.emit(batch),
+              resync: () => resync.emit(),
+            },
+            scope,
+            { signal, onStart: markStarted }
+          );
+          return Promise.race([started, subscription]);
         },
-        scope,
-        markStarted
+        {
+          timeoutMs: options.startupQueueTimeoutMs ?? DEFAULT_STARTUP_QUEUE_TIMEOUT_MS,
+          signal: scope.signal,
+        }
       );
-      await Promise.race([started, subscription]);
       await runWithTimeout(() => subscription, {
         timeoutMs: options.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS,
         signal: scope.signal,

--- a/packages/core/src/services/fs-watch/node/component.ts
+++ b/packages/core/src/services/fs-watch/node/component.ts
@@ -2,6 +2,8 @@ import { defineWireComponent } from '@emdash/wire/worker';
 import { z } from 'zod';
 import { fsWatchContract } from '#services/fs-watch/api';
 import { createFsWatchController } from '#services/fs-watch/impl/controller';
+import { nativeWatchBackend } from '#services/fs-watch/impl/native-backend';
+import { createWatchService } from '#services/fs-watch/impl/watch-service';
 
 export const fsWatchComponentConfigSchema = z.object({});
 
@@ -10,12 +12,26 @@ export const fsWatchComponent = defineWireComponent({
   contract: fsWatchContract,
   requirements: {},
   configSchema: fsWatchComponentConfigSchema,
-  create: ({ instance, logger, scope }) =>
-    instance({
+  create: ({ fatal, instance, logger, scope }) => {
+    const onError = (context: string, error: unknown): void => logger.warn(context, { error });
+    const backend = nativeWatchBackend({ onError });
+    const service = createWatchService({
+      scope,
+      backend,
+      onError,
+    });
+    const failureSignal = backend.failureSignal;
+    const onBackendFailure = (): void =>
+      fatal(failureSignal.reason ?? new Error('Native watcher backend failed'));
+    failureSignal.addEventListener('abort', onBackendFailure, { once: true });
+    scope.add(() => failureSignal.removeEventListener('abort', onBackendFailure));
+    return instance({
       scope,
       controller: createFsWatchController({
         scope,
-        onError: (context, error) => logger.warn(context, { error }),
+        service,
+        onError,
       }),
-    }),
+    });
+  },
 });

--- a/packages/core/src/services/fs-watch/node/index.ts
+++ b/packages/core/src/services/fs-watch/node/index.ts
@@ -12,6 +12,8 @@ export type CreateNativeWatchServiceOptions = Readonly<{
   onError?: NativeWatchBackendOptions['onError'];
   subscribe?: NativeWatchBackendOptions['subscribe'];
   maxConcurrentStarts?: NativeWatchBackendOptions['maxConcurrentStarts'];
+  startupTimeoutMs?: number;
+  startupQueueTimeoutMs?: number;
 }>;
 
 export function createNativeWatchService(
@@ -25,6 +27,8 @@ export function createNativeWatchService(
     }),
     scope: options.scope,
     graceMs: options.graceMs,
+    startupTimeoutMs: options.startupTimeoutMs,
+    startupQueueTimeoutMs: options.startupQueueTimeoutMs,
     onError: options.onError,
   });
 }

--- a/packages/core/src/services/fs-watch/node/index.ts
+++ b/packages/core/src/services/fs-watch/node/index.ts
@@ -1,19 +1,12 @@
 import type { Scope } from '@emdash/shared/concurrency';
 import type { IWatchService } from '#services/fs-watch/api';
-import {
-  nativeWatchBackend,
-  type NativeWatchBackendOptions,
-} from '#services/fs-watch/impl/native-backend';
+import type { WatchOnError } from '#services/fs-watch/impl/backend';
+import { nativeWatchBackend } from '#services/fs-watch/impl/native-backend';
 import { createWatchService } from '#services/fs-watch/impl/watch-service';
 
 export type CreateNativeWatchServiceOptions = Readonly<{
   scope?: Scope;
-  graceMs?: number;
-  onError?: NativeWatchBackendOptions['onError'];
-  subscribe?: NativeWatchBackendOptions['subscribe'];
-  maxConcurrentStarts?: NativeWatchBackendOptions['maxConcurrentStarts'];
-  startupTimeoutMs?: number;
-  startupQueueTimeoutMs?: number;
+  onError?: WatchOnError;
 }>;
 
 export function createNativeWatchService(
@@ -22,13 +15,8 @@ export function createNativeWatchService(
   return createWatchService({
     backend: nativeWatchBackend({
       onError: options.onError,
-      subscribe: options.subscribe,
-      maxConcurrentStarts: options.maxConcurrentStarts,
     }),
     scope: options.scope,
-    graceMs: options.graceMs,
-    startupTimeoutMs: options.startupTimeoutMs,
-    startupQueueTimeoutMs: options.startupQueueTimeoutMs,
     onError: options.onError,
   });
 }

--- a/packages/core/src/services/fs-watch/node/index.ts
+++ b/packages/core/src/services/fs-watch/node/index.ts
@@ -11,13 +11,18 @@ export type CreateNativeWatchServiceOptions = Readonly<{
   graceMs?: number;
   onError?: NativeWatchBackendOptions['onError'];
   subscribe?: NativeWatchBackendOptions['subscribe'];
+  maxConcurrentStarts?: NativeWatchBackendOptions['maxConcurrentStarts'];
 }>;
 
 export function createNativeWatchService(
   options: CreateNativeWatchServiceOptions = {}
 ): IWatchService {
   return createWatchService({
-    backend: nativeWatchBackend({ onError: options.onError, subscribe: options.subscribe }),
+    backend: nativeWatchBackend({
+      onError: options.onError,
+      subscribe: options.subscribe,
+      maxConcurrentStarts: options.maxConcurrentStarts,
+    }),
     scope: options.scope,
     graceMs: options.graceMs,
     onError: options.onError,

--- a/packages/shared/src/concurrency/resource-cache.test.ts
+++ b/packages/shared/src/concurrency/resource-cache.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createManualClock } from '../testing';
+import { createManualClock, deferred } from '../testing';
 import { acquireResourceAsResult, createResourceCache } from './resource-cache';
 import type { Scope } from './scope';
 
@@ -23,6 +23,56 @@ describe('createResourceCache', () => {
     expect(cleanup).not.toHaveBeenCalled();
     await second.release();
     expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels in-flight creation when its final lease is released', async () => {
+    const started = deferred<void>();
+    const stopped = deferred<void>();
+    const onError = vi.fn();
+    const cache = createResourceCache({
+      key: (key: string) => key,
+      onError,
+      cancelPendingOnRelease: true,
+      create: async (_key: string, scope: Scope) => {
+        started.resolve();
+        await new Promise<never>((_resolve, reject) => {
+          const onAbort = (): void => {
+            stopped.resolve();
+            reject(scope.signal.reason);
+          };
+          scope.signal.addEventListener('abort', onAbort, { once: true });
+        });
+      },
+    });
+
+    const lease = cache.acquire('pending');
+    const ready = lease.ready();
+    await started.promise;
+    await lease.release();
+
+    await stopped.promise;
+    await expect(ready).rejects.toThrow();
+    expect(cache.peek('pending')).toBeUndefined();
+    expect(onError).not.toHaveBeenCalled();
+    await cache.dispose();
+  });
+
+  it('retains in-flight creation by default when its final lease is released', async () => {
+    const creation = deferred<{ key: string }>();
+    const create = vi.fn(() => creation.promise);
+    const cache = createResourceCache({ key: (key: string) => key, create });
+    const released = cache.acquire('pending');
+    const releasedReady = released.ready();
+    await vi.waitFor(() => expect(create).toHaveBeenCalledOnce());
+    await released.release();
+
+    const replacement = cache.acquire('pending');
+    creation.resolve({ key: 'pending' });
+
+    await expect(replacement.ready()).resolves.toBe(await releasedReady);
+    expect(create).toHaveBeenCalledOnce();
+    await replacement.release();
+    await cache.dispose();
   });
 
   it('registers the idle-timer cleanup once per entry regardless of release cycles', async () => {

--- a/packages/shared/src/concurrency/resource-cache.ts
+++ b/packages/shared/src/concurrency/resource-cache.ts
@@ -15,6 +15,7 @@ export type CreateResourceCacheOptions<K, T> = {
   scope?: Scope;
   label?: string;
   idleTtlMs?: number;
+  cancelPendingOnRelease?: boolean;
   clock?: Clock;
   create: (key: K, scope: Scope) => Promise<T> | T;
   onError?: (error: unknown, key: string) => void;
@@ -164,7 +165,7 @@ export function createResourceCache<K, T>(
       .catch(async (error: unknown) => {
         entry.createPromise = undefined;
         if (entries.get(entry.keyId) === entry) entries.delete(entry.keyId);
-        options.onError?.(error, entry.keyId);
+        if (!entry.scope.disposed) options.onError?.(error, entry.keyId);
         await entry.scope.dispose(error);
         throw error;
       });
@@ -176,7 +177,9 @@ export function createResourceCache<K, T>(
     if (entries.get(entry.keyId) !== entry) return Promise.resolve();
     if (entry.refCount > 0) entry.refCount -= 1;
     if (entry.refCount > 0) return Promise.resolve();
-    if (entry.createPromise && !entry.hasValue) return Promise.resolve();
+    if (entry.createPromise && !entry.hasValue) {
+      return options.cancelPendingOnRelease ? disposeEntry(entry) : Promise.resolve();
+    }
     return scheduleDispose(entry);
   }
 

--- a/packages/wire/docs/README.md
+++ b/packages/wire/docs/README.md
@@ -187,10 +187,12 @@ barrier: a consumer joining an already-attached topic will not cause the server 
 
 Use `resourcedStream()` when a successful attach must guarantee that an underlying resource is
 ready. Its host must be created with `createEventStreamHost(def, { activate })`, where `activate`
-resolves to the activation-owned disposer only after the resource is ready. The source registers
-the subscriber before activation begins, shares and retains the activation promise for all
-subscribers to the key, and invokes the disposer when the final subscriber leaves. Failed
-activation is not retained, so a later attach makes a fresh attempt.
+receives an `AbortSignal` and resolves to the activation-owned disposer only after the resource is
+ready. The source registers the subscriber before activation begins, shares and retains the
+activation promise for all subscribers to the key, and invokes the disposer when the final
+subscriber leaves. If the final subscriber leaves while activation is pending, the signal aborts
+and any late result is disposed. Failed activation is not retained, so a later attach makes a fresh
+attempt.
 
 This guarantee is enforced when a controller binds the endpoint: a resourced definition accepts
 its matching host or a forwarded client handle, but rejects a bare resolver. Forwarding preserves

--- a/packages/wire/docs/api/serving.md
+++ b/packages/wire/docs/api/serving.md
@@ -106,7 +106,7 @@ const connection = connect(pair.left, { instrumentation });
 
 - `call(path, input, { signal? })`.
 - `snapshot(topic)`.
-- `attach(topic, push, { onReattach? })`.
+- `attach(topic, push, { signal?, onReattach? })`.
 - `onDisconnect(cb)`.
 - `dispose()` to release the logical connection without closing its transport.
 
@@ -118,6 +118,10 @@ link is live and then calls each attachment's `onReattach` callback.
 Replicas use `onReattach` for live models, logs, and jobs to force a fresh
 snapshot after reattach. Direct client-handle consumers can use the same callback when
 they need to reseed UI state after reconnect.
+
+An attachment signal owns establishment for only that caller. Aborting it before readiness cancels
+the pending attach when no other caller still needs the topic, while shared callers remain attached.
+After `attach()` resolves, the returned unsubscribe owns the established interest.
 
 `dispose()` rejects pending calls, releases live attachments and blob channels, and
 unsubscribes the connection from transport events. It intentionally does not call
@@ -211,9 +215,9 @@ const controller = createController(api, {
 
 Cancellation is cooperative. Long-running handlers should pass the signal into
 their own async work, listen for `abort`, or periodically check
-`meta.signal?.aborted`. `snapshot` and `attach` requests also share the same
-server-side cancellation registry, though most live sources complete those
-requests synchronously.
+`meta.signal?.aborted`. `snapshot` and `attach` requests also share the same server-side
+cancellation registry. Resourced event-stream activation receives an `AbortSignal` so it can release
+partially-created resources when the final pending attachment disappears.
 
 Mutations are intentionally not cancellable through this API; they use
 `mutationId` for idempotency and retry. See [mutations](../live/mutations.md).

--- a/packages/wire/docs/live/event-stream.md
+++ b/packages/wire/docs/live/event-stream.md
@@ -50,7 +50,11 @@ host. `onActive` runs when the first subscriber attaches to a key, and `onIdle`
 runs when the last subscriber detaches:
 
 ```ts
-const fileEvents = createEventStreamHost(api.fileEvents, {
+const resourceEvents = resourcedStream({
+  key: z.object({ rootPath: z.string() }),
+  event: z.object({ kind: z.string(), path: z.string() }),
+});
+const fileEvents = createEventStreamHost(resourceEvents, {
   onActive(key) {
     void startWatcher(key);
   },
@@ -63,6 +67,23 @@ const fileEvents = createEventStreamHost(api.fileEvents, {
 This is useful for resources that should be recreated after reconnect. The wire
 client automatically reattaches live topics after reconnect, so `onActive` runs
 again in the new server process.
+
+When a successful attach must mean that the resource is ready, define the endpoint with
+`resourcedStream()` and provide `activate`. Activation receives a signal and resolves to its owned
+disposer:
+
+```ts
+const fileEvents = createEventStreamHost(api.fileEvents, {
+  async activate(key, signal) {
+    const watcher = await startWatcher(key, { signal });
+    return () => watcher.dispose();
+  },
+});
+```
+
+Concurrent subscribers share one activation. The host aborts pending activation when the final
+subscriber leaves, disposes a late result, and keeps activation alive when another subscriber still
+owns the key.
 
 You can also pass a resolver to `createController()` if another component owns
 the source:
@@ -88,6 +109,7 @@ const unsubscribe = await client.fileEvents.subscribe(
     onError(error, { retrying }) {
       if (!retrying) showFileEventStreamError(error.message);
     },
+    signal,
   }
 );
 ```

--- a/packages/wire/docs/runtime/components.md
+++ b/packages/wire/docs/runtime/components.md
@@ -189,6 +189,20 @@ void runWireComponentWorker(counterComponent);
 The client returned by `ready()` is stable across process generations. Calls fail while the worker is
 unavailable; the client does not buffer calls during restarts.
 
+## Unrecoverable Failures
+
+Component code can call `fatal(error)` when process-local state is poisoned and the current instance
+cannot safely serve later requests. Fatal failures retire the component scope exactly once. An
+in-process caller can observe the failure through `onFatal`; `runWireComponentWorker` exits with code
+`1`, allowing the owning `WireWorkerHost` to replace that process generation under its supervision
+policy.
+
+Use `fatal` only when replacing the instance is the recovery mechanism, such as a native operation
+that remains pending after its deadline and cannot be cancelled in-process. Expected request errors
+should still be returned or thrown through the contract. A fatal report does not make an unresponsive
+native call safe to overlap with another call in the same process; worker deployment recovers by
+terminating the process that owns the native state.
+
 ## Testing Components
 
 For in-process tests, create the component under a test scope and pass fake dependency clients
@@ -249,6 +263,8 @@ generation. They are not part of the component runtime API.
 ## Guidelines
 
 - Keep component factories synchronous and cheap.
+- Report poisoned process-local state through `fatal`; keep expected operation failures on the
+  contract.
 - Pass dependencies by name from the composition root; never look them up from a global registry.
 - Prefer contract requirements for shared capabilities that may cross process boundaries.
 - Use typed config for deployment-specific values such as paths, limits, executable names, and

--- a/packages/wire/docs/runtime/resource-cache.md
+++ b/packages/wire/docs/runtime/resource-cache.md
@@ -50,6 +50,10 @@ waiting forever on leaked consumers.
 - Every acquire receives its own idempotent lease.
 - `peek(key)` returns only completed active values.
 - Failed creation is not cached.
+- By default, releasing the final lease during creation retains the in-flight entry so a later
+  acquire can share it and the factory's terminal result remains authoritative.
+- Set `cancelPendingOnRelease: true` for resources such as watchers that have no useful lifetime
+  without a lease. Pending work must then observe the entry scope's signal and clean up late results.
 - `idleTtlMs` retains a zero-ref entry briefly so flapping demand can reuse it.
 - Acquiring during teardown waits for teardown to finish, then provisions fresh.
 

--- a/packages/wire/docs/runtime/workers.md
+++ b/packages/wire/docs/runtime/workers.md
@@ -82,4 +82,6 @@ void runWireComponentWorker(counterComponent);
 The child helper resolves the parent IPC channel, requests bootstrap config and dependency channels,
 serves framed runtime wire messages, sends the ready signal after the component controller is
 installed, disposes the child scope on shutdown/disconnect, and exits with code `1` if creation
-fails.
+fails. It also exits with code `1` when the component reports an unrecoverable failure through
+`fatal(error)`. The worker slot treats that exit like any other failed generation: it disconnects the
+old transport and applies the configured supervision schedule before starting a fresh process.

--- a/packages/wire/src/api/channel.ts
+++ b/packages/wire/src/api/channel.ts
@@ -59,6 +59,7 @@ export type LiveAttachmentErrorContext = {
 export type LiveSubscribeOptions = {
   onGap?: () => void;
   onError?: (error: unknown, context: LiveAttachmentErrorContext) => void;
+  signal?: AbortSignal;
 };
 
 export interface LiveSource {

--- a/packages/wire/src/api/client.ts
+++ b/packages/wire/src/api/client.ts
@@ -93,6 +93,7 @@ export type EventStreamSubscribeOptions<
   onEvent(event: EventStreamEvent<Def>): void;
   onGap?(): void;
   onError?: (error: WireError, context: { retrying: boolean }) => void;
+  signal?: AbortSignal;
 };
 
 export type EventStreamClientHandle<Def extends EventStreamEndpointDef = EventStreamEndpointDef> = {
@@ -312,6 +313,7 @@ export function createLiveClientHandle<T>(
           connection.attach(topic, cb, {
             onReattach: options?.onGap,
             onReattachError: options?.onError,
+            signal: options?.signal,
           }),
       };
     },

--- a/packages/wire/src/api/connect.ts
+++ b/packages/wire/src/api/connect.ts
@@ -38,6 +38,7 @@ export type CallOptions = {
 export type AttachOptions = {
   onReattach?: () => void;
   onReattachError?: (error: WireError, context: { retrying: boolean }) => void;
+  signal?: AbortSignal;
 };
 
 export type ConnectOptions = {
@@ -76,6 +77,7 @@ type Attachment = {
   established: Promise<void>;
   establishedSettled: boolean;
   attempt: object | null;
+  attemptAbort: AbortController | null;
   attachId: string | undefined;
 };
 
@@ -513,36 +515,50 @@ export function connect(transport: WireTransport, options: ConnectOptions = {}):
       >;
     },
     async attach(topic, push, attachOptions = {}) {
+      if (attachOptions.signal?.aborted) {
+        throw new WireError('CANCELLED', 'Wire attach cancelled');
+      }
       const entry = getOrCreateAttachment(topic);
       entry.pushes.add(push);
       if (attachOptions.onReattach) entry.onReattach.add(attachOptions.onReattach);
       if (attachOptions.onReattachError) entry.onReattachError.add(attachOptions.onReattachError);
 
-      try {
-        await entry.established;
-      } catch (error) {
+      let detached = false;
+      const detach = (): void => {
+        if (detached) return;
+        detached = true;
         entry.pushes.delete(push);
         if (attachOptions.onReattach) entry.onReattach.delete(attachOptions.onReattach);
         if (attachOptions.onReattachError)
           entry.onReattachError.delete(attachOptions.onReattachError);
-        throw error;
-      }
 
-      return () => {
         const current = attachments.get(topic);
-        if (current !== entry) return;
-        current.pushes.delete(push);
-        if (attachOptions.onReattach) current.onReattach.delete(attachOptions.onReattach);
-        if (attachOptions.onReattachError)
-          current.onReattachError.delete(attachOptions.onReattachError);
-        if (current.pushes.size > 0) return;
+        if (current !== entry || current.pushes.size > 0) return;
         attachments.delete(topic);
+        current.attemptAbort?.abort(new WireError('CANCELLED', 'Wire attach cancelled'));
+        current.attemptAbort = null;
         try {
           transport.post({ kind: 'detach', topic });
         } catch {
           // The peer may already be disconnected; local teardown is complete.
         }
       };
+
+      try {
+        await abortableAttachment(entry.established, attachOptions.signal, detach);
+      } catch (error) {
+        detach();
+        if (attachOptions.signal?.aborted) {
+          throw new WireError('CANCELLED', 'Wire attach cancelled');
+        }
+        throw error;
+      }
+
+      if (attachOptions.signal?.aborted) {
+        detach();
+        throw new WireError('CANCELLED', 'Wire attach cancelled');
+      }
+      return detach;
     },
     onDisconnect(cb): Unsubscribe {
       if (disposed) return () => {};
@@ -553,7 +569,8 @@ export function connect(transport: WireTransport, options: ConnectOptions = {}):
       if (disposed) return;
       disposed = true;
 
-      for (const topic of attachments.keys()) {
+      for (const [topic, entry] of attachments) {
+        entry.attemptAbort?.abort(new WireError('DISCONNECTED', 'Wire connection disposed'));
         try {
           transport.post({ kind: 'detach', topic });
         } catch {
@@ -612,6 +629,7 @@ export function connect(transport: WireTransport, options: ConnectOptions = {}):
       established: Promise.resolve(),
       establishedSettled: true,
       attempt: null,
+      attemptAbort: null,
       attachId: undefined,
     };
     attachments.set(topic, created);
@@ -625,7 +643,9 @@ export function connect(transport: WireTransport, options: ConnectOptions = {}):
     notifyReattach: boolean
   ): Promise<void> {
     const attempt = {};
+    const attemptAbort = new AbortController();
     entry.attempt = attempt;
+    entry.attemptAbort = attemptAbort;
     entry.establishedSettled = false;
     const staleAttachId = entry.attachId;
     const id = createRequestId();
@@ -640,16 +660,21 @@ export function connect(transport: WireTransport, options: ConnectOptions = {}):
         stale.reject(new WireError('DISCONNECTED', 'Wire attach superseded by reconnect'));
       }
     }
-    const established = request({ kind: 'attach', id, topic }).then(() => {});
+    const established = request(
+      { kind: 'attach', id, topic },
+      { signal: attemptAbort.signal }
+    ).then(() => {});
     established.then(
       () => {
         if (attachments.get(topic) !== entry || entry.attempt !== attempt) return;
         entry.establishedSettled = true;
+        entry.attemptAbort = null;
         if (notifyReattach) notifyReattached(entry);
       },
       (error: unknown) => {
         if (attachments.get(topic) !== entry || entry.attempt !== attempt) return;
         entry.establishedSettled = true;
+        entry.attemptAbort = null;
         const wireError = toWireError(error);
         if (notifyReattach) {
           const retrying = wireError.code === 'DISCONNECTED';
@@ -661,6 +686,36 @@ export function connect(transport: WireTransport, options: ConnectOptions = {}):
       }
     );
     return established;
+  }
+
+  function abortableAttachment(
+    established: Promise<void>,
+    signal: AbortSignal | undefined,
+    onAbort: () => void
+  ): Promise<void> {
+    if (!signal) return established;
+    if (signal.aborted) {
+      onAbort();
+      return Promise.reject(new WireError('CANCELLED', 'Wire attach cancelled'));
+    }
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const finish = (complete: () => void): void => {
+        if (settled) return;
+        settled = true;
+        signal.removeEventListener('abort', abort);
+        complete();
+      };
+      const abort = (): void => {
+        onAbort();
+        finish(() => reject(new WireError('CANCELLED', 'Wire attach cancelled')));
+      };
+      signal.addEventListener('abort', abort, { once: true });
+      established.then(
+        () => finish(resolve),
+        (error: unknown) => finish(() => reject(error))
+      );
+    });
   }
 
   function notifyReattached(entry: Attachment | undefined): void {

--- a/packages/wire/src/api/serve.ts
+++ b/packages/wire/src/api/serve.ts
@@ -304,6 +304,7 @@ export function serve(
                 (update) => post({ kind: 'update', topic: message.topic, update }),
                 {
                   onGap: () => post({ kind: 'topic-gap', topic: message.topic }),
+                  signal,
                   onError: (error, context) => {
                     post({
                       kind: 'topic-error',

--- a/packages/wire/src/live/endpoint-kinds.ts
+++ b/packages/wire/src/live/endpoint-kinds.ts
@@ -408,6 +408,7 @@ function createEventStreamClientHandle<Def extends EventStreamEndpointDef>(
         {
           onReattach: options.onGap,
           onReattachError: options.onError,
+          signal: options.signal,
         }
       );
     },

--- a/packages/wire/src/live/event-stream/event-stream.test.ts
+++ b/packages/wire/src/live/event-stream/event-stream.test.ts
@@ -205,6 +205,33 @@ describe('resourced event streams', () => {
     unsubscribe();
     expect(dispose).toHaveBeenCalledOnce();
   });
+
+  it('aborts pending activation when its final subscriber leaves', async () => {
+    const activation = deferred<() => void>();
+    let activationSignal: AbortSignal | undefined;
+    const host = createEventStreamHost(contract, {
+      activate: (_key, signal) => {
+        activationSignal = signal;
+        return activation.promise;
+      },
+    });
+    const controller = new AbortController();
+    const subscription = host
+      .resolve({ id: 'known' })
+      .subscribe(() => {}, { signal: controller.signal });
+
+    await vi.waitFor(() => expect(activationSignal).toBeDefined());
+    controller.abort(new Error('subscriber released'));
+
+    await expect(subscription).rejects.toThrow('subscriber released');
+    expect(activationSignal?.aborted).toBe(true);
+    expect(host.resolve({ id: 'known' }).subscriberCount).toBe(0);
+
+    const dispose = vi.fn();
+    activation.resolve(dispose);
+    await vi.waitFor(() => expect(dispose).toHaveBeenCalledOnce());
+    host.dispose();
+  });
 });
 
 function deferred<T>(): {

--- a/packages/wire/src/live/event-stream/source.ts
+++ b/packages/wire/src/live/event-stream/source.ts
@@ -1,6 +1,12 @@
 import { createEmitter, type Unsubscribe } from '@emdash/shared';
+import { abortableWait, abortReason } from '@emdash/shared/scheduling';
 import { stableStringify } from '@emdash/shared/util';
-import type { EventStreamSnapshotData, LiveSnapshot, LiveUpdate } from '../../api/channel';
+import type {
+  EventStreamSnapshotData,
+  LiveSnapshot,
+  LiveSubscribeOptions,
+  LiveUpdate,
+} from '../../api/channel';
 import type { EventStreamEndpointDef, EventStreamEvent, EventStreamKey } from '../../api/define';
 import type { EventStreamDelta } from '../protocol';
 
@@ -8,7 +14,7 @@ export type EventStreamSourceOptions = {
   generation?: number;
   onFirst?: () => void;
   onEmpty?: () => void;
-  activate?: () => Promise<Unsubscribe>;
+  activate?: (signal: AbortSignal) => Promise<Unsubscribe>;
 };
 
 type EventStreamSourceSubscribeResult<Resourced extends boolean> = Resourced extends true
@@ -28,9 +34,10 @@ export class EventStreamSource<Event = unknown, Resourced extends boolean = fals
   private readonly emitter = createEmitter<LiveUpdate>();
   private readonly onFirst: (() => void) | undefined;
   private readonly onEmpty: (() => void) | undefined;
-  private readonly activate: (() => Promise<Unsubscribe>) | undefined;
+  private readonly activate: ((signal: AbortSignal) => Promise<Unsubscribe>) | undefined;
   private readonly generation: number;
   private activation: Promise<void> | undefined;
+  private activationController: AbortController | undefined;
   private activationDisposer: Unsubscribe | undefined;
   private sequence = 0;
   private disposed = false;
@@ -70,8 +77,16 @@ export class EventStreamSource<Event = unknown, Resourced extends boolean = fals
     };
   }
 
-  subscribe(cb: (update: LiveUpdate) => void): EventStreamSourceSubscribeResult<Resourced> {
+  subscribe(
+    cb: (update: LiveUpdate) => void,
+    options: LiveSubscribeOptions = {}
+  ): EventStreamSourceSubscribeResult<Resourced> {
     if (this.disposed) throw new Error('EventStreamSource is disposed');
+    if (this.activate && options.signal?.aborted) {
+      return Promise.reject(
+        abortReason(options.signal)
+      ) as EventStreamSourceSubscribeResult<Resourced>;
+    }
     const wasEmpty = this.emitter.size === 0;
     const detach = this.emitter.subscribe(cb);
     let active = true;
@@ -90,7 +105,13 @@ export class EventStreamSource<Event = unknown, Resourced extends boolean = fals
     }
 
     const activation = this.activation ?? this.startActivation();
-    return activation.then(
+    const attached = abortableWait<void>({ signal: options.signal }, (settle) => {
+      activation.then(settle.resolve, settle.reject);
+      return () => {
+        if (options.signal?.aborted) unsubscribe();
+      };
+    });
+    return attached.then(
       () => unsubscribe,
       (error: unknown) => {
         unsubscribe();
@@ -107,8 +128,9 @@ export class EventStreamSource<Event = unknown, Resourced extends boolean = fals
   }
 
   private startActivation(): Promise<void> {
+    const controller = new AbortController();
     const activation = Promise.resolve()
-      .then(() => this.activate!())
+      .then(() => this.activate!(controller.signal))
       .then((disposer) => {
         if (this.activation !== activation) {
           disposer();
@@ -118,20 +140,28 @@ export class EventStreamSource<Event = unknown, Resourced extends boolean = fals
         if (this.disposed || this.emitter.size === 0) this.disposeActivation();
       });
     this.activation = activation;
+    this.activationController = controller;
     void activation.catch(() => {
       if (this.activation !== activation) return;
       this.activation = undefined;
+      this.activationController = undefined;
       this.activationDisposer = undefined;
     });
     return activation;
   }
 
   private disposeActivation(): void {
-    const disposer = this.activationDisposer;
-    if (!disposer) return;
-    this.activationDisposer = undefined;
+    const activation = this.activation;
+    if (!activation) return;
     this.activation = undefined;
-    disposer();
+    const controller = this.activationController;
+    this.activationController = undefined;
+    if (controller && !controller.signal.aborted) {
+      controller.abort(new Error('Event stream activation has no subscribers'));
+    }
+    const disposer = this.activationDisposer;
+    this.activationDisposer = undefined;
+    disposer?.();
   }
 }
 
@@ -151,7 +181,7 @@ type PlainEventStreamHostOptions<Def extends EventStreamEndpointDef> = {
 };
 
 type ResourcedEventStreamHostOptions<Def extends EventStreamEndpointDef> = {
-  activate: (key: EventStreamKey<Def>) => Promise<Unsubscribe>;
+  activate: (key: EventStreamKey<Def>, signal: AbortSignal) => Promise<Unsubscribe>;
 };
 
 export type EventStreamHostOptions<Def extends EventStreamEndpointDef = EventStreamEndpointDef> =
@@ -199,7 +229,8 @@ export function createEventStreamHost<Def extends EventStreamEndpointDef>(
         const sourceKey = key;
         const created = new EventStreamSource<EventStreamEvent<Def>, IsResourcedEventStream<Def>>({
           activate: def.resourced
-            ? () => (options as ResourcedEventStreamHostOptions<Def>).activate(sourceKey)
+            ? (signal) =>
+                (options as ResourcedEventStreamHostOptions<Def>).activate(sourceKey, signal)
             : undefined,
           onFirst: () => (options as PlainEventStreamHostOptions<Def>).onActive?.(sourceKey),
           onEmpty: () => removeIfEmpty(sourceKey, keyId, created),

--- a/packages/wire/src/rpc/event-stream.test.ts
+++ b/packages/wire/src/rpc/event-stream.test.ts
@@ -1,6 +1,6 @@
 import type { Unsubscribe } from '@emdash/shared';
-import { waitFor } from '@emdash/shared/testing';
-import { describe, expect, it } from 'vitest';
+import { deferred, waitFor } from '@emdash/shared/testing';
+import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { connect } from '../api/connect';
 import { defineContract, eventStream, resourcedStream } from '../api/define';
@@ -113,5 +113,79 @@ describe('eventStream API', () => {
         events: (() => new EventStreamSource()) as never,
       })
     ).toThrowError(expect.objectContaining<Partial<WireError>>({ code: 'CONTRACT_MISMATCH' }));
+  });
+
+  it('cancels a pending resourced attachment when the caller aborts', async () => {
+    const resourcedContract = defineContract({
+      events: resourcedStream({
+        key: z.object({ id: z.string() }),
+        event: z.object({ message: z.string() }),
+      }),
+    });
+    const activation = deferred<Unsubscribe>();
+    let activationSignal: AbortSignal | undefined;
+    const host = createEventStreamHost(resourcedContract.events, {
+      activate: (_key, signal) => {
+        activationSignal = signal;
+        return activation.promise;
+      },
+    });
+    const wire = createTestWire(resourcedContract, { events: host });
+    const controller = new AbortController();
+    const attachment = wire.client.events
+      .handle({ id: 'known' })
+      .attach(() => {}, { signal: controller.signal });
+
+    await waitFor(() => activationSignal !== undefined);
+    controller.abort();
+
+    await expect(attachment).rejects.toMatchObject({ code: 'CANCELLED' });
+    expect(activationSignal?.aborted).toBe(true);
+    expect(host.resolve({ id: 'known' }).subscriberCount).toBe(0);
+
+    const dispose = vi.fn();
+    activation.resolve(dispose);
+    await waitFor(() => dispose.mock.calls.length === 1);
+    wire.dispose();
+    host.dispose();
+  });
+
+  it('keeps shared pending activation alive when only one caller aborts', async () => {
+    const resourcedContract = defineContract({
+      events: resourcedStream({
+        key: z.object({ id: z.string() }),
+        event: z.object({ message: z.string() }),
+      }),
+    });
+    const activation = deferred<Unsubscribe>();
+    let activationSignal: AbortSignal | undefined;
+    const dispose = vi.fn();
+    const host = createEventStreamHost(resourcedContract.events, {
+      activate: (_key, signal) => {
+        activationSignal = signal;
+        return activation.promise;
+      },
+    });
+    const wire = createTestWire(resourcedContract, { events: host });
+    const firstController = new AbortController();
+    const first = wire.client.events
+      .handle({ id: 'known' })
+      .attach(() => {}, { signal: firstController.signal });
+    const second = wire.client.events.handle({ id: 'known' }).attach(() => {});
+
+    await waitFor(() => activationSignal !== undefined);
+    firstController.abort();
+    await expect(first).rejects.toMatchObject({ code: 'CANCELLED' });
+    expect(activationSignal?.aborted).toBe(false);
+    expect(host.resolve({ id: 'known' }).subscriberCount).toBe(1);
+
+    activation.resolve(dispose);
+    const detachSecond = await second;
+    expect(dispose).not.toHaveBeenCalled();
+    detachSecond();
+    await waitFor(() => dispose.mock.calls.length === 1);
+
+    wire.dispose();
+    host.dispose();
   });
 });

--- a/packages/wire/src/worker/component/component.test.ts
+++ b/packages/wire/src/worker/component/component.test.ts
@@ -1,5 +1,5 @@
 import { createScope } from '@emdash/shared/concurrency';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import type { Controller } from '../../api/controller';
 import { defineContract, procedure } from '../../api/define';
@@ -71,6 +71,39 @@ describe('defineWireComponent', () => {
 
     await expect(withTimeout(scope.dispose(), 100)).resolves.toBeUndefined();
     expect(disposed).toBe(true);
+  });
+
+  it('reports one fatal failure and retires the component instance', async () => {
+    const scope = createScope({ label: 'test' });
+    const onFatal = vi.fn();
+    let disposed = 0;
+    let reportFatal: ((error: unknown) => void) | undefined;
+    const component = defineWireComponent({
+      id: 'greeter',
+      contract: greetingContract,
+      requirements: {},
+      configSchema: z.object({}),
+      create: ({ fatal, instance, scope }) => {
+        reportFatal = fatal;
+        scope.add(() => {
+          disposed += 1;
+        });
+        return instance({
+          scope,
+          controller: greeterController(),
+        });
+      },
+    });
+    component.create({ scope, dependencies: {}, config: {}, onFatal });
+    const failure = new Error('component poisoned');
+
+    reportFatal?.(failure);
+    reportFatal?.(new Error('duplicate failure'));
+    await vi.waitFor(() => expect(disposed).toBe(1));
+
+    expect(onFatal).toHaveBeenCalledOnce();
+    expect(onFatal).toHaveBeenCalledWith(failure);
+    await scope.dispose();
   });
 
   it('disposes controller resources once through direct instance disposal', async () => {

--- a/packages/wire/src/worker/component/define.ts
+++ b/packages/wire/src/worker/component/define.ts
@@ -29,6 +29,7 @@ export function defineWireComponent<
         options.dependencies as Record<string, unknown>
       );
       const componentScope = options.scope.child(`component:${definition.id}`);
+      let fatalReported = false;
 
       try {
         return definition.create({
@@ -37,6 +38,12 @@ export function defineWireComponent<
           config,
           logger: options.logger ?? componentScope.log,
           signal: componentScope.signal,
+          fatal: (error) => {
+            if (fatalReported || componentScope.disposed) return;
+            fatalReported = true;
+            void componentScope.dispose(error);
+            options.onFatal?.(error);
+          },
           instance: ({ scope, controller }) => {
             const instance = createInstance({
               contract: definition.contract,

--- a/packages/wire/src/worker/component/types.ts
+++ b/packages/wire/src/worker/component/types.ts
@@ -40,6 +40,7 @@ export type WireComponentCreateOptions<Requirements extends WireComponentRequire
   dependencies: ResolvedWireComponentRequirements<Requirements>;
   config: Config;
   logger?: Logger;
+  onFatal?: (error: unknown) => void;
 };
 
 export type WireComponentCreateContext<
@@ -52,6 +53,7 @@ export type WireComponentCreateContext<
   config: Config;
   logger: Logger;
   signal: AbortSignal;
+  fatal(error: unknown): void;
   instance(options: { scope: Scope; controller: Controller }): WireComponentInstance<Defs>;
 };
 

--- a/packages/wire/src/worker/run-component-worker.ts
+++ b/packages/wire/src/worker/run-component-worker.ts
@@ -61,10 +61,23 @@ export async function runWireComponentWorker<
   const port = options.port ?? resolveParentPort();
   const exit = options.exit ?? ((code: number) => process.exit(code));
   const scope = createScope({ label: `component-worker:${component.id}`, logger: options.logger });
+  let exitRequested = false;
 
   const shutdown = async (code: number): Promise<void> => {
+    if (exitRequested) return;
+    exitRequested = true;
     await scope.dispose();
     exit(code);
+  };
+  const fail = (error: unknown): void => {
+    if (exitRequested) return;
+    exitRequested = true;
+    options.logger?.error('component worker reported an unrecoverable failure', {
+      componentId: component.id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    void scope.dispose(error);
+    exit(1);
   };
   scope.add(
     port.onMessage((message) => {
@@ -81,7 +94,9 @@ export async function runWireComponentWorker<
       dependencies,
       config: bootstrap.config as Config,
       logger: options.logger,
+      onFatal: fail,
     }) as InternalWireComponentInstance<Defs>;
+    if (exitRequested) return;
     const stopServing = serve(
       parentPortChannelTransport(port, RUNTIME_CHANNEL),
       instance[componentControllerSymbol]
@@ -89,6 +104,8 @@ export async function runWireComponentWorker<
     scope.add(stopServing);
     port.send(WORKER_READY_SIGNAL);
   } catch (error) {
+    if (exitRequested) return;
+    exitRequested = true;
     await scope.dispose(error);
     options.logger?.error('component worker failed to start', {
       componentId: component.id,

--- a/packages/wire/src/worker/worker-slot.test.ts
+++ b/packages/wire/src/worker/worker-slot.test.ts
@@ -29,6 +29,23 @@ const apiComponent = defineWireComponent({
     }),
 });
 
+const fatalComponent = defineWireComponent({
+  id: 'fatal-demo',
+  contract: api,
+  requirements: {},
+  configSchema: z.object({}),
+  create: ({ fatal, instance, scope }) =>
+    instance({
+      scope,
+      controller: createController(api, {
+        ping: (input) => {
+          if (input === 'fail') fatal(new Error('component poisoned'));
+          return `pong:${input}`;
+        },
+      }),
+    }),
+});
+
 const dependencyApi = defineContract({
   suffix: procedure({ input: z.string(), output: z.string() }),
 });
@@ -122,6 +139,62 @@ describe('WireWorkerHost and WorkerSlot', () => {
     await expect(firstClient.ping('two')).resolves.toBe('pong:two');
     expect(spawner.processes).toHaveLength(2);
 
+    await host.dispose();
+  });
+
+  it('restarts a generation that reports an unrecoverable component failure', async () => {
+    const clock = createManualClock();
+    const spawner = new FakeWorkerProcessSpawner();
+    const scope = createScope({ label: 'root' });
+    const host = createWireWorkerHost({ scope, processSpawner: spawner, clock });
+    const worker = host.create(fatalComponent, {
+      executable: 'worker',
+      dependencies: {},
+      config: {},
+      shutdownGraceMs: 0,
+      supervision: {
+        restart: 'on-failure',
+        schedule: retrySchedules.sequence([0]),
+      },
+    });
+
+    const ready = worker.ready();
+    await flush();
+    const first = spawner.latest();
+    let firstExitCode: number | undefined;
+    void runWireComponentWorker(fatalComponent, {
+      port: first.childPort,
+      exit: (code) => {
+        firstExitCode = code;
+        first.emitExit({ code });
+      },
+    });
+    const client = await ready;
+    const previousGeneration = worker.state.kind === 'ready' ? worker.state.generation : 0;
+    const restarting = new Promise<void>((resolve) => {
+      const unsubscribe = worker.onStateChanged((state) => {
+        if (state.kind !== 'restarting') return;
+        unsubscribe();
+        resolve();
+      });
+    });
+
+    void client.ping('fail').catch(() => {});
+    await waitFor(() => firstExitCode !== undefined);
+    expect(firstExitCode).toBe(1);
+    await restarting;
+    await clock.runAll();
+    await waitFor(() => spawner.processes.length === 2);
+    const second = spawner.latest();
+    void runWireComponentWorker(fatalComponent, {
+      port: second.childPort,
+      exit: (code) => second.emitExit({ code }),
+    });
+    await waitFor(
+      () => worker.state.kind === 'ready' && worker.state.generation > previousGeneration
+    );
+
+    await expect(client.ping('healthy')).resolves.toBe('pong:healthy');
     await host.dispose();
   });
 


### PR DESCRIPTION
- cancel pending watcher acquisition when the final lease releases
- propagate cancellation across shared wire attachments and server-side activation
- serialize native subscription startup with fifo scheduling
- start readiness timeouts only after a native startup slot becomes available
- contain unsubscribe failures so watcher teardown cannot crash the shared service
- clean up native subscriptions that finish after cancellation
- keep pending resource cancellation explicit so unrelated caches preserve startup error semantics