### PR TITLE
fix(pull-requests): classify requested and startup-failed checks

### DIFF
--- a/apps/emdash-desktop/src/core/features/github/api/browser/checks/utils.test.ts
+++ b/apps/emdash-desktop/src/core/features/github/api/browser/checks/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { CheckRun } from './types';
-import { sortCheckRunsByLatest } from './utils';
+import { computeCheckBucket, sortCheckRunsByLatest } from './utils';
 
 function makeCheck(overrides: Partial<CheckRun> = {}): CheckRun {
   return {
@@ -19,6 +19,20 @@ function makeCheck(overrides: Partial<CheckRun> = {}): CheckRun {
     ...overrides,
   };
 }
+
+describe('computeCheckBucket', () => {
+  it('classifies requested checks as pending', () => {
+    expect(computeCheckBucket(makeCheck({ status: 'REQUESTED', conclusion: null }))).toBe(
+      'pending'
+    );
+  });
+
+  it('classifies startup failures as failed', () => {
+    expect(
+      computeCheckBucket(makeCheck({ status: 'COMPLETED', conclusion: 'STARTUP_FAILURE' }))
+    ).toBe('fail');
+  });
+});
 
 describe('sortCheckRunsByLatest', () => {
   it('orders runs newest first regardless of their result', () => {

--- a/apps/emdash-desktop/src/core/features/github/api/browser/checks/utils.ts
+++ b/apps/emdash-desktop/src/core/features/github/api/browser/checks/utils.ts
@@ -12,13 +12,19 @@ export function computeCheckBucket(check: CheckRun): CheckRunBucket {
     status === 'IN_PROGRESS' ||
     status === 'QUEUED' ||
     status === 'WAITING' ||
-    status === 'PENDING'
+    status === 'PENDING' ||
+    status === 'REQUESTED'
   ) {
     return 'pending';
   }
   if (!conclusion || conclusion === 'NEUTRAL') return 'skipping';
   if (conclusion === 'SUCCESS') return 'pass';
-  if (conclusion === 'FAILURE' || conclusion === 'TIMED_OUT' || conclusion === 'ACTION_REQUIRED')
+  if (
+    conclusion === 'FAILURE' ||
+    conclusion === 'TIMED_OUT' ||
+    conclusion === 'ACTION_REQUIRED' ||
+    conclusion === 'STARTUP_FAILURE'
+  )
     return 'fail';
   if (conclusion === 'CANCELLED' || conclusion === 'STALE') return 'cancel';
   if (conclusion === 'SKIPPED') return 'skipping';

--- a/apps/emdash-desktop/src/core/services/pull-requests/node/engine/pull-request-engine.db.test.ts
+++ b/apps/emdash-desktop/src/core/services/pull-requests/node/engine/pull-request-engine.db.test.ts
@@ -704,6 +704,58 @@ describe('PullRequestEngine', () => {
     });
   });
 
+  it('reports requested check runs as active', async () => {
+    const handle = await pullRequestSqliteStore.openTemp();
+    closeHandles.push(() => handle.close());
+    const store = new PullRequestStore(handle);
+    const repositoryUrl = 'https://github.com/emdash/emdash';
+    const pullRequestUrl = `${repositoryUrl}/pull/42`;
+    store.registerRepository(repositoryUrl);
+    store.savePullRequest(pullRequestFixture());
+    const graphql = vi.fn(async () => ({
+      repository: {
+        pullRequest: {
+          commits: {
+            nodes: [
+              {
+                commit: {
+                  statusCheckRollup: {
+                    contexts: {
+                      pageInfo: { hasNextPage: false, endCursor: null },
+                      nodes: [
+                        {
+                          __typename: 'CheckRun',
+                          name: 'CI',
+                          status: 'REQUESTED',
+                          conclusion: null,
+                          detailsUrl: 'https://github.com/checks/1',
+                          startedAt: null,
+                          completedAt: null,
+                          checkSuite: null,
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    }));
+    const { logger } = createStubLogger();
+    const engine = createEngine({
+      store,
+      githubAuth: fakeGitHubAuth(),
+      logger,
+      createOctokit: () => fakeOctokit(graphql),
+    });
+
+    await expect(
+      engine.syncChecks(repositoryUrl, pullRequestUrl, 'head', new AbortController().signal)
+    ).resolves.toEqual(ok(true));
+  });
+
   it('schedules background sync pages with retry through one account lane', async () => {
     const handle = await pullRequestSqliteStore.openTemp();
     closeHandles.push(() => handle.close());

--- a/apps/emdash-desktop/src/core/services/pull-requests/node/engine/pull-request-engine.ts
+++ b/apps/emdash-desktop/src/core/services/pull-requests/node/engine/pull-request-engine.ts
@@ -374,7 +374,7 @@ export class PullRequestEngine {
       return ok(
         nodes.some((node) =>
           node.__typename === 'CheckRun'
-            ? ['IN_PROGRESS', 'QUEUED', 'WAITING', 'PENDING'].includes(node.status)
+            ? ['IN_PROGRESS', 'QUEUED', 'WAITING', 'PENDING', 'REQUESTED'].includes(node.status)
             : node.state === 'PENDING'
         )
       );


### PR DESCRIPTION
### Description

GitHub checks can be `REQUESTED` while they're waiting to start, or end with `STARTUP_FAILURE` if they couldn't launch. Emdash currently shows both as skipped. This change shows them as pending and failed instead, so the PR status reflects what actually happened.

For the two affected states, the resulting buckets are:

```text
REQUESTED -> pending
STARTUP_FAILURE -> fail
```

### Related issues

None.

### Testing

- `pnpm --dir apps/emdash-desktop exec vitest run --project node src/core/features/github/api/browser/checks/utils.test.ts` (5 passed)
- `pnpm --dir apps/emdash-desktop exec vitest run --project main-db src/core/services/pull-requests/node/engine/pull-request-engine.db.test.ts` (18 passed)
- `pnpm --dir apps/emdash-desktop run format:check` (passed)
- `CI=1 EMDASH_TEST_SKIP_BROWSER=1 pnpm run affected` (passed)

### Screenshot/Recording (if applicable)

Not applicable. This changes check-state classification without changing the layout.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [ ] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
