### PR TITLE
fix(remote): recover chat after sleep and stabilize connection status

### DIFF
--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-panel.tsx
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-panel.tsx
@@ -569,16 +569,7 @@ const ComposerForStore = observer(function ComposerForStore({
   return createPortal(
     <>
       <input ref={fileInputRef} type="file" multiple hidden onChange={handleFileInputChange} />
-      {disabledReason && (
-        <div
-          className="mx-3 mb-1 rounded-md border bg-background/95 px-2 py-1 text-center text-xs text-foreground-muted"
-          tabIndex={0}
-          role="note"
-        >
-          {disabledReason}
-        </div>
-      )}
-      {store.loadError && (
+      {!disabledReason && store.loadError && (
         <div className="border-destructive/30 bg-destructive/5 mx-3 mb-1 flex items-center justify-between gap-2 rounded-md border px-2 py-1 text-xs">
           <span className="truncate text-foreground-muted">{store.loadError.message}</span>
           <Button variant="secondary" size="sm" onClick={() => store.retry()}>
@@ -586,14 +577,14 @@ const ComposerForStore = observer(function ComposerForStore({
           </Button>
         </div>
       )}
-      <div inert={disabledReason ? true : undefined}>
+      <div>
         <ChatComposer
           isWorking={a.isWorking}
           canSubmit={a.canSubmit}
           onSubmit={handleSubmit}
           onInputChange={(text) => store.setDraftText(text)}
-          onSubmitWhileWorking={handleSubmit}
-          onStop={a.isWorking ? handleStop : undefined}
+          onSubmitWhileWorking={a.canSubmit ? handleSubmit : undefined}
+          onStop={a.canCancel ? handleStop : undefined}
           permissionRequest={permissionRequest}
           permissionQueueCount={store.permissionQueue.length}
           onResolvePermission={handleResolvePermission}
@@ -605,16 +596,18 @@ const ComposerForStore = observer(function ComposerForStore({
           editorApiRef={editorApiRef}
           modelOptions={store.modelOptions}
           selectedModel={store.model ?? undefined}
-          onModelChange={handleModelChange}
+          onModelChange={store.liveActionsEnabled ? handleModelChange : undefined}
           effortOptions={store.effortOptions}
           selectedEffort={store.effort ?? undefined}
-          onEffortChange={handleEffortChange}
+          onEffortChange={store.liveActionsEnabled ? handleEffortChange : undefined}
           permissionModeOptions={store.permissionModeOptions}
           selectedPermissionMode={store.permissionMode ?? undefined}
-          onPermissionModeChange={handleModeChange}
+          onPermissionModeChange={store.liveActionsEnabled ? handleModeChange : undefined}
           collaborationModeOptions={store.collaborationModeOptions}
           selectedCollaborationMode={store.collaborationMode ?? undefined}
-          onCollaborationModeChange={handleCollaborationModeChange}
+          onCollaborationModeChange={
+            store.liveActionsEnabled ? handleCollaborationModeChange : undefined
+          }
           mcpServers={store.mcpServers}
           agentOptions={agentOptions}
           selectedAgent={providerId ?? undefined}
@@ -634,7 +627,7 @@ const ComposerForStore = observer(function ComposerForStore({
           queryCommands={querySlashItems}
           attachments={attachments}
           onAttachmentsChange={handleAttachmentsChange}
-          onAttach={handleAttach}
+          onAttach={store.liveActionsEnabled ? handleAttach : undefined}
           onImageFilesDropped={(files) => void addImageFiles(files)}
           onFilesDropped={(files) => void handleFilesDropped(files)}
           onViewImage={(att) => onViewerOpen(att.previewUrl, att.name)}

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-panel.tsx
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-panel.tsx
@@ -628,8 +628,12 @@ const ComposerForStore = observer(function ComposerForStore({
           attachments={attachments}
           onAttachmentsChange={handleAttachmentsChange}
           onAttach={store.liveActionsEnabled ? handleAttach : undefined}
-          onImageFilesDropped={(files) => void addImageFiles(files)}
-          onFilesDropped={(files) => void handleFilesDropped(files)}
+          onImageFilesDropped={
+            store.liveActionsEnabled ? (files) => void addImageFiles(files) : undefined
+          }
+          onFilesDropped={
+            store.liveActionsEnabled ? (files) => void handleFilesDropped(files) : undefined
+          }
           onViewImage={(att) => onViewerOpen(att.previewUrl, att.name)}
         />
       </div>

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
@@ -9,6 +9,7 @@ import type {
   SessionMcpServer,
 } from '@emdash/core/runtimes/acp/api/client';
 import { createScope, type Scope } from '@emdash/shared/concurrency';
+import { systemClock } from '@emdash/shared/scheduling';
 import type {
   CommandItem,
   ComposerCollaborationModeOption,
@@ -114,6 +115,8 @@ export class AcpChatStore {
   private _historyRefreshRequested = false;
   private _historyRefreshTask: Promise<void> | null = null;
   private _disposed = false;
+  private _attachmentRecovery: Scope | null = null;
+  private _attachedHostGeneration: number | undefined;
 
   constructor(
     readonly conversationId: string,
@@ -172,34 +175,25 @@ export class AcpChatStore {
       retry: action,
     });
     const initialHost = this.hostAccess?.state;
-    let lastHostGeneration = initialHost?.kind === 'ready' ? initialHost.hostGeneration : undefined;
+    this._attachedHostGeneration =
+      initialHost?.kind === 'ready' ? initialHost.hostGeneration : undefined;
     this._disposeHostReaction = reaction(
       () => this.hostAccess?.state,
       (state) => {
         const kind = state?.kind;
         if (state?.kind === 'ready') {
-          const changed = state.hostGeneration !== lastHostGeneration;
-          lastHostGeneration = state.hostGeneration;
+          const changed = state.hostGeneration !== this._attachedHostGeneration;
           const session = this.session;
-          if (changed && session) {
-            void session
-              .revalidate()
-              .then(() => {
-                if (this._disposed || this.session !== session || !session.usable) return;
-                runInAction(() => {
-                  this.loadError = null;
-                });
-              })
-              .catch((error) => {
-                if (this._disposed || this.session !== session) return;
-                runInAction(() => {
-                  this.loadError = toLoadError(error);
-                });
-              });
+          if (session && (changed || !session.usable)) {
+            this._recoverAttachment(session, state.hostGeneration);
           }
+        } else {
+          void this._attachmentRecovery?.dispose();
+          this._attachmentRecovery = null;
         }
         if (
           kind === 'ready' &&
+          !this.session &&
           this._bootstrapped &&
           !this.historyLoading &&
           this.loadError?.kind === 'unavailable'
@@ -340,8 +334,7 @@ export class AcpChatStore {
 
   get affordances(): AgentAffordances {
     const state = this.session?.sessionState.current();
-    const liveActionsEnabled =
-      this.hostAccess?.liveAction.kind !== 'disabled' && (this.session?.usable ?? false);
+    const liveActionsEnabled = this.liveActionsEnabled;
     const isResuming = state?.lifecycle === 'starting' || state?.lifecycle === 'replaying';
     return {
       isWorking: state?.isGenerating ?? false,
@@ -351,6 +344,10 @@ export class AcpChatStore {
       canSubmit: liveActionsEnabled && (state?.canSubmit ?? false),
       canCancel: liveActionsEnabled && (state?.canCancel ?? false),
     };
+  }
+
+  get liveActionsEnabled(): boolean {
+    return this.hostAccess?.liveAction.kind !== 'disabled' && (this.session?.usable ?? false);
   }
 
   get isEmpty(): boolean {
@@ -364,6 +361,18 @@ export class AcpChatStore {
   }
 
   retry(): void {
+    if (this.hostAccess?.liveAction.kind === 'disabled') {
+      void this.hostAccess.recover();
+      return;
+    }
+    if (this.session) {
+      const state = this.hostAccess?.state;
+      this._recoverAttachment(
+        this.session,
+        state?.kind === 'ready' ? state.hostGeneration : undefined
+      );
+      return;
+    }
     if (this.historyLoading || !this.loadError) return;
     this.historyLoading = true;
     this.loadError = null;
@@ -489,6 +498,7 @@ export class AcpChatStore {
   }
 
   stop(): void {
+    if (!this.liveActionsEnabled) return;
     void this.session
       ?.cancelTurn()
       .then((result) => {
@@ -498,6 +508,7 @@ export class AcpChatStore {
   }
 
   setModel(model: string): void {
+    if (!this.liveActionsEnabled) return;
     void this.session
       ?.setOption('model', model)
       .then((result) => {
@@ -511,6 +522,7 @@ export class AcpChatStore {
   }
 
   setMode(modeId: string): void {
+    if (!this.liveActionsEnabled) return;
     void this.session
       ?.setOption('mode', modeId)
       .then((result) => {
@@ -524,6 +536,7 @@ export class AcpChatStore {
   }
 
   setCollaborationMode(modeId: string): void {
+    if (!this.liveActionsEnabled) return;
     void this.session
       ?.setOption('collaborationMode', modeId)
       .then((result) => {
@@ -537,6 +550,7 @@ export class AcpChatStore {
   }
 
   setEffort(effort: string): void {
+    if (!this.liveActionsEnabled) return;
     void this.session
       ?.setOption('effort', effort)
       .then((result) => {
@@ -550,12 +564,14 @@ export class AcpChatStore {
   }
 
   resolvePermission(optionId: string): void {
+    if (!this.liveActionsEnabled) return;
     const request = this.permissionQueue[0];
     if (!request) return;
     void this.session?.resolvePermission(request.requestId, optionId);
   }
 
   editQueuedPrompt(id: string, text: string): void {
+    if (!this.liveActionsEnabled) return;
     const existing = this._queuedPromptModels().find((prompt) => prompt.id === id);
     if (!existing) return;
     const input: PromptInput = {
@@ -572,6 +588,7 @@ export class AcpChatStore {
   }
 
   deleteQueuedPrompt(id: string): void {
+    if (!this.liveActionsEnabled) return;
     void this.session
       ?.deleteQueuedPrompt(id)
       .then((result) => {
@@ -581,6 +598,7 @@ export class AcpChatStore {
   }
 
   reorderQueuedPrompts(ids: string[]): void {
+    if (!this.liveActionsEnabled) return;
     void this.session
       ?.changeQueuePromptOrder(ids)
       .then((result) => {
@@ -590,6 +608,7 @@ export class AcpChatStore {
   }
 
   sendQueuedPromptNow(id: string): void {
+    if (!this.liveActionsEnabled) return;
     void this._sendQueuedPromptNow(id);
   }
 
@@ -678,6 +697,41 @@ export class AcpChatStore {
         void this._refreshAuthStatus(providerId);
       }
     }
+  }
+
+  private _recoverAttachment(session: AcpLiveSession, generation: number | undefined): void {
+    void this._attachmentRecovery?.dispose();
+    const scope = this._scope.child('attachment-recovery');
+    this._attachmentRecovery = scope;
+    void scope
+      .run('reattach', async () => {
+        let attempt = 0;
+        while (!scope.signal.aborted && this.session === session) {
+          try {
+            await session.revalidate(scope.signal);
+            if (scope.signal.aborted || this.session !== session || !session.usable) return;
+            this._attachedHostGeneration = generation;
+            runInAction(() => {
+              this.loadError = null;
+            });
+            return;
+          } catch (error) {
+            if (scope.signal.aborted || this.session !== session) return;
+            const loadError = toLoadError(error);
+            runInAction(() => {
+              this.loadError = loadError;
+            });
+            if (loadError.kind === 'auth_required') return;
+          }
+          await systemClock.sleep(Math.min(1_000 * 2 ** attempt++, 15_000), {
+            signal: scope.signal,
+          });
+        }
+      })
+      .exit.finally(() => {
+        if (this._attachmentRecovery === scope) this._attachmentRecovery = null;
+        void scope.dispose();
+      });
   }
 
   private async _refreshAuthStatus(providerId: string): Promise<void> {

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
@@ -117,6 +117,7 @@ export class AcpChatStore {
   private _disposed = false;
   private _attachmentRecovery: Scope | null = null;
   private _attachedHostGeneration: number | undefined;
+  private _bootstrapFailed = false;
 
   constructor(
     readonly conversationId: string,
@@ -365,7 +366,7 @@ export class AcpChatStore {
       void this.hostAccess.recover();
       return;
     }
-    if (this.session) {
+    if (this.session && !this._bootstrapFailed) {
       const state = this.hostAccess?.state;
       this._recoverAttachment(
         this.session,
@@ -374,6 +375,8 @@ export class AcpChatStore {
       return;
     }
     if (this.historyLoading || !this.loadError) return;
+    void this._attachmentRecovery?.dispose();
+    this._attachmentRecovery = null;
     this.historyLoading = true;
     this.loadError = null;
     void this._runBootstrap();
@@ -672,6 +675,7 @@ export class AcpChatStore {
         }
         this.historyLoading = false;
         this.loadError = null;
+        this._bootstrapFailed = false;
         this._syncMessageCount();
       });
       void this._rehydrateDraftAttachmentPreviews();
@@ -684,6 +688,7 @@ export class AcpChatStore {
       });
       runInAction(() => {
         if (clientSession && this.session !== clientSession) clientSession.dispose();
+        this._bootstrapFailed = true;
         this.historyLoading = false;
         this.loadError =
           this.hostAccess?.liveAction.kind === 'disabled'
@@ -712,7 +717,9 @@ export class AcpChatStore {
             if (scope.signal.aborted || this.session !== session || !session.usable) return;
             this._attachedHostGeneration = generation;
             runInAction(() => {
-              this.loadError = null;
+              // Reattachment alone cannot recover a failed history/bootstrap load.
+              if (this._bootstrapFailed) this.retry();
+              else this.loadError = null;
             });
             return;
           } catch (error) {

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.ts
@@ -163,18 +163,20 @@ export class AcpLiveSession {
     }
   }
 
-  async revalidate(): Promise<void> {
+  async revalidate(signal: AbortSignal = this.scope.signal): Promise<void> {
     const validation = ++this.validation;
     runInAction(() => this.usableState.set(false));
     try {
       const result = await withTimeout(
         (signal) => this.client.attach({ conversationId: this.conversationId }, { signal }),
-        'Timed out reattaching ACP session'
+        'Timed out reattaching ACP session',
+        10_000,
+        signal
       );
       if (validation !== this.validation || this.disposed) return;
       if (!result.success) throw new AcpStartError(result.error);
-      await withTimeout(this.refreshStates(), 'Timed out refreshing ACP session');
-      if (!this.disposed && validation === this.validation)
+      await withTimeout(this.refreshStates(), 'Timed out refreshing ACP session', 10_000, signal);
+      if (!this.disposed && !signal.aborted && validation === this.validation)
         runInAction(() => this.usableState.set(true));
     } catch (error) {
       if (!this.disposed && validation === this.validation) throw error;
@@ -322,10 +324,12 @@ function readableError(error: unknown): Error {
 function withTimeout<T>(
   work: Promise<T> | ((signal: AbortSignal) => Promise<T>),
   message: string,
-  ms = 10_000
+  ms = 10_000,
+  signal?: AbortSignal
 ): Promise<T> {
   return runWithTimeout((signal) => (typeof work === 'function' ? work(signal) : work), {
     timeoutMs: ms,
+    signal,
   }).catch((error: unknown) => {
     if (error instanceof TimeoutError) throw new Error(message);
     throw error;

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-recovery.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-recovery.test.ts
@@ -27,6 +27,78 @@ const contract = defineContract({
 });
 
 describe('ACP attachment recovery over replaceable Wire', () => {
+  it.each(['cancel', 'dispose'] as const)(
+    'does not restore usability after %s during attachment',
+    async (action) => {
+      const transport = replaceableTransport();
+      const connection = connect(transport, { maxHeldCalls: 0 });
+      getClient.mockResolvedValue(client(contract, connection));
+      const first = peer('old');
+      const gate = deferred<void>();
+      const replacement = peer('new', gate.promise);
+      transport.install(first.transport);
+      const session = await AcpLiveSession.create('conversation');
+      try {
+        transport.detach();
+        transport.install(replacement.transport);
+        const controller = new AbortController();
+        const recovery = session.revalidate(action === 'cancel' ? controller.signal : undefined);
+        const settled = recovery.catch(() => {});
+        if (action === 'cancel') controller.abort();
+        else session.dispose();
+        await settled;
+        gate.resolve();
+        await Promise.resolve();
+        expect(session.usable).toBe(false);
+      } finally {
+        gate.resolve();
+        session.dispose();
+        connection.dispose();
+        transport.close();
+        await first.dispose();
+        await replacement.dispose();
+      }
+    }
+  );
+  it('requires a successful reattach before restoring usability after a timeout', async () => {
+    vi.useFakeTimers();
+    const transport = replaceableTransport();
+    const connection = connect(transport, { maxHeldCalls: 0 });
+    const rpc = client(contract, connection);
+    getClient.mockResolvedValue(rpc);
+    const first = peer('old');
+    const gate = deferred<void>();
+    const replacement = peer('new', gate.promise);
+    transport.install(first.transport);
+    const session = await AcpLiveSession.create('conversation');
+    try {
+      transport.detach();
+      transport.install(replacement.transport);
+      const recovery = expect(session.revalidate()).rejects.toThrow(
+        'Timed out reattaching ACP session'
+      );
+      await vi.advanceTimersByTimeAsync(10_000);
+      await recovery;
+      expect(session.usable).toBe(false);
+      gate.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+      await expect(rpc.acp.attach({ conversationId: 'conversation' })).resolves.toEqual(ok());
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(session.config.current().modelOptions?.selected).toBe('new');
+      expect(session.usable).toBe(false);
+      await session.revalidate();
+      expect(session.usable).toBe(true);
+    } finally {
+      gate.resolve();
+      session.dispose();
+      transport.close();
+      connection.dispose();
+      await first.dispose();
+      await replacement.dispose();
+      vi.useRealTimers();
+    }
+  });
+
   it('retains the logical session while reattaching and refreshing daemon-owned state', async () => {
     const transport = replaceableTransport();
     const connection = connect(transport, { maxHeldCalls: 0 });

--- a/apps/emdash-desktop/src/core/features/machines/browser/components/workspace-server-card.tsx
+++ b/apps/emdash-desktop/src/core/features/machines/browser/components/workspace-server-card.tsx
@@ -27,6 +27,10 @@ export function WorkspaceRuntimeRow({
   actions: WorkspaceServerActions;
   availability?: HostAvailabilityState;
 }) {
+  const reconnecting =
+    availability?.kind === 'preparing'
+      ? availability.phase !== 'provisioning'
+      : availability?.kind === 'unavailable' && availability.recovery === 'waiting';
   return (
     <div className="flex flex-col gap-3">
       <SettingsRow
@@ -36,7 +40,9 @@ export function WorkspaceRuntimeRow({
             {connected &&
               !loading &&
               state &&
-              (state.status === 'healthy' && availability?.kind !== 'ready' ? (
+              (reconnecting ? (
+                <Pill variant="neutral">Reconnecting</Pill>
+              ) : state.status === 'healthy' && availability?.kind !== 'ready' ? (
                 <Pill variant="neutral">
                   {availability?.kind === 'preparing' ? 'Checking' : 'Unverified'}
                 </Pill>
@@ -46,7 +52,11 @@ export function WorkspaceRuntimeRow({
           </span>
         }
         description={
-          <WorkspaceRuntimeDetails connected={connected} loading={loading} state={state} />
+          reconnecting ? (
+            'Restoring workspace access. Last observed runtime details remain available.'
+          ) : (
+            <WorkspaceRuntimeDetails connected={connected} loading={loading} state={state} />
+          )
         }
         control={
           connected && !loading && state ? (

--- a/apps/emdash-desktop/src/core/features/projects/browser/components/project-availability-banner.browser.test.tsx
+++ b/apps/emdash-desktop/src/core/features/projects/browser/components/project-availability-banner.browser.test.tsx
@@ -1,6 +1,6 @@
 import { ok } from '@emdash/shared';
 import { deferred } from '@emdash/shared/testing';
-import { act, type ReactNode } from 'react';
+import { act, useEffect, type ReactNode } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ProjectHostAccessState } from '@core/features/projects/api/browser/stores/project-context';
@@ -110,7 +110,7 @@ describe('ProjectAvailabilityBanner', () => {
     expect(recover).toHaveBeenCalledOnce();
   });
 
-  it('uses the SSH Machine name and keeps the banner above Project content', async () => {
+  it('keeps connection status below project content rather than above its tabs', async () => {
     await render(
       sshProject,
       { kind: 'degraded', situation: 'offline', recovery: 'automatic' },
@@ -121,13 +121,13 @@ describe('ProjectAvailabilityBanner', () => {
     const content = host.querySelector('[data-testid="project-content"]');
     expect(status?.textContent).toContain('Orion is offline');
     expect(status?.querySelector('button')?.textContent).toBe('Connect');
-    expect(status?.compareDocumentPosition(content!)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(status?.compareDocumentPosition(content!)).toBe(Node.DOCUMENT_POSITION_PRECEDING);
   });
 
   it.each([
-    ['connecting', 'Connecting to Orion', 'Open Machines'],
-    ['provisioning', 'Preparing Orion', 'Open Machines'],
-    ['handshaking', 'Preparing Orion', 'Open Machines'],
+    ['connecting', 'Reconnecting to Orion', 'Retry now'],
+    ['provisioning', 'Reconnecting to Orion', 'Retry now'],
+    ['handshaking', 'Reconnecting to Orion', 'Retry now'],
     ['attaching', 'Opening Project on Orion', null],
   ] as const)('announces %s progress politely', async (state, title, actionLabel) => {
     await render(sshProject, {
@@ -158,8 +158,8 @@ describe('ProjectAvailabilityBanner', () => {
     });
 
     const status = host.querySelector('[role="status"]');
-    expect(status?.textContent).toContain('Could not connect to Orion');
-    expect(status?.textContent).toContain('Automatic recovery will continue');
+    expect(status?.textContent).toContain('Reconnecting to Orion');
+    expect(status?.textContent).toContain('Your work stays open');
     expect(status?.textContent).not.toContain('private-connection-id');
     expect(status?.textContent).not.toContain('raw connection failure');
     const retry = [...(status?.querySelectorAll('button') ?? [])].find(
@@ -277,5 +277,31 @@ describe('ProjectAvailabilityBanner', () => {
 
     expect(host.querySelector('[role="status"]')).toBeNull();
     expect(host.textContent).toBe('');
+  });
+
+  it('preserves the mounted content and draft across readiness and retry phases', async () => {
+    const mount = vi.fn();
+    const unmount = vi.fn();
+    function Content() {
+      useEffect(() => {
+        mount();
+        return unmount;
+      }, []);
+      return <input aria-label="Draft" defaultValue="unfinished prompt" />;
+    }
+    await render(sshProject, { kind: 'ready', hostGeneration: 1 }, <Content />);
+    const input = host.querySelector('input');
+    const footer = host.querySelector('[data-testid="project-connection-status"]');
+    for (const situation of ['checking', 'handshaking', 'recovering', 'handshaking'] as const) {
+      await render(sshProject, { kind: 'degraded', situation, recovery: 'automatic' }, <Content />);
+      expect(host.querySelector('input')).toBe(input);
+      expect(input?.value).toBe('unfinished prompt');
+      expect(host.querySelector('[role="status"]')?.textContent).toContain('Reconnecting to Orion');
+      expect(host.querySelector('[data-testid="project-connection-status"]')).toBe(footer);
+    }
+    await render(sshProject, { kind: 'ready', hostGeneration: 2 }, <Content />);
+    expect(host.querySelector('input')).toBe(input);
+    expect(mount).toHaveBeenCalledOnce();
+    expect(unmount).not.toHaveBeenCalled();
   });
 });

--- a/apps/emdash-desktop/src/core/features/projects/browser/components/project-availability-banner.tsx
+++ b/apps/emdash-desktop/src/core/features/projects/browser/components/project-availability-banner.tsx
@@ -19,6 +19,7 @@ type ProjectAvailabilityBannerProps = {
   state: ProjectHostAccessState;
   machineName?: string;
   actionHandlers?: ProjectAvailabilityActionHandlers;
+  compact?: boolean;
 };
 
 export type ProjectAvailabilityLayout = 'frame' | 'inline';
@@ -28,6 +29,7 @@ export function ProjectAvailabilityBanner({
   state,
   machineName,
   actionHandlers,
+  compact = false,
 }: ProjectAvailabilityBannerProps) {
   const actionDescriptionId = useId();
   const pendingActionRef = useRef<ProjectAvailabilityAction['kind'] | null>(null);
@@ -65,7 +67,8 @@ export function ProjectAvailabilityBanner({
       aria-live={presentation.announcement}
       aria-atomic="true"
       className={cn(
-        'flex shrink-0 items-center gap-3 rounded-lg border px-4 py-3',
+        'flex shrink-0 items-center gap-3',
+        compact ? 'h-9 px-3' : 'rounded-lg border px-4 py-3',
         presentation.severity === 'error' || presentation.severity === 'warning'
           ? 'border-foreground-warning/30 bg-background-warning text-foreground'
           : 'border-border bg-background-1 text-foreground'
@@ -80,9 +83,13 @@ export function ProjectAvailabilityBanner({
             : 'text-foreground-warning'
         )}
       />
-      <div className="min-w-0 flex-1">
-        <p className="text-sm font-medium">{presentation.title}</p>
-        <p className="text-xs text-foreground-muted">{presentation.detail}</p>
+      <div className="min-w-0 flex-1" title={compact ? presentation.detail : undefined}>
+        <p className={compact ? 'truncate text-xs text-foreground-muted' : 'text-sm font-medium'}>
+          {presentation.title}
+        </p>
+        <p className={compact ? 'sr-only' : 'text-xs text-foreground-muted'}>
+          {presentation.detail}
+        </p>
       </div>
       {presentation.actions.length > 0 ? (
         <div className="flex shrink-0 items-center gap-2">
@@ -144,19 +151,25 @@ export function ProjectAvailabilityFrame({
     );
   }
 
-  if (state.kind === 'ready') return children;
-
   return (
     <div className="flex h-full min-h-0 w-full flex-col">
-      <div className="mx-auto w-full max-w-265 shrink-0 px-8 pt-6">
+      <div className="min-h-0 flex-1">{children}</div>
+      <div className="h-9 shrink-0 border-t border-border" data-testid="project-connection-status">
+        {state.kind === 'ready' ? (
+          <div className="flex h-9 items-center px-3 text-xs text-foreground-muted">
+            {project.type === 'ssh'
+              ? `Connected to ${machineName || 'Machine'}`
+              : 'Local workspace'}
+          </div>
+        ) : null}
         <ProjectAvailabilityBanner
+          compact
           project={project}
           state={state}
           machineName={machineName}
           actionHandlers={actionHandlers}
         />
       </div>
-      <div className="min-h-0 flex-1">{children}</div>
     </div>
   );
 }

--- a/apps/emdash-desktop/src/core/features/projects/browser/project-availability-presentation.test.ts
+++ b/apps/emdash-desktop/src/core/features/projects/browser/project-availability-presentation.test.ts
@@ -123,20 +123,20 @@ describe('classifyProjectAvailability', () => {
     [
       'connecting',
       { kind: 'degraded', situation: 'connecting', recovery: 'automatic' },
-      'Connecting to Orion',
-      ['Open Machines'],
+      'Reconnecting to Orion',
+      ['Retry now', 'Open Machines'],
     ],
     [
       'provisioning',
       { kind: 'degraded', situation: 'provisioning', recovery: 'automatic' },
-      'Preparing Orion',
-      ['Open Machines'],
+      'Reconnecting to Orion',
+      ['Retry now', 'Open Machines'],
     ],
     [
       'handshaking',
       { kind: 'degraded', situation: 'handshaking', recovery: 'automatic' },
-      'Preparing Orion',
-      ['Open Machines'],
+      'Reconnecting to Orion',
+      ['Retry now', 'Open Machines'],
     ],
     [
       'attaching',
@@ -167,19 +167,19 @@ describe('classifyProjectAvailability', () => {
   >([
     [
       'offline',
-      'Orion is offline',
+      'Reconnecting to Orion',
       ['Retry now', 'Open Machines'],
       ['Retry now', 'Open Diagnostics'],
     ],
     [
       'connection-failed',
-      'Could not connect to Orion',
+      'Reconnecting to Orion',
       ['Retry now', 'Open Machines'],
       ['Retry now', 'Open Diagnostics'],
     ],
     [
       'daemon-start-failed',
-      "Could not start Orion's workspace server",
+      'Reconnecting to Orion',
       ['Retry now', 'Open Machines'],
       ['Retry now', 'Open Diagnostics'],
     ],
@@ -210,7 +210,7 @@ describe('classifyProjectAvailability', () => {
     ],
     [
       'runtime-unavailable',
-      "Orion's workspace server is unavailable",
+      'Reconnecting to Orion',
       ['Retry now', 'Open Machines'],
       ['Retry now', 'Open Diagnostics'],
     ],

--- a/apps/emdash-desktop/src/core/features/projects/browser/project-availability-presentation.ts
+++ b/apps/emdash-desktop/src/core/features/projects/browser/project-availability-presentation.ts
@@ -78,6 +78,25 @@ export function classifyProjectAvailability({
   if (state.kind === 'ready') return null;
   const machineName = host.kind === 'ssh' ? host.machineName?.trim() || 'Machine' : undefined;
 
+  // A retry attempt and its backoff belong to the same recovery episode. Do not
+  // alternate startup claims and outage warnings as its internal phase changes.
+  if (
+    host.kind === 'ssh' &&
+    state.recovery === 'automatic' &&
+    ['checking', 'connecting', 'provisioning', 'handshaking', 'recovering'].includes(
+      state.situation
+    )
+  ) {
+    return {
+      severity: 'info',
+      announcement: 'polite',
+      title: `Reconnecting to ${machineName}`,
+      detail: 'Your work stays open. Live features resume when the connection returns.',
+      progress: true,
+      actions: [action('retry', 'Retry now'), action('diagnostics', 'Open Machines')],
+    };
+  }
+
   switch (state.situation) {
     case 'suspended':
       return offlinePresentation(host, machineName);
@@ -111,7 +130,7 @@ export function classifyProjectAvailability({
         detail:
           host.kind === 'local'
             ? 'The Project stays open while local services start.'
-            : 'SSH is connected. The workspace server is starting.',
+            : 'Preparing workspace access. Your work stays open.',
         progress: true,
         actions: host.kind === 'ssh' ? [action('diagnostics', 'Open Machines')] : [],
       };

--- a/apps/emdash-desktop/src/core/services/hosts/node/connection-supervisor.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/connection-supervisor.ts
@@ -284,7 +284,11 @@ export class HostConnectionSupervisor {
       this.publish({ kind: 'idle' });
     }
     if (this.active) {
-      if (cause !== 'retry' || state.kind !== 'recovering' || state.nextAttemptAt === undefined)
+      if (
+        (cause !== 'retry' && cause !== 'online') ||
+        state.kind !== 'recovering' ||
+        state.nextAttemptAt === undefined
+      )
         return;
       this.cancel();
     }
@@ -305,6 +309,18 @@ export class HostConnectionSupervisor {
     const epoch = this.epoch;
     void attemptScope
       .run('validate', async () => {
+        // Validate SSH alongside the retained Wire channel. A sleeping laptop can leave
+        // both objects apparently connected; serial deadlines needlessly delay recovery.
+        const sshHealthy = wireProbe
+          ? runWithTimeout((signal) => this.options.ssh.probe(signal), {
+              signal: attemptScope.signal,
+              clock: this.clock,
+              timeoutMs: this.options.healthTimeoutMs ?? 5_000,
+            }).then(
+              () => true,
+              () => false
+            )
+          : undefined;
         const validation = wireProbe
           ? this.runtimeConnection.probe(attemptScope.signal)
           : runWithTimeout((signal) => this.options.ssh.probe(signal), {
@@ -325,11 +341,12 @@ export class HostConnectionSupervisor {
             );
             this.resolveWaiters();
           },
-          () => {
+          async () => {
+            const resetPhysical = !wireProbe || (await sshHealthy) === false;
             if (!this.isCurrent(attemptScope, epoch)) return;
             this.publish({ kind: 'recovering', phase: 'handshaking', attempt: 1 });
             this.runtimeConnection.detach();
-            if (!wireProbe) this.resetSsh();
+            if (resetPhysical) this.resetSsh();
           }
         );
       })

--- a/apps/emdash-desktop/src/core/services/hosts/node/sleep-recovery.test.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/sleep-recovery.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createFaultPeer, createSupervisorDriver } from './testing/connection-supervisor-fixture';
+
+describe('sleep recovery', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it.each([true, false])('measures resume when SSH is silently dead: %s', async (deadSsh) => {
+    vi.useFakeTimers();
+    const peer = createFaultPeer();
+    let reportedConnected = true;
+    let deadPhysicalConnection = false;
+    const reset = vi.fn(() => {
+      reportedConnected = false;
+    });
+    const host = createSupervisorDriver(peer, {
+      ssh: {
+        connected: () => reportedConnected,
+        establish: async () => {
+          if (!reportedConnected) {
+            reportedConnected = true;
+            deadPhysicalConnection = false;
+          }
+        },
+        reset,
+        probe: () => (deadPhysicalConnection ? new Promise<void>(() => {}) : Promise.resolve()),
+      },
+      runtime: {
+        prepare: async () => ({
+          kind: 'ssh',
+          sshConnectionId: 'acceptance-host',
+          socketPath: '/workspace.sock',
+        }),
+        open: () => (deadPhysicalConnection ? new Promise(() => {}) : peer.openTransport()),
+        cancel() {},
+      },
+    });
+    try {
+      await host.connect();
+      deadPhysicalConnection = deadSsh;
+      peer.current.dropRequests = true;
+      host.supervisor.suspendSystem();
+      host.supervisor.resume();
+      await vi.advanceTimersByTimeAsync(5_000);
+      if (!deadSsh) {
+        expect(host.state.kind).toBe('ready');
+        expect(reset).not.toHaveBeenCalled();
+        expect(peer.opens).toBe(2);
+        return;
+      }
+      expect(reset).toHaveBeenCalledOnce();
+      expect(host.state.kind).toBe('ready');
+      expect(peer.opens).toBe(2);
+    } finally {
+      await host.dispose();
+      await peer.dispose();
+    }
+  });
+
+  it.each(['online', 'retry'] as const)(
+    'compares %s during scheduled recovery backoff',
+    async (cause) => {
+      vi.useFakeTimers();
+      const peer = createFaultPeer();
+      const host = createSupervisorDriver(peer);
+      try {
+        await host.connect();
+        peer.setOffline(true);
+        peer.current.disconnect();
+        await vi.advanceTimersByTimeAsync(68_500);
+        expect(host.state).toMatchObject({ kind: 'unavailable', recovery: 'waiting' });
+        const attempts = peer.opens;
+        const state = host.state;
+        if (state.kind !== 'unavailable' || state.nextAttemptAt === undefined)
+          throw new Error('missing retry');
+        const remaining = state.nextAttemptAt - Date.now();
+        expect(remaining).toBe(30_000);
+        peer.setOffline(false);
+        if (cause === 'retry') {
+          host.retry();
+        } else {
+          host.revalidate('online');
+          host.revalidate('focus');
+        }
+        await vi.advanceTimersByTimeAsync(0);
+        expect(peer.opens).toBe(attempts + 1);
+        expect(host.state.kind).toBe('ready');
+      } finally {
+        await host.dispose();
+        await peer.dispose();
+      }
+    }
+  );
+});

--- a/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
@@ -1,4 +1,5 @@
 import type { HistoryPage, SessionState } from '@emdash/core/runtimes/acp/api/client';
+import { observable, runInAction } from 'mobx';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { installChatUiRuntime } from '@core/features/conversations/api/browser/chat/chat-ui-runtime';
 import {
@@ -6,6 +7,7 @@ import {
   type AcpPromptAttachment,
 } from '@core/features/conversations/browser/acp/acp-chat-store';
 import { AcpLiveSession } from '@core/features/conversations/browser/acp/acp-live-session';
+import type { ProjectHostAccessState } from '@core/features/projects/api/browser/stores/project-context';
 
 type DraftState = {
   version: '1';
@@ -77,6 +79,105 @@ const connectSession = vi.fn(
 );
 
 describe('AcpChatStore prompt submission', () => {
+  it.each(['host-check', 'timer', 'retry'] as const)(
+    'recovers a timed-out attachment through %s without a new host generation',
+    async (trigger) => {
+      const hostState = observable.box<ProjectHostAccessState>({
+        kind: 'ready',
+        hostGeneration: 1,
+      });
+      const host = {
+        get state() {
+          return hostState.get();
+        },
+        get liveAction() {
+          return hostState.get().kind === 'ready'
+            ? { kind: 'enabled' }
+            : { kind: 'disabled', state: hostState.get() };
+        },
+      };
+      const usable = observable.box(true);
+      const revalidate = vi.fn<() => Promise<void>>(async () => {
+        runInAction(() => usable.set(false));
+        throw new Error('Timed out reattaching ACP session');
+      });
+      const store = new AcpChatStore('conversation-1', 'project-1', 'task-1', host as never);
+      store.session = {
+        sessionState: { current: idleState },
+        get usable() {
+          return usable.get();
+        },
+        revalidate,
+        dispose: vi.fn(),
+      } as never;
+      try {
+        runInAction(() => hostState.set({ kind: 'ready', hostGeneration: 2 }));
+        await vi.waitFor(() =>
+          expect(store.loadError?.message).toBe('Timed out reattaching ACP session')
+        );
+        expect(store.affordances.canSubmit).toBe(false);
+        revalidate.mockImplementation(async () => {
+          runInAction(() => usable.set(true));
+        });
+        if (trigger === 'host-check') {
+          runInAction(() =>
+            hostState.set({ kind: 'degraded', situation: 'checking', recovery: 'automatic' })
+          );
+          runInAction(() => hostState.set({ kind: 'ready', hostGeneration: 2 }));
+        } else if (trigger === 'retry') {
+          store.retry();
+        }
+        await vi.waitFor(() => expect(store.affordances.canSubmit).toBe(true), { timeout: 3_000 });
+        expect(revalidate).toHaveBeenCalledTimes(2);
+        expect(store.loadError).toBeNull();
+      } finally {
+        store.dispose();
+      }
+    }
+  );
+
+  it('routes retry to host recovery while access is disabled', () => {
+    const recover = vi.fn(async () => ({ success: true }));
+    const store = new AcpChatStore('conversation-1', 'project-1', 'task-1', {
+      state: { kind: 'degraded', situation: 'recovering', recovery: 'automatic' },
+      liveAction: { kind: 'disabled' },
+      recover,
+    } as never);
+    try {
+      store.retry();
+      expect(recover).toHaveBeenCalledOnce();
+      expect(store.session).toBeNull();
+    } finally {
+      store.dispose();
+    }
+  });
+
+  it('keeps drafting local while rejecting remote actions on an unusable session', () => {
+    const remoteAction = vi.fn();
+    const store = createStore(idleState(), remoteAction, {
+      usable: false,
+      setOption: remoteAction,
+      cancelTurn: remoteAction,
+      deleteQueuedPrompt: remoteAction,
+      changeQueuePromptOrder: remoteAction,
+    });
+    try {
+      store.setDraftText('keep writing offline');
+      store.setModel('model');
+      store.setMode('mode');
+      store.setEffort('high');
+      store.setCollaborationMode('plan');
+      store.stop();
+      store.deleteQueuedPrompt('queued');
+      store.reorderQueuedPrompts(['queued']);
+      expect(remoteAction).not.toHaveBeenCalled();
+      expect(store.draftText).toBe('keep writing offline');
+      expect(store.affordances.canSubmit).toBe(false);
+    } finally {
+      store.dispose();
+    }
+  });
+
   beforeAll(() => {
     installChatUiRuntime({
       createChatContext: () => ({}) as never,
@@ -664,6 +765,7 @@ function fakeLiveSession(
     mcpServers: new FakeRemote([]),
     loadHistory,
     terminalOutput: vi.fn(),
+    usable: true,
     sendPrompt: vi.fn(async () => ({ success: true, data: { queued: false } })),
     dispose: vi.fn(),
     ...overrides,
@@ -697,6 +799,7 @@ function createStore(
 ) {
   const store = new AcpChatStore('conversation-1', 'project-1', 'task-1');
   store.session = {
+    usable: true,
     sessionState: { current: () => state },
     sendPrompt,
     dispose: vi.fn(),

--- a/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
@@ -638,6 +638,52 @@ describe('AcpChatStore prompt submission', () => {
     store.dispose();
   });
 
+  it.each(['retry', 'host-recovery'] as const)(
+    'reloads failed bootstrap history through %s even with a retained session',
+    async (trigger) => {
+      const hostState = observable.box<ProjectHostAccessState>({
+        kind: 'ready',
+        hostGeneration: 1,
+      });
+      const failed = fakeLiveSession(idleState(), historyPage('initial'), {
+        revalidate: vi.fn(async () => {}),
+      });
+      failed.loadHistory.mockRejectedValueOnce(new Error('History unavailable'));
+      const recovered = fakeLiveSession(idleState(), historyPage('recovered'));
+      const create = vi
+        .spyOn(AcpLiveSession, 'create')
+        .mockResolvedValueOnce(failed.session)
+        .mockResolvedValueOnce(recovered.session);
+      const store = new AcpChatStore('conversation-1', 'project-1', 'task-1', {
+        get state() {
+          return hostState.get();
+        },
+        liveAction: { kind: 'enabled' },
+      } as never);
+      try {
+        store.bootstrap();
+        await vi.waitFor(() => expect(store.historyLoading).toBe(false));
+        expect(store.session).toBe(failed.session);
+        expect(store.loadError?.message).toBe('History unavailable');
+        expect(historySeed).not.toHaveBeenCalled();
+
+        if (trigger === 'retry') store.retry();
+        else runInAction(() => hostState.set({ kind: 'ready', hostGeneration: 2 }));
+
+        await vi.waitFor(() =>
+          expect(historySeed).toHaveBeenCalledWith([expect.objectContaining({ id: 'recovered' })])
+        );
+        expect(failed.session.dispose).toHaveBeenCalledOnce();
+        expect(recovered.loadHistory).toHaveBeenCalledWith(undefined, 100);
+        expect(store.historyLoading).toBe(false);
+        expect(store.loadError).toBeNull();
+      } finally {
+        store.dispose();
+        create.mockRestore();
+      }
+    }
+  );
+
   it('keeps the ordinary active-turn completion history refresh', async () => {
     const live = fakeLiveSession(idleState(), historyPage('initial'));
     const store = await bootstrapWithSession(live.session);

--- a/docs/adr/0008-host-connection-supervisor.md
+++ b/docs/adr/0008-host-connection-supervisor.md
@@ -141,7 +141,15 @@ health deadline.
 
 Resume immediately makes pre-sleep evidence uncertain and supersedes unfinished pre-sleep
 attempts. Probe an established attachment before replacing it. Focus/online hints are
-coalesced and throttled; neither bypasses stopped/blocked policy. Detect long scheduling gaps
+coalesced and throttled; neither bypasses stopped/blocked policy. Validate retained SSH and Wire
+evidence concurrently so dead SSH does not consume
+another channel-open deadline before replacement. An online hint expedites a scheduled backoff
+without cancelling useful in-flight work. ACP attachment retries belong to the retained chat
+session and continue after transient failure even within the same Host generation; only successful
+attachment plus snapshot refresh records that generation as recovered. Cancellation fences late
+attachment responses. The Project content tree remains mounted across availability transitions,
+with a compact connection footer below the workspace instead of a banner above its tabs.
+Detect long scheduling gaps
 as additional uncertainty; do not rely on paused timers replaying missed health intervals.
 Use elapsed time for deadlines, and explicit resume/gap handling for evidence freshness.
 


### PR DESCRIPTION
- validate stale connections concurrently and resume retries when the network returns
- retry timed-out chat attachments without requiring a new host connection
- move connection status below the workspace and preserve mounted content through recovery
- keep drafts editable while gating remote actions and removing duplicate outage notices

validation: 115 focused node tests and 46 browser tests pass alongside desktop typecheck and changed-file lint

risk: changes ssh recovery timing and chat attachment cancellation without restarting the remote daemon