### PR TITLE
fix(workbench): show pointer cursor on task tabs

### DIFF
--- a/apps/emdash-desktop/src/core/primitives/workbench-shell/browser/tabs/tab-bar/generic-tab-item.tsx
+++ b/apps/emdash-desktop/src/core/primitives/workbench-shell/browser/tabs/tab-bar/generic-tab-item.tsx
@@ -133,7 +133,7 @@ export const GenericTabItem = observer(function GenericTabItem({
           title={fullTitle}
           data-tabid={tab.tabId}
           className={cn(
-            'group relative flex h-full flex-col text-sm',
+            'group relative flex h-full cursor-pointer flex-col text-sm',
             tab.isActive ? 'text-foreground' : 'text-foreground-muted hover:text-foreground'
           )}
         >


### PR DESCRIPTION
### Description

Hovering a task tab (for example `Claude (1)`) showed the text-selection I-beam instead of the hand cursor. The generic tab chip in `generic-tab-item.tsx` is a `div` with `role="button"` and never set a cursor, so the browser fell back to `cursor: auto` over the label text. This adds `cursor-pointer` to the chip, which fixes every tab kind built on it (conversation, file, diff, browser).

### Related issues

None.

### Testing

- `pnpm run typecheck`: clean
- `pnpm run format`: no changes
- `oxlint` on the tab-bar directory: clean
- Manually verified in the dev app that hovering a task tab shows the hand cursor.

### Screenshot/Recording (if applicable)

Screenshot pending.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEh7r9i5zUdVNdcca25FFv
