### PR TITLE
fix(acp): use structured locations for transcript file reads

### DIFF
--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/transcript-file-commands.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/transcript-file-commands.test.ts
@@ -50,14 +50,28 @@ describe('createTranscriptFileCommands', () => {
       openFile
     );
 
-    for (const source of ['diff', 'file-op', 'resource-link', 'prose-link'] as const) {
-      commands.onOpenFile({ path: `src/${source}.ts`, itemId: source, source });
-    }
+    commands.onOpenFile({ path: 'src/diff.ts', itemId: 'diff', source: 'diff' });
+    commands.onOpenFile({
+      path: 'src/file-op.ts',
+      line: 17,
+      itemId: 'file-op',
+      source: 'file-op',
+    });
+    commands.onOpenFile({
+      path: 'src/resource-link.ts',
+      itemId: 'resource-link',
+      source: 'resource-link',
+    });
+    commands.onOpenFile({
+      path: 'src/prose-link.ts',
+      itemId: 'prose-link',
+      source: 'prose-link',
+    });
     commands.openMentionFile('src/mention.ts');
 
     expect(openFile.mock.calls).toEqual([
       ['project-1', 'task-1', 'src/diff.ts'],
-      ['project-1', 'task-1', 'src/file-op.ts'],
+      ['project-1', 'task-1', 'src/file-op.ts', { line: 17 }],
       ['project-1', 'task-1', 'src/resource-link.ts'],
       ['project-1', 'task-1', 'src/prose-link.ts'],
       ['project-1', 'task-1', 'src/mention.ts'],

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/transcript-file-commands.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/transcript-file-commands.ts
@@ -15,7 +15,12 @@ type TranscriptFileContext = {
   taskId: string;
 };
 
-type TranscriptFileOpener = (projectId: string, taskId: string, filePath: string) => Promise<void>;
+type TranscriptFileOpener = (
+  projectId: string,
+  taskId: string,
+  filePath: string,
+  options?: { line?: number }
+) => Promise<void>;
 
 export type TranscriptFileCommands = {
   classifyLink: NonNullable<ChatCommands['classifyLink']>;
@@ -53,13 +58,17 @@ export function createTranscriptFileCommands(
   context: TranscriptFileContext,
   openFile: TranscriptFileOpener = openFileInAdjacentPane
 ): TranscriptFileCommands {
-  const open = (filePath: string) => {
-    void openFile(context.projectId, context.taskId, filePath);
+  const open = (filePath: string, line?: number) => {
+    if (line === undefined) {
+      void openFile(context.projectId, context.taskId, filePath);
+      return;
+    }
+    void openFile(context.projectId, context.taskId, filePath, { line });
   };
 
   return {
     classifyLink: classifyTranscriptLink,
-    onOpenFile: ({ path }) => open(path),
+    onOpenFile: ({ path, line }) => open(path, line),
     openMentionFile: open,
   };
 }

--- a/apps/emdash-desktop/src/core/features/editor/api/browser/open-file-in-file-editor.test.ts
+++ b/apps/emdash-desktop/src/core/features/editor/api/browser/open-file-in-file-editor.test.ts
@@ -7,10 +7,12 @@ import {
 } from './open-file-in-file-editor';
 
 const mocks = vi.hoisted(() => ({
+  getTaskComposition: vi.fn(),
   getTaskStore: vi.fn(),
   getWorkspace: vi.fn(),
   openFile: vi.fn(),
   openPath: vi.fn(),
+  requestSelection: vi.fn(),
 }));
 
 vi.mock('@core/features/tasks/api/browser/task-state/task-selectors', () => ({
@@ -20,6 +22,10 @@ vi.mock('@core/features/tasks/api/browser/task-state/task-selectors', () => ({
 
 vi.mock('@core/features/workbench/api/browser/open-file', () => ({
   openFile: mocks.openFile,
+}));
+
+vi.mock('@core/features/workbench/api/browser/task-composition-selectors', () => ({
+  getTaskComposition: mocks.getTaskComposition,
 }));
 
 vi.mock('@core/features/workspaces/api/browser/stores/workspace-registry', () => ({
@@ -42,6 +48,14 @@ describe('task file opening', () => {
       workspaceId: 'workspace-1',
       path: '/repo',
     });
+    mocks.getTaskComposition.mockReturnValue({
+      paneLayout: {
+        focusedPane: {
+          activeResourceOfKind: () => ({ requestSelection: mocks.requestSelection }),
+        },
+      },
+    });
+    mocks.openFile.mockReturnValue(true);
     mocks.openPath.mockResolvedValue({ success: true, data: undefined });
   });
 
@@ -80,6 +94,24 @@ describe('task file opening', () => {
         reveal: true,
       }
     );
+  });
+
+  it('selects the structured tool location after opening the file', async () => {
+    await openFileInAdjacentPane('project-1', 'task-1', 'src/location.ts', { line: 17 });
+
+    expect(mocks.requestSelection).toHaveBeenCalledWith({
+      lineNumber: 17,
+      startColumn: 1,
+      endColumn: 1,
+    });
+  });
+
+  it('does not request a selection when opening fails', async () => {
+    mocks.openFile.mockReturnValue(false);
+
+    await openFileInAdjacentPane('project-1', 'task-1', 'src/location.ts', { line: 17 });
+
+    expect(mocks.requestSelection).not.toHaveBeenCalled();
   });
 
   it('opens absolute paths outside the workspace through the same seam, never the OS', async () => {

--- a/apps/emdash-desktop/src/core/features/editor/api/browser/open-file-in-file-editor.ts
+++ b/apps/emdash-desktop/src/core/features/editor/api/browser/open-file-in-file-editor.ts
@@ -1,10 +1,12 @@
 import type { HostFileRef } from '@emdash/core/primitives/path/api';
+import type { FileTabResource } from '@core/features/editor/api/browser/task-editor/stores/file-tab-resource';
 import {
   asProvisioned,
   getTaskStore,
 } from '@core/features/tasks/api/browser/task-state/task-selectors';
 import { openFile } from '@core/features/workbench/api/browser/open-file';
 import { openWithOS } from '@core/features/workbench/api/browser/open-with-os';
+import { getTaskComposition } from '@core/features/workbench/api/browser/task-composition-selectors';
 import { workspaceRegistry } from '@core/features/workspaces/api/browser/stores/workspace-registry';
 import {
   absoluteRuntimePath,
@@ -46,7 +48,7 @@ export async function openFileInTaskEditor(
   projectId: string,
   taskId: string,
   filePath: string,
-  options: { target?: 'active' | 'right' } = {}
+  options: { target?: 'active' | 'right'; line?: number } = {}
 ): Promise<void> {
   const provisioned = asProvisioned(getTaskStore(projectId, taskId));
   if (!provisioned) return;
@@ -58,10 +60,21 @@ export async function openFileInTaskEditor(
     return;
   }
 
-  openFile(ref, {
+  const opened = openFile(ref, {
     context: { projectId, taskId },
     target: options.target ?? 'active',
     reveal: true,
+  });
+  if (!opened || options.line === undefined) return;
+
+  const resource = getTaskComposition(
+    projectId,
+    taskId
+  )?.paneLayout.focusedPane.activeResourceOfKind<FileTabResource>('file');
+  resource?.requestSelection({
+    lineNumber: Math.max(1, Math.trunc(options.line)),
+    startColumn: 1,
+    endColumn: 1,
   });
 }
 
@@ -74,9 +87,10 @@ export async function openFileInTaskEditor(
 export async function openFileInAdjacentPane(
   projectId: string,
   taskId: string,
-  filePath: string
+  filePath: string,
+  options: { line?: number } = {}
 ): Promise<void> {
-  return openFileInTaskEditor(projectId, taskId, filePath, { target: 'right' });
+  return openFileInTaskEditor(projectId, taskId, filePath, { ...options, target: 'right' });
 }
 
 /**

--- a/packages/chat-ui/src/commands.ts
+++ b/packages/chat-ui/src/commands.ts
@@ -41,6 +41,7 @@ export type ChatCommands = {
    */
   onOpenFile?: (arg: {
     path: string;
+    line?: number;
     itemId: string;
     source: 'diff' | 'file-op' | 'resource-link' | 'prose-link';
   }) => void;

--- a/packages/chat-ui/src/components/engine/unit-registry.ts
+++ b/packages/chat-ui/src/components/engine/unit-registry.ts
@@ -133,7 +133,7 @@ function toUnitData(item: ToolNode, ctx: SegmentCtx): ToolPresentationData {
     case 'execute-tool-call':
       return executeFromItem(item, ctx);
     case 'read-tool-call':
-      return readFileOpFromItem(item, ctx);
+      return item.locations?.length ? readFileOpFromItem(item, ctx) : toolFromItem(item, ctx);
     case 'create-file-tool-call':
       return createFileDiffFromItem(item, ctx);
     case 'modify-file-tool-call':

--- a/packages/chat-ui/src/components/rows/tools/file-op/FileOperation.tsx
+++ b/packages/chat-ui/src/components/rows/tools/file-op/FileOperation.tsx
@@ -4,7 +4,7 @@ import { IconError, IconShieldAlert } from '@components/primitives/icons';
 import { basename } from '@lib/path';
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 import { For, Show, createEffect } from 'solid-js';
-import type { ChatFileOpToolCall, FileOpKind } from '@/model';
+import type { ChatFileOpToolCall, FileOp, FileOpKind } from '@/model';
 import {
   chevronSm,
   fileOpErrorIcon,
@@ -54,8 +54,13 @@ export function FileOpRow(props: FileOpRowProps) {
   const commands = useCommands();
   const verb = () => VERB[props.item.op];
 
-  const openFile = (path: string) => {
-    commands().onOpenFile?.({ path, itemId: props.item.id, source: 'file-op' });
+  const openFile = (op: FileOp) => {
+    commands().onOpenFile?.({
+      path: op.path,
+      ...(op.line !== undefined ? { line: op.line } : {}),
+      itemId: props.item.id,
+      source: 'file-op',
+    });
   };
 
   return (
@@ -78,7 +83,7 @@ export function FileOpRow(props: FileOpRowProps) {
             verb={verb()}
             path={op().path}
             lineH={props.lineH}
-            onClick={() => openFile(op().path)}
+            onClick={() => openFile(op())}
           />
         )}
       </Show>
@@ -140,8 +145,13 @@ export function FileOpList(props: FileOpListProps) {
   const commands = useCommands();
   const verb = () => VERB[props.item.op];
 
-  const openFile = (path: string) => {
-    commands().onOpenFile?.({ path, itemId: props.item.id, source: 'file-op' });
+  const openFile = (op: FileOp) => {
+    commands().onOpenFile?.({
+      path: op.path,
+      ...(op.line !== undefined ? { line: op.line } : {}),
+      itemId: props.item.id,
+      source: 'file-op',
+    });
   };
 
   return (
@@ -157,7 +167,7 @@ export function FileOpList(props: FileOpListProps) {
             verb={verb()}
             path={op.path}
             lineH={props.lineH}
-            onClick={() => openFile(op.path)}
+            onClick={() => openFile(op)}
           />
         )}
       </For>
@@ -218,8 +228,13 @@ export function FileOperation(props: FileOperationProps) {
   const verb = () => VERB[props.item.op];
   const expanded = () => !!props.collapsed;
 
-  const openFile = (path: string) => {
-    commands().onOpenFile?.({ path, itemId: props.item.id, source: 'file-op' });
+  const openFile = (op: FileOp) => {
+    commands().onOpenFile?.({
+      path: op.path,
+      ...(op.line !== undefined ? { line: op.line } : {}),
+      itemId: props.item.id,
+      source: 'file-op',
+    });
   };
 
   return (
@@ -238,12 +253,7 @@ export function FileOperation(props: FileOperationProps) {
           }
         >
           {(op) => (
-            <FileRowItem
-              verb={verb()}
-              path={op().path}
-              lineH={16}
-              onClick={() => openFile(op().path)}
-            />
+            <FileRowItem verb={verb()} path={op().path} lineH={16} onClick={() => openFile(op())} />
           )}
         </Show>
       }
@@ -265,12 +275,7 @@ export function FileOperation(props: FileOperationProps) {
         <Show when={expanded()}>
           <For each={props.item.ops}>
             {(op) => (
-              <FileRowItem
-                verb={verb()}
-                path={op.path}
-                lineH={16}
-                onClick={() => openFile(op.path)}
-              />
+              <FileRowItem verb={verb()} path={op.path} lineH={16} onClick={() => openFile(op)} />
             )}
           </For>
         </Show>

--- a/packages/chat-ui/src/components/rows/tools/file-op/file-op.def.contract.test.tsx
+++ b/packages/chat-ui/src/components/rows/tools/file-op/file-op.def.contract.test.tsx
@@ -1,0 +1,40 @@
+import type { SegmentCtx } from '@core/units';
+import { describe, expect, it } from 'vitest';
+import type { ToolNode } from '@/model';
+import { readFileOpFromItem } from './file-op.def';
+
+const ctx = {
+  pendingToolCallIds: () => new Set<string>(),
+} as SegmentCtx;
+
+function readItem(overrides: Partial<Extract<ToolNode, { kind: 'read-tool-call' }>> = {}) {
+  return {
+    kind: 'read-tool-call',
+    id: 'read-1',
+    seq: 0,
+    toolCallId: 'call-1',
+    title: 'Read File',
+    status: 'done',
+    locations: [],
+    ...overrides,
+  } satisfies Extract<ToolNode, { kind: 'read-tool-call' }>;
+}
+
+describe('readFileOpFromItem', () => {
+  it('projects every structured ACP location, including line numbers', () => {
+    expect(
+      readFileOpFromItem(
+        readItem({
+          locations: [{ path: '/workspace/a.ts', line: 7 }, { path: '/workspace/b.ts' }],
+        }),
+        ctx
+      )
+    ).toMatchObject({
+      ops: [{ path: '/workspace/a.ts', line: 7 }, { path: '/workspace/b.ts' }],
+    });
+  });
+
+  it('has no file operations when structured locations are absent', () => {
+    expect(readFileOpFromItem(readItem({ locations: undefined }), ctx)).toMatchObject({ ops: [] });
+  });
+});

--- a/packages/chat-ui/src/components/rows/tools/file-op/file-op.def.tsx
+++ b/packages/chat-ui/src/components/rows/tools/file-op/file-op.def.tsx
@@ -28,7 +28,7 @@ export function readFileOpFromItem(
     op: 'read',
     status: item.status,
     awaitingPermission: ctx.pendingToolCallIds().has(item.toolCallId),
-    ops: item.path || item.resource ? [{ path: item.path ?? item.resource! }] : [],
+    ops: item.locations ?? [],
   };
 }
 

--- a/packages/chat-ui/src/components/rows/tools/tool/tool.def.tsx
+++ b/packages/chat-ui/src/components/rows/tools/tool/tool.def.tsx
@@ -10,31 +10,35 @@ import { toolRoot, toolVars } from './tool.css';
 export function toolFromItem(item: ToolNode, ctx: SegmentCtx): ChatToolCall {
   const base = 'toolCallId' in item ? item : null;
   const name =
-    item.kind === 'search-tool-call'
-      ? 'Search'
-      : item.kind === 'mcp-tool-call'
-        ? 'MCP'
-        : item.kind === 'web-fetch-tool-call'
-          ? 'Fetch'
-          : item.kind === 'spawn-subagent-tool-call'
-            ? 'Subagent'
-            : item.kind === 'unknown-tool-call'
-              ? item.name
-              : item.kind === 'tool-group'
-                ? item.label
-                : 'Tool';
+    item.kind === 'read-tool-call'
+      ? item.title
+      : item.kind === 'search-tool-call'
+        ? 'Search'
+        : item.kind === 'mcp-tool-call'
+          ? 'MCP'
+          : item.kind === 'web-fetch-tool-call'
+            ? 'Fetch'
+            : item.kind === 'spawn-subagent-tool-call'
+              ? 'Subagent'
+              : item.kind === 'unknown-tool-call'
+                ? item.name
+                : item.kind === 'tool-group'
+                  ? item.label
+                  : 'Tool';
   const inputSummary =
-    item.kind === 'search-tool-call'
-      ? `${item.query}${item.matchCount !== undefined ? ` (${item.matchCount} matches)` : ''}`
-      : item.kind === 'mcp-tool-call'
-        ? [item.server, item.tool].filter(Boolean).join('.')
-        : item.kind === 'web-fetch-tool-call'
-          ? (item.pageTitle ?? item.url)
-          : item.kind === 'spawn-subagent-tool-call'
-            ? `${item.name}${item.background ? ' (background)' : ''}`
-            : item.kind === 'unknown-tool-call'
-              ? (item.toolKind ?? undefined)
-              : base?.inputSummary;
+    item.kind === 'read-tool-call'
+      ? undefined
+      : item.kind === 'search-tool-call'
+        ? `${item.query}${item.matchCount !== undefined ? ` (${item.matchCount} matches)` : ''}`
+        : item.kind === 'mcp-tool-call'
+          ? [item.server, item.tool].filter(Boolean).join('.')
+          : item.kind === 'web-fetch-tool-call'
+            ? (item.pageTitle ?? item.url)
+            : item.kind === 'spawn-subagent-tool-call'
+              ? `${item.name}${item.background ? ' (background)' : ''}`
+              : item.kind === 'unknown-tool-call'
+                ? (item.toolKind ?? undefined)
+                : base?.inputSummary;
   return {
     kind: 'tool',
     id: item.id,

--- a/packages/chat-ui/src/model.ts
+++ b/packages/chat-ui/src/model.ts
@@ -113,6 +113,7 @@ export type FileOpKind = 'read' | 'edit' | 'delete' | 'move';
 /** A single file touched by a file-operation tool call. */
 export type FileOp = {
   path: string;
+  line?: number;
 };
 
 /**

--- a/packages/chat-ui/src/open-file.contract.test.tsx
+++ b/packages/chat-ui/src/open-file.contract.test.tsx
@@ -113,7 +113,7 @@ describe('open-file command contract', () => {
           id: 'file-op-1',
           op: 'read',
           status: 'done',
-          ops: [{ path: 'src/file-op.ts' }],
+          ops: [{ path: 'src/file-op.ts', line: 17 }],
         },
         {
           kind: 'resource-link',
@@ -138,9 +138,60 @@ describe('open-file command contract', () => {
 
     expect(onOpenFile.mock.calls.map(([arg]) => arg)).toEqual([
       { path: 'src/diff.ts', itemId: 'edit-1:src/diff.ts', source: 'diff' },
-      { path: 'src/file-op.ts', itemId: 'file-op-1', source: 'file-op' },
+      { path: 'src/file-op.ts', line: 17, itemId: 'file-op-1', source: 'file-op' },
       { path: 'src/resource.ts', itemId: 'resource-1', source: 'resource-link' },
     ]);
+  });
+
+  it('opens a read tool from its structured location instead of its quoted title', async () => {
+    const onOpenFile = vi.fn();
+    const host = mount(
+      [
+        {
+          kind: 'read-tool-call',
+          id: 'read-1',
+          seq: 0,
+          toolCallId: 'call-1',
+          title: "Read file '/workspace/AGENTS.md'",
+          status: 'done',
+          locations: [{ path: '/workspace/AGENTS.md', line: 12 }],
+        },
+      ],
+      { onOpenFile }
+    );
+    await nextPaint();
+
+    clickableRowForPath(host, '/workspace/AGENTS.md').click();
+
+    expect(onOpenFile).toHaveBeenCalledWith({
+      path: '/workspace/AGENTS.md',
+      line: 12,
+      itemId: 'read-1',
+      source: 'file-op',
+    });
+  });
+
+  it('renders a read tool without locations as a non-clickable status row', async () => {
+    const onOpenFile = vi.fn();
+    const host = mount(
+      [
+        {
+          kind: 'read-tool-call',
+          id: 'read-1',
+          seq: 0,
+          toolCallId: 'call-1',
+          title: 'Read File',
+          status: 'done',
+          locations: [],
+        },
+      ],
+      { onOpenFile }
+    );
+    await nextPaint();
+
+    expect(host.textContent).toContain('Read File');
+    expect(host.querySelector('[role="button"]')).toBeNull();
+    expect(onOpenFile).not.toHaveBeenCalled();
   });
 
   it('routes file mentions through onClickMention', async () => {

--- a/packages/core/src/primitives/acp-transcript/api/index.ts
+++ b/packages/core/src/primitives/acp-transcript/api/index.ts
@@ -3,6 +3,7 @@ export type {
   EnrichHook,
   NormalizedDiff,
   NormalizedEvent,
+  NormalizedToolLocation,
   NormalizedToolStatus,
   PlanEntryInput,
   SessionUsage,

--- a/packages/core/src/primitives/acp-transcript/api/normalized-event.ts
+++ b/packages/core/src/primitives/acp-transcript/api/normalized-event.ts
@@ -28,6 +28,11 @@ export type NormalizedDiff = {
   newText: string;
 };
 
+export type NormalizedToolLocation = {
+  path: string;
+  line?: number;
+};
+
 export type NormalizedToolStatus = 'pending' | 'in_progress' | 'completed' | 'failed';
 
 export type NormalizedEvent =
@@ -51,6 +56,7 @@ export type NormalizedEvent =
       status: NormalizedToolStatus | null;
       parentToolCallId: string | null;
       diffs: NormalizedDiff[];
+      locations: NormalizedToolLocation[];
       inputSummary?: string;
       outputText?: string;
       terminalId?: string;
@@ -102,11 +108,14 @@ export type NormalizedEvent =
   | {
       kind: 'tool_update';
       toolCallId: string;
-      title: string | null;
-      toolKind: string | null;
-      status: NormalizedToolStatus | null;
+      title?: string | null;
+      toolKind?: string | null;
+      status?: NormalizedToolStatus | null;
       parentToolCallId: string | null;
-      diffs: NormalizedDiff[];
+      /** Present only when ACP supplied content; an empty array explicitly clears prior diffs. */
+      diffs?: NormalizedDiff[];
+      /** Present only when ACP supplied locations; an empty array explicitly clears them. */
+      locations?: NormalizedToolLocation[];
       inputSummary?: string;
       outputText?: string;
       terminalId?: string;

--- a/packages/core/src/runtimes/acp/api/models/turns/tool-calls.ts
+++ b/packages/core/src/runtimes/acp/api/models/turns/tool-calls.ts
@@ -9,8 +9,15 @@ export interface BaseToolCallItem {
   title: string;
   status: ToolStatus;
   inputSummary?: string;
+  /** Structured ACP file locations. An empty array means the tool currently has none. */
+  locations?: ToolCallLocation[];
   parentToolCallId?: string;
   children?: ToolNode[];
+}
+
+export interface ToolCallLocation {
+  path: string;
+  line?: number;
 }
 
 export interface ExecuteToolCall extends BaseToolCallItem {
@@ -22,8 +29,6 @@ export interface ExecuteToolCall extends BaseToolCallItem {
 
 export interface ReadToolCall extends BaseToolCallItem {
   kind: 'read-tool-call';
-  path?: string;
-  resource?: string;
 }
 
 export interface FileToolCallBase extends BaseToolCallItem {
@@ -118,6 +123,14 @@ export const baseToolCallItemSchema = z.object({
   status: toolStatusSchema,
   /** Provider/plugin-generated short input description for compact display. */
   inputSummary: z.string().optional(),
+  locations: z
+    .array(
+      z.object({
+        path: z.string(),
+        line: z.number().int().nonnegative().optional(),
+      })
+    )
+    .optional(),
   /** Raw provider parent id used to rebuild the tree; not a render link. */
   parentToolCallId: z.string().optional(),
   /** Nested provider or reducer-derived tool nodes owned by this call. */
@@ -135,8 +148,6 @@ export const executeToolCallSchema = baseToolCallItemSchema.extend({
 
 export const readToolCallSchema = baseToolCallItemSchema.extend({
   kind: z.literal('read-tool-call'),
-  path: z.string().optional(),
-  resource: z.string().optional(),
 });
 
 export const fileToolCallBaseSchema = baseToolCallItemSchema.extend({

--- a/packages/core/src/runtimes/acp/api/reducer/acp-transcript-parser.test.ts
+++ b/packages/core/src/runtimes/acp/api/reducer/acp-transcript-parser.test.ts
@@ -69,10 +69,7 @@ function toolUpdateDone(toolCallId: string): SessionUpdate {
     sessionUpdate: 'tool_call_update',
     sessionId: 'sess-1',
     toolCallId,
-    title: null,
-    kind: null,
     status: 'completed',
-    content: [],
   } as unknown as SessionUpdate;
 }
 
@@ -476,6 +473,96 @@ describe('AcpTranscriptParser', () => {
     });
   });
 
+  it('uses structured read locations without parsing the human-readable title', () => {
+    const p = new AcpTranscriptParser(deps());
+    p.push(userChunk('u1', 'read a file'));
+    p.push({
+      sessionUpdate: 'tool_call',
+      sessionId: 'sess-1',
+      toolCallId: 'read-1',
+      title: "Read file '/workspace/AGENTS.md'",
+      kind: 'read',
+      status: 'in_progress',
+      content: [],
+      locations: [{ path: '/workspace/AGENTS.md', line: 12 }],
+    } as unknown as SessionUpdate);
+    p.push(toolUpdateDone('read-1'));
+
+    expect(p.activeTurn?.items.find((item) => item.kind === 'read-tool-call')).toMatchObject({
+      kind: 'read-tool-call',
+      title: "Read file '/workspace/AGENTS.md'",
+      status: 'done',
+      locations: [{ path: '/workspace/AGENTS.md', line: 12 }],
+    });
+  });
+
+  it('applies locations-only updates with replace and clear semantics', () => {
+    const p = new AcpTranscriptParser(deps());
+    p.push(userChunk('u1', 'read files'));
+    p.push({
+      sessionUpdate: 'tool_call',
+      sessionId: 'sess-1',
+      toolCallId: 'read-1',
+      title: 'Read File',
+      kind: 'read',
+      status: 'pending',
+      content: [],
+      locations: [],
+    } as unknown as SessionUpdate);
+    p.push({
+      sessionUpdate: 'tool_call_update',
+      sessionId: 'sess-1',
+      toolCallId: 'read-1',
+      locations: [{ path: '/workspace/a.ts', line: 3 }, { path: '/workspace/b.ts' }],
+    } as unknown as SessionUpdate);
+
+    expect(p.activeTurn?.items.find((item) => item.kind === 'read-tool-call')).toMatchObject({
+      locations: [{ path: '/workspace/a.ts', line: 3 }, { path: '/workspace/b.ts' }],
+    });
+
+    p.push({
+      sessionUpdate: 'tool_call_update',
+      sessionId: 'sess-1',
+      toolCallId: 'read-1',
+      locations: [],
+    } as unknown as SessionUpdate);
+
+    expect(p.activeTurn?.items.find((item) => item.kind === 'read-tool-call')).toMatchObject({
+      locations: [],
+    });
+  });
+
+  it('does not let a presentation title override an explicit execute kind', () => {
+    const p = new AcpTranscriptParser(deps());
+    p.push(userChunk('u1', 'run a command'));
+    p.push(toolCallUpdate('exec-1', 'Read package metadata', 'execute'));
+
+    expect(p.activeTurn?.items.find((item) => item.kind.endsWith('-tool-call'))).toMatchObject({
+      kind: 'execute-tool-call',
+      command: 'Read package metadata',
+    });
+  });
+
+  it('reclassifies a tool when a later update supplies its read kind and locations', () => {
+    const p = new AcpTranscriptParser(deps());
+    p.push(userChunk('u1', 'use a tool'));
+    p.push(toolCallUpdate('tool-1', 'Working', 'other'));
+    p.push({
+      sessionUpdate: 'tool_call_update',
+      sessionId: 'sess-1',
+      toolCallId: 'tool-1',
+      kind: 'read',
+      title: 'Reading source',
+      locations: [{ path: '/workspace/source.ts' }],
+    } as unknown as SessionUpdate);
+
+    expect(p.activeTurn?.items.find((item) => item.kind.endsWith('-tool-call'))).toMatchObject({
+      kind: 'read-tool-call',
+      title: 'Reading source',
+      locations: [{ path: '/workspace/source.ts' }],
+    });
+  });
+
   it('pushEvent can materialize enriched special tool events', () => {
     const p = new AcpTranscriptParser(deps());
     p.push(userChunk('u1', 'search'));
@@ -607,6 +694,44 @@ describe('AcpTranscriptParser', () => {
     expect(fileOps).toHaveLength(2);
     expect(fileOps.every((item) => item.toolCallId === 'tc-multi')).toBe(true);
     expect(fileOps.every((item) => item.status === 'done')).toBe(true);
+  });
+
+  it('replaces and clears file operations when an update replaces ACP content', () => {
+    const p = new AcpTranscriptParser(deps());
+    p.push(userChunk('u1', 'patch files'));
+    p.push({
+      sessionUpdate: 'tool_call_update',
+      sessionId: 'sess-1',
+      toolCallId: 'tc-replace',
+      title: 'Apply patch',
+      kind: 'edit',
+      status: 'in_progress',
+      content: [
+        { type: 'diff', path: 'src/a.ts', oldText: 'a', newText: 'aa' },
+        { type: 'diff', path: 'src/b.ts', oldText: 'b', newText: 'bb' },
+      ],
+    } as unknown as SessionUpdate);
+    p.push({
+      sessionUpdate: 'tool_call_update',
+      sessionId: 'sess-1',
+      toolCallId: 'tc-replace',
+      content: [{ type: 'diff', path: 'src/b.ts', oldText: 'b', newText: 'bbb' }],
+    } as unknown as SessionUpdate);
+
+    expect(
+      p.activeTurn?.items.filter((item) => 'toolCallId' in item && item.toolCallId === 'tc-replace')
+    ).toMatchObject([{ kind: 'modify-file-tool-call', path: 'src/b.ts', newText: 'bbb' }]);
+
+    p.push({
+      sessionUpdate: 'tool_call_update',
+      sessionId: 'sess-1',
+      toolCallId: 'tc-replace',
+      content: [],
+    } as unknown as SessionUpdate);
+
+    expect(
+      p.activeTurn?.items.filter((item) => 'toolCallId' in item && item.toolCallId === 'tc-replace')
+    ).toEqual([]);
   });
 
   it('diff-less edit tool_update does not create a placeholder tool call', () => {

--- a/packages/core/src/runtimes/acp/api/reducer/decode.ts
+++ b/packages/core/src/runtimes/acp/api/reducer/decode.ts
@@ -14,8 +14,13 @@
  *   - Returns { kind: 'ignored' } for variants not yet rendered.
  */
 
-import type { SessionUpdate, ToolCallContent } from '@agentclientprotocol/sdk';
-import type { NormalizedDiff, NormalizedEvent, NormalizedToolStatus } from './normalized-event';
+import type { SessionUpdate, ToolCallContent, ToolCallLocation } from '@agentclientprotocol/sdk';
+import type {
+  NormalizedDiff,
+  NormalizedEvent,
+  NormalizedToolLocation,
+  NormalizedToolStatus,
+} from './normalized-event';
 
 function extractDiffs(
   content: ReadonlyArray<ToolCallContent> | null | undefined
@@ -28,6 +33,19 @@ function extractDiffs(
     }
   }
   return diffs;
+}
+
+function extractLocations(
+  locations: ReadonlyArray<ToolCallLocation> | null | undefined
+): NormalizedToolLocation[] {
+  return (locations ?? []).map((location) => ({
+    path: location.path,
+    ...(location.line !== undefined && location.line !== null ? { line: location.line } : {}),
+  }));
+}
+
+function hasOwnField<T extends object>(value: T, field: PropertyKey): boolean {
+  return Object.prototype.hasOwnProperty.call(value, field);
 }
 
 function collectTextPayload(value: unknown, parts: string[]): void {
@@ -141,6 +159,7 @@ export function decodeSessionUpdate(update: SessionUpdate): NormalizedEvent {
         status: (update.status as NormalizedToolStatus | undefined) ?? null,
         parentToolCallId: null,
         diffs: extractDiffs(update.content),
+        locations: extractLocations(update.locations),
         ...(inputSummary !== undefined ? { inputSummary } : {}),
         ...(terminalId !== undefined ? { terminalId } : {}),
       };
@@ -150,14 +169,19 @@ export function decodeSessionUpdate(update: SessionUpdate): NormalizedEvent {
       const inputSummary = extractInputSummary(update);
       const outputText = extractTextOutput(update.content ?? undefined);
       const terminalId = extractTerminalId(update);
+      const hasContent = hasOwnField(update, 'content');
+      const hasLocations = hasOwnField(update, 'locations');
       return {
         kind: 'tool_update',
         toolCallId: update.toolCallId,
-        title: update.title ?? null,
-        toolKind: update.kind ?? null,
-        status: (update.status as NormalizedToolStatus | undefined | null) ?? null,
         parentToolCallId: null,
-        diffs: extractDiffs(update.content ?? undefined),
+        ...(hasOwnField(update, 'title') ? { title: update.title ?? null } : {}),
+        ...(hasOwnField(update, 'kind') ? { toolKind: update.kind ?? null } : {}),
+        ...(hasOwnField(update, 'status')
+          ? { status: (update.status as NormalizedToolStatus | undefined | null) ?? null }
+          : {}),
+        ...(hasContent ? { diffs: extractDiffs(update.content) } : {}),
+        ...(hasLocations ? { locations: extractLocations(update.locations) } : {}),
         ...(inputSummary !== undefined ? { inputSummary } : {}),
         ...(outputText !== undefined ? { outputText } : {}),
         ...(terminalId !== undefined ? { terminalId } : {}),

--- a/packages/core/src/runtimes/acp/api/reducer/index.ts
+++ b/packages/core/src/runtimes/acp/api/reducer/index.ts
@@ -15,6 +15,7 @@ export type {
   TranscriptTurnInitiator,
   TranscriptTurnOutcome,
   ToolCallItem,
+  ToolCallLocation,
   ToolGroup,
   ToolNode,
   ToolStatus,
@@ -35,6 +36,7 @@ export type {
   EnrichHook,
   NormalizedDiff,
   NormalizedEvent,
+  NormalizedToolLocation,
   NormalizedToolStatus,
 } from './normalized-event';
 

--- a/packages/core/src/runtimes/acp/api/reducer/item-fold.ts
+++ b/packages/core/src/runtimes/acp/api/reducer/item-fold.ts
@@ -27,7 +27,12 @@ import type {
   ToolStatus,
 } from '../models/turns';
 import { makeDiffId, makeMessageId, makePlanId, makeThinkingId, makeToolId } from './ids';
-import type { NormalizedDiff, NormalizedEvent, NormalizedToolStatus } from './normalized-event';
+import type {
+  NormalizedDiff,
+  NormalizedEvent,
+  NormalizedToolLocation,
+  NormalizedToolStatus,
+} from './normalized-event';
 import { toolRunStatus, wrapToolRuns } from './tool-runs';
 
 export type FoldEvent =
@@ -69,8 +74,8 @@ function searchQueryFromTitle(title: string): string {
   return title.replace(/^search\s+/i, '');
 }
 
-function isReadKind(toolKind: string | null | undefined, title?: string | null): boolean {
-  return toolKind === 'read' || toolKind === 'read_file' || title?.startsWith('Read ') === true;
+function isReadKind(toolKind: string | null | undefined): boolean {
+  return toolKind === 'read' || toolKind === 'read_file';
 }
 
 function isEditKind(toolKind: string | null | undefined): boolean {
@@ -87,11 +92,6 @@ function isMcpToolKind(toolKind: string | null | undefined): boolean {
 
 function isWebFetchKind(toolKind: string | null | undefined): boolean {
   return toolKind === 'web-fetch' || toolKind === 'web_fetch' || toolKind === 'fetch';
-}
-
-function inferReadPath(title: string): string | undefined {
-  const match = /^Read\s+(.+?)(?:\s+\(|$)/.exec(title);
-  return match?.[1];
 }
 
 function compareSeq(a: { seq: number }, b: { seq: number }): number {
@@ -137,7 +137,8 @@ function baseToolFields(
   title: string,
   status: NormalizedToolStatus | null,
   parentToolCallId: string | undefined,
-  inputSummary?: string
+  inputSummary?: string,
+  locations?: NormalizedToolLocation[]
 ): Omit<ToolCallItem, 'kind'> {
   return {
     id,
@@ -146,6 +147,7 @@ function baseToolFields(
     title,
     status: mapToolStatus(status) ?? 'running',
     ...(inputSummary !== undefined ? { inputSummary } : {}),
+    ...(locations !== undefined ? { locations } : {}),
     ...(parentToolCallId !== undefined ? { parentToolCallId } : {}),
   };
 }
@@ -161,6 +163,7 @@ export function createToolCallItem(params: {
   inputSummary?: string;
   outputText?: string;
   terminalId?: string;
+  locations?: NormalizedToolLocation[];
 }): ToolCallItem {
   const base = baseToolFields(
     params.id,
@@ -169,7 +172,8 @@ export function createToolCallItem(params: {
     params.title,
     params.status,
     params.parentToolCallId,
-    params.inputSummary
+    params.inputSummary,
+    params.locations
   );
   const { title, toolKind } = params;
   if (isSubagentKind(toolKind)) {
@@ -184,12 +188,8 @@ export function createToolCallItem(params: {
   if (isWebFetchKind(toolKind)) {
     return { kind: 'web-fetch-tool-call', ...base, url: title };
   }
-  if (isReadKind(toolKind, title)) {
-    return {
-      kind: 'read-tool-call',
-      ...base,
-      ...(inferReadPath(title) ? { path: inferReadPath(title) } : {}),
-    };
+  if (isReadKind(toolKind)) {
+    return { kind: 'read-tool-call', ...base };
   }
   if (isExecuteKind(toolKind)) {
     return {
@@ -205,33 +205,61 @@ export function createToolCallItem(params: {
 
 function updateToolCallItem(
   item: ToolCallItem,
-  title: string | null,
-  status: NormalizedToolStatus | null,
-  outputText?: string,
-  terminalId?: string,
-  inputSummary?: string
+  patch: {
+    title?: string | null;
+    toolKind?: string | null;
+    status?: NormalizedToolStatus | null;
+    outputText?: string;
+    terminalId?: string;
+    inputSummary?: string;
+    locations?: NormalizedToolLocation[];
+  }
 ): ToolCallItem {
-  const mapped = mapToolStatus(status ?? undefined);
-  const nextTitle = title ?? item.title;
+  const mapped = mapToolStatus(patch.status);
+  const nextTitle = patch.title ?? item.title;
+  const nextLocations = patch.locations ?? item.locations;
+  const nextInputSummary = patch.inputSummary ?? item.inputSummary;
+
+  if (patch.toolKind !== undefined && patch.toolKind !== null) {
+    const reclassified = createToolCallItem({
+      id: item.id,
+      seq: item.seq,
+      toolCallId: item.toolCallId,
+      title: nextTitle,
+      toolKind: patch.toolKind,
+      status: patch.status ?? null,
+      parentToolCallId: item.parentToolCallId,
+      ...(nextInputSummary !== undefined ? { inputSummary: nextInputSummary } : {}),
+      ...(patch.outputText !== undefined ? { outputText: patch.outputText } : {}),
+      ...(patch.terminalId !== undefined ? { terminalId: patch.terminalId } : {}),
+      ...(nextLocations !== undefined ? { locations: nextLocations } : {}),
+    });
+    if (reclassified.kind !== item.kind) {
+      return {
+        ...reclassified,
+        status: mapped ?? item.status,
+        ...(item.children?.length ? { children: item.children } : {}),
+      };
+    }
+  }
+
   const common = {
     ...item,
     ...(mapped !== undefined ? { status: mapped } : {}),
-    ...(title !== null ? { title: title } : {}),
-    ...(inputSummary !== undefined ? { inputSummary } : {}),
+    ...(patch.title !== undefined && patch.title !== null ? { title: patch.title } : {}),
+    ...(patch.inputSummary !== undefined ? { inputSummary: patch.inputSummary } : {}),
+    ...(patch.locations !== undefined ? { locations: patch.locations } : {}),
   };
   switch (item.kind) {
     case 'execute-tool-call':
       return {
         ...common,
-        ...(title !== null ? { command: nextTitle } : {}),
-        ...(outputText !== undefined ? { outputText } : {}),
-        ...(terminalId !== undefined ? { terminalId } : {}),
+        ...(patch.title !== undefined && patch.title !== null ? { command: nextTitle } : {}),
+        ...(patch.outputText !== undefined ? { outputText: patch.outputText } : {}),
+        ...(patch.terminalId !== undefined ? { terminalId: patch.terminalId } : {}),
       };
     case 'read-tool-call':
-      return {
-        ...common,
-        ...(title !== null && inferReadPath(nextTitle) ? { path: inferReadPath(nextTitle) } : {}),
-      };
+      return common;
     case 'create-file-tool-call':
       return common;
     case 'modify-file-tool-call':
@@ -241,18 +269,33 @@ function updateToolCallItem(
     case 'search-tool-call':
       return {
         ...common,
-        ...(title !== null ? { query: searchQueryFromTitle(nextTitle) } : {}),
+        ...(patch.title !== undefined && patch.title !== null
+          ? { query: searchQueryFromTitle(nextTitle) }
+          : {}),
       };
     case 'mcp-tool-call':
-      return { ...common, ...(title !== null ? { tool: nextTitle } : {}) };
+      return {
+        ...common,
+        ...(patch.title !== undefined && patch.title !== null ? { tool: nextTitle } : {}),
+      };
     case 'web-fetch-tool-call':
-      return { ...common, ...(title !== null ? { pageTitle: nextTitle } : {}) };
+      return {
+        ...common,
+        ...(patch.title !== undefined && patch.title !== null ? { pageTitle: nextTitle } : {}),
+      };
     case 'spawn-subagent-tool-call':
-      return { ...common, ...(title !== null ? { name: nextTitle } : {}) };
+      return {
+        ...common,
+        ...(patch.title !== undefined && patch.title !== null ? { name: nextTitle } : {}),
+      };
     case 'create-plan-tool-call':
       return common;
     case 'unknown-tool-call':
-      return { ...common, ...(title !== null ? { name: nextTitle } : {}) };
+      return {
+        ...common,
+        ...(patch.toolKind !== undefined ? { toolKind: patch.toolKind } : {}),
+        ...(patch.title !== undefined && patch.title !== null ? { name: nextTitle } : {}),
+      };
   }
 }
 
@@ -357,16 +400,26 @@ function finalizeOpenThinking(items: TranscriptItem[], now: number): TranscriptI
   return changed ? result : items;
 }
 
-function upsertFileOperations(
+function replaceFileOperations(
   items: TranscriptItem[],
   toolId: string,
   toolCallId: string,
   title: string,
   parentToolCallId: string | undefined,
   diffs: NormalizedDiff[],
-  status: NormalizedToolStatus | null
+  status: NormalizedToolStatus | null | undefined
 ): TranscriptItem[] {
-  let result = items;
+  const desiredIds = new Set(diffs.map((diff) => makeDiffId(toolId, diff.path)));
+  let result = items.filter((item) => {
+    switch (item.kind) {
+      case 'create-file-tool-call':
+      case 'modify-file-tool-call':
+      case 'delete-file-tool-call':
+        return item.toolCallId !== toolCallId || desiredIds.has(item.id);
+      default:
+        return true;
+    }
+  });
   for (const d of diffs) {
     const id = makeDiffId(toolId, d.path);
     const mapped = mapToolStatus(status);
@@ -433,7 +486,7 @@ function upsertFileOperations(
 function updateFileOperationStatuses(
   items: TranscriptItem[],
   toolCallId: string,
-  status: NormalizedToolStatus | null
+  status: NormalizedToolStatus | null | undefined
 ): TranscriptItem[] {
   const mapped = mapToolStatus(status);
   if (mapped === undefined) return items;
@@ -620,7 +673,7 @@ export function foldItem(
       const parentToolCallId = event.parentToolCallId ?? undefined;
       const base = finalizeOpenThinking(flatItems, at);
       if (event.diffs.length > 0) {
-        const next = upsertFileOperations(
+        const next = replaceFileOperations(
           base,
           toolId,
           event.toolCallId,
@@ -645,6 +698,7 @@ export function foldItem(
         ...(event.inputSummary !== undefined ? { inputSummary: event.inputSummary } : {}),
         ...(event.outputText !== undefined ? { outputText: event.outputText } : {}),
         ...(event.terminalId !== undefined ? { terminalId: event.terminalId } : {}),
+        ...(event.locations.length > 0 ? { locations: event.locations } : {}),
       });
       const next = upsertToolCallItem(base, tool);
       return normalizeToolStructure(next, turnId);
@@ -653,9 +707,10 @@ export function foldItem(
     case 'tool_update': {
       const toolId = makeToolId(turnId, event.toolCallId);
       const parentToolCallId = event.parentToolCallId ?? undefined;
-      const base = finalizeOpenThinking(flatItems, at);
-      if (event.diffs.length > 0) {
-        const next = upsertFileOperations(
+      let base = finalizeOpenThinking(flatItems, at);
+      const hadFileOperations = hasFileOperationsForToolCall(base, event.toolCallId);
+      if (event.diffs !== undefined) {
+        base = replaceFileOperations(
           base,
           toolId,
           event.toolCallId,
@@ -664,21 +719,23 @@ export function foldItem(
           event.diffs,
           event.status
         );
-        return normalizeToolStructure(next, turnId);
+        if (event.diffs.length > 0) return normalizeToolStructure(base, turnId);
+        if (hadFileOperations) return normalizeToolStructure(base, turnId);
       }
 
       const idx = base.findIndex((it) => isToolCallItem(it) && it.id === toolId);
       let next: TranscriptItem[];
       if (idx >= 0) {
         const tool = base[idx] as ToolCallItem;
-        const updated = updateToolCallItem(
-          tool,
-          event.title,
-          event.status,
-          event.outputText,
-          event.terminalId,
-          event.inputSummary
-        );
+        const updated = updateToolCallItem(tool, {
+          ...(event.title !== undefined ? { title: event.title } : {}),
+          ...(event.toolKind !== undefined ? { toolKind: event.toolKind } : {}),
+          ...(event.status !== undefined ? { status: event.status } : {}),
+          ...(event.outputText !== undefined ? { outputText: event.outputText } : {}),
+          ...(event.terminalId !== undefined ? { terminalId: event.terminalId } : {}),
+          ...(event.inputSummary !== undefined ? { inputSummary: event.inputSummary } : {}),
+          ...(event.locations !== undefined ? { locations: event.locations } : {}),
+        });
         next = base.map((it, i) => (i === idx ? updated : it));
       } else if (hasFileOperationsForToolCall(base, event.toolCallId)) {
         next = base;
@@ -692,12 +749,13 @@ export function foldItem(
             seq: nextSeq(base),
             toolCallId: event.toolCallId,
             title: event.title ?? 'unknown',
-            toolKind: event.toolKind,
-            status: event.status,
+            toolKind: event.toolKind ?? null,
+            status: event.status ?? null,
             parentToolCallId,
             ...(event.inputSummary !== undefined ? { inputSummary: event.inputSummary } : {}),
             ...(event.outputText !== undefined ? { outputText: event.outputText } : {}),
             ...(event.terminalId !== undefined ? { terminalId: event.terminalId } : {}),
+            ...(event.locations !== undefined ? { locations: event.locations } : {}),
           })
         );
       }

--- a/packages/core/src/runtimes/acp/api/reducer/normalized-event.ts
+++ b/packages/core/src/runtimes/acp/api/reducer/normalized-event.ts
@@ -2,5 +2,6 @@ export type {
   EnrichHook,
   NormalizedDiff,
   NormalizedEvent,
+  NormalizedToolLocation,
   NormalizedToolStatus,
 } from '#primitives/acp-transcript/api';

--- a/packages/plugins/src/agents/impl/claude/acp-transform.test.ts
+++ b/packages/plugins/src/agents/impl/claude/acp-transform.test.ts
@@ -17,6 +17,7 @@ function makeToolCall(
     parentToolCallId: null,
     diffs: [],
     ...overrides,
+    locations: overrides.locations ?? [],
   };
 }
 

--- a/packages/plugins/src/agents/impl/claude/acp-transform.ts
+++ b/packages/plugins/src/agents/impl/claude/acp-transform.ts
@@ -55,7 +55,7 @@ export function enrichClaudeUpdate(update: NormalizedEvent, raw: SessionUpdate):
       kind: 'subagent',
       toolCallId: normalizedUpdate.toolCallId,
       title: asyncLaunch?.description ?? normalizedUpdate.title ?? 'Agent',
-      status: asyncLaunch ? 'in_progress' : normalizedUpdate.status,
+      status: asyncLaunch ? 'in_progress' : (normalizedUpdate.status ?? null),
       parentToolCallId: parentPatch.parentToolCallId ?? normalizedUpdate.parentToolCallId,
       inputSummary: agentInputSummary(raw),
       ...(asyncLaunch ? { background: true } : {}),

--- a/packages/plugins/src/agents/impl/codex/__snapshots__/acp-fixture.test.ts.snap
+++ b/packages/plugins/src/agents/impl/codex/__snapshots__/acp-fixture.test.ts.snap
@@ -324,7 +324,11 @@ I think I need to form an answer after reviewing the relevant information. Using
             {
               "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:3:tool:call_8Xe7CkBGWr56UnafQajA6tJm",
               "kind": "read-tool-call",
-              "path": "file '/tmp/emdash-acp-fixture-1783042314643/packages/core/src/acp/agent-update.ts'",
+              "locations": [
+                {
+                  "path": "/tmp/emdash-acp-fixture-1783042314643/packages/core/src/acp/agent-update.ts",
+                },
+              ],
               "seq": 3,
               "status": "done",
               "title": "Read file '/tmp/emdash-acp-fixture-1783042314643/packages/core/src/acp/agent-update.ts'",
@@ -333,7 +337,11 @@ I think I need to form an answer after reviewing the relevant information. Using
             {
               "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:3:tool:call_x033kE3l2l9CKnHIIMOL1MlJ",
               "kind": "read-tool-call",
-              "path": "file '/tmp/emdash-acp-fixture-1783042314643/packages/core/src/acp/session-machine.ts'",
+              "locations": [
+                {
+                  "path": "/tmp/emdash-acp-fixture-1783042314643/packages/core/src/acp/session-machine.ts",
+                },
+              ],
               "seq": 4,
               "status": "done",
               "title": "Read file '/tmp/emdash-acp-fixture-1783042314643/packages/core/src/acp/session-machine.ts'",
@@ -342,7 +350,11 @@ I think I need to form an answer after reviewing the relevant information. Using
             {
               "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:3:tool:call_cJhMBU98lbEuPzKi0p4PHRCt",
               "kind": "read-tool-call",
-              "path": "file '/tmp/emdash-acp-fixture-1783042314643/packages/core/src/acp/session-machine.ts'",
+              "locations": [
+                {
+                  "path": "/tmp/emdash-acp-fixture-1783042314643/packages/core/src/acp/session-machine.ts",
+                },
+              ],
               "seq": 5,
               "status": "done",
               "title": "Read file '/tmp/emdash-acp-fixture-1783042314643/packages/core/src/acp/session-machine.ts'",
@@ -366,7 +378,11 @@ I think I need to form an answer after reviewing the relevant information. Using
         {
           "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:3:tool:call_EpbDQ39xyA1D5C7qfQS7LEVO",
           "kind": "read-tool-call",
-          "path": "file '/tmp/emdash-acp-fixture-1783042314643/packages/core/src/acp/session-machine.ts'",
+          "locations": [
+            {
+              "path": "/tmp/emdash-acp-fixture-1783042314643/packages/core/src/acp/session-machine.ts",
+            },
+          ],
           "seq": 7,
           "status": "done",
           "title": "Read file '/tmp/emdash-acp-fixture-1783042314643/packages/core/src/acp/session-machine.ts'",
@@ -419,7 +435,11 @@ I need to respond with just a plan since the user is asking for a checklist or t
             {
               "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:4:tool:call_L8H2vFMxU8sqVLUvHG38FwYj",
               "kind": "read-tool-call",
-              "path": "file '/tmp/emdash-acp-fixture-1783042314643/packages/core/src/acp/agent-update.test.ts'",
+              "locations": [
+                {
+                  "path": "/tmp/emdash-acp-fixture-1783042314643/packages/core/src/acp/agent-update.test.ts",
+                },
+              ],
               "seq": 3,
               "status": "done",
               "title": "Read file '/tmp/emdash-acp-fixture-1783042314643/packages/core/src/acp/agent-update.test.ts'",
@@ -428,7 +448,11 @@ I need to respond with just a plan since the user is asking for a checklist or t
             {
               "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:4:tool:call_4aV1pRthSPJZGbDql5SiEfWG",
               "kind": "read-tool-call",
-              "path": "file '/tmp/emdash-acp-fixture-1783042314643/apps/emdash-desktop/src/renderer/features/tasks/acp/acp-update-mapper.ts'",
+              "locations": [
+                {
+                  "path": "/tmp/emdash-acp-fixture-1783042314643/apps/emdash-desktop/src/renderer/features/tasks/acp/acp-update-mapper.ts",
+                },
+              ],
               "seq": 4,
               "status": "done",
               "title": "Read file '/tmp/emdash-acp-fixture-1783042314643/apps/emdash-desktop/src/renderer/features/tasks/acp/acp-update-mapper.ts'",


### PR DESCRIPTION
- preserve structured tool locations across initial calls and later updates
- stop deriving file paths and tool kinds from human-readable titles
- apply correct replacement and clearing semantics to locations and diffs
- render multiple read locations with optional line numbers
- open transcript files at provider-reported lines in the editor