### PR TITLE
linux: drop macos dialog message and allow creating folders

### DIFF
--- a/apps/emdash-desktop/src/main/core/app/service.ts
+++ b/apps/emdash-desktop/src/main/core/app/service.ts
@@ -606,9 +606,12 @@ class AppService implements Disposable {
   }): Promise<string | undefined> {
     const result = await dialog.showOpenDialog(getMainWindow()!, {
       title: args.title,
-      properties: ['openDirectory'],
-      message: args.message,
+      properties:
+        process.platform === 'darwin'
+          ? ['openDirectory']
+          : ['openDirectory', 'createDirectory'],
       defaultPath: args.defaultPath,
+      ...(process.platform === 'darwin' ? { message: args.message } : {}),
     });
     if (result.canceled) return undefined;
     return result.filePaths[0];
@@ -621,7 +624,7 @@ class AppService implements Disposable {
     const result = await dialog.showOpenDialog(getMainWindow()!, {
       title: args.title,
       properties: ['openFile'],
-      message: args.message,
+      ...(process.platform === 'darwin' ? { message: args.message } : {}),
       filters: [
         {
           name: 'Audio',


### PR DESCRIPTION
## summary
electron on linux does not support `message` on `showOpenDialog`, so the directory picker could fail or look broken. `createDirectory` was also false, so you could not make a new folder from the picker.

message stays on darwin. linux/win get `createDirectory: true` without that option.

closes #2336

## test plan
- [ ] linux: add workspace / pick directory and confirm the dialog opens
- [ ] linux: create a folder from the picker
- [ ] macos: still shows the extra message on the directory dialog
