### PR TITLE
fix(tabs): soften active indicators and reflect terminal focus

### DIFF
--- a/apps/emdash-desktop/src/core/features/terminals/browser/task-terminal/terminal-drawer-tab-bar.tsx
+++ b/apps/emdash-desktop/src/core/features/terminals/browser/task-terminal/terminal-drawer-tab-bar.tsx
@@ -30,6 +30,7 @@ export type TerminalShellMenuState =
   | Readonly<{ kind: 'ready'; availability: TerminalShellAvailability[] }>;
 
 interface TerminalDrawerTabBarProps {
+  isFocused: boolean;
   mode: TerminalDrawerMode;
   onModeChange: (mode: TerminalDrawerMode) => void;
   lifecycleScriptsMgr: LifecycleScriptsStore | null;
@@ -62,6 +63,7 @@ const SCRIPT_STATUS_MAP: Record<LifecycleScriptStatus, ScriptStatusKind> = {
 };
 
 export const TerminalDrawerTabBar = observer(function TerminalDrawerTabBar({
+  isFocused,
   mode,
   onModeChange,
   lifecycleScriptsMgr,
@@ -103,6 +105,7 @@ export const TerminalDrawerTabBar = observer(function TerminalDrawerTabBar({
                 icon={<Terminal className="size-3" />}
                 label={terminal.data.name}
                 isActive={activeTerminalId === terminal.data.id}
+                isFocused={isFocused}
                 dragData={{
                   type: TERMINAL_DRAWER_DRAG_TYPE,
                   terminalId: terminal.data.id,
@@ -152,6 +155,7 @@ export const TerminalDrawerTabBar = observer(function TerminalDrawerTabBar({
               icon={<ScriptStatus status={SCRIPT_STATUS_MAP[script.status]} size={12} />}
               label={script.data.label}
               isActive={activeScriptId === script.data.id}
+              isFocused={isFocused}
               onSelect={() => onSelectScript(script.data.id)}
               iconAction={
                 <Tooltip.Root>
@@ -282,6 +286,7 @@ interface DrawerItemTabProps {
   icon: ReactNode;
   label: string;
   isActive: boolean;
+  isFocused: boolean;
   onSelect: () => void;
   onRename?: (name: string) => void;
   onHover?: () => void;
@@ -295,6 +300,7 @@ function DrawerItemTab({
   icon,
   label,
   isActive,
+  isFocused,
   onSelect,
   onRename,
   onHover,
@@ -323,7 +329,14 @@ function DrawerItemTab({
         isDragging && 'opacity-50'
       )}
     >
-      {isActive && <div className="absolute inset-x-0 bottom-0 h-0.5 bg-foreground" />}
+      {isActive && (
+        <div
+          className={cn(
+            'absolute inset-x-0 bottom-0 h-0.5',
+            isFocused ? 'bg-(--primary-button-background)' : 'bg-border-1'
+          )}
+        />
+      )}
       {isEditing && onRename ? (
         <div className="flex min-w-0 flex-1 items-center gap-1.5 px-3">
           <span className="shrink-0">{icon}</span>

--- a/apps/emdash-desktop/src/core/features/terminals/contributions/browser/task-terminal/terminal-panel-focus.browser.test.tsx
+++ b/apps/emdash-desktop/src/core/features/terminals/contributions/browser/task-terminal/terminal-panel-focus.browser.test.tsx
@@ -1,0 +1,127 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TerminalsPanel } from './terminal-panel';
+
+const mocks = vi.hoisted(() => ({
+  drawerScopeFocused: false,
+  tabBarIsFocused: undefined as boolean | undefined,
+}));
+
+vi.mock('@core/features/tasks/api/browser/hooks/use-is-active-task', () => ({
+  useIsActiveTask: () => true,
+}));
+
+vi.mock('@core/features/tasks/contributions/browser/task-view-context', () => ({
+  useTaskViewContext: () => ({ projectId: 'project-1', taskId: 'task-1' }),
+}));
+
+vi.mock('@core/features/terminals/api/browser/use-terminal-shell-availability', () => ({
+  useTerminalShellAvailability: () => ({
+    data: [],
+    isError: false,
+    isFetching: false,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock('@core/features/terminals/browser/task-terminal/terminal-drawer-tab-bar', () => ({
+  TerminalDrawerTabBar: ({ isFocused }: { isFocused: boolean }) => {
+    mocks.tabBarIsFocused = isFocused;
+    return null;
+  },
+}));
+
+vi.mock('@core/features/terminals/browser/task-terminal/terminal-panel-selection', () => ({
+  resolveTerminalPanelActiveItem: () => ({ kind: 'terminal', id: '' }),
+}));
+
+vi.mock('@core/features/terminals/browser/task-terminal/terminal-pty-content', () => ({
+  TerminalPtyContent: () => null,
+}));
+
+vi.mock('@core/features/workbench/api/browser/tabs/use-pane-scope', () => ({
+  usePaneScope: () => ({
+    attachRef: () => {},
+    instance: undefined,
+    isFocused: mocks.drawerScopeFocused,
+  }),
+}));
+
+vi.mock('@core/features/workbench/api/browser/task-composition-context', () => ({
+  useTaskComposition: () => ({
+    terminalTabs: {
+      tabs: [],
+      activeTabId: undefined,
+      setActiveTab: vi.fn(),
+      removeTab: vi.fn(),
+    },
+    terminalDrawerActiveItem: undefined,
+    isTerminalDrawerOpen: true,
+    focusedRegion: 'bottom',
+    paneLayout: { groups: [] },
+    setFocusedRegion: vi.fn(),
+    setTerminalDrawerActiveItem: vi.fn(),
+    openNewTerminal: vi.fn(),
+  }),
+  useTerminals: () => ({
+    hostAccess: null,
+    sessions: new Map(),
+    renameTerminal: vi.fn(),
+  }),
+  useWorkspace: () => ({
+    get: () => null,
+    sshConnectionId: null,
+  }),
+  useWorkspaceId: () => 'workspace-1',
+}));
+
+vi.mock('@core/features/workspaces/contributions/browser/workspace-stores', () => ({
+  lifecycleScriptsStoreToken: Symbol('lifecycle-scripts'),
+}));
+
+vi.mock('@core/manifests/browser/project-availability-ui', () => ({
+  projectAvailabilityUi: {
+    getLiveActionDisabledReason: () => null,
+    LiveActionGuard: ({ children }: { children: React.ReactNode }) => children,
+  },
+}));
+
+vi.mock('@core/primitives/view-scopes/react', () => ({
+  ViewScopeInstanceProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+beforeAll(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+describe('TerminalsPanel focus indicator', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    mocks.drawerScopeFocused = false;
+    mocks.tabBarIsFocused = undefined;
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    host.remove();
+  });
+
+  it('uses the live drawer scope instead of the remembered focused region', async () => {
+    await act(async () => root.render(<TerminalsPanel key="unfocused" />));
+
+    expect(mocks.tabBarIsFocused).toBe(false);
+
+    mocks.drawerScopeFocused = true;
+    await act(async () => root.render(<TerminalsPanel key="focused" />));
+
+    expect(mocks.tabBarIsFocused).toBe(true);
+  });
+});

--- a/apps/emdash-desktop/src/core/features/terminals/contributions/browser/task-terminal/terminal-panel.tsx
+++ b/apps/emdash-desktop/src/core/features/terminals/contributions/browser/task-terminal/terminal-panel.tsx
@@ -57,7 +57,7 @@ export const TerminalsPanel = observer(function TerminalsPanel() {
         }
       : { kind: 'loading' };
 
-  const autoFocus =
+  const shouldAutoFocus =
     isActive && taskView.isTerminalDrawerOpen && taskView.focusedRegion === 'bottom';
 
   const lifecycleScriptTabs = lifecycleScriptsMgr?.tabs ?? [];
@@ -124,10 +124,11 @@ export const TerminalsPanel = observer(function TerminalsPanel() {
   };
 
   const activeStore = mode === 'terminals' ? terminalTabView : (lifecycleScriptsMgr ?? undefined);
-  const { attachRef: attachPaneScope, instance: paneScopeInstance } = usePaneScope(
-    `terminal-drawer:${projectId}:${taskId}`,
-    activeStore ?? terminalTabView
-  );
+  const {
+    attachRef: attachPaneScope,
+    instance: paneScopeInstance,
+    isFocused,
+  } = usePaneScope(`terminal-drawer:${projectId}:${taskId}`, activeStore ?? terminalTabView);
 
   const handleCreate = async (shell?: TerminalShellId) => {
     if (liveActionsDisabled) return;
@@ -218,6 +219,7 @@ export const TerminalsPanel = observer(function TerminalsPanel() {
         }}
       >
         <TerminalDrawerTabBar
+          isFocused={isFocused}
           projectId={projectId}
           liveActionsDisabled={liveActionsDisabled}
           mode={mode}
@@ -250,7 +252,7 @@ export const TerminalsPanel = observer(function TerminalsPanel() {
           className="min-h-0 flex-1"
           activeSession={activeSession}
           allSessionIds={allSessionIds}
-          autoFocus={autoFocus}
+          autoFocus={shouldAutoFocus}
           emptyState={mode === 'scripts' ? scriptsEmptyState : terminalEmptyState}
           unavailableState={
             <EmptyState

--- a/apps/emdash-desktop/src/core/primitives/workbench-shell/browser/tabs/tab-bar/generic-tab-item.tsx
+++ b/apps/emdash-desktop/src/core/primitives/workbench-shell/browser/tabs/tab-bar/generic-tab-item.tsx
@@ -141,7 +141,7 @@ export const GenericTabItem = observer(function GenericTabItem({
             <div
               className={cn(
                 'absolute inset-x-0 bottom-0 h-0.5',
-                isFocusedPane ? 'bg-foreground' : 'bg-foreground/35'
+                isFocusedPane ? 'bg-(--primary-button-background)' : 'bg-border-1'
               )}
             />
           )}


### PR DESCRIPTION
- uses the chat ui primary green for focused workbench and terminal tabs
- keeps unfocused tab indicators neutral across main panes and the terminal drawer
- derives terminal drawer emphasis from live pane focus instead of remembered task region state