### PR TITLE
feat(acp): surface provider command descriptions as execute row titles

### DIFF
--- a/apps/emdash-desktop/src/core/primitives/workbench-shell/browser/tabs/tab-bar/generic-tab-item.tsx
+++ b/apps/emdash-desktop/src/core/primitives/workbench-shell/browser/tabs/tab-bar/generic-tab-item.tsx
@@ -133,7 +133,7 @@ export const GenericTabItem = observer(function GenericTabItem({
           title={fullTitle}
           data-tabid={tab.tabId}
           className={cn(
-            'group relative flex h-full flex-col text-sm',
+            'group relative flex h-full cursor-pointer flex-col text-sm',
             tab.isActive ? 'text-foreground' : 'text-foreground-muted hover:text-foreground'
           )}
         >

--- a/packages/core/src/primitives/acp-transcript/api/normalized-event.ts
+++ b/packages/core/src/primitives/acp-transcript/api/normalized-event.ts
@@ -107,6 +107,7 @@ export type NormalizedEvent =
       status: NormalizedToolStatus | null;
       parentToolCallId: string | null;
       diffs: NormalizedDiff[];
+      inputSummary?: string;
       outputText?: string;
       terminalId?: string;
     }

--- a/packages/core/src/runtimes/acp/api/reducer/acp-transcript-parser.test.ts
+++ b/packages/core/src/runtimes/acp/api/reducer/acp-transcript-parser.test.ts
@@ -388,6 +388,53 @@ describe('AcpTranscriptParser', () => {
     });
   });
 
