### PR TITLE
fix(workbench): keep Open in Emdash and Cancel visible in the external link dialog

### DIFF
--- a/apps/emdash-desktop/src/core/features/workbench/browser/external-link-choice-dialog.tsx
+++ b/apps/emdash-desktop/src/core/features/workbench/browser/external-link-choice-dialog.tsx
@@ -75,27 +75,29 @@ export function ExternalLinkChoiceDialog({
           </Tooltip.Provider>
         </div>
       </Dialog.Body>
-      <Dialog.Footer className="flex-col-reverse sm:flex-col-reverse">
-        <Button className="w-full" variant="secondary" onClick={controller.dismiss}>
-          Cancel
-        </Button>
-        <Button
-          className="w-full"
-          variant="secondary"
-          disabled={!canOpenInEmdashBrowser}
-          onClick={() => controller.complete('emdash-browser')}
-        >
-          <Globe className="size-4" />
-          Open in Emdash
-        </Button>
-        <Button
-          className="w-full"
-          variant="primary"
-          onClick={() => controller.complete('external-browser')}
-        >
-          <ExternalLink className="size-4" />
-          Open in Browser
-        </Button>
+      <Dialog.Footer>
+        <div className="flex w-full flex-col-reverse gap-2">
+          <Button className="w-full" variant="secondary" onClick={controller.dismiss}>
+            Cancel
+          </Button>
+          <Button
+            className="w-full"
+            variant="secondary"
+            disabled={!canOpenInEmdashBrowser}
+            onClick={() => controller.complete('emdash-browser')}
+          >
+            <Globe className="size-4" />
+            Open in Emdash
+          </Button>
+          <Button
+            className="w-full"
+            variant="primary"
+            onClick={() => controller.complete('external-browser')}
+          >
+            <ExternalLink className="size-4" />
+            Open in Browser
+          </Button>
+        </div>
       </Dialog.Footer>
     </>
   );


### PR DESCRIPTION
### Description

"Open in Emdash" (and "Cancel") in the external link dialog were unreachable: only "Open in Browser" was ever visible, even inside a task view where the button was enabled.

**Root cause.** `Dialog.Footer` from `@emdash/ui` sets `flex-direction: row` at `min-width: 640px` in an unlayered vanilla-extract stylesheet (`packages/ui/src/react/primitives/dialog/dialog.css.ts`). The dialog passed `className="flex-col-reverse sm:flex-col-reverse"`, but that is a layered Tailwind utility and loses to the kit's own rule. Three `w-full` buttons were laid out in a row inside a 384px dialog with `overflow-hidden`, so two of them were clipped past the left edge. Measured in the running app (dialog at x 508–892):

| Button | x range | visible |
|---|---|---|
| Open in Browser | 520–880 | yes |
| Open in Emdash | 152–512 | no (clipped) |
| Cancel | -216–144 | no (off-screen) |

The button was `disabled: false` in the DOM the whole time; a programmatic `.click()` on it opened the in-app browser pane, a real mouse could not reach it. The navigation ref and task composition lookup in `open-external-link.ts` were not at fault.

Regressed in 688357b91 (port of the dialog to `@emdash/ui` `Dialog`); the previous Tailwind-based footer honored the override.

**Fix.** Stack the buttons in a wrapper the dialog owns instead of overriding the footer's layout. No behavior change otherwise.

### Related issues

Reported in-app: "Open in Emdash" appeared unavailable while inside a task view (remote/SSH project). No upstream issue filed.

### Testing

- `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck` in `apps/emdash-desktop`: pass
- `vitest --project node` for `src/core/features/workbench` and `src/core/features/terminals`: 26 files, 175 tests pass
- Manual, dev build (`pnpm run dev`) with a copy of a real data dir, remote SSH task, Claude Code TUI in the agent pane: plain-click on `http://localhost:8083/admin` shows the dialog with all three buttons stacked and hit-testable (measured: each at x 520–880, heights 32px, `elementFromPoint` returns the button). Choosing "Open in Emdash" opens a browser pane in the task.
- Layout can't be asserted in the node test project; the existing render test still passes.

### Screenshot/Recording (if applicable)

Before (only "Open in Browser" reachable):

![before](https://raw.githubusercontent.com/tkohout/emdash/eb724113db36f75b08c41cfb0158fd0b9d757000/external-link-dialog/dialog-before.png)

After:

![after](https://raw.githubusercontent.com/tkohout/emdash/eb724113db36f75b08c41cfb0158fd0b9d757000/external-link-dialog/dialog-after.png)

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed (n/a)
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for commit messages and the PR title

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jTBcTyHoPSSBk7Y6AGFnw

