### PR TITLE
feat(projects): rename a project from the project menus

### DIFF
--- a/apps/emdash-desktop/src/core/features/projects/api/browser/stores/project-manager.ts
+++ b/apps/emdash-desktop/src/core/features/projects/api/browser/stores/project-manager.ts
@@ -638,6 +638,16 @@ export class ProjectManagerStore {
     }
   }
 
+  async renameProject(projectId: string, name: string): Promise<void> {
+    await (await getProjectsWireClient()).renameProject({ projectId, name });
+    const store = this.projects.get(projectId);
+    const data = store?.data;
+    if (!store || !data) return;
+    runInAction(() => {
+      store.updateData({ ...data, name });
+    });
+  }
+
   async updateProjectConnection(projectId: string, newConnectionId: string): Promise<void> {
     await (
       await getProjectsWireClient()

--- a/apps/emdash-desktop/src/core/features/projects/api/node/project-events.ts
+++ b/apps/emdash-desktop/src/core/features/projects/api/node/project-events.ts
@@ -4,6 +4,7 @@ import type { Project } from '@core/primitives/projects/api';
 
 export type ProjectCrudHooks = {
   'project:created': (project: Project) => void | Promise<void>;
+  'project:renamed': (projectId: string, name: string) => void | Promise<void>;
   'project:deleted': (projectId: string) => void | Promise<void>;
 };
 

--- a/apps/emdash-desktop/src/core/features/projects/api/wire-contract.ts
+++ b/apps/emdash-desktop/src/core/features/projects/api/wire-contract.ts
@@ -188,6 +188,10 @@ export const projectsWireContract = defineContract({
     input: z.object({ projectId: z.string(), connectionId: z.string() }),
     output: z.void(),
   }),
+  renameProject: procedure({
+    input: z.object({ projectId: z.string(), name: z.string().min(1) }),
+    output: z.void(),
+  }),
   recoverAttachment: procedure({
     input: projectIdInputSchema,
     output: z.custom<Result<void, ProjectRecoveryRequestError>>(),

--- a/apps/emdash-desktop/src/core/features/projects/browser/components/main-panel/project-header.browser.test.tsx
+++ b/apps/emdash-desktop/src/core/features/projects/browser/components/main-panel/project-header.browser.test.tsx
@@ -6,6 +6,7 @@ import { ProjectHeader } from './project-header';
 const mocks = vi.hoisted(() => ({
   confirmDeleteProject: vi.fn(),
   openExternal: vi.fn(),
+  openRenameProject: vi.fn(),
 }));
 
 const state = vi.hoisted(() => ({
@@ -29,6 +30,10 @@ vi.mock('@core/features/projects/api/browser/stores/project-selectors', () => ({
 
 vi.mock('@core/features/projects/contributions/browser/use-confirm-delete-project', () => ({
   useConfirmDeleteProject: () => mocks.confirmDeleteProject,
+}));
+
+vi.mock('@core/manifests/browser/modal-api', () => ({
+  useOpenModal: () => mocks.openRenameProject,
 }));
 
 vi.mock('@core/features/source-control/api/browser/stores/source-control-selectors', () => ({
@@ -75,6 +80,7 @@ describe('ProjectHeader', () => {
   beforeEach(() => {
     mocks.confirmDeleteProject.mockReset();
     mocks.openExternal.mockReset();
+    mocks.openRenameProject.mockReset();
     state.project.type = 'local';
     state.project.connectionId = undefined;
     host = document.createElement('div');
@@ -116,6 +122,23 @@ describe('ProjectHeader', () => {
       projectId: 'project-1',
       projectLabel: 'Emdash',
     });
+  });
+
+  it('opens the rename modal with the current name from the actions menu', async () => {
+    await act(async () => root.render(<ProjectHeader projectId="project-1" />));
+
+    const actions = host.querySelector<HTMLButtonElement>('[aria-label="Project actions"]');
+    await act(async () => actions?.click());
+    const rename = [...document.querySelectorAll<HTMLElement>('[role="menuitem"]')].find(
+      (item) => item.textContent === 'Rename Project'
+    );
+    expect(rename).not.toBeUndefined();
+    await act(async () => rename?.click());
+    expect(mocks.openRenameProject).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      currentName: 'Emdash',
+    });
+    expect(mocks.confirmDeleteProject).not.toHaveBeenCalled();
   });
 
   it('uses the remote Project icon and SSH Open In target', async () => {

--- a/apps/emdash-desktop/src/core/features/projects/browser/components/main-panel/project-header.tsx
+++ b/apps/emdash-desktop/src/core/features/projects/browser/components/main-panel/project-header.tsx
@@ -8,6 +8,7 @@ import {
   FolderOpen,
   GithubIcon,
   Globe,
+  Pencil,
   Trash2,
 } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
@@ -18,6 +19,7 @@ import {
 import { useConfirmDeleteProject } from '@core/features/projects/contributions/browser/use-confirm-delete-project';
 import { OpenInMenu } from '@core/features/settings/contributions/browser/open-in-menu';
 import { getGitRepositoryStore } from '@core/features/source-control/api/browser/stores/source-control-selectors';
+import { useOpenModal } from '@core/manifests/browser/modal-api';
 import { openExternal } from '@core/primitives/desktop-host/browser/host-client';
 import { isGitHubDotComHost, parseRepositoryRef } from '@core/primitives/repository/api';
 
@@ -26,6 +28,7 @@ export const ProjectHeader = observer(function ProjectHeader({ projectId }: { pr
   const project = store?.data;
   const displayName = projectDisplayName(store) ?? 'this project';
   const confirmDeleteProject = useConfirmDeleteProject();
+  const openRename = useOpenModal('renameProjectModal');
   const repositoryStore = getGitRepositoryStore(projectId);
   const baseRemoteUrl = repositoryStore?.baseRemote?.url;
   const repository = parseRepositoryRef(repositoryStore?.canonicalRepositoryUrl);
@@ -97,6 +100,15 @@ export const ProjectHeader = observer(function ProjectHeader({ projectId }: { pr
               <EllipsisIcon />
             </DropdownMenu.Trigger>
             <DropdownMenu.Content align="end">
+              <DropdownMenu.Item
+                onClick={() => {
+                  void openRename({ projectId, currentName: displayName });
+                }}
+              >
+                <Pencil />
+                Rename Project
+              </DropdownMenu.Item>
+              <DropdownMenu.Separator />
               <DropdownMenu.Item
                 variant="destructive"
                 onClick={() => {

--- a/apps/emdash-desktop/src/core/features/projects/browser/components/rename-project-modal.browser.test.tsx
+++ b/apps/emdash-desktop/src/core/features/projects/browser/components/rename-project-modal.browser.test.tsx
@@ -1,0 +1,132 @@
+import { Dialog } from '@emdash/ui/react/primitives';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RenameProjectModal } from './rename-project-modal';
+
+const mocks = vi.hoisted(() => ({
+  complete: vi.fn(),
+  dismiss: vi.fn(),
+  renameProject: vi.fn(),
+}));
+
+vi.mock('@core/features/projects/api/browser/stores/project-selectors', () => ({
+  getProjectManagerStore: () => ({
+    renameProject: mocks.renameProject,
+  }),
+}));
+
+vi.mock('@core/manifests/browser/modal-api', () => ({
+  useModalController: () => ({
+    complete: mocks.complete,
+    dismiss: mocks.dismiss,
+  }),
+}));
+
+beforeAll(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+function setInputValue(input: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+function pressEnter(input: HTMLInputElement): void {
+  input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+}
+
+describe('RenameProjectModal', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    mocks.complete.mockReset();
+    mocks.dismiss.mockReset();
+    mocks.renameProject.mockReset();
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    host.remove();
+  });
+
+  async function renderModal(): Promise<HTMLInputElement> {
+    await act(async () => {
+      root.render(
+        <Dialog.Root open>
+          <RenameProjectModal projectId="project-1" currentName="Emdash" />
+        </Dialog.Root>
+      );
+    });
+    const input = host.querySelector<HTMLInputElement>('input');
+    if (!input) throw new Error('rename input not rendered');
+    return input;
+  }
+
+  it('renames once and completes when Enter is pressed', async () => {
+    mocks.renameProject.mockResolvedValue(undefined);
+    const input = await renderModal();
+
+    await act(async () => setInputValue(input, '  Emdash Desktop  '));
+    await act(async () => pressEnter(input));
+
+    expect(mocks.renameProject).toHaveBeenCalledTimes(1);
+    expect(mocks.renameProject).toHaveBeenCalledWith('project-1', 'Emdash Desktop');
+    expect(mocks.complete).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores repeated Enter while a rename is pending', async () => {
+    let finish: () => void = () => {};
+    mocks.renameProject.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve;
+        })
+    );
+    const input = await renderModal();
+
+    await act(async () => setInputValue(input, 'Emdash Desktop'));
+    await act(async () => pressEnter(input));
+    await act(async () => pressEnter(input));
+    await act(async () => pressEnter(input));
+
+    expect(mocks.renameProject).toHaveBeenCalledTimes(1);
+    expect(mocks.complete).not.toHaveBeenCalled();
+
+    await act(async () => finish());
+    expect(mocks.complete).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not submit an empty or unchanged name', async () => {
+    const input = await renderModal();
+
+    await act(async () => pressEnter(input));
+    await act(async () => setInputValue(input, '   '));
+    await act(async () => pressEnter(input));
+
+    expect(mocks.renameProject).not.toHaveBeenCalled();
+    expect(host.textContent).toContain('Project name cannot be empty.');
+  });
+
+  it('shows the failure and re-enables submission', async () => {
+    mocks.renameProject.mockRejectedValueOnce(new Error('Project missing not found'));
+    mocks.renameProject.mockResolvedValueOnce(undefined);
+    const input = await renderModal();
+
+    await act(async () => setInputValue(input, 'Emdash Desktop'));
+    await act(async () => pressEnter(input));
+    expect(host.textContent).toContain('Project missing not found');
+    expect(mocks.complete).not.toHaveBeenCalled();
+
+    await act(async () => pressEnter(input));
+    expect(mocks.renameProject).toHaveBeenCalledTimes(2);
+    expect(mocks.complete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/emdash-desktop/src/core/features/projects/browser/components/rename-project-modal.tsx
+++ b/apps/emdash-desktop/src/core/features/projects/browser/components/rename-project-modal.tsx
@@ -26,7 +26,7 @@ export const RenameProjectModal = observer(function RenameProjectModal({
   const isValid = !isEmpty && !isUnchanged;
 
   const handleSubmit = useCallback(async () => {
-    if (!isValid) return;
+    if (!isValid || isSubmitting) return;
     setIsSubmitting(true);
     setError(null);
     try {
@@ -36,7 +36,7 @@ export const RenameProjectModal = observer(function RenameProjectModal({
       setError(e instanceof Error ? e.message : 'Failed to rename project');
       setIsSubmitting(false);
     }
-  }, [isValid, projectId, trimmedName, complete]);
+  }, [isValid, isSubmitting, projectId, trimmedName, complete]);
 
   return (
     <>

--- a/apps/emdash-desktop/src/core/features/projects/browser/components/rename-project-modal.tsx
+++ b/apps/emdash-desktop/src/core/features/projects/browser/components/rename-project-modal.tsx
@@ -1,0 +1,88 @@
+import { Button, Dialog, Field, Input } from '@emdash/ui/react/primitives';
+import { observer } from 'mobx-react-lite';
+import { useCallback, useState } from 'react';
+import { getProjectManagerStore } from '@core/features/projects/api/browser/stores/project-selectors';
+import { useModalController } from '@core/manifests/browser/modal-api';
+import { ConfirmButton } from '@core/primitives/keybindings/browser/confirm-button';
+import { defineModal } from '@core/primitives/modals/react';
+
+type RenameProjectModalArgs = {
+  projectId: string;
+  currentName: string;
+};
+
+export const RenameProjectModal = observer(function RenameProjectModal({
+  projectId,
+  currentName,
+}: RenameProjectModalArgs) {
+  const { complete, dismiss } = useModalController('renameProjectModal');
+  const [name, setName] = useState(currentName);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const trimmedName = name.trim();
+  const isEmpty = trimmedName.length === 0;
+  const isUnchanged = trimmedName === currentName;
+  const isValid = !isEmpty && !isUnchanged;
+
+  const handleSubmit = useCallback(async () => {
+    if (!isValid) return;
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await getProjectManagerStore().renameProject(projectId, trimmedName);
+      complete();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to rename project');
+      setIsSubmitting(false);
+    }
+  }, [isValid, projectId, trimmedName, complete]);
+
+  return (
+    <>
+      <Dialog.Header showCloseButton={false}>
+        <Dialog.Title>Rename project</Dialog.Title>
+      </Dialog.Header>
+      <Dialog.Body className="pt-0">
+        <Field.Group>
+          <Field.Root>
+            <Field.Label>Project name</Field.Label>
+            <Input
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+                setError(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') void handleSubmit();
+              }}
+              autoFocus
+            />
+            {isEmpty && (
+              <p className="text-destructive mt-1 text-xs">Project name cannot be empty.</p>
+            )}
+            {error && <p className="text-destructive mt-1 text-xs">{error}</p>}
+          </Field.Root>
+        </Field.Group>
+      </Dialog.Body>
+      <Dialog.Footer>
+        <Button variant="secondary" onClick={dismiss}>
+          Cancel
+        </Button>
+        <ConfirmButton
+          variant="primary"
+          onClick={() => void handleSubmit()}
+          disabled={!isValid || isSubmitting}
+        >
+          {isSubmitting ? 'Renaming...' : 'Rename'}
+        </ConfirmButton>
+      </Dialog.Footer>
+    </>
+  );
+});
+
+export const renameProjectModal = defineModal<void>()({
+  id: 'renameProjectModal',
+  component: RenameProjectModal,
+  size: 'xs',
+});

--- a/apps/emdash-desktop/src/core/features/projects/browser/stores/project-manager.test.ts
+++ b/apps/emdash-desktop/src/core/features/projects/browser/stores/project-manager.test.ts
@@ -58,6 +58,7 @@ const mocks = vi.hoisted(() => ({
   navigationNavigate: vi.fn(),
   taskListLoad: vi.fn(),
   taskProvision: vi.fn(),
+  renameProject: vi.fn(),
   updateProjectConnection: vi.fn(),
   updateProjectSettings: vi.fn(),
 }));
@@ -237,6 +238,7 @@ function createProjectWire() {
         error: { type: 'unused', message: 'unused' },
       }),
     },
+    renameProject: (input: unknown) => mocks.renameProject(input),
     updateProjectConnection: (input: unknown) => mocks.updateProjectConnection(input),
     updateProjectSettings: (input: unknown) => mocks.updateProjectSettings(input),
     delete: (input: unknown) => mocks.projectWireDelete(input),
@@ -304,6 +306,7 @@ describe('ProjectManagerStore project creation', () => {
     mocks.mementoSubjectRelease.mockResolvedValue(undefined);
     mocks.taskListLoad.mockResolvedValue(undefined);
     mocks.taskProvision.mockResolvedValue(undefined);
+    mocks.renameProject.mockResolvedValue(undefined);
     mocks.updateProjectConnection.mockResolvedValue(undefined);
     mocks.projectWireProgressCallbacks.length = 0;
     mocks.projectWireCancel.mockResolvedValue(undefined);
@@ -825,6 +828,38 @@ describe('ProjectManagerStore project creation', () => {
     expect(projectStore.context).toEqual({ kind: 'available', context });
     expect(context.project).toBe(record);
     expect(record.type === 'ssh' ? record.connectionId : null).toBe('ssh-2');
+  });
+
+  it('renames a project in place without replacing its store or context', async () => {
+    const project = sshProject();
+    projectListState.set({ projects: [project] });
+    const store = new ProjectManagerStore();
+    await store.load();
+    await vi.waitFor(() => expect(store.projects.get(project.id)?.context?.kind).toBe('available'));
+    const projectStore = store.projects.get(project.id)!;
+    const lifecycle = projectStore.context;
+    if (lifecycle?.kind !== 'available') throw new Error('Expected available context');
+    const record = lifecycle.context.project;
+
+    await store.renameProject(project.id, 'Renamed');
+
+    expect(mocks.renameProject).toHaveBeenCalledWith({ projectId: project.id, name: 'Renamed' });
+    expect(store.projects.get(project.id)).toBe(projectStore);
+    expect(projectStore.name).toBe('Renamed');
+    expect(projectStore.data?.name).toBe('Renamed');
+    expect(lifecycle.context.project).toBe(record);
+    expect(record.name).toBe('Renamed');
+  });
+
+  it('leaves the store untouched when the rename request fails', async () => {
+    const project = sshProject();
+    projectListState.set({ projects: [project] });
+    const store = new ProjectManagerStore();
+    await store.load();
+    mocks.renameProject.mockRejectedValueOnce(new Error('Project not found'));
+
+    await expect(store.renameProject(project.id, 'Renamed')).rejects.toThrow('Project not found');
+    expect(store.projects.get(project.id)?.name).toBe(project.name);
   });
 
   it('inspects the final clone path instead of the parent directory', async () => {

--- a/apps/emdash-desktop/src/core/features/projects/contributions/browser.ts
+++ b/apps/emdash-desktop/src/core/features/projects/contributions/browser.ts
@@ -1,6 +1,7 @@
 import { addProjectModal } from '../browser/components/add-project-modal/add-project-modal';
 import { directorySelectorModal } from '../browser/components/directory-selector-modal';
 import { relinkProjectModal } from '../browser/components/relink-project-modal';
+import { renameProjectModal } from '../browser/components/rename-project-modal';
 import { projectConfigImportModal } from '../browser/components/settings-view/project-config-import-modal';
 import { shareProjectConfigModal } from '../browser/components/settings-view/share-project-config-modal';
 import { projectViewRuntime } from '../browser/view';
@@ -14,6 +15,7 @@ export const projectsBrowserContributions = {
     projectConfigImportModal,
     directorySelectorModal,
     relinkProjectModal,
+    renameProjectModal,
   ],
   projectAvailabilityUi: projectAvailabilityUiContribution,
 } as const;

--- a/apps/emdash-desktop/src/core/features/projects/node/controller.ts
+++ b/apps/emdash-desktop/src/core/features/projects/node/controller.ts
@@ -14,6 +14,7 @@ import { deleteProject, type ProjectDeletionDependencies } from './operations/de
 import { ensureDefaultRepositoriesRoot } from './operations/ensure-default-repositories-root';
 import { getProjects } from './operations/getProjects';
 import { initializeRepository } from './operations/initialize-repository';
+import { renameProject } from './operations/renameProject';
 import { resolveRepositoryDestination } from './operations/resolve-repository-destination';
 import { updateProjectConnection } from './operations/updateProjectConnection';
 import { countProjectsUsingGithubAccount } from './settings/count-projects-using-github-account';
@@ -58,5 +59,6 @@ export function createProjectOperations(dependencies: ProjectOperationDependenci
       countProjectsUsingGithubAccount(db, accountId),
     updateProjectConnection: (projectId: string, connectionId: string) =>
       updateProjectConnection(db, dependencies.runtimes, projects, projectId, connectionId),
+    renameProject: (projectId: string, name: string) => renameProject(db, projectId, name),
   };
 }

--- a/apps/emdash-desktop/src/core/features/projects/node/operations/renameProject.db.test.ts
+++ b/apps/emdash-desktop/src/core/features/projects/node/operations/renameProject.db.test.ts
@@ -1,0 +1,68 @@
+import { openFixture } from '@tooling/utils/db';
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { projectEvents } from '@core/features/projects/api/node/project-events';
+import { appDbPokes } from '@core/services/app-db/node/pokes';
+import { projects } from '@core/services/app-db/node/schema';
+import { renameProject } from './renameProject';
+
+describe('renameProject', () => {
+  let fixture: Awaited<ReturnType<typeof openFixture>>;
+
+  beforeEach(async () => {
+    fixture = await openFixture('empty');
+    await fixture.db.insert(projects).values([
+      { id: 'project', name: 'Old name', updatedAt: '2026-01-01T00:00:00.000Z' },
+      { id: 'other', name: 'Other', updatedAt: '2026-01-01T00:00:00.000Z' },
+    ]);
+  });
+
+  afterEach(() => {
+    fixture.close();
+    vi.restoreAllMocks();
+  });
+
+  it('stores the trimmed name, bumps updatedAt, pokes the list, and emits project:renamed', async () => {
+    const poke = vi.spyOn(appDbPokes.projects, 'poke');
+    const emit = vi.spyOn(projectEvents, '_emit');
+
+    await renameProject(fixture.db, 'project', '  New name  ');
+
+    const [row] = await fixture.db.select().from(projects).where(eq(projects.id, 'project'));
+    expect(row?.name).toBe('New name');
+    expect(row?.updatedAt).not.toBe('2026-01-01T00:00:00.000Z');
+    expect(poke).toHaveBeenCalledWith({ projectId: 'project' });
+    expect(emit).toHaveBeenCalledWith('project:renamed', 'project', 'New name');
+
+    const [other] = await fixture.db.select().from(projects).where(eq(projects.id, 'other'));
+    expect(other?.name).toBe('Other');
+  });
+
+  it('rejects an empty name without touching the row', async () => {
+    const poke = vi.spyOn(appDbPokes.projects, 'poke');
+    const emit = vi.spyOn(projectEvents, '_emit');
+
+    await expect(renameProject(fixture.db, 'project', '   ')).rejects.toThrow(
+      'Project name cannot be empty'
+    );
+
+    const [row] = await fixture.db.select().from(projects).where(eq(projects.id, 'project'));
+    expect(row?.name).toBe('Old name');
+    expect(poke).not.toHaveBeenCalled();
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('fails for an unknown or deleted project', async () => {
+    await fixture.db
+      .update(projects)
+      .set({ deletedAt: '2026-01-02T00:00:00.000Z' })
+      .where(eq(projects.id, 'other'));
+
+    await expect(renameProject(fixture.db, 'missing', 'Name')).rejects.toThrow(
+      'Project missing not found'
+    );
+    await expect(renameProject(fixture.db, 'other', 'Name')).rejects.toThrow(
+      'Project other not found'
+    );
+  });
+});

--- a/apps/emdash-desktop/src/core/features/projects/node/operations/renameProject.ts
+++ b/apps/emdash-desktop/src/core/features/projects/node/operations/renameProject.ts
@@ -1,0 +1,24 @@
+import { and, eq, isNull } from 'drizzle-orm';
+import { projectEvents } from '@core/features/projects/api/node/project-events';
+import type { AppDb } from '@core/services/app-db/node/db';
+import { appDbPokes } from '@core/services/app-db/node/pokes';
+import { projects } from '@core/services/app-db/node/schema';
+
+/**
+ * Changes a project's display name. Nothing keys on the name, but the search index
+ * caches it, so listeners are told through `project:renamed`.
+ */
+export async function renameProject(db: AppDb, projectId: string, name: string): Promise<void> {
+  const nextName = name.trim();
+  if (nextName.length === 0) throw new Error('Project name cannot be empty');
+
+  const updated = await db
+    .update(projects)
+    .set({ name: nextName, updatedAt: new Date().toISOString() })
+    .where(and(eq(projects.id, projectId), isNull(projects.deletedAt)))
+    .returning({ id: projects.id });
+  if (updated.length === 0) throw new Error(`Project ${projectId} not found`);
+
+  appDbPokes.projects.poke({ projectId });
+  projectEvents._emit('project:renamed', projectId, nextName);
+}

--- a/apps/emdash-desktop/src/core/features/projects/node/project-attachment-manager.test.ts
+++ b/apps/emdash-desktop/src/core/features/projects/node/project-attachment-manager.test.ts
@@ -482,7 +482,7 @@ describe('ProjectAttachmentManager', () => {
     await scope.dispose();
   });
 
-  it('disposes a late Provider when the durable Project revision changed during attachment', async () => {
+  it('keeps a late Provider when only Project display metadata changed during attachment', async () => {
     const scope = createScope({ label: 'project-attachment-manager-test' });
     const availability = createHostAvailability({
       scope,
@@ -506,6 +506,50 @@ describe('ProjectAttachmentManager', () => {
     await vi.waitFor(() => expect(peek(state).kind).toBe('attaching'));
     project = {
       ...project,
+      name: 'Renamed Project',
+      updatedAt: '2026-08-13T00:00:01.000Z',
+    };
+
+    opened.resolve(ok(provider));
+
+    await vi.waitFor(() =>
+      expect(peek(state)).toEqual({
+        kind: 'attached',
+        establishedHostGeneration: 1,
+      })
+    );
+    expect(provider.dispose).not.toHaveBeenCalled();
+    expect(manager.requireAttached(project.id)).toEqual(ok(provider));
+
+    await owner.dispose();
+    await scope.dispose();
+  });
+
+  it('disposes a late Provider when the Project base ref changed during attachment', async () => {
+    const scope = createScope({ label: 'project-attachment-manager-test' });
+    const availability = createHostAvailability({
+      scope,
+      readiness: { prepare: async () => ok() },
+    });
+    let project = sshProject();
+    const provider = projectProvider();
+    const opened = deferred<ReturnType<typeof ok<ProjectProvider>>>();
+    const open = vi.fn(() => opened.promise);
+    const manager = createProjectAttachmentManager({
+      scope,
+      availability,
+      adapter: {
+        loadProject: async () => ({ ...project }),
+        statRepository: async () => ok({ type: 'directory' as const }),
+        open,
+      },
+    });
+    const owner = createScope({ label: 'project-owner' });
+    const state = manager.track(project.id, owner);
+    await vi.waitFor(() => expect(peek(state).kind).toBe('attaching'));
+    project = {
+      ...project,
+      baseRef: 'develop',
       updatedAt: '2026-08-13T00:00:01.000Z',
     };
 

--- a/apps/emdash-desktop/src/core/features/projects/node/project-attachment-manager.ts
+++ b/apps/emdash-desktop/src/core/features/projects/node/project-attachment-manager.ts
@@ -418,7 +418,7 @@ export class ProjectAttachmentManagerService implements ProjectAttachmentManager
         return;
       }
       entry.attempt = undefined;
-      entry.project = project;
+      entry.project = currentProject;
       entry.provider = opened.data;
       entry.providerReleased = false;
       uncommittedProvider = undefined;
@@ -553,7 +553,7 @@ function repositoryStatError(project: Project, failure: FsError | RuntimeResolve
 }
 
 function attachmentProjectIdentity(project: Project): string {
-  return [project.id, project.updatedAt, attachmentTargetIdentity(project)].join('\0');
+  return [project.id, project.baseRef ?? '', attachmentTargetIdentity(project)].join('\0');
 }
 
 function attachmentTargetIdentity(project: Project): string {

--- a/apps/emdash-desktop/src/core/features/projects/node/wire-controller.ts
+++ b/apps/emdash-desktop/src/core/features/projects/node/wire-controller.ts
@@ -78,6 +78,7 @@ export function createProjectsWireController(
         projectOperations.countProjectsUsingGithubAccount(accountId),
       updateProjectConnection: ({ projectId, connectionId }) =>
         projectOperations.updateProjectConnection(projectId, connectionId),
+      renameProject: ({ projectId, name }) => projectOperations.renameProject(projectId, name),
       recoverAttachment: ({ projectId }) => dependencies.projects.recover(projectId),
       getHostHomeDir: async (input) => {
         const runtime = await acquireHostRuntime(dependencies, input);

--- a/apps/emdash-desktop/src/core/features/search/node/search-service.test.ts
+++ b/apps/emdash-desktop/src/core/features/search/node/search-service.test.ts
@@ -6,6 +6,7 @@ import { createController } from '@emdash/wire/rpc';
 import { createTestWire } from '@emdash/wire/testing';
 import Database from 'better-sqlite3';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { projectEvents } from '@core/features/projects/api/node/project-events';
 import { hostPathFromNative } from '@core/primitives/desktop-runtime/api';
 import { portablePath } from '@core/primitives/desktop-runtime/api';
 import { contentSearchRuntimeContract } from '../api';
@@ -137,6 +138,51 @@ describe('SearchService runtime file search', () => {
 });
 
 describe('SearchService palette entity search', () => {
+  it('re-titles an indexed project when it is renamed', async () => {
+    const sqlite = new Database(':memory:');
+    sqlite.exec(`
+      CREATE VIRTUAL TABLE search_index USING fts5(
+        item_type,
+        item_id UNINDEXED,
+        project_id UNINDEXED,
+        task_id UNINDEXED,
+        title,
+        keywords,
+        tokenize = 'trigram case_sensitive 0'
+      );
+      INSERT INTO search_index VALUES
+        ('project', 'project-1', NULL, NULL, 'Old project', '/repo/old');
+    `);
+    const service = createSearchService({
+      db: {} as never,
+      sqlite,
+      acquireWorkspaceRuntime: mocks.workspaceGet,
+      searchFileSearchRoot: mocks.fileSearch,
+      getSearchExclusions: mocks.getSearchExclusions,
+      tasks: { on: vi.fn() } as never,
+    });
+
+    try {
+      service.initialize();
+      const onRenamed = vi
+        .mocked(projectEvents.on)
+        .mock.calls.find(([name]) => name === 'project:renamed')?.[1] as
+        | ((projectId: string, name: string) => void)
+        | undefined;
+      expect(onRenamed).toBeDefined();
+      onRenamed?.('project-1', 'Fresh project');
+
+      await expect(
+        service.searchEntities({ kind: 'project', query: 'fresh', context: {} })
+      ).resolves.toEqual([expect.objectContaining({ id: 'project-1', title: 'Fresh project' })]);
+      await expect(
+        service.searchEntities({ kind: 'project', query: 'old project', context: {} })
+      ).resolves.toEqual([]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
   it('returns kind-filtered candidates for one-character queries', async () => {
     const sqlite = new Database(':memory:');
     sqlite.exec(`

--- a/apps/emdash-desktop/src/core/features/search/node/search-service.ts
+++ b/apps/emdash-desktop/src/core/features/search/node/search-service.ts
@@ -86,6 +86,7 @@ export class SearchService {
     this.deps.tasks.on('task:deleted', (taskId) => this.removeByType('task', taskId));
 
     projectEvents.on('project:created', (project) => this.upsertProject(project));
+    projectEvents.on('project:renamed', (projectId, name) => this.renameProject(projectId, name));
     projectEvents.on('project:deleted', (projectId) => this.removeByType('project', projectId));
 
     conversationEvents.on('conversation:created', (conversation) =>
@@ -366,6 +367,16 @@ export class SearchService {
         projectId: project.id,
         error: String(e),
       });
+    }
+  }
+
+  private renameProject(projectId: string, name: string): void {
+    try {
+      this.deps.sqlite
+        .prepare(`UPDATE search_index SET title = ? WHERE item_type = 'project' AND item_id = ?`)
+        .run(name, projectId);
+    } catch (e) {
+      log.warn('SearchService: renameProject failed', { projectId, error: String(e) });
     }
   }
 

--- a/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/project-item.tsx
+++ b/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/project-item.tsx
@@ -5,6 +5,7 @@ import {
   FolderInput,
   FolderOpen,
   Loader2,
+  Pencil,
   Plus,
   Trash2,
   TriangleAlert,
@@ -60,6 +61,7 @@ export const SidebarProjectItem = observer(function SidebarProjectItem({
   const taskParams = useViewParams(taskViewDef);
   const openCreateTaskModal = useOpenModal('taskModal');
   const confirmDeleteProject = useConfirmDeleteProject();
+  const openRenameProject = useOpenModal('renameProjectModal');
 
   const project = getProjectStore(projectId);
 
@@ -225,6 +227,16 @@ export const SidebarProjectItem = observer(function SidebarProjectItem({
         </SidebarMenuRow>
       </ContextMenu.Trigger>
       <ContextMenu.Content>
+        <ContextMenu.Item
+          disabled={project.state === 'unregistered'}
+          onClick={() => {
+            void openRenameProject({ projectId, currentName: project.name ?? '' });
+          }}
+        >
+          <Pencil className="size-4" />
+          Rename Project
+        </ContextMenu.Item>
+        <ContextMenu.Separator />
         <ContextMenu.Item
           variant="destructive"
           onClick={() => {


### PR DESCRIPTION
### Description

Projects could only be named when they were added; there was no rename path in the UI or the Wire API, and the only workaround was editing `projects.name` in SQLite by hand. This adds one.

- **Wire + node**: `renameProject` procedure on the projects contract, backed by `node/operations/renameProject.ts`. It trims the name, rejects an empty name, updates `projects.name` and `updated_at` for non-deleted rows only, pokes `appDbPokes.projects` so the `projectList` live model refreshes in every window, and emits a new `project:renamed` event.
- **Search index**: `SearchService` cached project titles and only learned about projects on `project:created` / `project:deleted`, so a rename would have left stale titles in ⌘K search. It now subscribes to `project:renamed` and re-titles the indexed row.
- **Store**: `ProjectManagerStore.renameProject` calls the procedure and updates the existing `ProjectStore` in place via `updateData`, so the project context and record identity are preserved (same pattern as `updateProjectConnection`).
- **UI**: "Rename Project" in the project header's actions menu and in the sidebar project row's context menu (disabled while a project is still being created). Both open `renameProjectModal`, modeled on the task rename dialog.

Where the name is read, for the record: display in the header, sidebar, titlebar, palette, automations, diff panel, and settings labels; sorting of host workspace groups; error message text in machine and deletion flows; and the search index above. Nothing derives paths, worktree names, branch names, or identifiers from it.

### Related issues

None filed.

### Testing

- `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck` in `apps/emdash-desktop`: pass
- `renameProject.db.test.ts` (main-db, real SQLite): trim + `updated_at` + poke + `project:renamed` emitted; empty name rejected with no write and no event; unknown and soft-deleted projects rejected. Written first and seen failing.
- `project-manager.test.ts`: rename updates the store in place and preserves context and record identity; a failed request leaves the store untouched.
- `search-service.test.ts` (real FTS5 table): `project:renamed` re-titles the indexed project; the old title no longer matches.
- `project-header.browser.test.tsx`: the actions menu offers "Rename Project" and opens the modal with the current name.
- Projects + search node and DB suites: 46 files, 418 tests pass. Projects browser suites: 12 files, 40 tests pass.
- Manual, dev build: renamed a project from the header menu and from the sidebar context menu. Header title and sidebar label updated immediately, the dialog closed, the new name was persisted in `emdash4.db`, and the `search_index` row was re-titled at once (verified with an FTS `MATCH` query and in the ⌘K palette).

### Screenshot/Recording (if applicable)

Captured on a fresh data dir with the emdash repo as the only project.

Header actions menu and sidebar context menu:

![header](https://raw.githubusercontent.com/tkohout/emdash/eb724113db36f75b08c41cfb0158fd0b9d757000/rename-project/header-menu.png)

![sidebar](https://raw.githubusercontent.com/tkohout/emdash/eb724113db36f75b08c41cfb0158fd0b9d757000/rename-project/sidebar-context-menu.png)

Rename dialog, and the result:

![dialog](https://raw.githubusercontent.com/tkohout/emdash/eb724113db36f75b08c41cfb0158fd0b9d757000/rename-project/rename-dialog.png)

![renamed](https://raw.githubusercontent.com/tkohout/emdash/eb724113db36f75b08c41cfb0158fd0b9d757000/rename-project/renamed.png)

⌘K search finds the project under its new name right after the rename (no restart):

![search](https://raw.githubusercontent.com/tkohout/emdash/eb724113db36f75b08c41cfb0158fd0b9d757000/rename-project/search-finds-renamed.png)

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed (no docs cover project menus)
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for commit messages and the PR title

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jTBcTyHoPSSBk7Y6AGFnw
