### PR TITLE
treat missing git as inspect-failed instead of not-a-repo

### DIFF
--- a/packages/core/src/runtimes/workspace-registry/node/inspect-path.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/inspect-path.ts
@@ -46,7 +46,7 @@ export async function inspectWorkspacePath(
     }));
   } catch (error) {
     // Exit 128 = not inside a git work tree: a plain directory, not a failure.
-    if (error instanceof ExecError && error.exitCode !== null) return { kind: 'directory' };
+    if (error instanceof ExecError && error.exitCode === 128) return { kind: 'directory' };
     return {
       kind: 'inspect-failed',
       message: error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
## summary
any git `ExecError` was treated as a plain directory. on nixos (and anywhere git is missing from PATH) `git` exits 127, so a real repo looked like a non-repo.

only exit 128 is "not a git repo". other exec failures stay `inspect-failed`.

closes #2990

## test plan
- [ ] PATH without git: opening a git workspace should fail inspect instead of looking like a folder
- [ ] a real non-repo directory still inspects as a directory (exit 128)
- [ ] normal git workspaces still work
