### PR TITLE
shorten tmux session names

### DIFF
--- a/apps/emdash-desktop/src/core/features/tasks/api/node/task-session-manager.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/api/node/task-session-manager.ts
@@ -1,6 +1,6 @@
 import { hostRefKey, type SerializedHostRef } from '@emdash/core/primitives/host/api';
 import type { HostFileRef } from '@emdash/core/primitives/path/api';
-import { makeTmuxSessionName } from '@emdash/core/services/pty/api';
+import { tmuxSessionNamesFor } from '@emdash/core/services/pty/api';
 import {
   runtimeResolveErrorAsError,
   type RuntimeBroker,
@@ -131,8 +131,8 @@ async function cleanupDetachedSessions(
     return;
   }
   const { conversationIds, terminalIds } = await getTaskSessionLeafIds(db, projectId, taskId);
-  const sessionNames = [...conversationIds, ...terminalIds].map((leafId) =>
-    makeTmuxSessionName(makePtySessionId(projectId, taskId, leafId))
+  const sessionNames = [...conversationIds, ...terminalIds].flatMap((leafId) =>
+    tmuxSessionNamesFor(makePtySessionId(projectId, taskId, leafId))
   );
   if (sessionNames.length > 0) {
     await runtime.data.terminals.killTmuxSessions({ sessionNames });

--- a/apps/emdash-desktop/src/main/core/runtime/operations/session-cleanup.ts
+++ b/apps/emdash-desktop/src/main/core/runtime/operations/session-cleanup.ts
@@ -3,7 +3,7 @@ import {
   sshConnectionIdOf,
   type SerializedHostRef,
 } from '@emdash/core/primitives/host/api';
-import { makeTmuxSessionName } from '@emdash/core/services/pty/api';
+import { tmuxSessionNamesFor } from '@emdash/core/services/pty/api';
 import { and, eq, inArray, isNull, ne, or } from 'drizzle-orm';
 import { hostFileRefFromNativePath } from '@core/primitives/desktop-runtime/api';
 import { makePtySessionId } from '@core/primitives/pty/api';
@@ -101,9 +101,9 @@ export async function resolveLifecycleSessionTargets(
     }
     for (const row of [...acpRows, ...tuiRows, ...terminalRows]) {
       if (row.projectId === null || row.taskId === null) continue;
-      targets.tmuxSessionNames.add(
-        makeTmuxSessionName(makePtySessionId(row.projectId, row.taskId, row.id))
-      );
+      for (const name of tmuxSessionNamesFor(makePtySessionId(row.projectId, row.taskId, row.id))) {
+        targets.tmuxSessionNames.add(name);
+      }
     }
   }
 

--- a/packages/core/src/runtimes/terminals/node/runtime/runtime.ts
+++ b/packages/core/src/runtimes/terminals/node/runtime/runtime.ts
@@ -35,6 +35,7 @@ import {
   buildTerminalEnv,
   killTmuxSession,
   makeTmuxSessionName,
+  tmuxSessionNamesFor,
   resolveLocalPtySpawn,
   PtyRegistry,
   type PtySession,
@@ -386,7 +387,7 @@ export class TerminalsRuntime {
     const config = this.interactiveConfigs.get(sessionKey);
     if (!config?.spec.tmux || process.platform === 'win32') return;
     await this.withExecutionContext((exec) =>
-      killTmuxSession(exec, makeTmuxSessionName(sessionKey))
+      Promise.all(tmuxSessionNamesFor(sessionKey).map((name) => killTmuxSession(exec, name)))
     );
   }
 

--- a/packages/core/src/services/pty/api/index.ts
+++ b/packages/core/src/services/pty/api/index.ts
@@ -37,6 +37,7 @@ export {
   killTmuxSession,
   listTmuxSessionActivity,
   makeTmuxSessionName,
+  tmuxSessionNamesFor,
   parseTmuxSessionActivity,
   TMUX_SESSION_PREFIX,
 } from './tmux';

--- a/packages/core/src/services/pty/api/tmux.test.ts
+++ b/packages/core/src/services/pty/api/tmux.test.ts
@@ -7,7 +7,31 @@ import type { IExecutionContext } from '#primitives/exec/api';
 import { createBoundExec } from '#services/exec/api/bound-exec';
 // oxlint-disable-next-line emdash/core-module-boundaries -- tests distinguish wrapped execution errors from raw execFile errors at the same primitive boundary
 import { ExecError } from '#services/exec/api/types';
-import { listTmuxSessionActivity, parseTmuxSessionActivity } from './tmux';
+import {
+  decodeTmuxSessionName,
+  listTmuxSessionActivity,
+  makeTmuxSessionName,
+  parseTmuxSessionActivity,
+  TMUX_SESSION_PREFIX,
+  tmuxSessionNamesFor,
+} from './tmux';
+
+describe('makeTmuxSessionName', () => {
+  it('uses a short hashed session name and still decodes the previous encoding', () => {
+    const sessionId = 'project:task:leaf';
+    const name = makeTmuxSessionName(sessionId);
+    expect(name.startsWith(TMUX_SESSION_PREFIX)).toBe(true);
+    expect(name.length).toBeLessThan(TMUX_SESSION_PREFIX.length + 20);
+    expect(decodeTmuxSessionName(name)).toBeNull();
+
+    const names = tmuxSessionNamesFor(sessionId);
+    expect(names).toContain(name);
+    expect(names).toHaveLength(2);
+    const legacy = names.find((candidate) => candidate !== name);
+    expect(legacy).toBeDefined();
+    expect(decodeTmuxSessionName(legacy!)).toBe(sessionId);
+  });
+});
 
 describe('parseTmuxSessionActivity', () => {
   it('parses session activity timestamps as milliseconds', () => {

--- a/packages/core/src/services/pty/api/tmux.ts
+++ b/packages/core/src/services/pty/api/tmux.ts
@@ -1,7 +1,9 @@
+import { createHash } from 'node:crypto';
 import type { IExecutionContext } from '#primitives/exec/api';
 
 export const TMUX_SESSION_PREFIX = 'emdash-';
 const TMUX_HISTORY_LIMIT = 100_000;
+const TMUX_SESSION_HASH_LENGTH = 16;
 
 export function buildTmuxShellLine(sessionName: string, commandLine: string): string {
   const quotedName = JSON.stringify(sessionName);
@@ -16,9 +18,20 @@ export function buildTmuxShellLine(sessionName: string, commandLine: string): st
   return `/bin/sh -c ${JSON.stringify(script)}`;
 }
 
+function encodeTmuxSessionIdV1(sessionId: string): string {
+  return `${TMUX_SESSION_PREFIX}${Buffer.from(sessionId, 'utf8').toString('base64url')}`;
+}
+
 export function makeTmuxSessionName(sessionId: string): string {
-  const encoded = Buffer.from(sessionId, 'utf8').toString('base64url');
-  return `${TMUX_SESSION_PREFIX}${encoded}`;
+  const digest = createHash('sha256')
+    .update(sessionId)
+    .digest('base64url')
+    .slice(0, TMUX_SESSION_HASH_LENGTH);
+  return `${TMUX_SESSION_PREFIX}${digest}`;
+}
+
+export function tmuxSessionNamesFor(sessionId: string): string[] {
+  return [...new Set([makeTmuxSessionName(sessionId), encodeTmuxSessionIdV1(sessionId)])];
 }
 
 export function decodeTmuxSessionName(sessionName: string): string | null {
@@ -27,7 +40,7 @@ export function decodeTmuxSessionName(sessionName: string): string | null {
   if (!encoded) return null;
   try {
     const sessionId = Buffer.from(encoded, 'base64url').toString('utf8');
-    if (makeTmuxSessionName(sessionId) !== sessionName) return null;
+    if (encodeTmuxSessionIdV1(sessionId) !== sessionName) return null;
     return sessionId;
   } catch {
     return null;


### PR DESCRIPTION
closes #2706

we were base64url-encoding the full pty session id so status-left ate the whole bar.

new names are emdash- plus 16 chars of sha256. cleanup still kills the old long names so leftover sessions from previous builds do not leak.

tested by: pnpm --dir packages/core exec vitest run src/services/pty/api/tmux.test.ts