### PR TITLE
fix(secrets): configure linux secure storage before app ready

### DIFF
--- a/apps/emdash-desktop/src/entry/main.test.ts
+++ b/apps/emdash-desktop/src/entry/main.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  bootstrapMain: vi.fn(async () => {}),
+  events: [] as string[],
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    commandLine: {},
+    isPackaged: false,
+    whenReady: vi.fn(async () => {}),
+  },
+  dialog: {
+    showErrorBox: vi.fn(),
+  },
+}));
+
+vi.mock('@main/host/chromium-command-line', () => ({
+  configureChromiumCommandLine: vi.fn(() => {
+    mocks.events.push('configure-command-line');
+  }),
+}));
+
+vi.mock('@main/bootstrap', () => {
+  mocks.events.push('import-bootstrap');
+  return {
+    main: mocks.bootstrapMain.mockImplementation(async () => {
+      mocks.events.push('run-bootstrap');
+    }),
+  };
+});
+
+beforeEach(() => {
+  mocks.bootstrapMain.mockClear();
+  mocks.events.length = 0;
+});
+
+it('configures Chromium before asynchronously importing bootstrap', async () => {
+  await import('./main');
+  await vi.waitFor(() => expect(mocks.bootstrapMain).toHaveBeenCalledOnce());
+
+  expect(mocks.events).toEqual(['configure-command-line', 'import-bootstrap', 'run-bootstrap']);
+});

--- a/apps/emdash-desktop/src/entry/main.ts
+++ b/apps/emdash-desktop/src/entry/main.ts
@@ -1,4 +1,5 @@
 import { app, dialog } from 'electron';
+import { configureChromiumCommandLine } from '@main/host/chromium-command-line';
 
 // Packaged Electron does not set NODE_ENV, so environment-keyed defaults (such
 // as the wire validation policy) would otherwise resolve to their development
@@ -6,6 +7,11 @@ import { app, dialog } from 'electron';
 if (app.isPackaged && !process.env.NODE_ENV) {
   process.env.NODE_ENV = 'production';
 }
