### PR TITLE
feat(chat-ui): group adjacent thinking blocks

### DIFF
--- a/packages/chat-ui/src/components/engine/UnitRow.tsx
+++ b/packages/chat-ui/src/components/engine/UnitRow.tsx
@@ -193,7 +193,7 @@ export function UnitRow(props: UnitRowProps) {
   };
 
   let previousExpansionState = untrack(expansionState);
-  let heldExpandedIds = new Set<string>();
+  const heldExpandedIds = new Set<string>();
   const shouldAnimate = (): boolean => {
     const current = expansionState();
     const previous = new Map(previousExpansionState.map(({ id, expanded }) => [id, expanded]));
@@ -201,14 +201,13 @@ export function UnitRow(props: UnitRowProps) {
       ({ id, expanded }) => previous.has(id) && previous.get(id) !== expanded
     );
     if (changed) {
-      // Keep this set intact across follow-up measurement passes during the
-      // same tween. Those passes are not disclosure transitions and must not
-      // unmount collapsing content early.
-      heldExpandedIds = new Set(
-        current
-          .filter(({ id, expanded }) => previous.get(id) === true && !expanded)
-          .map(({ id }) => id)
-      );
+      // Accumulate closing ids while a retargeted row tween is active. An id
+      // reopening mid-flight releases only its own hold.
+      for (const { id, expanded } of current) {
+        const wasExpanded = previous.get(id);
+        if (wasExpanded === true && !expanded) heldExpandedIds.add(id);
+        if (wasExpanded === false && expanded) heldExpandedIds.delete(id);
+      }
     }
     previousExpansionState = current;
     return changed;
@@ -255,6 +254,10 @@ export function UnitRow(props: UnitRowProps) {
   const animatedReserved = () => tweenHandle.height();
   const animating = () => tweenHandle.animating();
 
+  createEffect(() => {
+    if (!animating()) heldExpandedIds.clear();
+  });
+
   // ── Deferred clip release ─────────────────────────────────────────────────
   // When the tween finishes, hold overflow:hidden + the settled height for one
   // rAF before releasing to height:auto / overflow:visible. This prevents a
@@ -284,6 +287,10 @@ export function UnitRow(props: UnitRowProps) {
 
   const rowItemId = () => props.unit.itemId;
   const collapsing = () => animating() && animatedReserved() > logicalReserved();
+  const displayExpandedId = () => {
+    if (collapsing() && heldExpandedIds.has(rowItemId())) return rowItemId();
+    return props.expandedId;
+  };
 
   // Display viewState: override isCollapsed for this row's id while collapsing
   // so def.Render keeps rendering the expanded state.
@@ -308,7 +315,7 @@ export function UnitRow(props: UnitRowProps) {
     measureEpoch: props.measureEpoch,
     // While collapsing a user-message card: hold expandedId so the expanded
     // render is kept alive during the tween.
-    expandedId: collapsing() && heldExpandedIds.has(rowItemId()) ? rowItemId() : props.expandedId,
+    expandedId: displayExpandedId(),
   });
 
   // ── Animated clip ─────────────────────────────────────────────────────────

--- a/packages/chat-ui/src/components/engine/UnitRow.tsx
+++ b/packages/chat-ui/src/components/engine/UnitRow.tsx
@@ -179,18 +179,38 @@ export function UnitRow(props: UnitRowProps) {
   // change `logicalReserved` too, but must SNAP — otherwise the reserved height
   // animates during initial layout and the scrollbar jumps.
   //
-  // We detect a real toggle by comparing the row's expand signature to the value
-  // captured at the previous target change. `shouldAnimate` is invoked untracked
-  // exactly once per target change so lastExpandSig stays in lockstep.
+  // We detect a real toggle by comparing every disclosure id declared by the
+  // unit to the state captured at the previous target change. `shouldAnimate`
+  // is invoked untracked exactly once per target change so the snapshot stays
+  // in lockstep. Composite units can declare nested ids through collapseIds.
   // Inverted semantics throughout: `isCollapsed(id) === true` means "expanded".
-  const rowExpanded = (): boolean =>
-    props.viewState.isCollapsed(props.unit.itemId) || props.expandedId === props.unit.itemId;
+  const expansionState = (): Array<{ id: string; expanded: boolean }> => {
+    const ids = def()?.collapseIds?.(props.unit.data) ?? [props.unit.itemId];
+    return ids.map((id) => ({
+      id,
+      expanded: props.viewState.isCollapsed(id) || props.expandedId === id,
+    }));
+  };
 
-  let lastExpandSig = untrack(rowExpanded);
+  let previousExpansionState = untrack(expansionState);
+  let heldExpandedIds = new Set<string>();
   const shouldAnimate = (): boolean => {
-    const cur = rowExpanded();
-    const changed = cur !== lastExpandSig;
-    lastExpandSig = cur;
+    const current = expansionState();
+    const previous = new Map(previousExpansionState.map(({ id, expanded }) => [id, expanded]));
+    const changed = current.some(
+      ({ id, expanded }) => previous.has(id) && previous.get(id) !== expanded
+    );
+    if (changed) {
+      // Keep this set intact across follow-up measurement passes during the
+      // same tween. Those passes are not disclosure transitions and must not
+      // unmount collapsing content early.
+      heldExpandedIds = new Set(
+        current
+          .filter(({ id, expanded }) => previous.get(id) === true && !expanded)
+          .map(({ id }) => id)
+      );
+    }
+    previousExpansionState = current;
     return changed;
   };
 
@@ -269,7 +289,7 @@ export function UnitRow(props: UnitRowProps) {
   // so def.Render keeps rendering the expanded state.
   const displayViewState = {
     isCollapsed: (id: string): boolean => {
-      if (collapsing() && id === rowItemId()) {
+      if (collapsing() && heldExpandedIds.has(id)) {
         // Inverted semantics in use throughout: "collapsed" flag = "expanded"
         // So returning true = "expanded" = keep the expanded content mounted.
         return true;
@@ -288,7 +308,7 @@ export function UnitRow(props: UnitRowProps) {
     measureEpoch: props.measureEpoch,
     // While collapsing a user-message card: hold expandedId so the expanded
     // render is kept alive during the tween.
-    expandedId: collapsing() ? rowItemId() : props.expandedId,
+    expandedId: collapsing() && heldExpandedIds.has(rowItemId()) ? rowItemId() : props.expandedId,
   });
 
   // ── Animated clip ─────────────────────────────────────────────────────────

--- a/packages/chat-ui/src/components/engine/unit-registry.ts
+++ b/packages/chat-ui/src/components/engine/unit-registry.ts
@@ -18,6 +18,7 @@
 import { messageFromItem, messageUnitDef } from '@components/rows/message/message.def';
 import { planFromItem, planUnitDef } from '@components/rows/plan/plan.def';
 import { resourceLinkUnitDef } from '@components/rows/resource-link/resource-link.def';
+import { thinkingGroupUnitDef } from '@components/rows/thinking/thinking-group.def';
 import { thinkingUnitDef } from '@components/rows/thinking/thinking.def';
 import {
   createFileDiffFromItem,
@@ -49,6 +50,7 @@ import type {
   ChatSubagentToolCall,
   ChatToolCall,
   SyntheticItem,
+  ThinkingGroupItem,
   ToolNode,
 } from '@/model';
 import { ROW_INSET_X } from './row-metrics';
@@ -180,6 +182,11 @@ function toolNodeSegment(kind: ToolNode['kind']): ItemSegmenter {
 export const SEGMENTERS: Record<string, ItemSegmenter> = {
   message: messageSegmenter,
   thinking: nativePassthrough<ChatItem>('thinking', (item) => item, COMPOSITE_CHROME),
+  'thinking-group': nativePassthrough<ThinkingGroupItem>(
+    'thinking-group',
+    (item) => item,
+    COMPOSITE_CHROME
+  ),
   tool: nativePassthrough<ChatItem>('tool', (item) => item, COMPOSITE_CHROME),
   'file-op': nativePassthrough<ChatItem>('file-op', (item) => item, COMPOSITE_CHROME),
   execute: nativePassthrough<ChatItem>('execute', (item) => item, COMPOSITE_CHROME),
@@ -222,6 +229,7 @@ export const UNIT_REGISTRY: Record<string, RegistryUnitDef> = {
   diff: diffUnitDef as unknown as RegistryUnitDef,
   plan: planUnitDef as unknown as RegistryUnitDef,
   thinking: thinkingUnitDef as unknown as RegistryUnitDef,
+  'thinking-group': thinkingGroupUnitDef as unknown as RegistryUnitDef,
   'file-op': fileOpUnitDef as unknown as RegistryUnitDef,
   subagent: subagentUnitDef as unknown as RegistryUnitDef,
   tool: toolUnitDef as unknown as RegistryUnitDef,

--- a/packages/chat-ui/src/components/rows/thinking/thinking-group.def.tsx
+++ b/packages/chat-ui/src/components/rows/thinking/thinking-group.def.tsx
@@ -1,0 +1,165 @@
+import { useTheme } from '@components/contexts/ThemeContext';
+import { HEADER_ROW_EXTRA_H } from '@components/engine/row-metrics';
+import { CollapseHeader } from '@components/primitives/CollapseHeader';
+import type { MeasureCtx, RenderCtx } from '@core/define';
+import { defineUnit } from '@core/units';
+import { pxTokens } from '@styles/px-tokens';
+import { assignInlineVars } from '@vanilla-extract/dynamic';
+import { For, Show, createEffect, createMemo, createSignal, onCleanup } from 'solid-js';
+import type { ChatThinking, ThinkingGroupItem } from '@/model';
+import {
+  THINKING_VARS,
+  ThinkingUnitRender,
+  thinkingMeasure,
+  thinkingUnitDef,
+} from './thinking.def';
+import { thinkingCardVars, thinkingGroupChild, thinkingRoot } from './thinking.css';
+import { sx } from '@styles/sprinkles.css';
+
+type ThinkingGroupVars = {
+  childGap: number;
+};
+
+const THINKING_GROUP_VARS: ThinkingGroupVars = {
+  childGap: 6,
+};
+
+function headerH(ctx: MeasureCtx): number {
+  return ctx.theme.fonts.body.lineHeight + HEADER_ROW_EXTRA_H;
+}
+
+function activeStep(item: ThinkingGroupItem): ChatThinking | undefined {
+  for (let i = item.steps.length - 1; i >= 0; i -= 1) {
+    if (item.steps[i].status === 'thinking') return item.steps[i];
+  }
+  return undefined;
+}
+
+function groupDurationMs(item: ThinkingGroupItem, now: number): number | undefined {
+  let total = 0;
+  for (const step of item.steps) {
+    if (step.status === 'thinking') {
+      total += Math.max(0, now - step.startedAt);
+      continue;
+    }
+    if (step.durationMs === undefined) return undefined;
+    total += step.durationMs;
+  }
+  return total;
+}
+
+function formatDuration(durationMs: number): string {
+  if (durationMs < 1000) return '<1s';
+  return `${Math.floor(durationMs / 1000)}s`;
+}
+
+function ThinkingGroupHeader(props: {
+  item: ThinkingGroupItem;
+  expanded: boolean;
+  height: number;
+}) {
+  const [now, setNow] = createSignal(Date.now());
+  let timer: ReturnType<typeof setInterval> | undefined;
+
+  createEffect(() => {
+    clearInterval(timer);
+    timer = undefined;
+    if (!activeStep(props.item)) return;
+
+    setNow(Date.now());
+    timer = setInterval(() => setNow(Date.now()), 1000);
+    onCleanup(() => clearInterval(timer));
+  });
+
+  const label = () => {
+    const active = activeStep(props.item);
+    const duration = groupDurationMs(props.item, now());
+    if (active) {
+      return `Reasoning · step ${props.item.steps.length}${duration === undefined ? '' : ` · ${formatDuration(duration)}`}`;
+    }
+    return `Reasoned in ${props.item.steps.length} steps${duration === undefined ? '' : ` · ${formatDuration(duration)}`}`;
+  };
+
+  return (
+    <CollapseHeader
+      id={props.item.id}
+      expanded={props.expanded}
+      active={activeStep(props.item) !== undefined}
+      height={props.height}
+    >
+      {label()}
+    </CollapseHeader>
+  );
+}
+
+function childrenH(item: ThinkingGroupItem, ctx: MeasureCtx, vars: ThinkingGroupVars): number {
+  return item.steps.reduce(
+    (height, step) => height + vars.childGap + thinkingMeasure(step, ctx, THINKING_VARS),
+    0
+  );
+}
+
+function thinkingGroupH(item: ThinkingGroupItem, ctx: MeasureCtx, vars: ThinkingGroupVars): number {
+  const height = headerH(ctx);
+  return ctx.expanded(item.id) ? height + childrenH(item, ctx, vars) : height;
+}
+
+function ThinkingGroupRender(props: {
+  data: ThinkingGroupItem;
+  ctx: RenderCtx;
+  vars: ThinkingGroupVars;
+}) {
+  const theme = useTheme();
+  const mCtx = () => props.ctx.measureCtx?.();
+  const isExpanded = () => props.ctx.viewState.isCollapsed(props.data.id);
+  const hH = () => theme().fonts.body.lineHeight + HEADER_ROW_EXTRA_H;
+
+  const totalH = createMemo(() => {
+    const ctx = mCtx();
+    if (!ctx) return hH();
+    return thinkingGroupH(props.data, ctx, props.vars);
+  });
+
+  return (
+    <div
+      class={`${sx({ color: 'fgPassive' })} ${thinkingRoot}`}
+      style={assignInlineVars(thinkingCardVars, pxTokens({ height: totalH() }))}
+    >
+      <ThinkingGroupHeader item={props.data} expanded={isExpanded()} height={hH()} />
+      <Show when={isExpanded()}>
+        <For each={props.data.steps}>
+          {(step) => (
+            <div class={thinkingGroupChild}>
+              <ThinkingUnitRender data={step} ctx={props.ctx} vars={THINKING_VARS} />
+            </div>
+          )}
+        </For>
+      </Show>
+    </div>
+  );
+}
+
+export const thinkingGroupUnitDef = defineUnit<ThinkingGroupItem, ThinkingGroupVars>({
+  kind: 'thinking-group',
+  margin: { top: 6, bottom: 6 },
+  vars: THINKING_GROUP_VARS,
+
+  estimate(item, ctx, vars): number {
+    const height = headerH(ctx);
+    if (!ctx.expanded(item.id)) return height;
+
+    const estimateStep = thinkingUnitDef.estimate;
+    return item.steps.reduce(
+      (total, step) =>
+        total +
+        vars.childGap +
+        (estimateStep
+          ? estimateStep(step, ctx, THINKING_VARS)
+          : thinkingMeasure(step, ctx, THINKING_VARS)),
+      height
+    );
+  },
+
+  measure: thinkingGroupH,
+  Render: ThinkingGroupRender,
+});

--- a/packages/chat-ui/src/components/rows/thinking/thinking-group.def.tsx
+++ b/packages/chat-ui/src/components/rows/thinking/thinking-group.def.tsx
@@ -14,7 +14,6 @@ import {
   thinkingUnitDef,
 } from './thinking.def';
 import { thinkingCardVars, thinkingGroupChild, thinkingRoot } from './thinking.css';
-import { sx } from '@styles/sprinkles.css';
 
 type ThinkingGroupVars = {
   childGap: number;
@@ -122,7 +121,7 @@ function ThinkingGroupRender(props: {
 
   return (
     <div
-      class={`${sx({ color: 'fgPassive' })} ${thinkingRoot}`}
+      class={thinkingRoot}
       style={assignInlineVars(thinkingCardVars, pxTokens({ height: totalH() }))}
     >
       <ThinkingGroupHeader item={props.data} expanded={isExpanded()} height={hH()} />
@@ -143,6 +142,7 @@ export const thinkingGroupUnitDef = defineUnit<ThinkingGroupItem, ThinkingGroupV
   kind: 'thinking-group',
   margin: { top: 6, bottom: 6 },
   vars: THINKING_GROUP_VARS,
+  collapseIds: (item) => [item.id, ...item.steps.map((step) => step.id)],
 
   estimate(item, ctx, vars): number {
     const height = headerH(ctx);

--- a/packages/chat-ui/src/components/rows/thinking/thinking-group.def.tsx
+++ b/packages/chat-ui/src/components/rows/thinking/thinking-group.def.tsx
@@ -73,10 +73,11 @@ function ThinkingGroupHeader(props: {
   const label = () => {
     const active = activeStep(props.item);
     const duration = groupDurationMs(props.item, now());
+    const durationLabel = duration === undefined ? '' : ` · ${formatDuration(duration)}`;
     if (active) {
-      return `Reasoning · step ${props.item.steps.length}${duration === undefined ? '' : ` · ${formatDuration(duration)}`}`;
+      return `Reasoning · step ${props.item.steps.length}${durationLabel}`;
     }
-    return `Reasoned in ${props.item.steps.length} steps${duration === undefined ? '' : ` · ${formatDuration(duration)}`}`;
+    return `Reasoned in ${props.item.steps.length} steps${durationLabel}`;
   };
 
   return (

--- a/packages/chat-ui/src/components/rows/thinking/thinking.css.ts
+++ b/packages/chat-ui/src/components/rows/thinking/thinking.css.ts
@@ -15,3 +15,5 @@ export const thinkingCardVars = createVariableThemeContract<ThinkingStyleVars>({
 // (e.g. during a mid-tween frame or a stale virtualizer size) degrades to
 // clipped content rather than spilling over the following row.
 export const thinkingRoot = style({ height: thinkingCardVars.height, overflow: 'hidden' });
+
+export const thinkingGroupChild = style({ marginTop: '6px' });

--- a/packages/chat-ui/src/components/rows/thinking/thinking.def.tsx
+++ b/packages/chat-ui/src/components/rows/thinking/thinking.def.tsx
@@ -22,7 +22,7 @@ export type ThinkingVars = {
   windowH: number;
 };
 
-const THINKING_VARS: ThinkingVars = {
+export const THINKING_VARS: ThinkingVars = {
   padY: 8,
   windowH: 72,
 };
@@ -82,7 +82,7 @@ function ThinkingHeader(props: { item: ChatThinking; expanded: boolean; headerH:
   );
 }
 
-function thinkingMeasure(item: ChatThinking, ctx: MeasureCtx, vars: ThinkingVars): number {
+export function thinkingMeasure(item: ChatThinking, ctx: MeasureCtx, vars: ThinkingVars): number {
   const headerH = thinkingHeaderH(ctx);
   const isExpanded = ctx.expanded(item.id);
 
@@ -95,7 +95,11 @@ function thinkingMeasure(item: ChatThinking, ctx: MeasureCtx, vars: ThinkingVars
   return headerH + body.height;
 }
 
-function ThinkingUnitRender(props: { data: ChatThinking; ctx: RenderCtx; vars: ThinkingVars }) {
+export function ThinkingUnitRender(props: {
+  data: ChatThinking;
+  ctx: RenderCtx;
+  vars: ThinkingVars;
+}) {
   const theme = useTheme();
   const mCtx = () => props.ctx.measureCtx?.();
   // Inverted semantics: stored "collapsed" bool = "expanded".

--- a/packages/chat-ui/src/core/units.ts
+++ b/packages/chat-ui/src/core/units.ts
@@ -138,6 +138,8 @@ export type SegmentCtx = {
  *              resolve to 8px via the user message's margin (top: 8, bottom: 8).
  * `estimate` — O(1) height heuristic for off-screen units at setCount/prepend.
  *              Falls back to `genericEstimate` when omitted.
+ * `collapseIds` — ids whose disclosure state changes this unit's height. Omit
+ *                 when the unit only responds to its own item id.
  * `measure`  — exact height (px); called only for visible units.
  *              Returns a number — no Measured<L> tree.
  * `Render`   — Solid component; receives `data` (the unit payload), `ctx`,
@@ -147,6 +149,7 @@ export type UnitDef<D, V extends Record<string, number> = {}> = {
   kind: string;
   vars?: V;
   margin?: Margin;
+  collapseIds?(data: D): readonly string[];
   estimate?(data: D, ctx: MeasureCtx, vars: V): number;
   measure(data: D, ctx: MeasureCtx, vars: V): number;
   Render: Component<{ data: D; ctx: RenderCtx; vars: V }>;

--- a/packages/chat-ui/src/model.ts
+++ b/packages/chat-ui/src/model.ts
@@ -107,6 +107,20 @@ export type ChatThinking = {
   durationMs?: number;
 };
 
+/**
+ * Presentation-only group for two or more adjacent reasoning segments.
+ *
+ * The source transcript keeps each segment as an independent `ChatThinking`
+ * item. The flattening pass wraps adjacent siblings so the renderer can offer
+ * one disclosure control without losing protocol ordering or segment data.
+ */
+export type ThinkingGroupItem = {
+  kind: 'thinking-group';
+  /** Synthetic parent id; child thinking rows retain their own disclosure ids. */
+  id: string;
+  steps: readonly ChatThinking[];
+};
+
 /** ACP tool-call categories that represent file operations. */
 export type FileOpKind = 'read' | 'edit' | 'delete' | 'move';
 
@@ -311,7 +325,7 @@ export type TurnOutcomeItem = {
   outcome: TranscriptTurnOutcome;
 };
 
-export type SyntheticItem = WorkingItem | TurnOutcomeItem;
+export type SyntheticItem = ThinkingGroupItem | WorkingItem | TurnOutcomeItem;
 
 export type ChatItem =
   | TranscriptItem

--- a/packages/chat-ui/src/state/flatten.test.ts
+++ b/packages/chat-ui/src/state/flatten.test.ts
@@ -1,14 +1,20 @@
 import { unit } from '@core/units';
 import type { ItemSegmenter, SegmentCtx, SegmentItem, UnitDef } from '@core/units';
 import { describe, expect, it } from 'vitest';
-import type { ChatItem, ChatMessage, TranscriptTurn } from '@/model';
+import type {
+  ChatItem,
+  ChatMessage,
+  ChatThinking,
+  ThinkingGroupItem,
+  TranscriptTurn,
+} from '@/model';
 import { applyTurnEvent } from '@/stories/_harness/turn-reducer';
 import { collectUserTurnUnits, flattenTier, makeUnitsView } from './flatten';
 import { createTranscript } from './transcript';
 
 const MSG_MARGIN_TOP = 8;
 
-function passthrough(kind: ChatItem['kind']): ItemSegmenter {
+function passthrough(kind: SegmentItem['kind']): ItemSegmenter {
   return {
     kind,
     segment: (item: SegmentItem) => [unit(item.kind, item, item, { key: 'self' })],
@@ -19,6 +25,7 @@ const STUB_SEGMENTERS: Record<string, ItemSegmenter> = {
   message: passthrough('message'),
   tool: passthrough('tool'),
   thinking: passthrough('thinking'),
+  'thinking-group': passthrough('thinking-group'),
   'file-op': passthrough('file-op'),
   execute: passthrough('execute'),
   diff: passthrough('diff'),
@@ -32,6 +39,18 @@ function userMsg(id: string, seq = 0, text = 'hello'): ChatMessage {
 
 function tool(id: string, seq = 0): ChatItem {
   return { kind: 'tool', id, seq, name: 'bash', status: 'done' } as ChatItem;
+}
+
+function thinking(id: string, seq = 0, status: 'thinking' | 'done' = 'done'): ChatThinking {
+  return {
+    kind: 'thinking',
+    id,
+    seq,
+    status,
+    text: `Reasoning ${id}`,
+    startedAt: 0,
+    ...(status === 'done' ? { durationMs: 1000 } : {}),
+  };
 }
 
 function turn(id: string, seq: number, ...items: ChatItem[]): TranscriptTurn {
@@ -60,6 +79,7 @@ const STUB_UNIT_DEFS: StubUnitDefs = {
   message: { margin: { top: 8, bottom: 8 } },
   tool: { margin: { top: 2, bottom: 2 } },
   thinking: { margin: { top: 6, bottom: 6 } },
+  'thinking-group': { margin: { top: 6, bottom: 6 } },
   'file-op': { margin: { top: 2, bottom: 2 } },
   execute: { margin: { top: 2, bottom: 2 } },
   diff: { margin: { top: 2, bottom: 6 } },
@@ -128,6 +148,67 @@ describe('flatten — basic', () => {
     tx.history.seed([turn('t1', 0, item)]);
     const view = flattenAll(tx);
     expect(view.at(0)?.data).toBe(tx.state.committedTurns[0].items[0]);
+  });
+});
+
+describe('flatten — adjacent thinking groups', () => {
+  it('wraps two or more adjacent thinking items in one presentation group', () => {
+    const tx = createTranscript();
+    tx.history.seed([turn('t1', 0, userMsg('u', 0), thinking('th-1', 1), thinking('th-2', 2))]);
+
+    const view = flattenAll(tx);
+    expect(view.length).toBe(2);
+    expect(view.at(1)).toMatchObject({
+      kind: 'thinking-group',
+      itemId: 'th-1:thinking-group',
+      id: 'th-1:thinking-group#self',
+    });
+    const group = view.at(1)?.data as ThinkingGroupItem | undefined;
+    expect(group?.steps.map((step) => step.id)).toEqual(['th-1', 'th-2']);
+  });
+
+  it('keeps one thinking item as the existing thinking row', () => {
+    const tx = createTranscript();
+    tx.history.seed([turn('t1', 0, thinking('th-1'))]);
+
+    expect(flattenAll(tx).at(0)).toMatchObject({
+      kind: 'thinking',
+      itemId: 'th-1',
+      id: 'th-1#self',
+    });
+  });
+
+  it('does not group thinking across another visible item or a turn boundary', () => {
+    const tx = createTranscript();
+    tx.history.seed([
+      turn('t1', 0, thinking('th-1', 0), tool('tool-1', 1), thinking('th-2', 2)),
+      turn('t2', 1, thinking('th-3', 0)),
+    ]);
+
+    const view = flattenAll(tx);
+    expect(Array.from({ length: view.length }, (_, i) => view.at(i)?.kind)).toEqual([
+      'thinking',
+      'tool',
+      'thinking',
+      'thinking',
+    ]);
+  });
+
+  it('keeps the group id stable while more adjacent steps arrive', () => {
+    const first = flattenTier(
+      [turn('t1', 0, thinking('th-1', 0), thinking('th-2', 1, 'thinking'))],
+      { ...segCtx, active: true },
+      STUB_SEGMENTERS
+    );
+    const grown = flattenTier(
+      [turn('t1', 0, thinking('th-1', 0), thinking('th-2', 1), thinking('th-3', 2, 'thinking'))],
+      { ...segCtx, active: true },
+      STUB_SEGMENTERS
+    );
+
+    expect(first[0].id).toBe('th-1:thinking-group#self');
+    expect(grown[0].id).toBe(first[0].id);
+    expect((grown[0].data as ThinkingGroupItem).steps).toHaveLength(3);
   });
 });
 

--- a/packages/chat-ui/src/state/flatten.ts
+++ b/packages/chat-ui/src/state/flatten.ts
@@ -41,7 +41,14 @@
 import { resolveSeamGap } from '@core/spacing';
 import type { ItemSegmenter, Margin, RenderUnit, SegmentCtx } from '@core/units';
 import { stampGroupRoles } from '@core/units';
-import type { ChatItem, ChatMessage, SyntheticItem, TranscriptTurn } from '@/model';
+import type {
+  ChatItem,
+  ChatMessage,
+  ChatThinking,
+  SyntheticItem,
+  ThinkingGroupItem,
+  TranscriptTurn,
+} from '@/model';
 import type { ToolHeaderState } from './tool-header-state';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -49,6 +56,14 @@ import type { ToolHeaderState } from './tool-header-state';
 /** Returns true when the item is a user-role message (boundary seam sentinel). */
 function itemIsUser(item: ChatItem): boolean {
   return item.kind === 'message' && (item as ChatMessage).role === 'user';
+}
+
+function thinkingGroup(steps: readonly ChatThinking[]): ThinkingGroupItem {
+  return {
+    kind: 'thinking-group',
+    id: `${steps[0].id}:thinking-group`,
+    steps,
+  };
 }
 
 // ── ItemNode ──────────────────────────────────────────────────────────────────
@@ -115,8 +130,19 @@ export function flattenTier(
 
   for (const turn of turns) {
     const items = turn.items as readonly ChatItem[];
-    for (const item of items) {
-      processItem(item);
+    for (let i = 0; i < items.length; ) {
+      const item = items[i];
+      if (item.kind !== 'thinking') {
+        processItem(item);
+        i += 1;
+        continue;
+      }
+
+      let end = i + 1;
+      while (end < items.length && items[end].kind === 'thinking') end += 1;
+      const steps = items.slice(i, end) as ChatThinking[];
+      processItem(steps.length === 1 ? item : thinkingGroup(steps));
+      i = end;
     }
 
     if (ctx.active && shouldShowWorking(items)) {

--- a/packages/chat-ui/src/stories/rows/messages/agent/thinking.stories.tsx
+++ b/packages/chat-ui/src/stories/rows/messages/agent/thinking.stories.tsx
@@ -129,6 +129,98 @@ export const DoneCollapsed: Story = {
   ),
 };
 
+export const GroupedCollapsed: Story = {
+  render: () => (
+    <ChatHost
+      items={[
+        {
+          kind: 'thinking',
+          id: 'th-group-1',
+          status: 'done',
+          text: 'First I traced the provider updates into the transcript reducer.',
+          startedAt: Date.now() - 41000,
+          durationMs: 9000,
+        },
+        {
+          kind: 'thinking',
+          id: 'th-group-2',
+          status: 'done',
+          text: 'Then I checked how synthesized segment IDs close around tool updates.',
+          startedAt: Date.now() - 30000,
+          durationMs: 10000,
+        },
+        {
+          kind: 'thinking',
+          id: 'th-group-3',
+          status: 'done',
+          text: 'Finally I chose a presentation-only group so the source transcript stays exact.',
+          startedAt: Date.now() - 18000,
+          durationMs: 18000,
+        },
+      ]}
+      height={100}
+    />
+  ),
+};
+
+export const GroupedExpanded: Story = {
+  render: () => {
+    const items: ChatItem[] = [
+      {
+        kind: 'thinking',
+        id: 'th-group-expanded-1',
+        status: 'done',
+        text: 'First I traced the **provider updates** into the transcript reducer.',
+        startedAt: Date.now() - 26000,
+        durationMs: 8000,
+      },
+      {
+        kind: 'thinking',
+        id: 'th-group-expanded-2',
+        status: 'done',
+        text: 'Then I verified that each reasoning segment retains its own stable ID and text.',
+        startedAt: Date.now() - 16000,
+        durationMs: 7000,
+      },
+      {
+        kind: 'thinking',
+        id: 'th-group-expanded-3',
+        status: 'done',
+        text: 'The renderer can now expose one disclosure control without flattening those semantics.',
+        startedAt: Date.now() - 7000,
+        durationMs: 7000,
+      },
+    ];
+    const script: ScriptStep[] = [
+      {
+        kind: 'call',
+        fn: (api: TranscriptApi) => {
+          api.history.seed([
+            {
+              id: 'thinking-group-turn',
+              seq: 0,
+              initiator: 'agent',
+              items: items as TranscriptTurn['items'],
+              outcome: { kind: 'done' },
+            },
+          ]);
+        },
+      },
+      { kind: 'wait', ms: 100 },
+      {
+        kind: 'call',
+        fn: () => {
+          const btn = document.querySelector(
+            '[data-collapse-id="th-group-expanded-1:thinking-group"]'
+          ) as HTMLElement;
+          btn?.click();
+        },
+      },
+    ];
+    return <ScriptedChat script={script} height={360} />;
+  },
+};
+
 export const DoneExpanded: Story = {
   render: () => {
     const script: ScriptStep[] = [

--- a/packages/chat-ui/src/thinking-group.contract.test.tsx
+++ b/packages/chat-ui/src/thinking-group.contract.test.tsx
@@ -118,6 +118,35 @@ describe('thinking group contract', () => {
     expect(host.textContent).toContain('First I inspected the transcript reducer');
   });
 
+  it('animates an individual child disclosure through the enclosing unit row', async () => {
+    const { header, host } = await mountThinkingGroup();
+    const clip = header.parentElement?.parentElement as HTMLElement | undefined;
+    header.click();
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    await nextPaint();
+    expect(clip?.style.height).toBe('auto');
+
+    host.querySelector<HTMLElement>('[data-collapse-id="thinking-1"]')?.click();
+    await nextPaint();
+
+    expect(clip?.style.overflow).toBe('hidden');
+    expect(clip?.style.height).not.toBe('auto');
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    await nextPaint();
+    expect(clip?.style.height).toBe('auto');
+
+    host.querySelector<HTMLElement>('[data-collapse-id="thinking-1"]')?.click();
+    await nextPaint();
+    expect(clip?.style.overflow).toBe('hidden');
+    expect(host.textContent).toContain('First I inspected the transcript reducer');
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    await nextPaint();
+    expect(clip?.style.height).toBe('auto');
+    expect(host.textContent).not.toContain('First I inspected the transcript reducer');
+  });
+
   it('shows the active step preview only after revealing the child rows', async () => {
     const { header, host } = await mountThinkingGroup('thinking');
 

--- a/packages/chat-ui/src/thinking-group.contract.test.tsx
+++ b/packages/chat-ui/src/thinking-group.contract.test.tsx
@@ -147,6 +147,32 @@ describe('thinking group contract', () => {
     expect(host.textContent).not.toContain('First I inspected the transcript reducer');
   });
 
+  it('keeps overlapping collapsing child bodies mounted until the retargeted tween settles', async () => {
+    const { header, host } = await mountThinkingGroup();
+    header.click();
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    await nextPaint();
+
+    host.querySelector<HTMLElement>('[data-collapse-id="thinking-1"]')?.click();
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    host.querySelector<HTMLElement>('[data-collapse-id="thinking-2"]')?.click();
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    await nextPaint();
+
+    host.querySelector<HTMLElement>('[data-collapse-id="thinking-1"]')?.click();
+    await nextPaint();
+    host.querySelector<HTMLElement>('[data-collapse-id="thinking-2"]')?.click();
+    await nextPaint();
+
+    expect(host.textContent).toContain('First I inspected the transcript reducer');
+    expect(host.textContent).toContain('Then I checked the renderer');
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    await nextPaint();
+    expect(host.textContent).not.toContain('First I inspected the transcript reducer');
+    expect(host.textContent).not.toContain('Then I checked the renderer');
+  });
+
   it('shows the active step preview only after revealing the child rows', async () => {
     const { header, host } = await mountThinkingGroup('thinking');
 

--- a/packages/chat-ui/src/thinking-group.contract.test.tsx
+++ b/packages/chat-ui/src/thinking-group.contract.test.tsx
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createChatContext } from '@/chat-context';
+import { createChatView } from '@/chat-view';
+import type { ChatThinking, TranscriptTurn } from '@/model';
+import { createChatState } from '@/state/chat-state';
+
+const nextPaint = (): Promise<void> =>
+  new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups.splice(0)) cleanup();
+});
+
+function steps(status: 'thinking' | 'done' = 'done'): ChatThinking[] {
+  const now = Date.now();
+  return [
+    {
+      kind: 'thinking',
+      id: 'thinking-1',
+      seq: 0,
+      status: 'done',
+      text: 'First I inspected the transcript reducer and identified the segment boundary.',
+      startedAt: now - 9000,
+      durationMs: 9000,
+    },
+    {
+      kind: 'thinking',
+      id: 'thinking-2',
+      seq: 1,
+      status,
+      text: 'Then I checked the renderer and chose a presentation-only grouping boundary.',
+      startedAt: now - 7000,
+      ...(status === 'done' ? { durationMs: 7000 } : {}),
+    },
+  ];
+}
+
+async function mountThinkingGroup(status: 'thinking' | 'done' = 'done') {
+  const context = createChatContext();
+  const state = createChatState(context);
+  const turn: TranscriptTurn = {
+    id: 'turn-1',
+    seq: 0,
+    initiator: 'agent',
+    items: steps(status) as TranscriptTurn['items'],
+  };
+  state.transcript.history.seed([turn]);
+
+  const host = document.createElement('div');
+  host.style.cssText = 'position:fixed;top:0;left:0;width:800px;height:400px;';
+  document.body.appendChild(host);
+  const view = createChatView({ context, state, parent: host });
+
+  cleanups.push(() => {
+    view.dispose();
+    state.dispose();
+    context.dispose();
+    host.remove();
+  });
+
+  await nextPaint();
+  const header = host.querySelector<HTMLElement>('[data-collapse-id="thinking-1:thinking-group"]');
+  if (!header) throw new Error('Thinking group header did not render');
+  return { header, host };
+}
+
+describe('thinking group contract', () => {
+  it('renders one collapsed summary with summed duration', async () => {
+    const { header, host } = await mountThinkingGroup();
+
+    expect(header.textContent).toContain('Reasoned in 2 steps · 16s');
+    expect(header.getAttribute('aria-expanded')).toBe('false');
+    expect(host.querySelector('[data-collapse-id="thinking-1"]')).toBeNull();
+  });
+
+  it('reveals collapsed thinking rows that expand independently', async () => {
+    const { header, host } = await mountThinkingGroup();
+    header.click();
+    await nextPaint();
+
+    const firstStep = host.querySelector<HTMLElement>('[data-collapse-id="thinking-1"]');
+    const secondStep = host.querySelector<HTMLElement>('[data-collapse-id="thinking-2"]');
+    expect(firstStep?.getAttribute('aria-expanded')).toBe('false');
+    expect(secondStep?.getAttribute('aria-expanded')).toBe('false');
+    expect(host.textContent).not.toContain('First I inspected the transcript reducer');
+
+    firstStep?.click();
+    await nextPaint();
+
+    expect(firstStep?.getAttribute('aria-expanded')).toBe('true');
+    expect(secondStep?.getAttribute('aria-expanded')).toBe('false');
+    expect(host.textContent).toContain('First I inspected the transcript reducer');
+    expect(host.textContent).not.toContain('Then I checked the renderer');
+  });
+
+  it('preserves a child expansion when the parent is closed and reopened', async () => {
+    const { header, host } = await mountThinkingGroup();
+    header.click();
+    await nextPaint();
+
+    host.querySelector<HTMLElement>('[data-collapse-id="thinking-1"]')?.click();
+    await nextPaint();
+    header.click();
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    await nextPaint();
+    expect(header.getAttribute('aria-expanded')).toBe('false');
+    expect(host.querySelector('[data-collapse-id="thinking-1"]')).toBeNull();
+
+    header.click();
+    await nextPaint();
+    expect(
+      host
+        .querySelector<HTMLElement>('[data-collapse-id="thinking-1"]')
+        ?.getAttribute('aria-expanded')
+    ).toBe('true');
+    expect(host.textContent).toContain('First I inspected the transcript reducer');
+  });
+
+  it('shows the active step preview only after revealing the child rows', async () => {
+    const { header, host } = await mountThinkingGroup('thinking');
+
+    expect(header.textContent).toContain('Reasoning · step 2');
+    expect(host.textContent).not.toContain('presentation-only grouping boundary');
+
+    header.click();
+    await nextPaint();
+    expect(host.textContent).toContain('presentation-only grouping boundary');
+  });
+});


### PR DESCRIPTION
- groups consecutive thinking blocks behind one collapsible reasoning summary
- shows the combined step count and reasoning duration
- reuses ThinkingUnitRender for independently expandable child steps
- keeps single thinking blocks unchanged and respects visible transcript boundaries
- preserves child expansion state when the parent group closes and reopens