### PR TITLE
fix(acp): replace ready config catalogs atomically

### DIFF
--- a/agents/architecture/acp-runtime.md
+++ b/agents/architecture/acp-runtime.md
@@ -137,8 +137,10 @@ queues, permissions, terminals, active turns, plans, and agents.
 While a rematerialized session's provider config catalog is pending, the handle projects the
 retained catalog to avoid transiently removing its controls. A ready catalog atomically replaces
 all retained model, effort, mode, and collaboration-mode groups; explicit empty or unsupported
-groups are authoritative and must not fall back to retained values. Available commands have a
-separate readiness lifecycle and are retained independently while materialization is pending.
+groups are authoritative and must not fall back to retained values. Successful `newSession` and
+`loadSession` handshakes end the pending phase; omitted or null config options produce a ready empty
+catalog. Available commands have a separate readiness lifecycle and are retained independently
+while materialization is pending.
 
 On worker boot, every valid persisted intent is restored only as a lightweight suspended index row;
 the worker never starts a provider from disk. The first desktop `attach` hydrates a handle using a

--- a/agents/architecture/acp-runtime.md
+++ b/agents/architecture/acp-runtime.md
@@ -35,8 +35,9 @@ not mix cross-session routing with per-session state projection.
   lifecycle leak assertions.
   `SessionsListProjector` composes live handle summaries with lightweight suspended-intent rows.
 - `SessionCell` owns one live activation: the state machine, transcript reducer, permission broker,
-  prompt queue effects, and turn quiescence. It does not own the conversation-lifetime projection
-  or retained rematerialization descriptor.
+  prompt queue effects, turn quiescence, and whether the provider's config catalog is pending or
+  ready. It does not own the conversation-lifetime projection or retained rematerialization
+  descriptor.
 - The ACP connection source owns provider processes through `createResourceCache`.
   Cache identity includes provider, cwd, and an opaque fingerprint of the requested environment;
   the process route id stays provider/cwd plus generation and can host multiple ACP sessions with
@@ -132,6 +133,12 @@ summaries, usage, and observation time. During one runtime generation, its handl
 move between `closed`, `suspended`, `materializing`, and `active`; suspended and materializing
 projections keep controls visible and prompt submission enabled while clearing activation-local
 queues, permissions, terminals, active turns, plans, and agents.
+
+While a rematerialized session's provider config catalog is pending, the handle projects the
+retained catalog to avoid transiently removing its controls. A ready catalog atomically replaces
+all retained model, effort, mode, and collaboration-mode groups; explicit empty or unsupported
+groups are authoritative and must not fall back to retained values. Available commands have a
+separate readiness lifecycle and are retained independently while materialization is pending.
 
 On worker boot, every valid persisted intent is restored only as a lightweight suspended index row;
 the worker never starts a provider from disk. The first desktop `attach` hydrates a handle using a

