### PR TITLE
feat(muse): add Muse Code CLI as agent provider

### DIFF
--- a/agents/integrations/providers.md
+++ b/agents/integrations/providers.md
@@ -7,9 +7,9 @@
 - `src/main/core/dependencies/dependency-managers.ts`
 - `src/main/core/pty/`
 
-## Current Providers (36)
+## Current Providers (37)
 
-codex, claude, grok, devin, qwen, qoder, droid, antigravity, cursor, copilot, amp, commandcode, opencode, hermes, charm, auggie, goose, kimi, kilocode, kiro, rovo, cline, codebuddy, continue, codebuff, freebuff, mistral, jules, junie, oh-my-pi, pi, prime-agent, autohand, letta, mimocode, zero
+codex, claude, grok, devin, qwen, qoder, droid, antigravity, cursor, copilot, amp, commandcode, opencode, hermes, charm, auggie, goose, kimi, kilocode, kiro, rovo, cline, codebuddy, continue, codebuff, freebuff, mistral, jules, junie, oh-my-pi, pi, prime-agent, autohand, letta, mimocode, zero, muse
 
 ## Current ACP-Capable Providers (23)
 

--- a/packages/plugins/src/agents/impl/muse/icon.ts
+++ b/packages/plugins/src/agents/impl/muse/icon.ts
@@ -1,0 +1,12 @@
+import type { PluginIconAsset } from '@emdash/shared/plugins';
+
+export const icon: PluginIconAsset = {
+  kind: 'svg',
+  alt: 'Muse Code CLI',
+  variants: [
+    {
+      minSize: 0,
+      light: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" rx="14" fill="#0082FB"/><text x="32" y="46" font-family="ui-monospace, Menlo, monospace" font-size="38" font-weight="800" text-anchor="middle" fill="#ffffff">M</text></svg>`,
+    },
+  ],
+};

--- a/packages/plugins/src/agents/impl/muse/index.test.ts
+++ b/packages/plugins/src/agents/impl/muse/index.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { provider } from './index';
+
+const baseContext = {
+  cli: 'muse',
+  autoApprove: false,
+  initialPrompt: undefined,
+  sessionId: 'emdash-session-id',
+  providerSessionId: undefined,
+  isResuming: false,
+  model: '',
+};
+
+describe('muse provider', () => {
+  it('declares positional argv prompt delivery and stateless sessions', () => {
+    expect(provider.capabilities.prompt).toEqual({ kind: 'argv', flag: '' });
+    expect(provider.capabilities.sessions).toEqual({ kind: 'stateless' });
+    expect(provider.capabilities.autoApprove).toEqual({ kind: 'supported' });
+  });
+
+  it('probes the muse binary with the Meta install script', () => {
+    expect(provider.capabilities.hostDependency).toMatchObject({
+      id: 'muse',
+      binaryNames: ['muse'],
+    });
+    const commands = provider.capabilities.hostDependency.installCommands!;
+    for (const platform of ['macos', 'linux'] as const) {
+      expect(commands[platform]![0].command).toContain('https://dev.meta.ai/install.sh');
+    }
+  });
+
+  it('passes a fresh prompt positionally with --yolo when auto-approved', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      autoApprove: true,
+      initialPrompt: 'implement the task',
+    });
+
+    expect(command).toEqual({
+      command: 'muse',
+      args: ['--yolo', 'implement the task'],
+      env: {},
+    });
+  });
+
+  it('omits --yolo without auto-approve', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      initialPrompt: 'implement the task',
+    });
+
+    expect(command).toEqual({
+      command: 'muse',
+      args: ['implement the task'],
+      env: {},
+    });
+  });
+
+  it('starts an empty fresh session in interactive mode', () => {
+    const command = provider.behavior.prompt!.buildCommand(baseContext);
+
+    expect(command).toEqual({
+      command: 'muse',
+      args: [],
+      env: {},
+    });
+  });
+});

