### PR TITLE
feat(chat): show model effort in composer

### DIFF
--- a/packages/ui/src/react/components/chat-composer/chat-composer.css.ts
+++ b/packages/ui/src/react/components/chat-composer/chat-composer.css.ts
@@ -206,10 +206,15 @@ export const permissionModeTrigger = style({
   paddingRight: '0.1875rem',
 });
 
+export const selectedModelEffort = style({
+  color: vars.foregroundMuted,
+});
+
 export const mcpTrigger = style([
   svgContainer,
   {
     display: 'inline-flex',
+    height: '1.75rem',
     alignItems: 'center',
     gap: '0.25rem',
     borderRadius: tokenVars.radiusMd,

--- a/packages/ui/src/react/components/chat-composer/chat-composer.test.tsx
+++ b/packages/ui/src/react/components/chat-composer/chat-composer.test.tsx
@@ -13,6 +13,29 @@ import { ChatComposer } from './index';
 afterEach(cleanup);
 
 describe('ChatComposer', () => {
+  it('shows the selected effort beside the model and keeps the MCP trigger compact', () => {
+    const { container, getByRole } = render(
+      <ChatComposer
+        modelOptions={{ 'gpt-5.6-sol': { name: 'GPT-5.6-Sol' } }}
+        selectedModel="gpt-5.6-sol"
+        onModelChange={() => {}}
+        effortOptions={{ high: { name: 'High' } }}
+        selectedEffort="high"
+        onEffortChange={() => {}}
+        mcpServers={[
+          { name: 'Filesystem', transport: 'stdio' },
+          { name: 'GitHub', transport: 'http' },
+        ]}
+        onSubmit={() => {}}
+      />
+    );
+
+    const modelTrigger = container.querySelector('[data-slot="combobox-trigger"]');
+    expect(modelTrigger?.textContent).toBe('GPT-5.6-Sol High');
+    const mcpTrigger = getByRole('button', { name: '2 session MCP servers' });
+    expect(mcpTrigger.textContent).toBe('2');
+  });
+
   it('caps the permission-mode popup at its compact width', async () => {
     render(
       <ChatComposer

--- a/packages/ui/src/react/components/chat-composer/index.tsx
+++ b/packages/ui/src/react/components/chat-composer/index.tsx
@@ -1013,6 +1013,12 @@ export function ChatComposer({
                       }}
                     >
                       {selected?.name ?? 'Model…'}
+                      {selected && selectedEffortItem ? (
+                        <span className={styles.selectedModelEffort}>
+                          {' '}
+                          {selectedEffortItem.name}
+                        </span>
+                      ) : null}
                     </span>
                   </span>
                 )}
@@ -1096,9 +1102,15 @@ export function ChatComposer({
             )}
             {mcpServers.length > 0 && (
               <Popover.Root>
-                <Popover.Trigger className={styles.mcpTrigger} disabled={disabled}>
+                <Popover.Trigger
+                  className={styles.mcpTrigger}
+                  disabled={disabled}
+                  aria-label={`${mcpServers.length} session MCP ${
+                    mcpServers.length === 1 ? 'server' : 'servers'
+                  }`}
+                >
                   <McpIcon size={12} />
-                  MCP {mcpServers.length}
+                  {mcpServers.length}
                 </Popover.Trigger>
                 <Popover.Content
                   align="start"


### PR DESCRIPTION
- show the selected effort beside the model name using muted text
- reduce the mcp control to its icon and server count
- align the mcp hover area with adjacent toolbar controls
- preserve an accessible label for the compact mcp control