### PR TITLE
set StartupWMClass for gnome dock grouping

### DIFF
--- a/apps/emdash-desktop/electron-builder.canary.config.ts
+++ b/apps/emdash-desktop/electron-builder.canary.config.ts
@@ -70,6 +70,9 @@ const config: Configuration = {
     category: 'Development',
     executableName: APP_NAME_LOWER,
     icon: 'src/assets/images/emdash/emdash-canary.png',
+    desktop: {
+      StartupWMClass: PRODUCT_NAME,
+    },
     target: [
       { target: 'AppImage', arch: ['x64'] },
       { target: 'deb', arch: ['x64'] },

--- a/apps/emdash-desktop/electron-builder.config.ts
+++ b/apps/emdash-desktop/electron-builder.config.ts
@@ -63,6 +63,9 @@ const config: Configuration = {
   linux: {
     category: 'Development',
     icon: 'src/assets/images/emdash/emdash.png',
+    desktop: {
+      StartupWMClass: PRODUCT_NAME,
+    },
     target: [
       { target: 'AppImage', arch: ['x64'] },
       { target: 'deb', arch: ['x64'] },


### PR DESCRIPTION
closes #2881

on gnome wayland the running window was untracked because the desktop file did not declare StartupWMClass matching the electron product name.

set it to PRODUCT_NAME in both linux builder configs (stable and canary).

tested by: config-only