### PR TITLE
add NSLocalNetworkUsageDescription for lan ssh

### DIFF
--- a/apps/emdash-desktop/electron-builder.canary.config.ts
+++ b/apps/emdash-desktop/electron-builder.canary.config.ts
@@ -49,6 +49,8 @@ const config: Configuration = {
     extendInfo: {
       NSMicrophoneUsageDescription:
         'Emdash needs microphone access for voice dictation and voice mode features.',
+      NSLocalNetworkUsageDescription:
+        'Emdash needs local network access to connect to SSH hosts on your network.',
     },
     target: [
       { target: 'dmg', arch: ['arm64'] },

--- a/apps/emdash-desktop/electron-builder.config.ts
+++ b/apps/emdash-desktop/electron-builder.config.ts
@@ -43,6 +43,8 @@ const config: Configuration = {
     extendInfo: {
       NSMicrophoneUsageDescription:
         'Emdash needs microphone access for voice dictation and voice mode features.',
+      NSLocalNetworkUsageDescription:
+        'Emdash needs local network access to connect to SSH hosts on your network.',
     },
     target: [
       { target: 'dmg', arch: ['arm64'] },


### PR DESCRIPTION
closes #2984

macos local network privacy needs a usage string or it just blocks the connect and never puts emdash in the settings list. NSAllowsLocalNetworking is ats, not that permission.

this adds the key next to the existing mic string in both stable and canary electron-builder configs so a notarized build can actually prompt.

tested by: config-only, same pattern as NSMicrophoneUsageDescription