+  it('reads execute descriptions from rawInput on the initial tool_call', () => {
+    const p = new AcpTranscriptParser(deps());
+    p.push(userChunk('u1', 'list packages'));
+    p.push({
+      ...toolCallUpdate('exec-1', 'ls packages', 'execute'),
+      rawInput: { command: 'ls packages', description: 'List packages directory' },
+    } as unknown as SessionUpdate);
+
+    expect(p.activeTurn?.items.find((i) => i.kind === 'execute-tool-call')).toMatchObject({
+      command: 'ls packages',
+      inputSummary: 'List packages directory',
+    });
+  });
+
+  it('adopts a description that only arrives on a later tool_call_update', () => {
+    // Claude Code's ACP adapter opens Bash calls with title "Terminal" and an
+    // empty rawInput, then sends the command + description on the next update,
+    // echoing the description as a text content block.
+    const p = new AcpTranscriptParser(deps());
+    p.push(userChunk('u1', 'what branch am I on'));
+    p.push({
+      ...toolCallUpdate('exec-1', 'Terminal', 'execute'),
+      status: 'pending',
+      rawInput: {},
+    } as unknown as SessionUpdate);
+    p.push({
+      sessionUpdate: 'tool_call_update',
+      sessionId: 'sess-1',
+      toolCallId: 'exec-1',
+      kind: 'execute',
+      title: 'git rev-parse --abbrev-ref HEAD',
+      content: [{ type: 'content', content: { type: 'text', text: 'Get current branch name' } }],
+      rawInput: {
+        command: 'git rev-parse --abbrev-ref HEAD',
+        description: 'Get current branch name',
+      },
+    } as unknown as SessionUpdate);
+
+    const item = p.activeTurn?.items.find((i) => i.kind === 'execute-tool-call');
+    expect(item).toMatchObject({
+      command: 'git rev-parse --abbrev-ref HEAD',
+      inputSummary: 'Get current branch name',
+      status: 'running',
+    });
+    expect(item).not.toHaveProperty('outputText');
+  });
+
   it('passes through standard terminalId on execute tool updates', () => {
     const p = new AcpTranscriptParser(deps());
     p.push(userChunk('u1', 'run it'));

--- a/packages/core/src/runtimes/acp/api/reducer/decode.ts
+++ b/packages/core/src/runtimes/acp/api/reducer/decode.ts
@@ -75,15 +75,23 @@ function extractTerminalId(update: SessionUpdate): string | undefined {
   return undefined;
 }
 
+/**
+ * Provider-supplied one-line purpose of a tool call. Checked on the update
+ * itself and inside `rawInput` (Claude Code's Bash tool carries a
+ * `description` argument there, and only on the `tool_call_update` that also
+ * delivers the command).
+ */
 function extractInputSummary(update: SessionUpdate): string | undefined {
   const raw = update as unknown as {
     inputSummary?: unknown;
     input_summary?: unknown;
     description?: unknown;
+    rawInput?: { description?: unknown } | null;
   };
   if (typeof raw.inputSummary === 'string') return raw.inputSummary;
   if (typeof raw.input_summary === 'string') return raw.input_summary;
   if (typeof raw.description === 'string') return raw.description;
+  if (typeof raw.rawInput?.description === 'string') return raw.rawInput.description;
   return undefined;
 }
 
@@ -139,7 +147,11 @@ export function decodeSessionUpdate(update: SessionUpdate): NormalizedEvent {
     }
 
     case 'tool_call_update': {
-      const outputText = extractTextOutput(update.content ?? undefined);
+      const inputSummary = extractInputSummary(update);
+      const contentText = extractTextOutput(update.content ?? undefined);
+      // Some adapters echo the description as a content block on the update
+      // that carries the command; that is a label, not command output.
+      const outputText = contentText === inputSummary ? undefined : contentText;
       const terminalId = extractTerminalId(update);
       return {
         kind: 'tool_update',
@@ -149,6 +161,7 @@ export function decodeSessionUpdate(update: SessionUpdate): NormalizedEvent {
         status: (update.status as NormalizedToolStatus | undefined | null) ?? null,
         parentToolCallId: null,
         diffs: extractDiffs(update.content ?? undefined),
+        ...(inputSummary !== undefined ? { inputSummary } : {}),
         ...(outputText !== undefined ? { outputText } : {}),
         ...(terminalId !== undefined ? { terminalId } : {}),
       };

--- a/packages/core/src/runtimes/acp/api/reducer/item-fold.ts
+++ b/packages/core/src/runtimes/acp/api/reducer/item-fold.ts
@@ -214,7 +214,8 @@ function updateToolCallItem(
   title: string | null,
   status: NormalizedToolStatus | null,
   outputText?: string,
-  terminalId?: string
+  terminalId?: string,
+  inputSummary?: string
 ): ToolCallItem {
   const mapped = mapToolStatus(status ?? undefined);
   const nextTitle = title ?? item.title;
@@ -222,6 +223,7 @@ function updateToolCallItem(
     ...item,
     ...(mapped !== undefined ? { status: mapped } : {}),
     ...(title !== null ? { title: title } : {}),
+    ...(inputSummary !== undefined ? { inputSummary } : {}),
   };
   switch (item.kind) {
     case 'execute-tool-call':
@@ -725,7 +727,8 @@ export function foldItem(
           event.title,
           event.status,
           event.outputText,
-          event.terminalId
+          event.terminalId,
+          event.inputSummary
         );
         next = base.map((it, i) => (i === idx ? updated : it));
       } else if (hasFileOperationsForToolCall(base, event.toolCallId)) {
@@ -743,6 +746,7 @@ export function foldItem(
             toolKind: event.toolKind,
             status: event.status,
             parentToolCallId,
+            ...(event.inputSummary !== undefined ? { inputSummary: event.inputSummary } : {}),
             ...(event.outputText !== undefined ? { outputText: event.outputText } : {}),
             ...(event.terminalId !== undefined ? { terminalId: event.terminalId } : {}),
           })


### PR DESCRIPTION
### Description

Every Bash call in the ACP chat rendered under the literal header **Execute**, even though Claude Code's ACP adapter sends a one-line description for each command (for example "Show working tree status").

The description lives inside `rawInput` and only arrives on the `tool_call_update` that also delivers the command; the initial `tool_call` is titled "Terminal" with an empty `rawInput`. The pipeline dropped it in three places:

- `decode.ts` only looked for a top-level `description` field, and only on `tool_call`.
- `item-fold.ts` never carried `inputSummary` across `tool_update` events.
- The same update echoes the description as a text content block, which the decoder treated as command output.

This PR reads `rawInput.description` on both update kinds, carries it onto the existing execute item, and skips a content block that is only the echoed description. The execute row header already preferred `inputSummary` over "Execute", so no chat-ui changes were needed.

Other providers: only the Claude fixture carries `rawInput.description`; the Codex fixture has none and its exact-snapshot test is unchanged. A provider that does send one would now get it as the row title, which is the intended behaviour.

### Related issues

None.

### Testing

- `pnpm exec vitest run` in `packages/core` (224 files, 1642 tests) and `packages/plugins` (61 files, 343 tests)
- `pnpm run format`, `pnpm run lint`
- `nx typecheck` for `@emdash/core`, `@emdash/plugins`, `@emdash/emdash-desktop`
- Two new parser tests: description on the initial `tool_call`, and the Claude case where it only arrives on the follow-up `tool_call_update`. Both failed before the change.
- Manual: dev app, Claude Code chat conversation running three shell commands (screenshots below).

### Screenshot/Recording (if applicable)

Collapsed rows now titled with the command description:

![execute rows with descriptions](https://raw.githubusercontent.com/tkohout/emdash/4012fec8c0e4a3f655099babf1babda333a1aba1/execute-descriptions.png)

Expanded row, command output intact:

![expanded execute row](https://raw.githubusercontent.com/tkohout/emdash/4012fec8c0e4a3f655099babf1babda333a1aba1/execute-descriptions-expanded.png)

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed (no doc changes needed)
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

