### PR TITLE
drop late xterm device-attribute replies after attach

### DIFF
--- a/apps/emdash-desktop/src/core/features/terminals/browser/pty/use-pty.ts
+++ b/apps/emdash-desktop/src/core/features/terminals/browser/pty/use-pty.ts
@@ -23,11 +23,13 @@ import {
   shouldPasteToTerminal,
 } from './pty-keybindings';
 import { getTerminalContextLink } from './terminal-context-link';
+import { isXtermCapabilityReply } from './xterm-auto-replies';
 
 const IS_MAC_PLATFORM =
   typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
 const IS_WINDOWS_PLATFORM = typeof navigator !== 'undefined' && /Win/.test(navigator.platform);
 const LAST_SELECTION_COPY_GRACE_MS = 2_000;
+const ATTACH_CAPABILITY_REPLY_GUARD_MS = 2_500;
 
 function getRecentSelection(selection: { text: string; capturedAt: number } | null): string {
   if (!selection) return '';
@@ -458,10 +460,12 @@ export function usePty(
       });
 
       // ── Handle terminal input ──────────────────────────────────────────────
+      const attachGuardUntil = Date.now() + ATTACH_CAPABILITY_REPLY_GUARD_MS;
       const handleTerminalInput = (data: string) => {
         onActivityRef.current?.();
 
         if (!data) return;
+        if (Date.now() < attachGuardUntil && isXtermCapabilityReply(data)) return;
 
         // First-message capture
         if (!firstMessageSentRef.current && onFirstMessageRef.current) {

--- a/apps/emdash-desktop/src/core/features/terminals/browser/pty/xterm-auto-replies.test.ts
+++ b/apps/emdash-desktop/src/core/features/terminals/browser/pty/xterm-auto-replies.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { isXtermCapabilityReply } from './xterm-auto-replies';
+
+describe('isXtermCapabilityReply', () => {
+  it('matches focus events and xterm.js device-attribute replies', () => {
+    expect(isXtermCapabilityReply('\x1b[I')).toBe(true);
+    expect(isXtermCapabilityReply('\x1b[O')).toBe(true);
+    expect(isXtermCapabilityReply('\x1b[?1;2c')).toBe(true);
+    expect(isXtermCapabilityReply('\x1b[>0;276;0c')).toBe(true);
+    expect(isXtermCapabilityReply('\x1bP>|xterm.js\x1b\\')).toBe(true);
+  });
+
+  it('does not match ordinary typed input', () => {
+    expect(isXtermCapabilityReply('ls\r')).toBe(false);
+    expect(isXtermCapabilityReply('1;2c')).toBe(false);
+    expect(isXtermCapabilityReply('')).toBe(false);
+  });
+});

--- a/apps/emdash-desktop/src/core/features/terminals/browser/pty/xterm-auto-replies.ts
+++ b/apps/emdash-desktop/src/core/features/terminals/browser/pty/xterm-auto-replies.ts
@@ -1,0 +1,9 @@
+const FOCUS_REPLY = /^\x1b\[[IO]$/;
+const DEVICE_ATTRIBUTES_REPLY = /^\x1b\[(?:\?|>)?[\d;]*c$/;
+const XTVERSION_REPLY = /^\x1bP>\|[\s\S]*?\x1b\\$/;
+
+export function isXtermCapabilityReply(data: string): boolean {
+  return (
+    FOCUS_REPLY.test(data) || DEVICE_ATTRIBUTES_REPLY.test(data) || XTVERSION_REPLY.test(data)
+  );
+}


### PR DESCRIPTION
## summary
xterm.js can emit DA replies (`ESC [ ? 0 c` / similar) after attach. those were going into the pty and showing up as `0c` / `0;0c` in the shell.

drop those sequences for 2.5s after attach. later user input is unchanged.

closes #2720

## test plan
- [ ] attach a restored tmux session and confirm no `0c` junk in the prompt
- [ ] type normally after attach
- [ ] `pnpm --dir apps/emdash-desktop exec vitest run src/core/features/terminals/browser/pty/xterm-auto-replies.test.ts`