+
+// Electron consumes Chromium switches during initialization. Keep this call
+// synchronous at module scope, before bootstrap's dynamic import crosses an
+// event-loop boundary and `ready` may be emitted.
+configureChromiumCommandLine({ commandLine: app.commandLine });
 
 async function start(): Promise<void> {
   try {

--- a/apps/emdash-desktop/src/main/bootstrap/boot/phases/prepare-electron.ts
+++ b/apps/emdash-desktop/src/main/bootstrap/boot/phases/prepare-electron.ts
@@ -1,10 +1,6 @@
 import { app } from 'electron';
 import devIcon from '@/assets/images/emdash/emdash-dev.png?asset';
 import { initializeFileLogger, registerProcessErrorLogging } from '@main/host/file-logger';
-import {
-  LIBSECRET_PASSWORD_STORE,
-  shouldForceLibsecretBackend,
-} from '@main/host/linux-secret-storage';
 import { registerAppScheme } from '@main/host/protocol';
 import { log } from '@main/lib/logger';
 import type { AppConfig } from '../../core/config';
@@ -12,17 +8,6 @@ import { step } from '../../core/phase';
 import { BootAborted, type BootSignals } from '../types';
 
 export async function prepareElectron(config: AppConfig, signals: BootSignals): Promise<void> {
-  if (process.platform === 'linux') {
-    app.commandLine.appendSwitch('ozone-platform-hint', 'auto');
-    if (
-      shouldForceLibsecretBackend(process.env, {
-        passwordStoreSwitchPresent: app.commandLine.hasSwitch('password-store'),
-      })
-    ) {
-      app.commandLine.appendSwitch('password-store', LIBSECRET_PASSWORD_STORE);
-    }
-  }
-
   registerAppScheme();
   initializeFileLogger();
   registerProcessErrorLogging(log);

--- a/apps/emdash-desktop/src/main/host/chromium-command-line.test.ts
+++ b/apps/emdash-desktop/src/main/host/chromium-command-line.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import { configureChromiumCommandLine } from './chromium-command-line';
+
+function createCommandLine(initialSwitches: string[] = []) {
+  const switches = new Set(initialSwitches);
+  return {
+    appendSwitch: vi.fn((name: string) => switches.add(name)),
+    hasSwitch: vi.fn((name: string) => switches.has(name)),
+  };
+}
+
+describe('configureChromiumCommandLine', () => {
+  it('configures Linux switches synchronously without requiring a D-Bus environment variable', () => {
+    const commandLine = createCommandLine();
+
+    configureChromiumCommandLine({
+      commandLine,
+      env: { XDG_CURRENT_DESKTOP: 'Hyprland' },
+      platform: 'linux',
+    });
+
+    expect(commandLine.appendSwitch).toHaveBeenNthCalledWith(1, 'ozone-platform-hint', 'auto');
+    expect(commandLine.appendSwitch).toHaveBeenNthCalledWith(
+      2,
+      'password-store',
+      'gnome-libsecret'
+    );
+  });
+
+  it('preserves an explicit password-store switch', () => {
+    const commandLine = createCommandLine(['password-store']);
+
+    configureChromiumCommandLine({
+      commandLine,
+      env: { XDG_CURRENT_DESKTOP: 'Hyprland' },
+      platform: 'linux',
+    });
+
+    expect(commandLine.appendSwitch).toHaveBeenCalledOnce();
+    expect(commandLine.appendSwitch).toHaveBeenCalledWith('ozone-platform-hint', 'auto');
+  });
+
+  it("leaves KDE to Chromium's KWallet selection", () => {
+    const commandLine = createCommandLine();
+
+    configureChromiumCommandLine({
+      commandLine,
+      env: { XDG_CURRENT_DESKTOP: 'Plasma' },
+      platform: 'linux',
+    });
+
+    expect(commandLine.appendSwitch).toHaveBeenCalledOnce();
+    expect(commandLine.appendSwitch).toHaveBeenCalledWith('ozone-platform-hint', 'auto');
+  });
+
+  it('does nothing on non-Linux platforms', () => {
+    const commandLine = createCommandLine();
+
+    configureChromiumCommandLine({ commandLine, env: {}, platform: 'darwin' });
+
+    expect(commandLine.appendSwitch).not.toHaveBeenCalled();
+    expect(commandLine.hasSwitch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/emdash-desktop/src/main/host/chromium-command-line.ts
+++ b/apps/emdash-desktop/src/main/host/chromium-command-line.ts
@@ -1,0 +1,30 @@
+import { LIBSECRET_PASSWORD_STORE, shouldForceLibsecretBackend } from './linux-secret-storage';
+
+type ChromiumCommandLine = {
+  appendSwitch(name: string, value?: string): void;
+  hasSwitch(name: string): boolean;
+};
+
+type ConfigureChromiumCommandLineOptions = {
+  commandLine: ChromiumCommandLine;
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+};
+
+/** Apply Chromium switches that must be set before Electron emits `ready`. */
+export function configureChromiumCommandLine({
+  commandLine,
+  env = process.env,
+  platform = process.platform,
+}: ConfigureChromiumCommandLineOptions): void {
+  if (platform !== 'linux') return;
+
+  commandLine.appendSwitch('ozone-platform-hint', 'auto');
+  if (
+    shouldForceLibsecretBackend(env, {
+      passwordStoreSwitchPresent: commandLine.hasSwitch('password-store'),
+    })
+  ) {
+    commandLine.appendSwitch('password-store', LIBSECRET_PASSWORD_STORE);
+  }
+}

--- a/apps/emdash-desktop/src/main/host/linux-secret-storage.test.ts
+++ b/apps/emdash-desktop/src/main/host/linux-secret-storage.test.ts
@@ -1,26 +1,22 @@
 import { describe, expect, it } from 'vitest';
 import { shouldForceLibsecretBackend } from './linux-secret-storage';
 
-const BUS = 'unix:path=/run/user/1000/bus';
-
 describe('shouldForceLibsecretBackend', () => {
-  it('forces libsecret on an unrecognized desktop with a session bus (Hyprland/sway/…)', () => {
+  it('forces libsecret on an unrecognized desktop without relying on D-Bus environment', () => {
     expect(
       shouldForceLibsecretBackend({
-        DBUS_SESSION_BUS_ADDRESS: BUS,
         XDG_CURRENT_DESKTOP: 'Hyprland',
       })
     ).toBe(true);
   });
 
-  it('forces libsecret when no desktop is advertised but a session bus exists', () => {
-    expect(shouldForceLibsecretBackend({ DBUS_SESSION_BUS_ADDRESS: BUS })).toBe(true);
+  it('forces libsecret when no desktop is advertised', () => {
+    expect(shouldForceLibsecretBackend({})).toBe(true);
   });
 
   it('returns true on GNOME (harmless — Chromium already selects libsecret there)', () => {
     expect(
       shouldForceLibsecretBackend({
-        DBUS_SESSION_BUS_ADDRESS: BUS,
         XDG_CURRENT_DESKTOP: 'ubuntu:GNOME',
       })
     ).toBe(true);
@@ -28,30 +24,32 @@ describe('shouldForceLibsecretBackend', () => {
 
   it('leaves KDE to its native kwallet backend', () => {
     expect(
-      shouldForceLibsecretBackend({ DBUS_SESSION_BUS_ADDRESS: BUS, XDG_CURRENT_DESKTOP: 'KDE' })
+      shouldForceLibsecretBackend({
+        XDG_CURRENT_DESKTOP: 'KDE',
+      })
     ).toBe(false);
     expect(
       shouldForceLibsecretBackend({
-        DBUS_SESSION_BUS_ADDRESS: BUS,
         XDG_CURRENT_DESKTOP: 'plasma:KDE',
       })
     ).toBe(false);
+    expect(
+      shouldForceLibsecretBackend({
+        XDG_CURRENT_DESKTOP: 'Plasma',
+      })
+    ).toBe(false);
+    expect(shouldForceLibsecretBackend({ KDE_FULL_SESSION: 'true' })).toBe(false);
+    expect(shouldForceLibsecretBackend({ KDE_SESSION_VERSION: '6' })).toBe(false);
   });
 
   it('does not override an explicit password-store switch', () => {
     expect(
       shouldForceLibsecretBackend(
         {
-          DBUS_SESSION_BUS_ADDRESS: BUS,
           XDG_CURRENT_DESKTOP: 'Hyprland',
         },
         { passwordStoreSwitchPresent: true }
       )
     ).toBe(false);
-  });
-
-  it('does nothing without a usable session bus (no Secret Service to reach)', () => {
-    expect(shouldForceLibsecretBackend({ XDG_CURRENT_DESKTOP: 'Hyprland' })).toBe(false);
-    expect(shouldForceLibsecretBackend({ DBUS_SESSION_BUS_ADDRESS: '   ' })).toBe(false);
   });
 });

--- a/apps/emdash-desktop/src/main/host/linux-secret-storage.ts
+++ b/apps/emdash-desktop/src/main/host/linux-secret-storage.ts
@@ -12,19 +12,29 @@ export const LIBSECRET_PASSWORD_STORE = 'gnome-libsecret';
  * Service is on the session bus, which breaks every encrypted-secret feature
  * (account sign-in, cached GitHub/Linear tokens, SSH credentials, …). See #1875.
  *
- * Force `gnome-libsecret` when a session bus is present (a Secret Service can
- * only live on D-Bus) and the desktop is not KDE — KDE is left to its native
- * kwallet auto-detection. With no session bus we leave the default untouched:
- * there is no Secret Service to reach, so forcing would not help. On GNOME the
- * switch is a harmless no-op (Chromium already picks libsecret there).
+ * Force `gnome-libsecret` unless the desktop is KDE, which is left to its native
+ * KWallet auto-detection. We intentionally do not infer Secret Service
+ * availability from `DBUS_SESSION_BUS_ADDRESS`: it is only an address, services
+ * may be activated on demand, and Chromium will report whether the requested
+ * backend actually initialized. On GNOME the switch is a harmless no-op because
+ * Chromium already picks libsecret there.
  */
 export function shouldForceLibsecretBackend(
   env: NodeJS.ProcessEnv = process.env,
   options: { passwordStoreSwitchPresent?: boolean } = {}
 ): boolean {
   if (options.passwordStoreSwitchPresent) return false;
-  if (!env.DBUS_SESSION_BUS_ADDRESS?.trim()) return false;
-  const desktop = (env.XDG_CURRENT_DESKTOP ?? '').toLowerCase();
-  if (desktop.includes('kde')) return false;
-  return true;
+  return !isKdeDesktop(env);
+}
+
+function isKdeDesktop(env: NodeJS.ProcessEnv): boolean {
+  const desktops = (env.XDG_CURRENT_DESKTOP ?? '')
+    .split(':')
+    .map((desktop) => desktop.trim().toLowerCase());
+
+  return (
+    desktops.some((desktop) => desktop === 'kde' || desktop === 'plasma') ||
+    env.KDE_FULL_SESSION?.trim().toLowerCase() === 'true' ||
+    Boolean(env.KDE_SESSION_VERSION?.trim())
+  );
 }


### PR DESCRIPTION
- moves chromium password-store configuration into the synchronous entry path before async bootstrap begins
- forces gnome-libsecret on non-kde linux without relying on the dbus session address environment variable
- preserves explicit password-store overrides and kde or plasma kwallet selection
- retains plaintext backend rejection and protects startup ordering with regression coverage