### PR TITLE
A decision record the task worktrees share

### DIFF
--- a/.knos/decisions.md
+++ b/.knos/decisions.md
@@ -2,6 +2,14 @@
 
 <!-- Written by `knos export`. Commit this file. -->
 
+<!--
+Reading this file needs nothing installed: it is plain markdown, and a fresh
+clone picks it up as-is. The live claim/withhold server is a separate, optional
+step - `pip install knos` (Python 3.10+), which the MCP entry launches as
+`python -m knos.mcp`. Without it, everything below still reads normally.
+-->
+
+
 A second clone reads this on its first question - it is one of the decision
 records knos looks for. Nothing here is private: secrets and private paths
 never reach it.

--- a/.knos/decisions.md
+++ b/.knos/decisions.md
@@ -1,0 +1,22 @@
+# Decisions and current work
+
+<!-- Written by `knos export`. Commit this file. -->
+
+A second clone reads this on its first question - it is one of the decision
+records knos looks for. Nothing here is private: secrets and private paths
+never reach it.
+
+
+## Decisions
+
+- **worktrees live under the project's configured directory** - Task worktrees are created under the project's DB-backed worktree directory setting rather than a fixed path.  _(agents/workflows/worktrees.md)_
+- **branch prefix is configurable, suffix is random** - The prefix defaults to `emdash` and is configurable in app settings; generated task branch names add a random suffix by default, and repository settings can disable only the suffix.  _(agents/workflows/worktrees.md)_
+- **creation is a four-step foreground pipeline** - `inspect -> resolve-base -> add-worktree -> verify`, with the base ref fetched only when it is not locally resolvable.  _(agents/workflows/worktrees.md)_
+- **worktree creation goes through the provider pattern** - It is managed by the project provider rather than called directly.  _(agents/workflows/worktrees.md)_
+
+## Being worked on right now
+
+_Nothing claimed._
+
+---
+<sub>knos export. Claims lapse after 30 minutes.</sub>

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "knos": {
+      "command": "python",
+      "args": [
+        "-m",
+        "knos.mcp"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
`agents/workflows/worktrees.md` documents the creation pipeline - `inspect -> resolve-base -> add-worktree -> verify` - and each task worktree gets its own branch off the configured prefix. That is clean isolation for files. It is not a channel for decisions: what was decided inside one task worktree does not reach the next one, and `.claude/settings.json` is `bypassPermissions`, so nothing pauses to ask.

**What's in the PR**

- `.knos/decisions.md` - a record every worktree of the repo shares, keyed on `git rev-parse --git-common-dir` rather than `--show-toplevel`. Seeded from `agents/workflows/worktrees.md`, each line citing its source.
- `.mcp.json` - one server, three tools, stdio.

The creation pipeline is untouched.

**Disclosure:** I wrote Knos. It is a local MCP server - three tools, no ports, no network, no account, no model download. The record is seeded from your own docs rather than mine so it is checkable rather than promotional. Close it if a third-party entry isn't wanted; the `.knos/decisions.md` half needs no install and works as plain markdown either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)