--- a/packages/core/src/runtimes/acp/api/reducer/config-derive.ts
+++ b/packages/core/src/runtimes/acp/api/reducer/config-derive.ts
@@ -51,8 +51,8 @@ function selectOptions(opt: SessionConfigOption): RawOption[] {
  *
  * `configId` preserves the provider-owned ACP config option id, `selected` is taken from
  * `currentValue`, and `available` is the full options list.
- * Returns partial — only groups present in `options` are set; others stay null.
- * The runtime merges this partial into the existing SessionConfigState.
+ * Returns a complete catalog snapshot. Groups absent from `options` are set to null so an
+ * authoritative provider update removes capabilities that are no longer available.
  */
 export function deriveConfigGroups(
   options: ReadonlyArray<SessionConfigOption>

--- a/packages/core/src/runtimes/acp/node/runtime/conversation-handle.test.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/conversation-handle.test.ts
@@ -1,8 +1,9 @@
 import { systemClock } from '@emdash/shared/scheduling';
 import { cell, peek } from '@emdash/wire/state';
 import { describe, expect, it, vi } from 'vitest';
-import { acpErr, initialSessionConfigState } from '#runtimes/acp/api';
+import { acpErr, initialSessionConfigState, type SessionConfigState } from '#runtimes/acp/api';
 import { makeStartInput } from '#runtimes/acp/node/acp-test-support';
+import type { SessionConfigCatalog } from '#runtimes/acp/node/session/cell';
 import {
   closedSessionState,
   type SessionLiveModels,
@@ -74,6 +75,82 @@ describe('ConversationHandle', () => {
       },
       sessionId: 'session-2',
     });
+  });
+
+  it('retains pending capabilities and atomically replaces them when the catalog is ready', () => {
+    const setup = makeHandle();
+    const firstMaterialization = setup.handle.beginMaterialization();
+    if (!firstMaterialization) throw new Error('expected materialization epoch');
+    const firstRecord = makeRecord(setup.handle, firstMaterialization.epoch);
+    const firstCell = firstRecord.cell as unknown as {
+      config: SessionConfigState;
+      configCatalog: SessionConfigCatalog;
+    };
+    firstCell.config = {
+      ...initialSessionConfigState,
+      modelOptions: {
+        configId: 'model',
+        selected: 'opus',
+        available: [
+          { id: 'opus', name: 'Opus' },
+          { id: 'haiku', name: 'Haiku' },
+        ],
+      },
+      efforts: {
+        configId: 'effort',
+        selected: 'medium',
+        available: [{ id: 'medium', name: 'Medium' }],
+      },
+    };
+    firstCell.configCatalog = readyConfigCatalog(firstCell.config);
+    setup.handle.attachProvisional(firstRecord);
+    setup.handle.activate(firstRecord);
+
+    const secondMaterialization = setup.handle.beginMaterialization();
+    if (!secondMaterialization) throw new Error('expected rematerialization epoch');
+    const record = makeRecord(setup.handle, secondMaterialization.epoch);
+    const recordCell = record.cell as unknown as {
+      config: SessionConfigState;
+      configCatalog: SessionConfigCatalog;
+    };
+    setup.handle.attachProvisional(record);
+
+    let source = peek(setup.projection.source);
+    expect(source.kind).toBe('active');
+    if (source.kind !== 'active') throw new Error('expected active projection');
+    expect(source.snapshot.config.modelOptions?.selected).toBe('opus');
+    expect(source.snapshot.config.efforts?.selected).toBe('medium');
+
+    recordCell.config = {
+      ...initialSessionConfigState,
+      modelOptions: {
+        configId: 'model',
+        selected: 'haiku',
+        available: [
+          { id: 'opus', name: 'Opus' },
+          { id: 'haiku', name: 'Haiku' },
+        ],
+      },
+      efforts: null,
+    };
+    recordCell.configCatalog = readyConfigCatalog(recordCell.config);
+    setup.handle.syncRecord(record);
+
+    source = peek(setup.projection.source);
+    expect(source.kind).toBe('active');
+    if (source.kind !== 'active') throw new Error('expected active projection');
+    expect(source.snapshot.config.modelOptions?.selected).toBe('haiku');
+    expect(source.snapshot.config.efforts).toBeNull();
+
+    setup.handle.activate(record);
+    setup.handle.suspend();
+
+    const suspended = peek(setup.projection.source);
+    expect(suspended.kind).toBe('suspended');
+    if (suspended.kind !== 'suspended') throw new Error('expected suspended projection');
+    if (!suspended.retained) throw new Error('expected retained presentation');
+    expect(suspended.retained.lastKnownCapabilities.modelOptions?.selected).toBe('haiku');
+    expect(suspended.retained.lastKnownCapabilities.efforts).toBeNull();
   });
 
   it('persists an allowlisted versioned intent without provider environment secrets', () => {
@@ -228,11 +305,20 @@ function makeRecord(handle: ConversationHandle, epoch: number): SessionRecord {
     cell: {
       sessionState: { ...closedSessionState, lifecycle: 'ready', canSubmit: true },
       config: initialSessionConfigState,
+      configCatalog: { kind: 'pending' },
       usage: null,
       transcript: { title: null, plan: null, agents: [], activeTurn: null },
     } as unknown as SessionRecord['cell'],
     mcpServers: [],
     machineStateBinding: { dispose: () => {} },
     disposed: false,
+  };
+}
+
+function readyConfigCatalog(config: SessionConfigState): SessionConfigCatalog {
+  const { modelOptions, efforts, modeOptions, collaborationModeOptions } = config;
+  return {
+    kind: 'ready',
+    config: { modelOptions, efforts, modeOptions, collaborationModeOptions },
   };
 }

--- a/packages/core/src/runtimes/acp/node/runtime/conversation-handle.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/conversation-handle.ts
@@ -3,6 +3,7 @@ import { ok } from '@emdash/shared';
 import { createLifecycleCell, type LifecycleCell, type Scope } from '@emdash/shared/concurrency';
 import { acpErr } from '#runtimes/acp/api';
 import type { AgentTerminalManager } from '#runtimes/acp/node/agent-ports/terminal-manager';
+import type { SessionConfigCatalog } from '#runtimes/acp/node/session/cell';
 import {
   closedSessionState,
   emptyRetainedPresentation,
@@ -469,6 +470,7 @@ export class ConversationHandle {
     const lastKnownCapabilities = mergeCapabilities(
       this.retainedValue.lastKnownCapabilities,
       record.cell.config,
+      record.cell.configCatalog,
       this.stateValue === 'materializing'
     );
     return {
@@ -497,7 +499,8 @@ export class ConversationHandle {
       configured: this.retainedValue.configured,
       lastKnownCapabilities: mergeCapabilities(
         this.retainedValue.lastKnownCapabilities,
-        record.cell.config
+        record.cell.config,
+        record.cell.configCatalog
       ),
       lastKnownMcpServers: record.mcpServers,
       lastKnownUsage: record.cell.usage ?? this.retainedValue.lastKnownUsage,
@@ -558,14 +561,21 @@ function sameRetainedContent(
 function mergeCapabilities(
   retained: RetainedPresentation['lastKnownCapabilities'],
   current: RetainedPresentation['lastKnownCapabilities'],
+  catalog: SessionConfigCatalog,
   preservePendingCommands = false
 ): RetainedPresentation['lastKnownCapabilities'] {
+  const capabilities =
+    catalog.kind === 'ready'
+      ? catalog.config
+      : {
+          modelOptions: current.modelOptions ?? retained.modelOptions,
+          efforts: current.efforts ?? retained.efforts,
+          modeOptions: current.modeOptions ?? retained.modeOptions,
+          collaborationModeOptions:
+            current.collaborationModeOptions ?? retained.collaborationModeOptions ?? null,
+        };
   return {
-    modelOptions: current.modelOptions ?? retained.modelOptions,
-    efforts: current.efforts ?? retained.efforts,
-    modeOptions: current.modeOptions ?? retained.modeOptions,
-    collaborationModeOptions:
-      current.collaborationModeOptions ?? retained.collaborationModeOptions ?? null,
+    ...capabilities,
     availableCommands:
       preservePendingCommands && current.availableCommands.length === 0
         ? retained.availableCommands

--- a/packages/core/src/runtimes/acp/node/runtime/session-manager.test.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/session-manager.test.ts
@@ -515,6 +515,27 @@ describe('AcpRuntime session manager', () => {
     });
   });
 
+  it('replaces retained capabilities when a loaded session omits config options', async () => {
+    const h = makeAcpHarness({ lifecycle: { connectionIdleTtlMs: 0 } });
+    h.agent.newSession.mockResolvedValueOnce({
+      sessionId: 'session-1',
+      configOptions: [effortConfigOption('medium')],
+    });
+    const rt = new AcpRuntime(h.deps);
+    const input = makeStartInput({ conversationId: 'conv-omitted-config-options' });
+
+    await rt.launchSession(input);
+    const live = rt.sessionLiveModels(input.conversationId);
+    if (!live) throw new Error('expected stable live projection');
+    expect(peek(live.states.config)?.efforts?.selected).toBe('medium');
+
+    await rt.stopSession(input.conversationId);
+    h.agent.loadSession.mockResolvedValueOnce({});
+    await rt.launchSession(input);
+
+    expect(peek(live.states.config)?.efforts).toBeNull();
+  });
+
   it('keeps a newer runtime session id when attach races host-report convergence', async () => {
     const h = makeAcpHarness({ lifecycle: { connectionIdleTtlMs: 0 } });
     h.agent.newSession.mockResolvedValueOnce({ sessionId: 'replacement' });

--- a/packages/core/src/runtimes/acp/node/session/cell.test.ts
+++ b/packages/core/src/runtimes/acp/node/session/cell.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { FakeAcpAgent } from '#runtimes/acp/node/acp-test-support';
 import { SessionCell } from './cell';
 
-function makeCell(agent = new FakeAcpAgent()) {
+function makePendingCell(agent = new FakeAcpAgent()) {
   const cell = new SessionCell({
     conversationId: 'conv-1',
     providerId: 'claude',
@@ -14,8 +14,14 @@ function makeCell(agent = new FakeAcpAgent()) {
     resolveAttachment: vi.fn().mockResolvedValue({ data: '', mimeType: 'image/png' }),
     logger: noopLogger,
   });
-  cell.applySessionReady();
   return { cell, agent };
+}
+
+function makeCell(agent = new FakeAcpAgent()) {
+  const result = makePendingCell(agent);
+  const { cell } = result;
+  cell.applySessionReady();
+  return result;
 }
 
 describe('SessionCell prompts', () => {
@@ -144,11 +150,11 @@ describe('SessionCell permissions', () => {
 
 describe('SessionCell config options', () => {
   it('distinguishes a pending config catalog from an authoritative empty catalog', () => {
-    const { cell } = makeCell();
+    const { cell } = makePendingCell();
 
     expect(cell.configCatalog).toEqual({ kind: 'pending' });
 
-    cell.applySessionMeta({ configOptions: [] });
+    cell.applySessionReady();
 
     expect(cell.configCatalog).toEqual({
       kind: 'ready',

--- a/packages/core/src/runtimes/acp/node/session/cell.test.ts
+++ b/packages/core/src/runtimes/acp/node/session/cell.test.ts
@@ -143,6 +143,24 @@ describe('SessionCell permissions', () => {
 });
 
 describe('SessionCell config options', () => {
+  it('distinguishes a pending config catalog from an authoritative empty catalog', () => {
+    const { cell } = makeCell();
+
+    expect(cell.configCatalog).toEqual({ kind: 'pending' });
+
+    cell.applySessionMeta({ configOptions: [] });
+
+    expect(cell.configCatalog).toEqual({
+      kind: 'ready',
+      config: {
+        modelOptions: null,
+        efforts: null,
+        modeOptions: null,
+        collaborationModeOptions: null,
+      },
+    });
+  });
+
   it('sets mode through the provider config option and seeds the response', async () => {
     const { cell, agent } = makeCell();
     cell.applySessionMeta({

--- a/packages/core/src/runtimes/acp/node/session/cell.ts
+++ b/packages/core/src/runtimes/acp/node/session/cell.ts
@@ -53,12 +53,23 @@ export interface AcpChatHistory {
 
 type ConfigDimension = 'model' | 'effort' | 'collaborationMode';
 
+export type SessionConfigCatalog =
+  | { kind: 'pending' }
+  | {
+      kind: 'ready';
+      config: Pick<
+        SessionConfigState,
+        'modelOptions' | 'efforts' | 'modeOptions' | 'collaborationModeOptions'
+      >;
+    };
+
 export class SessionCell {
   readonly machine: SessionMachine;
   readonly transcript: AcpTranscriptParser;
   readonly rawLog: RawAcpLog;
   private readonly permissions = new PermissionBroker();
   private _acpSessionId: string;
+  private configCatalogState: SessionConfigCatalog['kind'] = 'pending';
   private quiesceTimer: ReturnType<typeof setTimeout> | null = null;
   private lastRunningAgentCount = 0;
   private readonly effectDriver: MachineEffectDriver<Effect>;
@@ -109,6 +120,15 @@ export class SessionCell {
 
   get config(): SessionConfigState {
     return this.transcript.config;
+  }
+
+  get configCatalog(): SessionConfigCatalog {
+    if (this.configCatalogState === 'pending') return { kind: 'pending' };
+    const { modelOptions, efforts, modeOptions, collaborationModeOptions } = this.config;
+    return {
+      kind: 'ready',
+      config: { modelOptions, efforts, modeOptions, collaborationModeOptions },
+    };
   }
 
   get usage(): SessionUsage | null {
@@ -201,6 +221,7 @@ export class SessionCell {
 
     const previousRunningAgentCount = this.lastRunningAgentCount;
     this.transcript.pushEvent(event);
+    if (event.kind === 'config') this.configCatalogState = 'ready';
     this.dispatchAgentsChangedIfNeeded(previousRunningAgentCount);
     if (idleTranscriptEvent) this.scheduleQuiesce();
     this.emitTranscriptChanged();
@@ -552,6 +573,7 @@ export class SessionCell {
         kind: 'config',
         options: meta.configOptions ?? [],
       });
+      this.configCatalogState = 'ready';
     }
     if (meta.modes?.currentModeId) {
       this.transcript.pushEvent({

--- a/packages/core/src/runtimes/acp/node/session/cell.ts
+++ b/packages/core/src/runtimes/acp/node/session/cell.ts
@@ -187,7 +187,7 @@ export class SessionCell {
     configOptions?: readonly SessionConfigOption[] | null;
   }): void {
     this.applyEvent({ type: 'SessionReady' });
-    this.seedTranscriptMeta(meta);
+    this.seedTranscriptMeta(meta, 'complete');
   }
 
   applySessionLoaded(meta?: {
@@ -195,7 +195,7 @@ export class SessionCell {
     configOptions?: readonly SessionConfigOption[] | null;
   }): void {
     this.applyEvent({ type: 'SessionLoaded' });
-    this.seedTranscriptMeta(meta);
+    this.seedTranscriptMeta(meta, 'complete');
   }
 
   applySessionMeta(meta: {
@@ -563,25 +563,33 @@ export class SessionCell {
     }
   }
 
-  private seedTranscriptMeta(meta?: {
-    modes?: SessionModeState | null;
-    configOptions?: readonly SessionConfigOption[] | null;
-  }): void {
-    if (!meta) return;
-    if (meta.configOptions !== undefined) {
+  private seedTranscriptMeta(
+    meta?: {
+      modes?: SessionModeState | null;
+      configOptions?: readonly SessionConfigOption[] | null;
+    },
+    catalogBoundary: 'incremental' | 'complete' = 'incremental'
+  ): void {
+    if (!meta && catalogBoundary === 'incremental') return;
+    const configOptions = meta?.configOptions;
+    const modes = meta?.modes;
+    const completesCatalog =
+      configOptions !== undefined ||
+      (catalogBoundary === 'complete' && this.configCatalogState === 'pending');
+    if (completesCatalog) {
       this.transcript.pushEvent({
         kind: 'config',
-        options: meta.configOptions ?? [],
+        options: configOptions ?? [],
       });
       this.configCatalogState = 'ready';
     }
-    if (meta.modes?.currentModeId) {
+    if (modes?.currentModeId) {
       this.transcript.pushEvent({
         kind: 'mode_selected',
-        modeId: meta.modes.currentModeId,
+        modeId: modes.currentModeId,
       });
     }
-    if (meta.configOptions !== undefined || meta.modes?.currentModeId) {
+    if (completesCatalog || modes?.currentModeId) {
       this.emitTranscriptChanged();
     }
   }


### PR DESCRIPTION
- model provider config catalogs as explicit pending and ready states in SessionCell
- retain previous capabilities only while a replacement catalog is pending
- atomically replace model effort mode and collaboration mode when the provider catalog becomes ready
- keep available command readiness independent from config catalog readiness
- prevent stale effort options from appearing when switching from opus to haiku