### PR TITLE
skip terminal grid sizing when available width is non-positive

### DIFF
--- a/apps/emdash-desktop/src/core/features/terminals/api/browser/pty/pty-dimensions.ts
+++ b/apps/emdash-desktop/src/core/features/terminals/api/browser/pty/pty-dimensions.ts
@@ -64,7 +64,7 @@ export function computeGridDimensions({
   const left = paddingPx + (padding?.left ?? 0);
   const availW = widthPx - scrollbarWidth - left - right;
   const availH = heightPx - top - bottom;
-  if (Number.isNaN(availW) || Number.isNaN(availH) || availH <= 0) return null;
+  if (Number.isNaN(availW) || Number.isNaN(availH) || availW <= 0 || availH <= 0) return null;
   return {
     cols: Math.max(MINIMUM_COLS, Math.floor(availW / cellWidth)),
     rows: Math.max(MINIMUM_ROWS, Math.floor(availH / cellHeight)),

--- a/apps/emdash-desktop/src/core/features/terminals/browser/pty/pty-dimensions.test.ts
+++ b/apps/emdash-desktop/src/core/features/terminals/browser/pty/pty-dimensions.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  computeGridDimensions,
   invalidateCellMetricsCache,
   measureDimensions,
   measureTerminalCell,
@@ -33,6 +34,20 @@ describe('measureDimensions', () => {
     });
     expect(measureDimensions(el, 8, 16)).toEqual({ cols: 100, rows: 25 });
     vi.unstubAllGlobals();
+  });
+});
+
+describe('computeGridDimensions', () => {
+  it('returns null when available width is not positive', () => {
+    expect(
+      computeGridDimensions({
+        widthPx: 4,
+        heightPx: 400,
+        cellWidth: 8,
+        cellHeight: 16,
+        paddingPx: 8,
+      })
+    ).toBeNull();
   });
 });
 


### PR DESCRIPTION
## summary
`computeGridDimensions` already bailed on `availH <= 0` but not width. a collapsed pane could still produce a bogus column count.

return null when `availW <= 0` as well.

## test plan
- [ ] collapse a pane so the terminal has no usable width and confirm no throw / zero-col resize
- [ ] `pnpm --dir apps/emdash-desktop exec vitest run src/core/features/terminals/browser/pty/pty-dimensions.test.ts`