--- a/packages/plugins/src/agents/impl/muse/index.ts
+++ b/packages/plugins/src/agents/impl/muse/index.ts
@@ -1,0 +1,58 @@
+import {
+  definePlugin,
+  registerPluginBehavior,
+} from '@emdash/core/services/agent-plugins/api/plugins';
+import { buildStandardCommand } from '@emdash/core/services/agent-plugins/api/plugins/helpers';
+import { icon } from './icon';
+
+export const plugin = definePlugin(
+  {
+    id: 'muse',
+    name: 'Muse Code',
+    description: "Meta's terminal coding agent for planning, writing, and validating code changes.",
+    websiteUrl: 'https://developer.meta.com/ai/products/muse-code/',
+  },
+  {
+    autoApprove: {
+      kind: 'supported',
+    },
+    hostDependency: {
+      id: 'muse',
+      binaryNames: ['muse'],
+      installDocs: 'https://developer.meta.com/ai/products/muse-code/',
+      installCommands: {
+        macos: [
+          {
+            method: 'curl',
+            command: 'curl -fsSL https://dev.meta.ai/install.sh | bash',
+            recommended: true,
+          },
+        ],
+        linux: [
+          {
+            method: 'curl',
+            command: 'curl -fsSL https://dev.meta.ai/install.sh | bash',
+          },
+        ],
+      },
+    },
+    prompt: {
+      kind: 'argv',
+      flag: '',
+    },
+    sessions: {
+      kind: 'stateless',
+    },
+  },
+  { icon }
+);
+
+export const provider = registerPluginBehavior(plugin, {
+  prompt: {
+    buildCommand: (ctx) =>
+      buildStandardCommand(ctx, {
+        autoApproveFlag: '--yolo',
+        initialPromptFlag: '',
+      }),
+  },
+});

--- a/packages/plugins/src/agents/registry.ts
+++ b/packages/plugins/src/agents/registry.ts
@@ -29,6 +29,7 @@ import { provider as kiro } from './impl/kiro';
 import { provider as letta } from './impl/letta';
 import { provider as mimocode } from './impl/mimocode';
 import { provider as mistral } from './impl/mistral';
+import { provider as muse } from './impl/muse';
 import { provider as ohMyPi } from './impl/oh-my-pi';
 import { provider as opencode } from './impl/opencode';
 import { provider as pi } from './impl/pi';
@@ -80,6 +81,7 @@ for (const p of [
   autohand,
   mimocode,
   zero,
+  muse,
 ]) {
   pluginRegistry.register(p);
 }


### PR DESCRIPTION
Adds Meta's Muse Code CLI (`muse`) as a selectable agent provider, so anyone with `muse` on PATH can run it in Emdash task worktrees.

What is included (v1, PTY-only like rovo):
- Positional argv prompt delivery: `muse [PROMPT]` opens the interactive TUI with the task prompt.
- Auto-approve via `--yolo` (Muse's documented skip-approval mode).
- PATH detection for the `muse` binary with the official installer (`curl -fsSL https://dev.meta.ai/install.sh | bash`) on macOS/Linux. No Windows entry: Muse Code ships for macOS and Linux only.
- `stateless` sessions: the TUI root command takes no `--session-id` (only headless `exec` does), and resume is a `resume` subcommand, so deterministic session isolation is not possible yet.
- Provider icon, registry entry, and `agents/integrations/providers.md` count (36 -> 37).

Deliberately out of scope for follow-ups:
- Resumable sessions via `muse resume --last / <uuid>` (needs a custom subcommand builder).
- Hook/event integration, MCP, selectable models, and `muse login` auth helper.

Validation run locally:
- `packages/plugins`: 348/348 tests pass (incl. 5 new muse tests), typecheck clean, oxlint clean, `format:check` clean.
- Desktop suite: 3482 passed; browser project 218/218 on re-run (one full parallel run showed flaky browser timeouts that pass in isolation and on rerun; CI skips browser projects).