### PR TITLE
feat(chat-ui): fold execute rows to a single header line

### DIFF
--- a/packages/chat-ui/src/components/primitives/CardHeader.tsx
+++ b/packages/chat-ui/src/components/primitives/CardHeader.tsx
@@ -22,6 +22,8 @@ export type CardHeaderProps = {
   height: number;
   /** Whether the section is currently expanded. */
   expanded: boolean;
+  /** Whether to draw the separator between the header and body. */
+  bodyVisible: boolean;
   /** Leading icon shown until the header row is hovered. */
   icon: JSX.Element;
   /** Header label content. */
@@ -43,12 +45,13 @@ export type CardHeaderProps = {
 
 export function CardHeader(props: CardHeaderProps) {
   return (
-    <div
+    <button
+      type="button"
       class={cardHeader}
       style={{ height: `${props.height}px` }}
-      role="button"
       aria-expanded={props.expanded ? 'true' : 'false'}
       data-collapse-id={props.id}
+      data-body-visible={props.bodyVisible ? '' : undefined}
     >
       <span class={cardHeaderLeft}>
         <span class={cardLeadingSlot} aria-hidden="true">
@@ -86,6 +89,6 @@ export function CardHeader(props: CardHeaderProps) {
           </span>
         </Show>
       </span>
-    </div>
+    </button>
   );
 }

--- a/packages/chat-ui/src/components/primitives/CollapsibleCard.tsx
+++ b/packages/chat-ui/src/components/primitives/CollapsibleCard.tsx
@@ -31,6 +31,8 @@ export type CollapsibleCardProps = {
   headerH: number;
   /** Whether the card is currently expanded. */
   expanded: boolean;
+  /** Whether body content is visible below the header. */
+  bodyVisible?: boolean;
   /**
    * When true, applies the text-shimmer animation to the header label
    * (use while the item is running / streaming).
@@ -66,6 +68,7 @@ export function CollapsibleCard(props: CollapsibleCardProps) {
         id={props.id}
         height={props.headerH}
         expanded={props.expanded}
+        bodyVisible={props.bodyVisible !== false}
         icon={props.icon}
         title={props.header}
         active={props.active}

--- a/packages/chat-ui/src/components/primitives/card-header.css.ts
+++ b/packages/chat-ui/src/components/primitives/card-header.css.ts
@@ -1,22 +1,43 @@
 import { style } from '@vanilla-extract/css';
 import { vars } from '@styles/theme.css';
 
+const cardInnerRadius = `calc(${vars.radiusLg} - 1px)`;
+
 // Uses content-box intentionally: the borderBottom is counted by card chrome
 // measurement helpers as the header separator.
 export const cardHeader = style({
   display: 'flex',
+  appearance: 'none',
+  boxSizing: 'content-box',
+  width: 'calc(100% - 16px)',
   alignItems: 'center',
   justifyContent: 'space-between',
   gap: '6px',
-  paddingLeft: '8px',
-  paddingRight: '8px',
+  margin: 0,
+  padding: '0 8px',
+  background: 'transparent',
+  border: 0,
+  borderRadius: cardInnerRadius,
   cursor: 'pointer',
   color: vars.fgMuted,
+  font: 'inherit',
   fontSize: vars.typeBodyFontSize,
-  borderBottom: `1px solid ${vars.border}`,
+  letterSpacing: 'inherit',
+  textAlign: 'left',
+  textTransform: 'inherit',
   transition: 'background 150ms',
   userSelect: 'none',
   selectors: {
+    '&[data-body-visible]': {
+      borderBottom: `1px solid ${vars.border}`,
+      borderBottomLeftRadius: 0,
+      borderBottomRightRadius: 0,
+    },
+    '&:focus-visible': {
+      boxShadow: 'inset 0 0 0 2px currentColor',
+      outline: '2px solid transparent',
+      outlineOffset: '-2px',
+    },
     '&:hover': { background: vars.bg3 },
   },
 });

--- a/packages/chat-ui/src/components/rows/tools/execute/Execute.tsx
+++ b/packages/chat-ui/src/components/rows/tools/execute/Execute.tsx
@@ -4,14 +4,16 @@
  * Renders ACP `kind: 'execute'` tool calls as a collapsible card:
  *
  *   ┌─────────────────────────────────────┐
- *   │  Execute                          › │  ← header (CollapsibleCard primitive)
+ *   │  Install dependencies             › │  ← header: description, else command
  *   ├─────────────────────────────────────┤
- *   │  pnpm run build --filter=...        │  ← body: mono, bash-highlighted
+ *   │  $ pnpm install                     │  ← body: mono, bash-highlighted
  *   │  ...                                │    clamped to collapsedMaxLines or
  *   └─────────────────────────────────────┘    expandedMaxLines with overflow scroll
  *
  * Header + card shell are provided by CollapsibleCard.
- * Body:   collapsed = clamped height + fade overlay; expanded = scrollable.
+ * Body:   collapsed = hidden (header-only row, in every status);
+ *         expanded  = command + output, clamped to expandedMaxLines with
+ *                     overflow scroll.
  */
 
 import { useCaches } from '@components/contexts/CachesContext';

--- a/packages/chat-ui/src/components/rows/tools/execute/Execute.tsx
+++ b/packages/chat-ui/src/components/rows/tools/execute/Execute.tsx
@@ -7,8 +7,8 @@
  *   │  Install dependencies             › │  ← header: description, else command
  *   ├─────────────────────────────────────┤
  *   │  $ pnpm install                     │  ← body: mono, bash-highlighted
- *   │  ...                                │    clamped to collapsedMaxLines or
- *   └─────────────────────────────────────┘    expandedMaxLines with overflow scroll
+ *   │  ...                                │    capped at expandedMaxLines with
+ *   └─────────────────────────────────────┘    overflow scroll
  *
  * Header + card shell are provided by CollapsibleCard.
  * Body:   collapsed = hidden (header-only row, in every status);

--- a/packages/chat-ui/src/components/rows/tools/execute/execute-layout.test.ts
+++ b/packages/chat-ui/src/components/rows/tools/execute/execute-layout.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import type { ChatExecute } from '@/model';
+import { executeHeaderTitle, executeShowsBody } from './execute-layout';
+
+function item(overrides: Partial<ChatExecute> = {}): ChatExecute {
+  return {
+    kind: 'execute',
+    id: 'x',
+    command: 'git status',
+    status: 'done',
+    startedAt: 0,
+    ...overrides,
+  };
+}
+
+describe('executeShowsBody', () => {
+  it('hides the body in every state unless the row is expanded', () => {
+    expect(executeShowsBody(item({ status: 'done' }), false)).toBe(false);
+    expect(executeShowsBody(item({ status: 'error' }), false)).toBe(false);
+    expect(executeShowsBody(item({ status: 'running' }), false)).toBe(false);
+  });
+
+  it('shows the body whenever the row is expanded', () => {
+    expect(executeShowsBody(item({ status: 'done' }), true)).toBe(true);
+    expect(executeShowsBody(item({ status: 'running' }), true)).toBe(true);
+  });
+});
+
+describe('executeHeaderTitle', () => {
+  it('prefers the provider description', () => {
+    expect(executeHeaderTitle(item({ inputSummary: 'Show working tree status' }))).toEqual({
+      text: 'Show working tree status',
+      mono: false,
+    });
+  });
+
+  it('falls back to the first command line, rendered as code', () => {
+    expect(executeHeaderTitle(item({ command: 'git status\ngit log' }))).toEqual({
+      text: 'git status',
+      mono: true,
+    });
+  });
+
+  it('ignores a blank description', () => {
+    expect(executeHeaderTitle(item({ inputSummary: '   ' }))).toEqual({
+      text: 'git status',
+      mono: true,
+    });
+  });
+
+  it('uses the generic label when the command has not arrived yet', () => {
+    expect(executeHeaderTitle(item({ command: '' }))).toEqual({ text: 'Execute', mono: false });
+  });
+});

--- a/packages/chat-ui/src/components/rows/tools/execute/execute-layout.ts
+++ b/packages/chat-ui/src/components/rows/tools/execute/execute-layout.ts
@@ -1,0 +1,37 @@
+/**
+ * execute-layout — pure display decisions for the execute row.
+ *
+ * Kept free of DOM and SolidJS so the collapsed/expanded geometry rules can be
+ * unit-tested in the node project and shared by measure() and Render.
+ */
+
+import type { ChatExecute } from '@/model';
+
+export type ExecuteHeaderTitle = {
+  text: string;
+  /** True when the title is the command itself and should be set in code font. */
+  mono: boolean;
+};
+
+/**
+ * Whether the card body (command + output) is visible.
+ *
+ * Only when the user expands the row. Running rows stay a single header line
+ * too (the shimmer shows activity) so nothing pops open and closes on its own
+ * while an agent works through several commands.
+ */
+export function executeShowsBody(_item: ChatExecute, isExpanded: boolean): boolean {
+  return isExpanded;
+}
+
+/**
+ * Header label: the provider description when present, otherwise the first
+ * line of the command so a collapsed row still says what ran.
+ */
+export function executeHeaderTitle(item: ChatExecute): ExecuteHeaderTitle {
+  const summary = item.inputSummary?.trim();
+  if (summary) return { text: summary, mono: false };
+  const firstLine = item.command.split('\n')[0]?.trim() ?? '';
+  if (firstLine) return { text: firstLine, mono: true };
+  return { text: 'Execute', mono: false };
+}

--- a/packages/chat-ui/src/components/rows/tools/execute/execute.css.ts
+++ b/packages/chat-ui/src/components/rows/tools/execute/execute.css.ts
@@ -15,6 +15,18 @@ globalStyle(`${executeBody}::-webkit-scrollbar`, {
   height: 'var(--execute-scrollbar-size)',
 });
 
+// ── Header ────────────────────────────────────────────────────────────────────
+
+/** Header title when it shows the command itself (no provider description). */
+export const executeHeaderCommand = style({
+  display: 'block',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  fontSize: vars.typeCodeFontSize,
+  fontFamily: vars.typeCodeFontFamily,
+});
+
 // ── Line ──────────────────────────────────────────────────────────────────────
 
 export const executeLine = style({

--- a/packages/chat-ui/src/components/rows/tools/execute/execute.def.tsx
+++ b/packages/chat-ui/src/components/rows/tools/execute/execute.def.tsx
@@ -8,7 +8,9 @@ import { defineUnit } from '@core/units';
 import { Show, createMemo } from 'solid-js';
 import type { ChatExecute } from '@/model';
 import { ExecuteBody } from './Execute';
+import { executeHeaderTitle, executeShowsBody } from './execute-layout';
 import { executeLines, maxOutputLineWidth, type ExecuteDisplayLine } from './execute-lines';
+import { executeHeaderCommand } from './execute.css';
 
 export { executeFromItem } from './execute.presenter';
 
@@ -23,8 +25,6 @@ export type ExecuteVars = {
   scrollbarSize: number;
   /** Visual separation between command text and the horizontal scrollbar. */
   scrollbarGap: number;
-  /** Max lines shown in the collapsed (preview) state. */
-  collapsedMaxLines: number;
   /** Max lines shown / scrollable in the expanded state. */
   expandedMaxLines: number;
 };
@@ -35,24 +35,28 @@ const EXECUTE_VARS: ExecuteVars = {
   linePadX: 12,
   scrollbarSize: 8,
   scrollbarGap: 3,
-  collapsedMaxLines: 2,
   expandedMaxLines: 16,
 };
 
-/** 3 borders: top card edge + header-separator + bottom card edge. */
-function chromeY(vars: ExecuteVars): number {
-  return 3 * vars.border;
+/**
+ * Vertical chrome. With a body: top card edge + header separator + bottom card
+ * edge. Header-only: the header's own separator is clipped by the card shell,
+ * so only the two card edges count.
+ */
+function chromeY(vars: ExecuteVars, showBody: boolean): number {
+  return (showBody ? 3 : 2) * vars.border;
 }
 
 function executeBodyH(
+  item: ChatExecute,
   lines: ExecuteDisplayLine[],
   codeLineH: number,
   isExpanded: boolean,
   vars: ExecuteVars
 ): { bodyH: number; contentH: number } {
   const contentH = lines.length * codeLineH;
-  const maxLines = isExpanded ? vars.expandedMaxLines : vars.collapsedMaxLines;
-  const cap = maxLines * codeLineH;
+  if (!executeShowsBody(item, isExpanded)) return { bodyH: 0, contentH };
+  const cap = vars.expandedMaxLines * codeLineH;
   const bodyH = Math.min(contentH, cap);
   return { bodyH, contentH };
 }
@@ -115,8 +119,11 @@ function scrollbarSpace(
 
 function executeUnitH(item: ChatExecute, ctx: MeasureCtx, vars: ExecuteVars): number {
   const isExpanded = ctx.expanded(item.id);
+  const showBody = executeShowsBody(item, isExpanded);
+  if (!showBody) return vars.rowH + chromeY(vars, false);
   const lines = executeLines(item);
   const { bodyH, contentH } = executeBodyH(
+    item,
     lines,
     ctx.theme.fonts.code.lineHeight,
     isExpanded,
@@ -124,7 +131,10 @@ function executeUnitH(item: ChatExecute, ctx: MeasureCtx, vars: ExecuteVars): nu
   );
   const hasVerticalOverflow = isExpanded && contentH > bodyH;
   return (
-    vars.rowH + bodyH + scrollbarSpace(item, lines, ctx, vars, hasVerticalOverflow) + chromeY(vars)
+    vars.rowH +
+    bodyH +
+    scrollbarSpace(item, lines, ctx, vars, hasVerticalOverflow) +
+    chromeY(vars, true)
   );
 }
 
@@ -133,26 +143,28 @@ function ExecuteUnitRender(props: { data: ChatExecute; ctx: RenderCtx; vars: Exe
   // Inverted semantics: stored "collapsed" bool = "expanded".
   const isExpanded = () => props.ctx.viewState.isCollapsed(props.data.id);
 
+  const showBody = () => executeShowsBody(props.data, isExpanded());
+  const title = createMemo(() => executeHeaderTitle(props.data));
+
   const lines = createMemo(() => executeLines(props.data));
   const codeLineH = createMemo(() => mCtx()?.theme.fonts.code.lineHeight ?? 0);
   const bodyGeometry = createMemo(() => {
     const lineH = codeLineH();
     if (!lineH) return { bodyH: 0, contentH: 0 };
-    return executeBodyH(lines(), lineH, isExpanded(), props.vars);
+    return executeBodyH(props.data, lines(), lineH, isExpanded(), props.vars);
   });
   const showScrollbar = createMemo(() => {
     const ctx = mCtx();
+    if (!ctx || !showBody()) return false;
     const geometry = bodyGeometry();
     const hasVerticalOverflow = isExpanded() && geometry.contentH > geometry.bodyH;
     const verticalScrollbarW = hasVerticalOverflow ? props.vars.scrollbarSize : 0;
-    return ctx
-      ? hasHorizontalOverflow(props.data, lines(), ctx, props.vars, verticalScrollbarW)
-      : false;
+    return hasHorizontalOverflow(props.data, lines(), ctx, props.vars, verticalScrollbarW);
   });
 
   const totalH = createMemo(() => {
     const ctx = mCtx();
-    if (!ctx) return props.vars.rowH + chromeY(props.vars);
+    if (!ctx) return props.vars.rowH + chromeY(props.vars, showBody());
     return executeUnitH(props.data, ctx, props.vars);
   });
 
@@ -168,9 +180,13 @@ function ExecuteUnitRender(props: { data: ChatExecute; ctx: RenderCtx; vars: Exe
       errorTitle={props.data.error}
       awaitingPermission={props.data.awaitingPermission}
       icon={<IconTerminal />}
-      header={props.data.inputSummary || 'Execute'}
+      header={
+        <span classList={{ [executeHeaderCommand]: title().mono }} title={title().text}>
+          {title().text}
+        </span>
+      }
     >
-      <Show when={codeLineH() > 0}>
+      <Show when={showBody() && codeLineH() > 0}>
         <ExecuteBody
           item={props.data}
           lines={lines()}
@@ -193,12 +209,14 @@ export const executeUnitDef = defineUnit<ChatExecute, ExecuteVars>({
   vars: EXECUTE_VARS,
 
   estimate(item, ctx, vars): number {
-    // Use the collapsed line cap and current width for stable initial geometry.
-    const lines = executeLines(item);
+    const isExpanded = ctx.expanded(item.id);
+    const showBody = executeShowsBody(item, isExpanded);
+    if (!showBody) return vars.rowH + chromeY(vars, false);
     // Approximate code line height — use a fixed fallback of 20px for estimate.
+    const lines = executeLines(item);
     const approxLineH = 20;
-    const { bodyH } = executeBodyH(lines, approxLineH, false, vars);
-    return vars.rowH + bodyH + scrollbarSpace(item, lines, ctx, vars, false) + chromeY(vars);
+    const { bodyH } = executeBodyH(item, lines, approxLineH, isExpanded, vars);
+    return vars.rowH + bodyH + scrollbarSpace(item, lines, ctx, vars, false) + chromeY(vars, true);
   },
 
   measure(item, ctx, vars): number {

--- a/packages/chat-ui/src/components/rows/tools/execute/execute.def.tsx
+++ b/packages/chat-ui/src/components/rows/tools/execute/execute.def.tsx
@@ -175,6 +175,7 @@ function ExecuteUnitRender(props: { data: ChatExecute; ctx: RenderCtx; vars: Exe
       height={totalH()}
       headerH={props.vars.rowH}
       expanded={isExpanded()}
+      bodyVisible={showBody()}
       active={props.data.status === 'running' && !props.data.awaitingPermission}
       error={props.data.status === 'error'}
       errorTitle={props.data.error}

--- a/packages/chat-ui/src/execute.contract.test.tsx
+++ b/packages/chat-ui/src/execute.contract.test.tsx
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import { createChatContext } from '@/chat-context';
+import { createChatView } from '@/chat-view';
+import type { ToolNode, TranscriptTurn } from '@/model';
+import { createChatState } from '@/state/chat-state';
+
+const nextPaint = (): Promise<void> =>
+  new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups.splice(0)) cleanup();
+});
+
+async function mountExecute() {
+  const context = createChatContext();
+  const state = createChatState(context);
+  const item: Extract<ToolNode, { kind: 'execute-tool-call' }> = {
+    kind: 'execute-tool-call',
+    id: 'execute-1',
+    seq: 0,
+    toolCallId: 'tool-execute-1',
+    title: 'git status',
+    inputSummary: 'Show working tree status',
+    command: 'git status',
+    outputText: 'On branch main\nnothing to commit, working tree clean',
+    status: 'done',
+  };
+  const turn: TranscriptTurn = {
+    id: 'turn-1',
+    seq: 0,
+    initiator: 'agent',
+    items: [item],
+  };
+  state.transcript.history.seed([turn]);
+
+  const host = document.createElement('div');
+  host.style.cssText = 'position:fixed;top:0;left:0;width:800px;height:300px;';
+  document.body.appendChild(host);
+  const view = createChatView({ context, state, parent: host });
+
+  cleanups.push(() => {
+    view.dispose();
+    state.dispose();
+    context.dispose();
+    host.remove();
+  });
+
+  await nextPaint();
+  const trigger = host.querySelector<HTMLButtonElement>('button[data-collapse-id="execute-1"]');
+  if (!trigger) throw new Error('Execute collapse trigger did not render');
+  const card = trigger.parentElement;
+  if (!(card instanceof HTMLElement)) throw new Error('Execute card did not render');
+  return { host, trigger, card };
+}
+
+describe('execute row collapse contract', () => {
+  it('renders a compact card and expands it with a pointer', async () => {
+    const { host, trigger, card } = await mountExecute();
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    expect(getComputedStyle(trigger).borderBottomWidth).toBe('0px');
+    expect(card.offsetHeight).toBe(34);
+    expect(trigger.offsetHeight).toBe(32);
+    expect(trigger.offsetWidth).toBe(card.clientWidth);
+    expect(host.textContent).not.toContain('$ git status');
+
+    await userEvent.click(trigger);
+    await nextPaint();
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    expect(getComputedStyle(trigger).borderBottomWidth).toBe('1px');
+    expect(host.textContent).toContain('$ git status');
+    expect(card.offsetHeight).toBeGreaterThan(34);
+  });
+
+  it('exposes a native button that expands from the keyboard', async () => {
+    const { host, trigger } = await mountExecute();
+
+    await userEvent.tab();
+    expect(document.activeElement).toBe(trigger);
+    const collapsedStyle = getComputedStyle(trigger);
+    expect(collapsedStyle.boxShadow).not.toBe('none');
+    expect(collapsedStyle.borderTopLeftRadius).not.toBe('0px');
+    expect(collapsedStyle.borderTopRightRadius).not.toBe('0px');
+    expect(collapsedStyle.borderBottomLeftRadius).not.toBe('0px');
+    await userEvent.keyboard('{Enter}');
+    await nextPaint();
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    expect(host.textContent).toContain('$ git status');
+    const expandedStyle = getComputedStyle(trigger);
+    expect(expandedStyle.borderTopLeftRadius).not.toBe('0px');
+    expect(expandedStyle.borderTopRightRadius).not.toBe('0px');
+    expect(expandedStyle.borderBottomLeftRadius).toBe('0px');
+  });
+});

--- a/packages/chat-ui/src/model.ts
+++ b/packages/chat-ui/src/model.ts
@@ -143,9 +143,10 @@ export type ChatFileOpToolCall = {
 /**
  * An execute tool call row — ACP `kind: 'execute'` commands (e.g. Bash).
  *
- * Rendered as a single non-interactive line: "Execute `{command}` {elapsed}s".
- * While running: shimmer + live ticking timer. When done: frozen duration if
- * durationMs is present; duration omitted if data is unavailable (e.g. replay).
+ * Rendered as a collapsible card. The header shows `inputSummary` when the
+ * provider supplied one, otherwise the first command line. The body (command
+ * and output) is hidden until the user expands the row, in every status; a
+ * running row only shimmers its header.
  */
 export type ChatExecute = {
   kind: 'execute';

--- a/packages/chat-ui/src/stories/rows/tools/execute.stories.tsx
+++ b/packages/chat-ui/src/stories/rows/tools/execute.stories.tsx
@@ -3,7 +3,7 @@
  */
 
 import type { Meta, StoryObj } from 'storybook-solidjs-vite';
-import { ChatHost, ScriptedChat } from '@/stories/_harness/chat-host';
+import { ChatHost, ChatHostExpanded, ScriptedChat } from '@/stories/_harness/chat-host';
 import { ToolStateMatrix } from '@/stories/_harness/state-matrix';
 import { scenario, seedStep, streamExecute } from '@/stories/_harness/streaming/scenario';
 
@@ -97,6 +97,49 @@ export const Done: Story = {
   ),
 };
 
+/** Finished command with a provider description: folds to a single header line. */
+export const DoneCompactWithDescription: Story = {
+  render: () => (
+    <ChatHost
+      items={[
+        {
+          kind: 'execute',
+          id: 'ex-compact-desc',
+          inputSummary: 'Show working tree status',
+          command: 'git status',
+          outputLines: ['On branch main', 'nothing to commit, working tree clean'],
+          status: 'done',
+          startedAt: Date.now() - 900,
+          durationMs: 900,
+        },
+      ]}
+      height={120}
+    />
+  ),
+};
+
+/** Same row expanded: the header keeps the description, the body shows command and output. */
+export const DoneExpandedWithDescription: Story = {
+  render: () => (
+    <ChatHostExpanded
+      expandId="ex-expanded-desc"
+      items={[
+        {
+          kind: 'execute',
+          id: 'ex-expanded-desc',
+          inputSummary: 'Show working tree status',
+          command: 'git status',
+          outputLines: ['On branch main', 'nothing to commit, working tree clean'],
+          status: 'done',
+          startedAt: Date.now() - 900,
+          durationMs: 900,
+        },
+      ]}
+      height={200}
+    />
+  ),
+};
+
 /** Duration omitted — e.g. when replaying from a stored transcript with no durationMs. */
 export const DoneNoDuration: Story = {
   render: () => (
@@ -155,7 +198,7 @@ export const LongCommand: Story = {
 
 /**
  * Multi-line command — exercises:
- *  - Collapsed cap (3 lines with fade overlay).
+ *  - Header-only collapsed state showing the first command line.
  *  - Click to expand (up to expandedMaxLines = 16, then scrollable).
  *  - Bash syntax highlighting across multiple statements.
  */

--- a/packages/core/src/runtimes/acp/api/reducer/acp-transcript-parser.test.ts
+++ b/packages/core/src/runtimes/acp/api/reducer/acp-transcript-parser.test.ts
@@ -402,10 +402,10 @@ describe('AcpTranscriptParser', () => {
     });
   });
 
-  it('adopts a description that only arrives on a later tool_call_update', () => {
-    // Claude Code's ACP adapter opens Bash calls with title "Terminal" and an
-    // empty rawInput, then sends the command + description on the next update,
-    // echoing the description as a text content block.
+  it('preserves matching description and content text for provider enrichment', () => {
+    // The baseline decoder is provider-neutral and must preserve content even
+    // when it matches a description. Provider enrichment can classify a known
+    // adapter-specific description echo without risking legitimate output.
     const p = new AcpTranscriptParser(deps());
     p.push(userChunk('u1', 'what branch am I on'));
     p.push({
@@ -430,9 +430,9 @@ describe('AcpTranscriptParser', () => {
     expect(item).toMatchObject({
       command: 'git rev-parse --abbrev-ref HEAD',
       inputSummary: 'Get current branch name',
+      outputText: 'Get current branch name',
       status: 'running',
     });
-    expect(item).not.toHaveProperty('outputText');
   });
 
   it('passes through standard terminalId on execute tool updates', () => {

--- a/packages/core/src/runtimes/acp/api/reducer/decode.ts
+++ b/packages/core/src/runtimes/acp/api/reducer/decode.ts
@@ -148,10 +148,7 @@ export function decodeSessionUpdate(update: SessionUpdate): NormalizedEvent {
 
     case 'tool_call_update': {
       const inputSummary = extractInputSummary(update);
-      const contentText = extractTextOutput(update.content ?? undefined);
-      // Some adapters echo the description as a content block on the update
-      // that carries the command; that is a label, not command output.
-      const outputText = contentText === inputSummary ? undefined : contentText;
+      const outputText = extractTextOutput(update.content ?? undefined);
       const terminalId = extractTerminalId(update);
       return {
         kind: 'tool_update',

--- a/packages/plugins/src/agents/impl/claude/acp-transform.test.ts
+++ b/packages/plugins/src/agents/impl/claude/acp-transform.test.ts
@@ -133,6 +133,52 @@ describe('enrichClaudeUpdate', () => {
     expect(enrichClaudeUpdate(update, raw)).toBe(update);
   });
 
+  it('removes a description echoed by Claude command metadata', () => {
+    const command = 'git rev-parse --abbrev-ref HEAD';
+    const description = 'Get current branch name';
+    const update = makeToolUpdate({
+      title: command,
+      toolKind: 'execute',
+      status: null,
+      inputSummary: description,
+      outputText: description,
+    });
+    const raw = {
+      sessionUpdate: 'tool_call_update',
+      toolCallId: 'tc-1',
+      title: command,
+      kind: 'execute',
+      content: [{ type: 'content', content: { type: 'text', text: description } }],
+      rawInput: { command, description },
+    } as unknown as SessionUpdate;
+
+    const result = enrichClaudeUpdate(update, raw);
+    expect(result).toMatchObject({
+      kind: 'tool_update',
+      title: command,
+      inputSummary: description,
+    });
+    expect(result).not.toHaveProperty('outputText');
+  });
+
+  it('preserves matching output outside Claude command metadata updates', () => {
+    const description = 'Get current branch name';
+    const update = makeToolUpdate({
+      inputSummary: description,
+      outputText: description,
+    });
+    const raw = {
+      sessionUpdate: 'tool_call_update',
+      toolCallId: 'tc-1',
+      title: null,
+      status: 'completed',
+      content: [{ type: 'content', content: { type: 'text', text: description } }],
+      rawInput: { description },
+    } as unknown as SessionUpdate;
+
+    expect(enrichClaudeUpdate(update, raw)).toBe(update);
+  });
+
   it('preserves all other fields on tool_call when enriching', () => {
     const update = makeToolCall({ toolCallId: 'tc-99', title: 'Read file', toolKind: 'read' });
     const raw = makeRaw({ claudeCode: { parentToolUseId: 'parent-1' } });

--- a/packages/plugins/src/agents/impl/claude/acp-transform.ts
+++ b/packages/plugins/src/agents/impl/claude/acp-transform.ts
@@ -33,6 +33,10 @@ export function enrichClaudeUpdate(update: NormalizedEvent, raw: SessionUpdate):
   }
 
   if (update.kind !== 'tool_call' && update.kind !== 'tool_update') return update;
+  const normalizedUpdate =
+    update.kind === 'tool_update' && isCommandDescriptionEcho(update, raw)
+      ? withoutOutputText(update)
+      : update;
 
   const parentToolUseId = (
     raw._meta as { claudeCode?: { parentToolUseId?: unknown } } | null | undefined
@@ -41,7 +45,7 @@ export function enrichClaudeUpdate(update: NormalizedEvent, raw: SessionUpdate):
   const parentPatch =
     typeof parentToolUseId === 'string' ? { parentToolCallId: parentToolUseId } : {};
   const outputPatch =
-    update.outputText === undefined && rawOutputText(raw) !== undefined
+    normalizedUpdate.outputText === undefined && rawOutputText(raw) !== undefined
       ? { outputText: rawOutputText(raw)! }
       : {};
 
@@ -49,10 +53,10 @@ export function enrichClaudeUpdate(update: NormalizedEvent, raw: SessionUpdate):
     const asyncLaunch = parseAsyncLaunch(raw);
     return {
       kind: 'subagent',
-      toolCallId: update.toolCallId,
-      title: asyncLaunch?.description ?? update.title ?? 'Agent',
-      status: asyncLaunch ? 'in_progress' : update.status,
-      parentToolCallId: parentPatch.parentToolCallId ?? update.parentToolCallId,
+      toolCallId: normalizedUpdate.toolCallId,
+      title: asyncLaunch?.description ?? normalizedUpdate.title ?? 'Agent',
+      status: asyncLaunch ? 'in_progress' : normalizedUpdate.status,
+      parentToolCallId: parentPatch.parentToolCallId ?? normalizedUpdate.parentToolCallId,
       inputSummary: agentInputSummary(raw),
       ...(asyncLaunch ? { background: true } : {}),
       ...(asyncLaunch?.agentId !== undefined ? { agentId: asyncLaunch.agentId } : {}),
@@ -60,8 +64,9 @@ export function enrichClaudeUpdate(update: NormalizedEvent, raw: SessionUpdate):
     };
   }
 
-  if (!parentPatch.parentToolCallId && outputPatch.outputText === undefined) return update;
-  return { ...update, ...parentPatch, ...outputPatch };
+  if (!parentPatch.parentToolCallId && outputPatch.outputText === undefined)
+    return normalizedUpdate;
+  return { ...normalizedUpdate, ...parentPatch, ...outputPatch };
 }
 
 type ClaudeMeta = {
@@ -98,6 +103,49 @@ function claudeToolName(raw: SessionUpdate): string | null {
 function agentInputSummary(raw: SessionUpdate): string | undefined {
   const input = (raw as { rawInput?: { description?: unknown } }).rawInput;
   return typeof input?.description === 'string' ? input.description : undefined;
+}
+
+function isCommandDescriptionEcho(
+  update: Extract<NormalizedEvent, { kind: 'tool_update' }>,
+  raw: SessionUpdate
+): boolean {
+  if (raw.sessionUpdate !== 'tool_call_update') return false;
+  const rawUpdate = raw as unknown as {
+    title?: unknown;
+    kind?: unknown;
+    content?: unknown;
+    rawInput?: { command?: unknown; description?: unknown } | null;
+    rawOutput?: unknown;
+  };
+  const command = rawUpdate.rawInput?.command;
+  const description = rawUpdate.rawInput?.description;
+  return (
+    rawUpdate.kind === 'execute' &&
+    typeof command === 'string' &&
+    typeof description === 'string' &&
+    rawUpdate.title === command &&
+    rawUpdate.rawOutput == null &&
+    singleTextContent(rawUpdate.content) === description &&
+    update.inputSummary === description &&
+    update.outputText === description
+  );
+}
+
+function singleTextContent(content: unknown): string | undefined {
+  if (!Array.isArray(content) || content.length !== 1) return undefined;
+  const block = content[0] as { type?: unknown; content?: unknown };
+  if (block.type !== 'content' || !block.content || typeof block.content !== 'object')
+    return undefined;
+  const payload = block.content as { type?: unknown; text?: unknown };
+  return payload.type === 'text' && typeof payload.text === 'string' ? payload.text : undefined;
+}
+
+function withoutOutputText(
+  update: Extract<NormalizedEvent, { kind: 'tool_update' }>
+): Extract<NormalizedEvent, { kind: 'tool_update' }> {
+  const result = { ...update };
+  delete result.outputText;
+  return result;
 }
 
 function parseAsyncLaunch(raw: SessionUpdate): AsyncLaunch | null {


### PR DESCRIPTION
### Description

Execute rows always rendered a card with the command and up to two lines of output visible, and the card opened and closed on its own as each command ran. A transcript with many shell calls became a wall of cards that kept moving. This folds every execute row to a single header line, in every status, and only opens it when the user asks.

### Before / after

Same transcript, same three commands. Before (base branch, with generalaction/emdash#3117 applied):

![before: three execute cards](https://raw.githubusercontent.com/tkohout/emdash/4012fec8c0e4a3f655099babf1babda333a1aba1/execute-descriptions.png)

After:

![after: three single-line rows](https://raw.githubusercontent.com/tkohout/emdash/36926627c6faf32b9a67afbf359e592c3930cddf/compact-collapsed.png)

### Why this is better

- **The description is the signal; the command is detail.** After #6 the header already says what the command was for ("Show working tree status"). Repeating the raw command underneath adds little at a glance, and the output tail was clipped to two lines anyway, so it rarely answered anything. Both are one click away, and the expanded state persists.
- **Nothing moves on its own.** Previously a running row opened its body and folded it again when done, so a turn with several commands was a sequence of cards popping open and closed. Now a running row is the same one line as a finished one, with a shimmer on the label. That's also how Claude desktop renders tool activity.
- **Tool-heavy turns get much shorter.** A row goes from header plus two code lines plus chrome to the header alone, roughly half the height. An agent turn that runs ten or twenty commands used to push the assistant's reasoning off screen. Now the prose between tool calls stays visible.
- **Consistency with the rest of the transcript.** Read, edit, search, and MCP rows are already single lines. Execute was the only tool row that permanently occupied a card.
- **Rows without a description still say what ran.** If a provider sends no description, the header shows the first command line in code font instead of the literal "Execute".

### Behaviour

- **Collapsed** (default, every status): header only. Running rows shimmer.
- **Expanded**: command and output, scrollable past 16 lines. Live output streams into an expanded row as before.
- **No provider description**: the header shows the first command line in code font.

A single command while running, one line with a shimmering label:

![running execute row](https://raw.githubusercontent.com/tkohout/emdash/a521eb575f15b5ff7af3d8bd2791e277b514c0da/compact-running-v2.png)

Same row after it finished:

![finished execute row](https://raw.githubusercontent.com/tkohout/emdash/a521eb575f15b5ff7af3d8bd2791e277b514c0da/compact-finished-v2.png)

### Implementation notes

The two rules live in a DOM-free `execute-layout.ts` so `measure()`, `estimate()`, and `Render` share them and they are unit-tested in the node project. With the body only ever shown expanded, the collapsed line cap goes away. When the body is hidden the header's own separator is clipped by the card shell, so vertical chrome drops from three borders to two and there is no double line at the bottom.

Stacked on #3117. GitHub cannot base a cross-fork PR on another fork branch, so this PR targets `main` and its diff includes the #3117 commit until that one merges; the chat-ui commit is the only new change here.

### Related issues

None. Builds on #3117.

### Testing

- `pnpm run test` in `packages/chat-ui` (21 files, 255 tests), including the new `execute-layout.test.ts`
- `pnpm run format`, `pnpm run lint`
- `nx typecheck` for `@emdash/chat-ui` and `@emdash/emdash-desktop`
- Two new stories: `DoneCompactWithDescription` and `DoneExpandedWithDescription`
- Manual: dev app, Claude Code chat conversation (screenshots above)

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed (doc comments in model and component)
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
