### PR TITLE
run ssh -G for typed hosts so system ProxyCommand still applies

### DIFF
--- a/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.test.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.test.ts
@@ -29,18 +29,9 @@ function deps(overrides: Partial<SshConnectDeps> = {}): SshConnectDeps {
     readFile: async () => 'PRIVATE KEY',
     getPassword: async () => secret('stored-password'),
     getPassphrase: async () => null,
-    resolveSshConfig: async () => ({
-      hostname: 'resolved.internal',
-      user: 'resolved-user',
-      port: 2201,
-      identityFile: [],
-      identityAgent: '/tmp/resolved-agent.sock',
-      identityAgentDisabled: false,
-      identitiesOnly: false,
-      proxyCommand: undefined,
-      proxyJump: undefined,
-      forwardAgent: false,
-    }),
+    resolveSshConfig: async () => {
+      throw new Error('no ssh config');
+    },
     findSshConfigByHostName: async () => undefined,
     spawnProxyCommand: () => ({
       sock: new PassThrough(),
@@ -193,6 +184,44 @@ describe('resolveSshConnectConfig', () => {
     });
     expect(jumps).toEqual(['bastion->manual.example.com:22']);
     expect(result.debugLogs).toEqual(['jump debug']);
+  });
+
+  it('uses ssh -G ProxyCommand for a typed hostname with no alias', async () => {
+    const spawned: string[] = [];
+    const result = await resolveSshConnectConfig(
+      {
+        kind: 'transient',
+        config: baseConfig({ authType: 'agent', host: 'work-host.internal.example' }),
+      },
+      deps({
+        resolveSshConfig: async (alias) => ({
+          hostname: alias,
+          user: '',
+          port: 22,
+          identityFile: [],
+          identityAgent: undefined,
+          identityAgentDisabled: false,
+          identitiesOnly: false,
+          proxyCommand: 'cloudflared access ssh --hostname %h',
+          proxyJump: undefined,
+          forwardAgent: false,
+        }),
+        env: { SSH_AUTH_SOCK: '/tmp/default-agent.sock' },
+        spawnProxyCommand: (command, tokens) => {
+          spawned.push(`${command} ${tokens.originalHost}`);
+          return {
+            sock: new PassThrough(),
+            cleanup: () => {},
+            debugLogs: ['system-config'],
+          };
+        },
+      })
+    );
+
+    expect(result.config.host).toBe('work-host.internal.example');
+    expect(result.config.sock).toBeDefined();
+    expect(spawned).toEqual(['cloudflared access ssh --hostname %h work-host.internal.example']);
+    expect(result.debugLogs).toEqual(['system-config']);
   });
 
   it('honors alias-resolved IdentityAgent none and SSH_AUTH_SOCK values', async () => {
@@ -494,8 +523,8 @@ describe('resolveSshConnectConfig', () => {
             identityAgent: '/tmp/legacy-agent.sock',
             identityAgentDisabled: false,
             identitiesOnly: false,
-            proxyCommand: 'should-not-run',
-            proxyJump: 'should-not-run',
+            proxyCommand: undefined,
+            proxyJump: undefined,
             forwardAgent: false,
           };
         },
@@ -508,7 +537,7 @@ describe('resolveSshConnectConfig', () => {
       })
     );
 
-    expect(resolvedAliases).toEqual(['legacy-host']);
+    expect(resolvedAliases).toEqual(['legacy-host', 'legacy-host']);
     expect(result.config).toMatchObject({
       host: 'legacy-host',
       port: 22,
@@ -574,7 +603,7 @@ describe('resolveSshConnectConfig', () => {
       })
     );
 
-    expect(resolvedAliases).toEqual(['dev.internal']);
+    expect(resolvedAliases).toEqual(['dev.internal', 'dev.internal']);
     expect(result.config).toMatchObject({
       host: 'dev.internal',
       username: 'alice',

--- a/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.ts
@@ -83,15 +83,17 @@ export async function resolveSshConnectConfig(
   const deps = { ...defaultDeps(), ...depsOverride };
   const base = baseConfigForInput(input);
   const alias = base.sshConfigAlias;
-  const resolved = alias ? await deps.resolveSshConfig(alias) : undefined;
+  const resolved = alias
+    ? await deps.resolveSshConfig(alias)
+    : await deps.resolveSshConfig(base.host).catch(() => undefined);
   const shouldResolveHostForAgent = !alias && base.authType === 'agent';
   const agentResolved = shouldResolveHostForAgent
     ? await resolveManualAgentSshConfig(base.host, deps)
     : resolved;
 
-  const host = resolved?.hostname || base.host;
-  const port = resolved?.port ?? base.port;
-  const username = resolved?.user || base.username;
+  const host = (alias ? resolved?.hostname || base.host : base.host).trim();
+  const port = alias ? (resolved?.port ?? base.port) : base.port;
+  const username = alias ? resolved?.user || base.username : base.username;
   const authResult = await buildAuthConfig(input, base, agentResolved, deps);
 
   const config: ConnectConfig = {
@@ -116,7 +118,7 @@ export async function resolveSshConnectConfig(
   let debugLogs: string[] = [];
   let cleanup = () => {};
   const tokens: ProxyTokens = { host, port, username, originalHost: alias ?? base.host };
-  const proxyCommand = alias ? resolved?.proxyCommand : undefined;
+  const proxyCommand = resolved?.proxyCommand;
   const proxyJump = resolved?.proxyJump ?? (!alias ? base.proxyJump : undefined);
 
   let transport: Omit<TransportResult, 'process'> | undefined;


### PR DESCRIPTION
## summary
typed ssh hostnames without an sshConfigAlias were skipping `ssh -G`, so wildcard / system `ProxyCommand` never applied and the client tried to resolve the hostname locally (`ENOTFOUND`).

this still uses the stored host/port/user instead of rewriting them from config. `ssh -G` is only used for proxy settings.

closes #2729

## test plan
- [ ] add a connection with a typed hostname that only matches a `Host *` / wildcard `ProxyCommand` in `~/.ssh/config` and connect
- [ ] connect with an sshConfigAlias still uses that alias for `-G`
- [ ] `pnpm --dir apps/emdash-desktop exec vitest run src/core/services/ssh/node/connect/resolve-ssh-connect-config.test.ts`
