### PR TITLE
expand directory symlinks that point outside the worktree

### DIFF
--- a/packages/core/src/runtimes/files/node/tree/directory-reader.test.ts
+++ b/packages/core/src/runtimes/files/node/tree/directory-reader.test.ts
@@ -20,9 +20,12 @@ describe('TreeDirectoryReader', () => {
     await mkdir(path.join(root, 'z-directory'));
     await writeFile(path.join(root, 'a.txt'), 'a');
     await writeFile(path.join(outside, 'outside.txt'), 'outside');
+    await mkdir(path.join(outside, 'outside-dir'));
+    await writeFile(path.join(outside, 'outside-dir', 'nested.txt'), 'nested');
     try {
       await symlink('z-directory', path.join(root, 'linked-directory'), 'dir');
       await symlink(path.join(outside, 'outside.txt'), path.join(root, 'outside-file'), 'file');
+      await symlink(path.join(outside, 'outside-dir'), path.join(root, 'outside-dir'), 'dir');
       await symlink('missing', path.join(root, 'missing-link'), 'file');
     } catch {
       return;
@@ -35,6 +38,7 @@ describe('TreeDirectoryReader', () => {
     if (!result.success) return;
     expect(result.data.map((entry) => entry.name)).toEqual([
       'linked-directory',
+      'outside-dir',
       'z-directory',
       'a.txt',
       'missing-link',
@@ -47,6 +51,19 @@ describe('TreeDirectoryReader', () => {
     expect(result.data.find((entry) => entry.name === 'outside-file')).toMatchObject({
       symlinkTargetKind: 'outside-root',
     });
+    const outsideDir = result.data.find((entry) => entry.name === 'outside-dir');
+    expect(outsideDir).toMatchObject({
+      kind: 'symlink',
+      symlinkTargetKind: 'directory',
+    });
+    expect(outsideDir && isExpandableFileEntry(outsideDir)).toBe(true);
+    const nested = await new TreeDirectoryReader(new RootPathPolicy(root)).readChildren(
+      relativePath('outside-dir')
+    );
+    expect(nested.success).toBe(true);
+    if (nested.success) {
+      expect(nested.data.map((entry) => entry.name)).toEqual(['nested.txt']);
+    }
     expect(result.data.find((entry) => entry.name === 'missing-link')).toMatchObject({
       symlinkTargetKind: 'missing',
     });

--- a/packages/core/src/runtimes/files/node/tree/directory-reader.ts
+++ b/packages/core/src/runtimes/files/node/tree/directory-reader.ts
@@ -25,11 +25,30 @@ export class TreeDirectoryReader {
 
   async readChildren(directoryPath: PortableRelativePath): Promise<Result<FileEntry[], FsError>> {
     const resolved = await this.paths.resolveFollowed(directoryPath);
-    if (!resolved.success) return resolved;
+    let listingRoot: string | undefined;
+    if (resolved.success) {
+      listingRoot = resolved.data.realPath;
+    } else if (resolved.error.type === 'invalid-path') {
+      const entry = this.paths.resolveEntry(directoryPath);
+      if (entry.success) {
+        try {
+          const metadata = await lstat(entry.data.absolutePath);
+          if (metadata.isSymbolicLink() || metadata.isDirectory()) {
+            listingRoot = entry.data.absolutePath;
+          }
+        } catch {
+          return resolved;
+        }
+      }
+    }
+    if (!listingRoot) {
+      if (resolved.success) return err({ type: 'not-found', path: directoryPath });
+      return resolved;
+    }
 
     let dirents;
     try {
-      dirents = await readdir(resolved.data.realPath, { withFileTypes: true });
+      dirents = await readdir(listingRoot, { withFileTypes: true });
     } catch (error) {
       return err(toFsError(error, directoryPath));
     }
@@ -41,7 +60,7 @@ export class TreeDirectoryReader {
       if (this.exclusions?.excludes(childPath.data)) continue;
       const classified = await this.readEntry(
         childPath.data,
-        path.join(resolved.data.realPath, dirent.name)
+        path.join(listingRoot, dirent.name)
       );
       if (classified.success) entries.push(classified.data);
       else if (classified.error.type !== 'not-found') return classified;
@@ -106,10 +125,10 @@ async function classifySymlink(
 
   try {
     const canonical = await realpath(absolutePath);
-    if (!containsPath(rootPath, canonical)) return { target, kind: 'outside-root' };
     const metadata = await stat(absolutePath);
     const statMetadata = { mtimeMs: Number(metadata.mtimeMs), size: Number(metadata.size) };
     if (metadata.isDirectory()) return { target, kind: 'directory', stat: statMetadata };
+    if (!containsPath(rootPath, canonical)) return { target, kind: 'outside-root' };
     if (metadata.isFile()) return { target, kind: 'file', stat: statMetadata };
     return { target, kind: 'other', stat: statMetadata };
   } catch (error) {


### PR DESCRIPTION
closes #3076

1.2 classified any realpath outside the root as outside-root before checking if it was a directory, so those links were not expandable.

directory targets stay kind directory even when the canonical path is outside. listing falls back to the in-root symlink path when resolveFollowed rejects the follow. file symlinks that escape the root are still outside-root.

tested by: pnpm --dir packages/core exec vitest run src/runtimes/files/node/tree/directory-reader.test.ts