### PR TITLE
fix(pty): preserve xdg directories for agents

### DIFF
--- a/packages/core/src/primitives/agent-env/api/index.test.ts
+++ b/packages/core/src/primitives/agent-env/api/index.test.ts
@@ -92,6 +92,24 @@ describe('buildAllowlistedAgentEnv', () => {
     expect(env.ANTHROPIC_API_KEY).toBe('included');
   });
 
+  it('forwards all persistent XDG base-directory variables', () => {
+    const env = buildAllowlistedAgentEnv({
+      XDG_CACHE_HOME: '/home/ada/.cache',
+      XDG_CONFIG_HOME: '/home/ada/.config',
+      XDG_DATA_HOME: '/home/ada/.local/share',
+      XDG_STATE_HOME: '/home/ada/.local/state',
+      XDG_UNSAFE_HOME: '/home/ada/.unsafe',
+    });
+
+    expect(env).toMatchObject({
+      XDG_CACHE_HOME: '/home/ada/.cache',
+      XDG_CONFIG_HOME: '/home/ada/.config',
+      XDG_DATA_HOME: '/home/ada/.local/share',
+      XDG_STATE_HOME: '/home/ada/.local/state',
+    });
+    expect(env.XDG_UNSAFE_HOME).toBeUndefined();
+  });
+
   it('forwards supported Prime configuration without leaking internal daemon state', () => {
     const env = buildAllowlistedAgentEnv({
       HOME: '/home/ada',

--- a/packages/core/src/primitives/agent-env/api/index.ts
+++ b/packages/core/src/primitives/agent-env/api/index.ts
@@ -116,7 +116,10 @@ export const AGENT_ENV_VARS = [
   'RLM_MAX_DEPTH',
   'VIBE_HOME',
   'XAI_API_KEY',
+  'XDG_CACHE_HOME',
   'XDG_CONFIG_HOME',
+  'XDG_DATA_HOME',
+  'XDG_STATE_HOME',
   'ZAI_API_KEY',
 ] as const;
 

--- a/packages/core/src/services/agent-plugins/api/plugins/plugin-host.test.ts
+++ b/packages/core/src/services/agent-plugins/api/plugins/plugin-host.test.ts
@@ -120,11 +120,21 @@ describe('AgentPluginHost', () => {
         env: { COMMAND_ENV: '1' },
       })
     );
-    const host = createHost([
-      plugin({
-        behavior: { prompt: { buildCommand } },
-      }),
-    ]);
+    const host = createHost(
+      [
+        plugin({
+          behavior: { prompt: { buildCommand } },
+        }),
+      ],
+      async () => ({
+        HOME: '/home/test',
+        PATH: '/bin',
+        XDG_CACHE_HOME: '/home/test/.cache',
+        XDG_CONFIG_HOME: '/home/test/.config',
+        XDG_DATA_HOME: '/home/test/.local/share',
+        XDG_STATE_HOME: '/home/test/.local/state',
+      })
+    );
 
     const result = await host.buildPromptCommand('test', {
       autoApprove: false,
@@ -140,6 +150,10 @@ describe('AgentPluginHost', () => {
           HOME: '/home/test',
           PATH: '/bin',
           COMMAND_ENV: '1',
+          XDG_CACHE_HOME: '/home/test/.cache',
+          XDG_CONFIG_HOME: '/home/test/.config',
+          XDG_DATA_HOME: '/home/test/.local/share',
+          XDG_STATE_HOME: '/home/test/.local/state',
         }),
       },
     });


### PR DESCRIPTION
- forwards xdg cache, data and state directories through the agent environment allowlist
- keeps direct agent launches aligned with user-level xdg configuration used by tools like omp
- verifies the plugin host passes the preserved xdg variables into prompt command environments