### PR TITLE
fix(release): restore posthog credentials

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -49,8 +49,9 @@ jobs:
     with:
       channel: canary
       release_id: ${{ needs.prepare-release.outputs.release_id }}
-      posthog_key: ${{ vars.POSTHOG_PROJECT_API_KEY }}
-      posthog_host: ${{ vars.POSTHOG_HOST }}
+    secrets:
+      POSTHOG_PROJECT_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
+      POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
 
   release-win:
     needs: [prepare-release]
@@ -62,8 +63,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-build
         with:
-          posthog-key: ${{ vars.POSTHOG_PROJECT_API_KEY }}
-          posthog-host: ${{ vars.POSTHOG_HOST }}
+          posthog-key: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
+          posthog-host: ${{ secrets.POSTHOG_HOST }}
           build-variant: canary
           windows-native: 'true'
       - name: Export Python path for native modules
@@ -133,8 +134,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-build
         with:
-          posthog-key: ${{ vars.POSTHOG_PROJECT_API_KEY }}
-          posthog-host: ${{ vars.POSTHOG_HOST }}
+          posthog-key: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
+          posthog-host: ${{ secrets.POSTHOG_HOST }}
           build-variant: canary
 
       - name: Import Apple signing certificate

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -11,16 +11,11 @@ on:
         description: Exact GitHub draft release id created by the caller
         required: true
         type: string
-      posthog_key:
-        description: Public PostHog project key embedded in the desktop client
+    secrets:
+      POSTHOG_PROJECT_API_KEY:
         required: false
-        type: string
-        default: ''
-      posthog_host:
-        description: Public PostHog host embedded in the desktop client
+      POSTHOG_HOST:
         required: false
-        type: string
-        default: ''
 
 permissions:
   contents: write
@@ -57,8 +52,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-build
         with:
-          posthog-key: ${{ inputs.posthog_key }}
-          posthog-host: ${{ inputs.posthog_host }}
+          posthog-key: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
+          posthog-host: ${{ secrets.POSTHOG_HOST }}
           build-variant: ${{ inputs.channel == 'canary' && 'canary' || 'prod' }}
           setup-python: 'false'
 

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -49,8 +49,9 @@ jobs:
     with:
       channel: stable
       release_id: ${{ needs.prepare-release.outputs.release_id }}
-      posthog_key: ${{ vars.POSTHOG_PROJECT_API_KEY }}
-      posthog_host: ${{ vars.POSTHOG_HOST }}
+    secrets:
+      POSTHOG_PROJECT_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
+      POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
 
   release-win:
     needs: [prepare-release]
@@ -62,8 +63,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-build
         with:
-          posthog-key: ${{ vars.POSTHOG_PROJECT_API_KEY }}
-          posthog-host: ${{ vars.POSTHOG_HOST }}
+          posthog-key: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
+          posthog-host: ${{ secrets.POSTHOG_HOST }}
           windows-native: 'true'
       - name: Export Python path for native modules
         shell: bash
@@ -129,8 +130,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-build
         with:
-          posthog-key: ${{ vars.POSTHOG_PROJECT_API_KEY }}
-          posthog-host: ${{ vars.POSTHOG_HOST }}
+          posthog-key: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
+          posthog-host: ${{ secrets.POSTHOG_HOST }}
 
       - name: Import Apple signing certificate
         uses: apple-actions/import-codesign-certs@v2


### PR DESCRIPTION
- restore posthog secrets across production and canary release workflows
- forward only the required secrets to linux builds
- preserve the verified publishing flow and restricted credential access