### PR TITLE
resize restored tmux panes to the current tab size

### DIFF
--- a/apps/emdash-desktop/src/core/features/terminals/browser/pty/use-pty-pane-resize.ts
+++ b/apps/emdash-desktop/src/core/features/terminals/browser/pty/use-pty-pane-resize.ts
@@ -205,7 +205,7 @@ export function usePtyPaneResize(
     const added = sessionIds.filter((id) => !prev.includes(id));
     sessionsRef.current = sessionIds;
     const dims = controllerDimsBoxRef.current!.get();
-    if (dims && added.length > 0 && hasCalibratedRef.current) {
+    if (dims && added.length > 0) {
       for (const id of added) {
         const frontendPty = getFrontendPty(id);
         frontendPty?.resizeBackend(dims.cols, dims.rows);

--- a/packages/core/src/services/pty/api/tmux.ts
+++ b/packages/core/src/services/pty/api/tmux.ts
@@ -10,7 +10,8 @@ export function buildTmuxShellLine(sessionName: string, commandLine: string): st
   const newSession = `tmux -u new-session -d -s ${quotedName} ${quotedCmd}`;
   const enableMouse = `tmux set-option -t ${quotedName} mouse on 2>/dev/null || true`;
   const setHistoryLimit = `tmux set-option -t ${quotedName} history-limit ${TMUX_HISTORY_LIMIT} 2>/dev/null || true`;
-  const configure = `(${enableMouse}) && (${setHistoryLimit})`;
+  const setWindowSize = `tmux set-option -t ${quotedName} window-size latest 2>/dev/null || true`;
+  const configure = `(${enableMouse}) && (${setHistoryLimit}) && (${setWindowSize})`;
   const attach = `tmux -u attach-session -t ${quotedName}`;
   const script = `(${checkExists} || ${newSession}) && ${configure} && ${attach}`;
   return `/bin/sh -c ${JSON.stringify(script)}`;


### PR DESCRIPTION
## summary
restored sessions skipped the first resize until a later calibration, so tmux often stayed at a leftover width (e.g. ~80 cols). new sessions now get `updatePtySize` immediately.

also sets `window-size latest` on new tmux sessions so the pane follows the current client instead of the first attach.

closes #2867

## test plan
- [ ] restore a tmux tab after shrinking/growing the window and confirm the pane fills the tab
- [ ] new session still sizes correctly on first attach
- [ ] `pnpm --dir apps/emdash-desktop exec vitest run src/core/services/pty/api/tmux.test.ts`
