### PR TITLE
make IdentityFilteredAgent a real ssh2 BaseAgent

### DIFF
--- a/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.test.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.test.ts
@@ -1,7 +1,6 @@
 import { PassThrough } from 'node:stream';
 import { secret } from '@emdash/shared';
-import type { BaseAgent, ParsedKey, SignCallback } from 'ssh2';
-import { utils } from 'ssh2';
+import ssh2, { type BaseAgent, type ParsedKey, type SignCallback, utils } from 'ssh2';
 import { describe, expect, it } from 'vitest';
 import type { SshConfig } from '@core/primitives/ssh/api';
 import type { SshConnectionRow } from '@core/services/app-db/node/schema';
@@ -295,6 +294,7 @@ describe('resolveSshConnectConfig', () => {
     expect(result.config.agent).toEqual(
       expect.objectContaining({ kind: 'identity-filtered-agent' })
     );
+    expect(result.config.agent).toBeInstanceOf(ssh2.BaseAgent);
     const agent = result.config.agent as BaseAgent;
     const identities = await new Promise<unknown[]>((resolve, reject) => {
       agent.getIdentities((error, keys) => {

--- a/apps/emdash-desktop/src/core/services/ssh/node/connect/ssh-connect-auth.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/connect/ssh-connect-auth.ts
@@ -1,6 +1,6 @@
 // Auth assembly: password, key, and agent selection with IdentitiesOnly filtering.
 import ssh2, {
-  type BaseAgent,
+  BaseAgent,
   type ConnectConfig,
   type IdentityCallback,
   type ParsedKey,
@@ -41,7 +41,7 @@ function comparablePublicKey(key: AgentPublicKey): ParsedKey | Buffer | string {
   return key;
 }
 
-class IdentityFilteredAgent implements BaseAgent {
+class IdentityFilteredAgent extends BaseAgent {
   readonly kind = 'identity-filtered-agent';
   declare getStream?: BaseAgent['getStream'];
 
@@ -50,6 +50,7 @@ class IdentityFilteredAgent implements BaseAgent {
     private readonly agent: BaseAgent,
     private readonly allowedKeys: ParsedKey[]
   ) {
+    super();
     if (agent.getStream) {
       this.getStream = agent.getStream.bind(agent);
     }


### PR DESCRIPTION
closes #2901

ssh2's isAgent check is instanceof BaseAgent. we only implemented the interface so IdentitiesOnly wrapping got silently dropped and agent auth failed with none.

class now extends BaseAgent and calls super(). added an instanceof assertion on the identities-only path.

tested by: pnpm --dir apps/emdash-desktop exec vitest run src/core/services/ssh/node/connect/resolve-ssh-connect-config.test.ts