### PR TITLE
feat(terminals): open links in the Emdash browser on option-click

### DIFF
--- a/apps/emdash-desktop/src/core/features/terminals/api/browser/pty/pty.ts
+++ b/apps/emdash-desktop/src/core/features/terminals/api/browser/pty/pty.ts
@@ -5,7 +5,7 @@ import {
   isPrimaryMouseButton,
 } from '@core/features/terminals/api/browser/pty/file-link-provider';
 import { buildTerminalFontFamily } from '@core/features/terminals/api/browser/pty/terminal-font';
-import { confirmOpenExternalLink } from '@core/features/workbench/api/browser/open-external-link';
+import { openExternalLinkFromMouseEvent } from '@core/features/workbench/api/browser/open-external-link';
 import { copyTextToClipboard } from '@core/primitives/desktop-host/browser/host-client';
 import { log } from '@core/primitives/logging/browser/logger';
 import { cssColorToHex, cssVar } from '@core/primitives/styling/browser/cssVars';
@@ -127,9 +127,10 @@ export class FrontendPty {
       allowProposedApi: true,
       scrollOnUserInput: false,
       linkHandler: {
-        activate: (_event: MouseEvent, text: string) => {
-          if (!isPrimaryMouseButton(_event)) return;
-          confirmOpenExternalLink(text, (error) => {
+        activate: (event: MouseEvent, text: string) => {
+          if (!isPrimaryMouseButton(event)) return;
+          this.suppressAltClickCursorMove(event);
+          openExternalLinkFromMouseEvent(event, text, (error) => {
             log.warn('FrontendPty: failed to open external link', { text, error });
           });
         },
@@ -143,7 +144,8 @@ export class FrontendPty {
     const webLinksAddon = new WebLinksAddon((event, uri) => {
       if (!isPrimaryMouseButton(event)) return;
       event.preventDefault();
-      confirmOpenExternalLink(uri);
+      this.suppressAltClickCursorMove(event);
+      openExternalLinkFromMouseEvent(event, uri);
     });
 
     this.terminal.loadAddon(webLinksAddon);
@@ -255,6 +257,20 @@ export class FrontendPty {
    */
   unmount(): void {
     ensureXtermHost().appendChild(this.ownedContainer);
+  }
+
+  /**
+   * xterm's SelectionService handles the same mouseup after a link activates and, with
+   * ⌥ held, sends cursor-movement keys to the PTY (`altClickMovesCursor`). An ⌥-click that
+   * opened a link should not also move the shell cursor, so the option is switched off for
+   * the remainder of this event dispatch only.
+   */
+  private suppressAltClickCursorMove(event: MouseEvent): void {
+    if (!event.altKey || !this.terminal.options.altClickMovesCursor) return;
+    this.terminal.options.altClickMovesCursor = false;
+    setTimeout(() => {
+      this.terminal.options.altClickMovesCursor = true;
+    }, 0);
   }
 
   /**

--- a/apps/emdash-desktop/src/core/features/workbench/api/browser/open-external-link.test.ts
+++ b/apps/emdash-desktop/src/core/features/workbench/api/browser/open-external-link.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { confirmOpenExternalLink } from './open-external-link';
+import {
+  confirmOpenExternalLink,
+  openExternalLinkFromMouseEvent,
+  openLinkInEmdashBrowser,
+} from './open-external-link';
 
 const mocks = vi.hoisted(() => ({
   clipboardWriteText: vi.fn(),
@@ -137,5 +141,115 @@ describe('confirmOpenExternalLink', () => {
     await Promise.resolve();
 
     expect(mocks.openExternal).not.toHaveBeenCalled();
+  });
+});
+
+function makeTaskView() {
+  return {
+    paneLayout: { open: vi.fn() },
+    setFocusedRegion: vi.fn(),
+  };
+}
+
+function activateTaskView() {
+  const taskView = makeTaskView();
+  mocks.navigationRef.viewId = 'task';
+  mocks.navigationRef.params = { projectId: 'project-1', taskId: 'task-1' };
+  mocks.getTaskComposition.mockReturnValue(taskView);
+  return taskView;
+}
+
+describe('openLinkInEmdashBrowser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.navigationRef.viewId = 'home';
+    mocks.navigationRef.params = {};
+    mocks.getTaskComposition.mockReturnValue(undefined);
+  });
+
+  it('opens a browser pane in the active task and focuses it', () => {
+    const taskView = activateTaskView();
+
+    expect(openLinkInEmdashBrowser('https://example.com/docs).')).toBe(true);
+
+    expect(taskView.paneLayout.open).toHaveBeenCalledWith('browser', {
+      initialUrl: 'https://example.com/docs',
+    });
+    expect(taskView.setFocusedRegion).toHaveBeenCalledWith('main');
+    expect(mocks.openModal).not.toHaveBeenCalled();
+  });
+
+  it('returns false outside a task view', () => {
+    expect(openLinkInEmdashBrowser('https://example.com/docs')).toBe(false);
+    expect(mocks.openModal).not.toHaveBeenCalled();
+  });
+
+  it('returns false when the task has no composition yet', () => {
+    mocks.navigationRef.viewId = 'task';
+    mocks.navigationRef.params = { projectId: 'project-1', taskId: 'task-1' };
+    mocks.getTaskComposition.mockReturnValue(undefined);
+
+    expect(openLinkInEmdashBrowser('https://example.com/docs')).toBe(false);
+  });
+
+  it('ignores non-http links', () => {
+    const taskView = activateTaskView();
+
+    expect(openLinkInEmdashBrowser('file:///etc/passwd')).toBe(false);
+    expect(taskView.paneLayout.open).not.toHaveBeenCalled();
+  });
+});
+
+describe('openExternalLinkFromMouseEvent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.navigationRef.viewId = 'home';
+    mocks.navigationRef.params = {};
+    mocks.getTaskComposition.mockReturnValue(undefined);
+    mocks.openModal.mockResolvedValue({
+      success: false,
+      error: { type: 'modal_dismissed', reason: 'explicit' },
+    });
+  });
+
+  it('opens in the Emdash browser without a dialog on option-click', () => {
+    const taskView = activateTaskView();
+
+    openExternalLinkFromMouseEvent({ altKey: true }, 'https://example.com/docs');
+
+    expect(taskView.paneLayout.open).toHaveBeenCalledWith('browser', {
+      initialUrl: 'https://example.com/docs',
+    });
+    expect(taskView.setFocusedRegion).toHaveBeenCalledWith('main');
+    expect(mocks.openModal).not.toHaveBeenCalled();
+  });
+
+  it('shows the dialog on a plain click even inside a task', () => {
+    const taskView = activateTaskView();
+
+    openExternalLinkFromMouseEvent({ altKey: false }, 'https://example.com/docs');
+
+    expect(taskView.paneLayout.open).not.toHaveBeenCalled();
+    expect(mocks.openModal).toHaveBeenCalledTimes(1);
+    expect(getModalArgs().url).toBe('https://example.com/docs');
+  });
+
+  it('falls back to the dialog on option-click when no task view can host a pane', () => {
+    openExternalLinkFromMouseEvent({ altKey: true }, 'https://example.com/docs');
+
+    expect(mocks.openModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards open errors from the dialog path', async () => {
+    const onError = vi.fn();
+    const failure = new Error('shell unavailable');
+    mocks.openModal.mockResolvedValue({ success: true, data: 'external-browser' });
+    mocks.openExternal.mockRejectedValue(failure);
+
+    openExternalLinkFromMouseEvent({ altKey: false }, 'https://example.com/docs', onError);
+
+    await vi.waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(failure);
+    });
   });
 });

--- a/apps/emdash-desktop/src/core/features/workbench/api/browser/open-external-link.ts
+++ b/apps/emdash-desktop/src/core/features/workbench/api/browser/open-external-link.ts
@@ -1,4 +1,5 @@
 import { toast } from '@emdash/ui/react/primitives';
+import type { TaskComposition } from '@core/features/workbench/api/browser/task-composition';
 import { getTaskComposition } from '@core/features/workbench/api/browser/task-composition-selectors';
 import { openModal } from '@core/manifests/browser/modal-api';
 import {
@@ -26,14 +27,49 @@ export function confirmOpenExternalLink(url: string, onError?: (error: unknown) 
   }).then((outcome) => {
     if (!outcome.success) return;
     if (outcome.data === 'emdash-browser') {
-      taskView?.paneLayout.open('browser', { initialUrl: normalizedUrl });
-      taskView?.setFocusedRegion('main');
+      openInTaskView(taskView, normalizedUrl);
       return;
     }
     void openExternal(normalizedUrl).catch((error) => {
       onError?.(error);
     });
   });
+}
+
+/**
+ * Opens the link in a browser pane of the active task without confirmation.
+ * Returns false when there is no task view to host the pane, or the link is not http(s).
+ */
+export function openLinkInEmdashBrowser(url: string): boolean {
+  const normalizedUrl = normalizeExternalHttpUrl(url);
+  if (!HTTP_URL_PATTERN.test(normalizedUrl)) return false;
+
+  const taskView = getActiveTaskView();
+  if (taskView === undefined) return false;
+
+  openInTaskView(taskView, normalizedUrl);
+  return true;
+}
+
+export type LinkModifierEvent = Pick<MouseEvent, 'altKey'>;
+
+/**
+ * Link activation from a pointer: ⌥-click opens the link directly in the Emdash
+ * browser; otherwise (or when no task pane can host it) the choice dialog is shown.
+ */
+export function openExternalLinkFromMouseEvent(
+  event: LinkModifierEvent,
+  url: string,
+  onError?: (error: unknown) => void
+): void {
+  if (event.altKey && openLinkInEmdashBrowser(url)) return;
+  confirmOpenExternalLink(url, onError);
+}
+
+function openInTaskView(taskView: TaskComposition | undefined, url: string): void {
+  if (taskView === undefined) return;
+  taskView.paneLayout.open('browser', { initialUrl: url });
+  taskView.setFocusedRegion('main');
 }
 
 async function copyExternalLink(url: string): Promise<boolean> {


### PR DESCRIPTION
### Description

In an agent/terminal pane, ⌥-click on a URL now opens it directly in Emdash's in-app browser pane, with no confirmation dialog. Plain left-click keeps the existing dialog.

- `open-external-link.ts`: the in-app path of `confirmOpenExternalLink` is extracted into `openLinkInEmdashBrowser(url): boolean` (false when there is no task view to host a pane, or the link is not http/https). New `openExternalLinkFromMouseEvent(event, url, onError)` opens in-app when `altKey` is held and a task pane is available, and otherwise falls through to the dialog.
- `pty.ts`: both terminal link handlers (the OSC 8 `linkHandler` and `WebLinksAddon`) route through the new helper. The `isPrimaryMouseButton` guard is unchanged; ⌥ + left click still reports as primary.
- `pty.ts`: xterm's `altClickMovesCursor` (on by default) turns any alt-click into cursor-movement keys written to the PTY from the same mouseup, after the link activates. `FrontendPty.suppressAltClickCursorMove` switches the option off for the remainder of that event dispatch so an ⌥-click that opened a link does not also poke the shell or agent prompt. Alt-click cursor movement still works when the click is not on a link.

⌘ is deliberately not mapped: ⌘-click already activates file links in the terminal (`isActivationModifierPressed`). Scope is the terminal handlers only; chat links and main-process link requests keep the dialog.

Independent of the dialog layout fix (generalaction/emdash#3110); both apply cleanly on main.

### Related issues

Follow-up to #3110. Requested as a faster path for opening dev-server links from the agent pane.

### Testing

- `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck` in `apps/emdash-desktop`: pass
- `open-external-link.test.ts`: 14 tests pass (8 new): in-app open + focus, false outside a task view, false when the task has no composition yet, non-http ignored, ⌥ skips the dialog, plain click shows the dialog, ⌥ falls back to the dialog with no task view, dialog error path forwards `onError`
- `vitest --project node` for `src/core/features/workbench` and `src/core/features/terminals`: 26 files, 183 tests pass
- Manual, dev build (`pnpm run dev`), remote SSH task with Claude Code in the agent pane, driven over the Chrome DevTools port with Alt held via `keyboard.down`:
  - ⌥-click on `http://localhost:8083/admin`: no dialog rendered, a new `localhost:8083` browser tab opened with the URL (screenshot below; connection refused is expected, the port lives on the remote host)
  - bytes written to the PTY during that click, captured via `terminal.onData`: only the SGR mouse reports the TUI had requested (`ESC[<8;16;40M` etc.), no cursor-movement sequences; `altClickMovesCursor` read back as `true` afterwards
  - plain click on the same link: dialog shown
- `FrontendPty` constructs a real xterm `Terminal`, so the suppression helper is covered by the manual run rather than a node unit test.

### Screenshot/Recording (if applicable)

⌥-click result, no dialog, pane opened directly:

![option-click](https://raw.githubusercontent.com/tkohout/emdash/eb724113db36f75b08c41cfb0158fd0b9d757000/external-link-dialog/option-click-opens-pane.png)

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed (no docs cover terminal link behavior)
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for commit messages and the PR title

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jTBcTyHoPSSBk7Y6AGFnw

