### PR TITLE
fix(acp)!: acknowledge prompts on session acceptance

### DIFF
--- a/agents/architecture/acp-runtime.md
+++ b/agents/architecture/acp-runtime.md
@@ -123,8 +123,11 @@ observe that state; the send acknowledgement no longer means the turn has finish
 
 The desktop subscribes before submission and refreshes snapshots after reattachment. A client
 prompt id follows the existing queue and synthesized user transcript message so a lost acknowledgement
-can be reconciled without matching text. A transport exception does not mean rejection and never
-automatically restores the prompt into the composer or resubmits it. This is not a durable outbox:
+can be reconciled without matching text. Wire marks failures known to occur before posting as
+"not-sent", including held-call overflow and cancellation or disposal before posting. This evidence
+survives gateway forwarding, allowing the desktop to report rejection and restore the draft.
+Failures without that evidence remain uncertain and do not restore or resubmit the prompt.
+This is not a durable outbox:
 provider-replayed history may lack the correlation id after a worker restart, leaving delivery
 explicitly uncertain. No receipt journal or new persistence authority is introduced.
 The changed acknowledgement semantics require protocol major 8. Older clients or servers must

--- a/agents/architecture/acp-runtime.md
+++ b/agents/architecture/acp-runtime.md
@@ -114,6 +114,22 @@ lifecycle cell. `setOption` updates one of the provider's model, mode, or effort
 waking a suspended session. Headless callers that need creation and activation as one atomic
 operation use `launch`; there is no public `ensureActivation`, `start`, or `resume` procedure.
 
+`sendPrompt` (protocol 8) waits for activation and attachment validation, then acknowledges
+once the live session accepts the prompt for dispatch or queuing. Its host-owned operation retains
+the activation lease until execution finishes; a desktop disconnect does not cancel that work.
+Startup/authentication failures are returned before acceptance. Provider failures after acceptance
+are published through the existing session and transcript state. Callers that need completion
+observe that state; the send acknowledgement no longer means the turn has finished.
+
+The desktop subscribes before submission and refreshes snapshots after reattachment. A client
+prompt id follows the existing queue and synthesized user transcript message so a lost acknowledgement
+can be reconciled without matching text. A transport exception does not mean rejection and never
+automatically restores the prompt into the composer or resubmits it. This is not a durable outbox:
+provider-replayed history may lack the correlation id after a worker restart, leaving delivery
+explicitly uncertain. No receipt journal or new persistence authority is introduced.
+The changed acknowledgement semantics require protocol major 8. Older clients or servers must
+upgrade through the existing protocol-incompatibility flow; there is no legacy sending fallback.
+
 The handle persists an explicitly allowlisted, versioned intent containing provider/session
 identity, cwd, desired model/mode/effort, and a bounded non-secret presentation snapshot. Provider
 environment, MCP credentials, runtime endpoints, and unknown descriptor fields are never persisted.

--- a/agents/architecture/workspace-server.md
+++ b/agents/architecture/workspace-server.md
@@ -121,7 +121,7 @@ The wire contract is versioned with a single [semver](https://semver.org) string
 [`packages/core/src/workspace-server/versions/index.ts`](../../packages/core/src/workspace-server/versions/index.ts):
 
 ```ts
-export const PROTOCOL_VERSION = '7.0.0';
+export const PROTOCOL_VERSION = '8.0.0';
 ```
 
 ### What each component means

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
@@ -49,7 +49,12 @@ import {
   type MementoHandle,
   type SubjectSpace,
 } from '@core/primitives/mementos/browser';
-import { AcpLiveSession, AcpStartError, asValueSource } from './acp-live-session';
+import {
+  AcpLiveSession,
+  AcpPromptDeliveryUnknownError,
+  AcpStartError,
+  asValueSource,
+} from './acp-live-session';
 import { bindSessionTerminalOutputs } from './acp-terminal-output-binding';
 
 export interface AgentAffordances {
@@ -102,6 +107,7 @@ export class AcpChatStore {
   messageCount = 0;
   draftText = '';
   draftAttachments: AcpPromptAttachment[] = [];
+  unconfirmedPromptIds: string[] = [];
 
   private _view: ChatView | null = null;
   private _bootstrapped = false;
@@ -143,6 +149,7 @@ export class AcpChatStore {
       messageCount: observable,
       draftText: observable,
       draftAttachments: observable.shallow,
+      unconfirmedPromptIds: observable.shallow,
       model: computed,
       modelOptions: computed,
       permissionMode: computed,
@@ -463,8 +470,8 @@ export class AcpChatStore {
       this.chatState.scroll.set(pinMode);
     }
 
-    void this._submitPrompt(text, promptAttachments, hiddenContext).then((accepted) => {
-      if (accepted) return;
+    void this._submitPrompt(text, promptAttachments, hiddenContext).then((outcome) => {
+      if (outcome !== 'rejected') return;
       runInAction(() => {
         if (this._disposed || submissionSequence !== this._submissionSequence) return;
         if (optimisticId && this.chatState.session.state.pendingPrompt?.id === optimisticId) {
@@ -768,12 +775,12 @@ export class AcpChatStore {
     text: string,
     attachments: StoredPromptAttachment[],
     hiddenContext?: string | Promise<string | undefined>
-  ): Promise<boolean> {
-    if (this.hostAccess?.liveAction.kind === 'disabled') return false;
+  ): Promise<'accepted' | 'rejected' | 'unknown'> {
+    if (this.hostAccess?.liveAction.kind === 'disabled') return 'rejected';
     const session = this.session;
     if (!session || !session.usable) {
       this._toastError('Failed to send message', new Error('ACP session is not connected'));
-      return false;
+      return 'rejected';
     }
 
     let resolvedHiddenContext: string | undefined;
@@ -794,12 +801,20 @@ export class AcpChatStore {
       });
       if (!result.success) {
         this._toastError('Failed to send message', result.error);
-        return false;
+        return 'rejected';
       }
-      return true;
+      return 'accepted';
     } catch (error) {
+      if (error instanceof AcpPromptDeliveryUnknownError) {
+        if (this._disposed) return 'unknown';
+        runInAction(() => {
+          this.unconfirmedPromptIds = [...this.unconfirmedPromptIds, error.promptId];
+          this._syncMessageCount();
+        });
+        return 'unknown';
+      }
       this._toastError('Failed to send message', error);
-      return false;
+      return 'rejected';
     }
   }
 
@@ -990,6 +1005,18 @@ export class AcpChatStore {
 
   private _syncMessageCount(): void {
     const state = this.chatState.transcript.state;
+    if (this.unconfirmedPromptIds.length > 0 && this.session) {
+      const accepted = new Set(
+        this.session.sessionState.current().queuedPrompts.map((prompt) => prompt.id)
+      );
+      const active = this.session.activeTurn.current();
+      for (const turn of [...state.committedTurns, ...(active ? [active] : [])]) {
+        for (const item of turn.items) {
+          if (item.kind === 'message' && item.promptId) accepted.add(item.promptId);
+        }
+      }
+      this.unconfirmedPromptIds = this.unconfirmedPromptIds.filter((id) => !accepted.has(id));
+    }
     const committedCount = state.committedTurns.reduce(
       (count, turn) => count + turn.items.length,
       0

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.test.ts
@@ -1,4 +1,5 @@
 import { createScope } from '@emdash/shared/concurrency';
+import { WireError } from '@emdash/wire/rpc';
 import { cell, flushStateTurn } from '@emdash/wire/state';
 import { reaction } from 'mobx';
 import { describe, expect, it, vi } from 'vitest';
@@ -36,6 +37,26 @@ describe('remoteValueState', () => {
 });
 
 describe('AcpLiveSession.sendPrompt', () => {
+  it.each(['DISCONNECTED', 'TIMEOUT', 'CANCELLED', 'SERIALIZATION'] as const)(
+    'uses delivery evidence rather than the %s code to distinguish rejection from uncertainty',
+    async (code) => {
+      for (const delivery of ['not-sent', undefined] as const) {
+        const error = new WireError(code, 'request failed', { delivery });
+        const sendPrompt = vi.fn().mockRejectedValue(error);
+        const session = Object.assign(Object.create(AcpLiveSession.prototype), {
+          conversationId: 'conversation-1',
+          client: { sendPrompt },
+        }) as AcpLiveSession;
+        const failure = await session
+          .sendPrompt({ text: 'hello' })
+          .catch((caught: unknown) => caught);
+        if (delivery) expect(failure).toBe(error);
+        else expect(failure).toBeInstanceOf(AcpPromptDeliveryUnknownError);
+        expect(sendPrompt).toHaveBeenCalledOnce();
+      }
+    }
+  );
+
   it('requests session acceptance with a prompt correlation id and allows activation to finish', async () => {
     const sendPrompt = vi.fn(async () => ({ success: true, data: { queued: false } }));
     const session = Object.assign(Object.create(AcpLiveSession.prototype), {

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.test.ts
@@ -3,7 +3,11 @@ import { cell, flushStateTurn } from '@emdash/wire/state';
 import { reaction } from 'mobx';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
-import { AcpLiveSession, remoteValueState } from './acp-live-session';
+import {
+  AcpLiveSession,
+  AcpPromptDeliveryUnknownError,
+  remoteValueState,
+} from './acp-live-session';
 
 describe('remoteValueState', () => {
   it('invalidates MobX reactions when the Wire state changes', async () => {
@@ -32,7 +36,7 @@ describe('remoteValueState', () => {
 });
 
 describe('AcpLiveSession.sendPrompt', () => {
-  it('disables the Wire deadline for the turn-long prompt call', async () => {
+  it('requests session acceptance with a prompt correlation id and allows activation to finish', async () => {
     const sendPrompt = vi.fn(async () => ({ success: true, data: { queued: false } }));
     const session = Object.assign(Object.create(AcpLiveSession.prototype), {
       conversationId: 'conversation-1',
@@ -44,11 +48,24 @@ describe('AcpLiveSession.sendPrompt', () => {
     expect(sendPrompt).toHaveBeenCalledWith(
       {
         conversationId: 'conversation-1',
+        promptId: expect.any(String),
         prompt: { text: 'hello' },
         placement: undefined,
       },
       { timeoutMs: 0 }
     );
+  });
+
+  it('preserves the submitted id when delivery confirmation is lost', async () => {
+    const sendPrompt = vi.fn().mockRejectedValue(new Error('disconnected'));
+    const session = Object.assign(Object.create(AcpLiveSession.prototype), {
+      conversationId: 'conversation-1',
+      client: { sendPrompt },
+    }) as AcpLiveSession;
+    const failure = await session.sendPrompt({ text: 'hello' }).catch((error: unknown) => error);
+    expect(failure).toBeInstanceOf(AcpPromptDeliveryUnknownError);
+    expect(failure).toMatchObject({ promptId: sendPrompt.mock.calls[0][0].promptId });
+    expect(sendPrompt).toHaveBeenCalledOnce();
   });
 });
 

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.ts
@@ -17,6 +17,7 @@ import { createEmitter, type Result, type Unsubscribe } from '@emdash/shared';
 import { createScope, type Scope } from '@emdash/shared/concurrency';
 import { TimeoutError, runWithTimeout } from '@emdash/shared/scheduling';
 import { ReplicaLog, createLineLogStore } from '@emdash/wire/live';
+import { WireError } from '@emdash/wire/rpc';
 import { observe, remote, whenReady, type Readable } from '@emdash/wire/state';
 import { observable, runInAction } from 'mobx';
 import { z } from 'zod';
@@ -222,6 +223,7 @@ export class AcpLiveSession {
         { timeoutMs: 0 }
       );
     } catch (error) {
+      if (error instanceof WireError && error.delivery === 'not-sent') throw error;
       throw new AcpPromptDeliveryUnknownError(promptId, error);
     }
   }

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.ts
@@ -76,6 +76,16 @@ export class AcpStartError extends Error {
   }
 }
 
+export class AcpPromptDeliveryUnknownError extends Error {
+  constructor(
+    readonly promptId: string,
+    cause: unknown
+  ) {
+    super('The connection interrupted confirmation of prompt delivery', { cause });
+    this.name = 'AcpPromptDeliveryUnknownError';
+  }
+}
+
 export class AcpLiveSession {
   readonly sessionState: RemoteValueState<SessionState>;
   readonly config: RemoteValueState<z.infer<typeof sessionConfigStateSchema>>;
@@ -201,14 +211,19 @@ export class AcpLiveSession {
     return { success: true, data: result.data.log };
   }
 
-  sendPrompt(
+  async sendPrompt(
     prompt: PromptInput,
     placement?: PromptPlacement
   ): Promise<Result<{ queued: boolean }, unknown>> {
-    return this.client.sendPrompt(
-      { conversationId: this.conversationId, prompt, placement },
-      { timeoutMs: 0 }
-    );
+    const promptId = crypto.randomUUID();
+    try {
+      return await this.client.sendPrompt(
+        { conversationId: this.conversationId, promptId, prompt, placement },
+        { timeoutMs: 0 }
+      );
+    } catch (error) {
+      throw new AcpPromptDeliveryUnknownError(promptId, error);
+    }
   }
 
   editQueuedPrompt(id: string, input: PromptInput): Promise<Result<void, unknown>> {

--- a/apps/emdash-desktop/src/core/features/conversations/node/wire-controller.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/wire-controller.test.ts
@@ -6,7 +6,7 @@ import {
 } from '@emdash/core/primitives/host/api';
 import { err, ok } from '@emdash/shared';
 import type { LiveSource } from '@emdash/wire/rpc';
-import { encodeTopic, isDownloadFileOpenResult, type WireFile } from '@emdash/wire/rpc';
+import { encodeTopic, isDownloadFileOpenResult, WireError, type WireFile } from '@emdash/wire/rpc';
 import { describe, expect, it, vi } from 'vitest';
 import { conversationsContract } from '../api';
 import type { ConversationsRuntimeResolveError as RuntimeResolveError } from '../api/runtime-adapter';
@@ -198,13 +198,14 @@ describe('createConversationsWireController', () => {
     ]);
   });
 
-  it('disables the worker Wire deadline for the turn-long ACP prompt call', async () => {
+  it('allows activation to finish before acknowledging prompt acceptance', async () => {
     const sendPrompt = vi.fn(async () => ok({ queued: false }));
     const controller = setupController({
       client: { acp: { sendPrompt } },
     });
     const input = {
       conversationId: target.conversationId,
+      promptId: crypto.randomUUID(),
       prompt: { text: 'hello' },
     };
 
@@ -212,6 +213,21 @@ describe('createConversationsWireController', () => {
 
     expect(sendPrompt).toHaveBeenCalledWith(input, { timeoutMs: 0 });
   });
+
+  it.each(['UNKNOWN_PROCEDURE', 'DISCONNECTED', 'TIMEOUT'] as const)(
+    'does not resend a prompt after %s',
+    async (code) => {
+      const sendPrompt = vi.fn().mockRejectedValue(new WireError(code, 'submission failed'));
+      const controller = setupController({ client: { acp: { sendPrompt } } });
+      const input = {
+        conversationId: target.conversationId,
+        promptId: crypto.randomUUID(),
+        prompt: { text: 'hello' },
+      };
+      await expect(controller.call('acp.sendPrompt', input)).rejects.toMatchObject({ code });
+      expect(sendPrompt).toHaveBeenCalledOnce();
+    }
+  );
 
   it('records submitted TUI input only after a successful carriage return', async () => {
     const sendInput = vi.fn(async () => ok(undefined));
@@ -404,6 +420,7 @@ describe('createConversationsWireController', () => {
     await expect(
       controller.call('acp.sendPrompt', {
         conversationId: target.conversationId,
+        promptId: '00000000-0000-4000-8000-000000000001',
         prompt: { text: 'hello' },
       })
     ).resolves.toEqual(err(attachmentError));

--- a/apps/emdash-desktop/src/core/features/projects/browser/components/project-availability-banner.browser.test.tsx
+++ b/apps/emdash-desktop/src/core/features/projects/browser/components/project-availability-banner.browser.test.tsx
@@ -272,12 +272,20 @@ describe('ProjectAvailabilityBanner', () => {
     expect(host.querySelector('button')?.getAttribute('aria-disabled')).toBe('false');
   });
 
-  it('renders no banner or reserved space when Host access is ready', async () => {
-    await render(sshProject, { kind: 'ready', hostGeneration: 2 });
+  it.each([localProject, sshProject])(
+    'renders no banner or reserved space when $type Host access is ready',
+    async (project) => {
+      await render(
+        project,
+        { kind: 'ready', hostGeneration: 2 },
+        <main data-testid="project-content">Project content</main>
+      );
 
-    expect(host.querySelector('[role="status"]')).toBeNull();
-    expect(host.textContent).toBe('');
-  });
+      expect(host.querySelector('[role="status"]')).toBeNull();
+      expect(host.querySelector('[data-testid="project-connection-status"]')).toBeNull();
+      expect(host.textContent).toBe('Project content');
+    }
+  );
 
   it('preserves the mounted content and draft across readiness and retry phases', async () => {
     const mount = vi.fn();
@@ -291,16 +299,19 @@ describe('ProjectAvailabilityBanner', () => {
     }
     await render(sshProject, { kind: 'ready', hostGeneration: 1 }, <Content />);
     const input = host.querySelector('input');
-    const footer = host.querySelector('[data-testid="project-connection-status"]');
+    expect(host.querySelector('[data-testid="project-connection-status"]')).toBeNull();
     for (const situation of ['checking', 'handshaking', 'recovering', 'handshaking'] as const) {
       await render(sshProject, { kind: 'degraded', situation, recovery: 'automatic' }, <Content />);
       expect(host.querySelector('input')).toBe(input);
       expect(input?.value).toBe('unfinished prompt');
       expect(host.querySelector('[role="status"]')?.textContent).toContain('Reconnecting to Orion');
-      expect(host.querySelector('[data-testid="project-connection-status"]')).toBe(footer);
+      expect(
+        host.querySelector<HTMLElement>('[data-testid="project-connection-status"]')?.offsetHeight
+      ).toBe(40);
     }
     await render(sshProject, { kind: 'ready', hostGeneration: 2 }, <Content />);
     expect(host.querySelector('input')).toBe(input);
+    expect(host.querySelector('[data-testid="project-connection-status"]')).toBeNull();
     expect(mount).toHaveBeenCalledOnce();
     expect(unmount).not.toHaveBeenCalled();
   });

--- a/apps/emdash-desktop/src/core/features/projects/browser/components/project-availability-banner.tsx
+++ b/apps/emdash-desktop/src/core/features/projects/browser/components/project-availability-banner.tsx
@@ -6,6 +6,7 @@ import {
   classifyProjectAvailability,
   type ProjectAvailabilityAction,
 } from '@core/features/projects/browser/project-availability-presentation';
+import { WORKBENCH_BOTTOM_BAR_HEIGHT_PX } from '@core/primitives/layouts/api';
 import { log } from '@core/primitives/logging/browser/logger';
 import type { LocalProject, SshProject } from '@core/primitives/projects/api';
 import { cn } from '@core/primitives/styling/browser/cn';
@@ -68,7 +69,7 @@ export function ProjectAvailabilityBanner({
       aria-atomic="true"
       className={cn(
         'flex shrink-0 items-center gap-3',
-        compact ? 'h-9 px-3' : 'rounded-lg border px-4 py-3',
+        compact ? 'px-3' : 'rounded-lg border px-4 py-3',
         presentation.severity === 'error' || presentation.severity === 'warning'
           ? 'border-foreground-warning/30 bg-background-warning text-foreground'
           : 'border-border bg-background-1 text-foreground'
@@ -154,22 +155,21 @@ export function ProjectAvailabilityFrame({
   return (
     <div className="flex h-full min-h-0 w-full flex-col">
       <div className="min-h-0 flex-1">{children}</div>
-      <div className="h-9 shrink-0 border-t border-border" data-testid="project-connection-status">
-        {state.kind === 'ready' ? (
-          <div className="flex h-9 items-center px-3 text-xs text-foreground-muted">
-            {project.type === 'ssh'
-              ? `Connected to ${machineName || 'Machine'}`
-              : 'Local workspace'}
-          </div>
-        ) : null}
-        <ProjectAvailabilityBanner
-          compact
-          project={project}
-          state={state}
-          machineName={machineName}
-          actionHandlers={actionHandlers}
-        />
-      </div>
+      {state.kind !== 'ready' ? (
+        <div
+          className="shrink-0 border-t border-border"
+          data-testid="project-connection-status"
+          style={{ height: WORKBENCH_BOTTOM_BAR_HEIGHT_PX }}
+        >
+          <ProjectAvailabilityBanner
+            compact
+            project={project}
+            state={state}
+            machineName={machineName}
+            actionHandlers={actionHandlers}
+          />
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/emdash-desktop/src/core/features/projects/browser/components/project-availability-banner.tsx
+++ b/apps/emdash-desktop/src/core/features/projects/browser/components/project-availability-banner.tsx
@@ -6,7 +6,7 @@ import {
   classifyProjectAvailability,
   type ProjectAvailabilityAction,
 } from '@core/features/projects/browser/project-availability-presentation';
-import { WORKBENCH_BOTTOM_BAR_HEIGHT_PX } from '@core/primitives/layouts/api';
+import { WORKBENCH_BOTTOM_BAR_HEIGHT_PX } from '@core/primitives/layouts/api/workbench-layout';
 import { log } from '@core/primitives/logging/browser/logger';
 import type { LocalProject, SshProject } from '@core/primitives/projects/api';
 import { cn } from '@core/primitives/styling/browser/cn';
@@ -69,7 +69,7 @@ export function ProjectAvailabilityBanner({
       aria-atomic="true"
       className={cn(
         'flex shrink-0 items-center gap-3',
-        compact ? 'px-3' : 'rounded-lg border px-4 py-3',
+        compact ? 'h-full w-full px-3' : 'rounded-lg border px-4 py-3',
         presentation.severity === 'error' || presentation.severity === 'warning'
           ? 'border-foreground-warning/30 bg-background-warning text-foreground'
           : 'border-border bg-background-1 text-foreground'
@@ -157,7 +157,7 @@ export function ProjectAvailabilityFrame({
       <div className="min-h-0 flex-1">{children}</div>
       {state.kind !== 'ready' ? (
         <div
-          className="shrink-0 border-t border-border"
+          className="flex shrink-0 items-center border-t border-border"
           data-testid="project-connection-status"
           style={{ height: WORKBENCH_BOTTOM_BAR_HEIGHT_PX }}
         >

--- a/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/left-sidebar.tsx
+++ b/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/left-sidebar.tsx
@@ -5,6 +5,7 @@ import { automationsViewDef } from '@core/features/automations/contributions/vie
 import { settingsViewDef } from '@core/features/settings/contributions/views';
 import { useOpenModal } from '@core/manifests/browser/modal-api';
 import { BoundShortcut } from '@core/primitives/keybindings/browser/shortcut';
+import { WORKBENCH_BOTTOM_BAR_HEIGHT_PX } from '@core/primitives/layouts/api';
 import {
   isCurrentView,
   useNavigate,
@@ -95,7 +96,10 @@ export const LeftSidebar: React.FC = observer(function LeftSidebar() {
             </SidebarMenuButton>
           </SidebarMenu>
         </SidebarFooter>
-        <div className="flex items-center justify-between gap-2 border-t border-border px-3 py-2">
+        <div
+          className="flex shrink-0 items-center justify-between gap-2 border-t border-border px-3"
+          style={{ height: WORKBENCH_BOTTOM_BAR_HEIGHT_PX }}
+        >
           <button
             type="button"
             className="flex h-6 w-full min-w-0 cursor-pointer items-center gap-2 rounded-lg px-3 text-sm text-foreground-muted focus:outline-none focus-visible:outline-none"

--- a/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/left-sidebar.tsx
+++ b/apps/emdash-desktop/src/core/features/workbench/browser/sidebar/left-sidebar.tsx
@@ -5,7 +5,7 @@ import { automationsViewDef } from '@core/features/automations/contributions/vie
 import { settingsViewDef } from '@core/features/settings/contributions/views';
 import { useOpenModal } from '@core/manifests/browser/modal-api';
 import { BoundShortcut } from '@core/primitives/keybindings/browser/shortcut';
-import { WORKBENCH_BOTTOM_BAR_HEIGHT_PX } from '@core/primitives/layouts/api';
+import { WORKBENCH_BOTTOM_BAR_HEIGHT_PX } from '@core/primitives/layouts/api/workbench-layout';
 import {
   isCurrentView,
   useNavigate,

--- a/apps/emdash-desktop/src/core/primitives/layouts/api/index.ts
+++ b/apps/emdash-desktop/src/core/primitives/layouts/api/index.ts
@@ -6,4 +6,4 @@ export {
   type SlotKind,
   type SlotSpec,
 } from './define-layout';
-export { workbenchLayout } from './workbench-layout';
+export { WORKBENCH_BOTTOM_BAR_HEIGHT_PX, workbenchLayout } from './workbench-layout';

--- a/apps/emdash-desktop/src/core/primitives/layouts/api/index.ts
+++ b/apps/emdash-desktop/src/core/primitives/layouts/api/index.ts
@@ -6,4 +6,4 @@ export {
   type SlotKind,
   type SlotSpec,
 } from './define-layout';
-export { WORKBENCH_BOTTOM_BAR_HEIGHT_PX, workbenchLayout } from './workbench-layout';
+export { workbenchLayout } from './workbench-layout';

--- a/apps/emdash-desktop/src/core/primitives/layouts/api/workbench-layout.ts
+++ b/apps/emdash-desktop/src/core/primitives/layouts/api/workbench-layout.ts
@@ -1,5 +1,7 @@
 import { defineLayout, slot } from './define-layout';
 
+export const WORKBENCH_BOTTOM_BAR_HEIGHT_PX = 40;
+
 export const workbenchLayout = defineLayout({
   id: 'workbench',
   slots: {

--- a/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
@@ -1,12 +1,26 @@
 import type { HistoryPage, SessionState } from '@emdash/core/runtimes/acp/api/client';
+import { deferred } from '@emdash/shared/testing';
+import { toast } from '@emdash/ui/react/primitives';
+import {
+  client,
+  connect,
+  createController,
+  createWireSessionHub,
+  defineContract,
+  memoryTransportPair,
+} from '@emdash/wire/rpc';
 import { observable, runInAction } from 'mobx';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { conversationsContract } from '@core/features/conversations/api';
 import { installChatUiRuntime } from '@core/features/conversations/api/browser/chat/chat-ui-runtime';
 import {
   AcpChatStore,
   type AcpPromptAttachment,
 } from '@core/features/conversations/browser/acp/acp-chat-store';
-import { AcpLiveSession } from '@core/features/conversations/browser/acp/acp-live-session';
+import {
+  AcpLiveSession,
+  AcpPromptDeliveryUnknownError,
+} from '@core/features/conversations/browser/acp/acp-live-session';
 import type { ProjectHostAccessState } from '@core/features/projects/api/browser/stores/project-context';
 
 type DraftState = {
@@ -136,6 +150,68 @@ describe('AcpChatStore prompt submission', () => {
     }
   );
 
+  it.each(['active', 'queued', 'history', 'unrelated'] as const)(
+    'reconciles a lost acknowledgement using %s state without restoring the draft',
+    async (source) => {
+      const promptId = crypto.randomUUID();
+      const sendPrompt = vi
+        .fn()
+        .mockRejectedValue(new AcpPromptDeliveryUnknownError(promptId, new Error('disconnected')));
+      const activeTurn = new FakeRemote<HistoryPage['turns'][number] | null>(null);
+      const live = fakeLiveSession(
+        idleState(),
+        { turns: [], nextCursor: null },
+        { sendPrompt, activeTurn }
+      );
+      const store = await bootstrapWithSession(live.session);
+      const errorToast = vi.spyOn(toast, 'error');
+      try {
+        store.submitPrompt('continue');
+        await vi.waitFor(() => expect(store.unconfirmedPromptIds).toEqual([promptId]));
+        expect(store.draftText).toBe('');
+        expect(errorToast).not.toHaveBeenCalled();
+        store.setDraftText('a new draft');
+        const turn: HistoryPage['turns'][number] = {
+          id: 'turn',
+          seq: 0,
+          initiator: 'user',
+          items: [
+            {
+              kind: 'message',
+              id: 'message',
+              seq: 0,
+              role: 'user',
+              text: 'continue',
+              promptId: source === 'unrelated' ? crypto.randomUUID() : promptId,
+            },
+          ],
+        };
+        if (source === 'queued') {
+          live.sessionState.set({
+            ...idleState(),
+            queuedPrompts: [{ id: promptId, text: 'continue', createdAt: 0, updatedAt: 0 }],
+          });
+        } else if (source === 'history') {
+          live.loadHistory.mockResolvedValue({
+            success: true,
+            data: { turns: [turn], nextCursor: null },
+          });
+          connectSessionOptions?.onTurnCommitted?.();
+        } else {
+          activeTurn.set(turn);
+        }
+        await vi.waitFor(() =>
+          expect(store.unconfirmedPromptIds).toEqual(source === 'unrelated' ? [promptId] : [])
+        );
+        expect(store.draftText).toBe('a new draft');
+        expect(sendPrompt).toHaveBeenCalledOnce();
+      } finally {
+        store.dispose();
+        errorToast.mockRestore();
+      }
+    }
+  );
+
   it('routes retry to host recovery while access is disabled', () => {
     const recover = vi.fn(async () => ({ success: true }));
     const store = new AcpChatStore('conversation-1', 'project-1', 'task-1', {
@@ -175,6 +251,68 @@ describe('AcpChatStore prompt submission', () => {
       expect(store.affordances.canSubmit).toBe(false);
     } finally {
       store.dispose();
+    }
+  });
+
+  it('does not report send failure or restore a remotely accepted prompt when the Wire reply is lost', async () => {
+    const gate = deferred<void>();
+    const received: string[] = [];
+    const contract = defineContract({ sendPrompt: conversationsContract.acp.sendPrompt });
+    const hub = createWireSessionHub(
+      createController(
+        contract,
+        {
+          sendPrompt: async ({ prompt, promptId }) => {
+            received.push(prompt.text);
+            transcriptTestState.activeTurnSnapshot = {
+              id: 'remote-turn',
+              seq: 0,
+              initiator: 'user',
+              items: [
+                { kind: 'message', id: 'user', seq: 0, role: 'user', text: prompt.text, promptId },
+              ],
+            };
+            await gate.promise;
+            return { success: true as const, data: { queued: false } };
+          },
+        },
+        { validate: 'full' }
+      )
+    );
+    const pair = memoryTransportPair();
+    hub.open('desktop', pair.right);
+    const connection = connect(pair.left);
+    const acp = client(contract, connection);
+    const sendPrompt = vi.fn((prompt) =>
+      AcpLiveSession.prototype.sendPrompt.call(
+        { client: acp, conversationId: 'conversation-1' } as never,
+        prompt
+      )
+    );
+    const store = createStore(idleState(), sendPrompt, {
+      activeTurn: { current: () => transcriptTestState.activeTurnSnapshot },
+    });
+    const errorToast = vi.spyOn(toast, 'error');
+    try {
+      store.submitPrompt('continue');
+      await vi.waitFor(() => expect(received).toEqual(['continue']));
+      pair.disconnect();
+      await vi.waitFor(() =>
+        expect(sendPrompt.mock.results[0]?.value).rejects.toBeInstanceOf(
+          AcpPromptDeliveryUnknownError
+        )
+      );
+      await Promise.resolve();
+      expect(store.draftText).toBe('');
+      expect(store.unconfirmedPromptIds).toEqual([]);
+      expect(errorToast).not.toHaveBeenCalled();
+      expect(received).toEqual(['continue']);
+    } finally {
+      gate.resolve();
+      store.dispose();
+      connection.dispose();
+      await hub.dispose();
+      errorToast.mockRestore();
     }
   });
 

--- a/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
@@ -93,6 +93,50 @@ const connectSession = vi.fn(
 );
 
 describe('AcpChatStore prompt submission', () => {
+  it.each(['disconnected', 'disposed', 'buffer-full'] as const)(
+    'restores the draft and clears the optimistic prompt after a %s pre-delivery failure',
+    async (reason) => {
+      const pair = memoryTransportPair();
+      const post = vi.fn(pair.left.post);
+      const connection = connect(
+        {
+          ...pair.left,
+          post,
+          ...(reason === 'buffer-full' ? { onReconnect: () => () => {} } : {}),
+        },
+        { maxHeldCalls: 0 }
+      );
+      if (reason === 'disposed') connection.dispose();
+      else pair.disconnect();
+      const acp = client(
+        defineContract({ sendPrompt: conversationsContract.acp.sendPrompt }),
+        connection
+      );
+      const sendPrompt = vi.fn((prompt) =>
+        AcpLiveSession.prototype.sendPrompt.call(
+          { client: acp, conversationId: 'conversation-1' } as never,
+          prompt
+        )
+      );
+      const store = createStore(idleState(), sendPrompt);
+      const errorToast = vi.spyOn(toast, 'error');
+      try {
+        store.setDraftText('keep this prompt');
+        store.submitPrompt('keep this prompt');
+        await vi.waitFor(() => expect(errorToast).toHaveBeenCalledOnce());
+        expect(store.draftText).toBe('keep this prompt');
+        expect(chatSessionTestState.pendingPrompt).toBeNull();
+        expect(store.unconfirmedPromptIds).toEqual([]);
+        expect(sendPrompt).toHaveBeenCalledOnce();
+        if (reason !== 'disconnected') expect(post).not.toHaveBeenCalled();
+      } finally {
+        store.dispose();
+        connection.dispose();
+        errorToast.mockRestore();
+      }
+    }
+  );
+
   it.each(['host-check', 'timer', 'retry'] as const)(
     'recovers a timed-out attachment through %s without a new host generation',
     async (trigger) => {

--- a/apps/workspace-server/src/api/controller.test.ts
+++ b/apps/workspace-server/src/api/controller.test.ts
@@ -52,12 +52,13 @@ describe('createWorkspaceWireController', () => {
     }
   });
 
-  it('disables the worker deadline for the turn-long ACP prompt call', async () => {
+  it('disables the worker deadline while activating the ACP session for prompt acceptance', async () => {
     const acp = createFakeAcpClient();
     const controller = createTestWorkspaceWireController({ acp });
     const signal = new AbortController().signal;
     const input = {
       conversationId: 'conversation-1',
+      promptId: '00000000-0000-4000-8000-000000000001',
       prompt: { text: 'hello' },
     };
 

--- a/packages/core/src/primitives/acp-transcript/api/normalized-event.ts
+++ b/packages/core/src/primitives/acp-transcript/api/normalized-event.ts
@@ -38,6 +38,7 @@ export type NormalizedToolStatus = 'pending' | 'in_progress' | 'completed' | 'fa
 export type NormalizedEvent =
   | {
       kind: 'message';
+      promptId?: string;
       role: 'user' | 'assistant';
       messageId: string | null;
       text: string;

--- a/packages/core/src/runtimes/acp/api/errors.ts
+++ b/packages/core/src/runtimes/acp/api/errors.ts
@@ -81,7 +81,7 @@ export const ACP_UNAMBIGUOUS_START_ERROR_TYPES = [
 export type AcpLaunchError = AcpStartError;
 export type AcpLoadHistoryError = AcpStartError;
 export type AcpTerminateError = IntentPersistenceFailedError;
-export type AcpSendPromptError = ConversationNotFoundError | InvalidStateError | PromptFailedError;
+export type AcpSendPromptError = ConversationNotFoundError | AcpStartError | PromptFailedError;
 export type AcpQueueMutationError = ConversationNotFoundError | InvalidStateError;
 export type AcpEditQueuedPromptError = AcpQueueMutationError;
 export type AcpDeleteQueuedPromptError = AcpQueueMutationError;
@@ -178,6 +178,11 @@ export const acpSendPromptErrorSchema = z.discriminatedUnion('type', [
   conversationNotFoundErrorSchema,
   invalidStateErrorSchema,
   promptFailedErrorSchema,
+  providerUnsupportedErrorSchema,
+  authRequiredErrorSchema,
+  spawnFailedErrorSchema,
+  initializeFailedErrorSchema,
+  newSessionFailedErrorSchema,
 ]);
 export const acpQueueMutationErrorSchema = z.discriminatedUnion('type', [
   conversationNotFoundErrorSchema,

--- a/packages/core/src/runtimes/acp/api/models/turns/messages.ts
+++ b/packages/core/src/runtimes/acp/api/models/turns/messages.ts
@@ -8,6 +8,8 @@ export const transcriptMessageSchema = z.object({
   /** Stable order within the owning turn, assigned once by the reducer. */
   seq: z.number().int(),
   role: z.enum(['user', 'assistant']),
+  /** Correlates an accepted prompt without matching message text. */
+  promptId: z.string().optional(),
   text: z.string(),
   /** Attachment metadata only; bytes are served separately by the runtime. */
   attachments: z.array(attachmentRefSchema).optional(),

--- a/packages/core/src/runtimes/acp/api/reducer/item-fold.ts
+++ b/packages/core/src/runtimes/acp/api/reducer/item-fold.ts
@@ -639,6 +639,7 @@ export function foldItem(
         seq: nextSeq(base),
         role: event.role,
         text: event.text,
+        ...(event.promptId ? { promptId: event.promptId } : {}),
         ...(event.attachments?.length ? { attachments: event.attachments } : {}),
       };
       return normalizeToolStructure([...base, newMsg], turnId);

--- a/packages/core/src/runtimes/acp/api/schemas.ts
+++ b/packages/core/src/runtimes/acp/api/schemas.ts
@@ -25,6 +25,8 @@ export const promptPlacementSchema = z.enum(['auto', 'queue']);
 export type PromptPlacement = z.infer<typeof promptPlacementSchema>;
 export const sendPromptCommandSchema = z.object({
   conversationId: z.string(),
+  /** Correlates session acceptance with the queue and transcript. */
+  promptId: z.string().uuid(),
   prompt: promptInputSchema,
   /** 'queue' always queues; 'auto' (default) delivers if idle and queues while a turn is active. */
   placement: promptPlacementSchema.optional(),

--- a/packages/core/src/runtimes/acp/node/api/contract.test.ts
+++ b/packages/core/src/runtimes/acp/node/api/contract.test.ts
@@ -99,12 +99,13 @@ describe('ACP API contract schemas', () => {
       await expect(
         wire.client.sendPrompt({
           conversationId: input.conversationId,
+          promptId: '00000000-0000-4000-8000-000000000001',
           prompt: { text: 'wake' },
         })
       ).resolves.toMatchObject({
         success: false,
         error: {
-          type: 'prompt_failed',
+          type: 'new_session_failed',
           cause: { name: 'Error', message: 'replacement failed' },
         },
       });

--- a/packages/core/src/runtimes/acp/node/api/procedures.ts
+++ b/packages/core/src/runtimes/acp/node/api/procedures.ts
@@ -39,16 +39,18 @@ export function createAcpProcedures(runtime: AcpRuntime) {
     terminate(input: { conversationId: string }): Promise<Result<void, AcpTerminateError>> {
       return runtime.terminateSession(input.conversationId);
     },
-    async sendPrompt(input: {
+    sendPrompt(input: {
       conversationId: string;
+      promptId: string;
       prompt: PromptInput;
       placement?: PromptPlacement;
     }): Promise<Result<{ queued: boolean }, AcpSendPromptError>> {
-      const result = await runtime.sendPrompt(input.conversationId, input.prompt, input.placement);
-      if (!result.success && isAcpWakeFailure(result.error)) {
-        return acpErr.promptFailed(wakeFailureCause(result.error));
-      }
-      return result as Result<{ queued: boolean }, AcpSendPromptError>;
+      return runtime.sendPrompt(
+        input.conversationId,
+        input.prompt,
+        input.placement,
+        input.promptId
+      );
     },
     editQueuedPrompt(input: {
       conversationId: string;

--- a/packages/core/src/runtimes/acp/node/runtime/prompt-acknowledgement.test.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/prompt-acknowledgement.test.ts
@@ -1,0 +1,247 @@
+import { randomUUID } from 'node:crypto';
+import { ok } from '@emdash/shared';
+import { deferred } from '@emdash/shared/testing';
+import { describe, expect, it, vi } from 'vitest';
+import { makeAcpHarness, makeStartInput } from '../acp-test-support';
+import { AcpRuntime } from './runtime';
+
+describe('prompt acceptance', () => {
+  it('waits for attachment validation before acknowledging or starting execution', async () => {
+    const attachment = deferred<{ data: string; mimeType: string }>();
+    const resolveAttachment = vi.fn().mockReturnValue(attachment.promise);
+    const h = makeAcpHarness({ resolveAttachment });
+    const runtime = new AcpRuntime(h.deps);
+    try {
+      await runtime.launchSession(makeStartInput());
+      let settled = false;
+      const submission = runtime
+        .sendPrompt('conv-1', {
+          text: 'hello',
+          attachments: [{ type: 'attachment', id: 'image', mimeType: 'image/png' }],
+        })
+        .then((result) => {
+          settled = true;
+          return result;
+        });
+      await vi.waitFor(() => expect(resolveAttachment).toHaveBeenCalledOnce());
+      expect(settled).toBe(false);
+      expect(h.agent.prompt).not.toHaveBeenCalled();
+      attachment.resolve({ data: '', mimeType: 'image/png' });
+      await expect(submission).resolves.toEqual(ok({ queued: false }));
+      expect(resolveAttachment).toHaveBeenCalledOnce();
+    } finally {
+      attachment.resolve({ data: '', mimeType: 'image/png' });
+      await runtime.dispose();
+    }
+  });
+
+  it('rejects invalid attachments while working without adding a queued prompt', async () => {
+    const turn = deferred<{ stopReason: 'end_turn' }>();
+    const h = makeAcpHarness({
+      resolveAttachment: vi.fn().mockRejectedValue(new Error('missing')),
+    });
+    h.agent.prompt.mockReturnValueOnce(turn.promise);
+    const runtime = new AcpRuntime(h.deps);
+    try {
+      await runtime.launchSession(makeStartInput());
+      await runtime.sendPrompt('conv-1', { text: 'first' });
+      await expect(
+        runtime.sendPrompt(
+          'conv-1',
+          {
+            text: 'next',
+            attachments: [{ type: 'attachment', id: 'missing', mimeType: 'image/png' }],
+          },
+          'queue'
+        )
+      ).resolves.toMatchObject({ success: false, error: { type: 'prompt_failed' } });
+      expect(runtime.getSessionState('conv-1').queuedPrompts).toEqual([]);
+      expect(h.agent.prompt).toHaveBeenCalledOnce();
+    } finally {
+      turn.resolve({ stopReason: 'end_turn' });
+      await runtime.dispose();
+    }
+  });
+
+  it('holds the execution lease after acknowledging until the turn settles', async () => {
+    const turn = deferred<{ stopReason: 'end_turn' }>();
+    const h = makeAcpHarness();
+    h.agent.prompt.mockReturnValueOnce(turn.promise);
+    const runtime = new AcpRuntime(h.deps);
+    try {
+      await runtime.attachSession(makeStartInput());
+      await runtime.manager.sendPrompt({
+        conversationId: 'conv-1',
+        promptId: randomUUID(),
+        prompt: { text: 'hello' },
+      });
+      let stopped = false;
+      const stop = runtime.stopSession('conv-1').then(() => {
+        stopped = true;
+      });
+      await vi.waitFor(() => expect(h.agent.closeSession).toHaveBeenCalledOnce());
+      expect(stopped).toBe(false);
+      turn.resolve({ stopReason: 'end_turn' });
+      await stop;
+      expect(stopped).toBe(true);
+    } finally {
+      turn.resolve({ stopReason: 'end_turn' });
+      await runtime.dispose();
+    }
+  });
+
+  it('rejects empty prompts without starting a turn', async () => {
+    const h = makeAcpHarness();
+    const runtime = new AcpRuntime(h.deps);
+    try {
+      await runtime.attachSession(makeStartInput());
+      await expect(
+        runtime.manager.sendPrompt({
+          conversationId: 'conv-1',
+          promptId: randomUUID(),
+          prompt: { text: '  ' },
+        })
+      ).resolves.toMatchObject({ success: false, error: { type: 'invalid_state' } });
+      expect(h.agent.prompt).not.toHaveBeenCalled();
+    } finally {
+      await runtime.dispose();
+    }
+  });
+  it('awaits activation but acknowledges before provider completion', async () => {
+    const activation = deferred<{ sessionId: string }>();
+    const turn = deferred<{ stopReason: 'end_turn' }>();
+    const h = makeAcpHarness();
+    h.agent.newSession.mockReturnValueOnce(activation.promise);
+    h.agent.prompt.mockReturnValueOnce(turn.promise);
+    const runtime = new AcpRuntime(h.deps);
+    await runtime.attachSession(makeStartInput());
+    let accepted = false;
+    const submission = runtime.manager
+      .sendPrompt({ conversationId: 'conv-1', promptId: randomUUID(), prompt: { text: 'hello' } })
+      .then((result) => {
+        accepted = true;
+        return result;
+      });
+    try {
+      await vi.waitFor(() => expect(h.agent.newSession).toHaveBeenCalledOnce());
+      expect(accepted).toBe(false);
+      expect(h.agent.prompt).not.toHaveBeenCalled();
+      activation.resolve({ sessionId: 'session-1' });
+      await expect(submission).resolves.toEqual(ok({ queued: false }));
+      expect(h.agent.prompt).toHaveBeenCalledOnce();
+      expect(runtime.getSessionState('conv-1').isGenerating).toBe(true);
+      turn.resolve({ stopReason: 'end_turn' });
+      await vi.waitFor(() => expect(runtime.getSessionState('conv-1').isGenerating).toBe(false));
+    } finally {
+      activation.resolve({ sessionId: 'session-1' });
+      turn.resolve({ stopReason: 'end_turn' });
+      await runtime.dispose();
+    }
+  });
+
+  it('returns authentication failure before accepting a prompt', async () => {
+    const h = makeAcpHarness();
+    h.agent.newSession.mockRejectedValueOnce({ code: -32000, message: 'Authentication required' });
+    const runtime = new AcpRuntime(h.deps);
+    try {
+      await runtime.attachSession(makeStartInput());
+      await expect(
+        runtime.manager.sendPrompt({
+          conversationId: 'conv-1',
+          promptId: randomUUID(),
+          prompt: { text: 'hello' },
+        })
+      ).resolves.toMatchObject({ success: false, error: { type: 'auth_required' } });
+      expect(h.agent.prompt).not.toHaveBeenCalled();
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  it.each(['auto', 'queue'] as const)(
+    'rejects invalid attachments before accepting %s placement',
+    async (placement) => {
+      const h = makeAcpHarness({
+        resolveAttachment: vi.fn().mockRejectedValue(new Error('missing attachment')),
+      });
+      const runtime = new AcpRuntime(h.deps);
+      try {
+        await runtime.launchSession(makeStartInput());
+        await expect(
+          runtime.manager.sendPrompt({
+            conversationId: 'conv-1',
+            promptId: randomUUID(),
+            placement,
+            prompt: {
+              text: 'hello',
+              attachments: [{ type: 'attachment', id: 'missing', mimeType: 'image/png' }],
+            },
+          })
+        ).resolves.toMatchObject({ success: false, error: { type: 'prompt_failed' } });
+        expect(runtime.getSessionState('conv-1').queuedPrompts).toEqual([]);
+        expect(runtime.getSessionState('conv-1').isGenerating).toBe(false);
+        expect(h.agent.prompt).not.toHaveBeenCalled();
+      } finally {
+        await runtime.dispose();
+      }
+    }
+  );
+
+  it.each(['auto', 'queue'] as const)(
+    'acknowledges a queued prompt exactly once with %s placement',
+    async (placement) => {
+      const turn = deferred<{ stopReason: 'end_turn' }>();
+      const h = makeAcpHarness();
+      h.agent.prompt.mockReturnValueOnce(turn.promise);
+      const runtime = new AcpRuntime(h.deps);
+      try {
+        await runtime.launchSession(makeStartInput());
+        await runtime.manager.sendPrompt({
+          conversationId: 'conv-1',
+          promptId: randomUUID(),
+          prompt: { text: 'first' },
+        });
+        const promptId = randomUUID();
+        await expect(
+          runtime.manager.sendPrompt({
+            conversationId: 'conv-1',
+            promptId,
+            placement,
+            prompt: { text: 'next' },
+          })
+        ).resolves.toEqual(ok({ queued: true }));
+        expect(runtime.getSessionState('conv-1').queuedPrompts).toMatchObject([
+          { id: promptId, text: 'next' },
+        ]);
+        expect(h.agent.prompt).toHaveBeenCalledOnce();
+        turn.resolve({ stopReason: 'end_turn' });
+        await vi.waitFor(() => expect(h.agent.prompt).toHaveBeenCalledTimes(2));
+      } finally {
+        turn.resolve({ stopReason: 'end_turn' });
+        await runtime.dispose();
+      }
+    }
+  );
+
+  it('reports provider failure in live state after successful acceptance', async () => {
+    const turn = deferred<{ stopReason: 'end_turn' }>();
+    const h = makeAcpHarness();
+    h.agent.prompt.mockReturnValueOnce(turn.promise);
+    const runtime = new AcpRuntime(h.deps);
+    try {
+      await runtime.launchSession(makeStartInput());
+      await expect(
+        runtime.manager.sendPrompt({
+          conversationId: 'conv-1',
+          promptId: randomUUID(),
+          prompt: { text: 'hello' },
+        })
+      ).resolves.toEqual(ok({ queued: false }));
+      turn.reject(new Error('provider failed'));
+      await vi.waitFor(() => expect(runtime.getSessionState('conv-1').lastTurnErrored).toBe(true));
+    } finally {
+      turn.resolve({ stopReason: 'end_turn' });
+      await runtime.dispose();
+    }
+  });
+});

--- a/packages/core/src/runtimes/acp/node/runtime/prompt-acknowledgement.wire.test.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/prompt-acknowledgement.wire.test.ts
@@ -1,0 +1,77 @@
+import { randomUUID } from 'node:crypto';
+import { deferred } from '@emdash/shared/testing';
+import {
+  client,
+  connect,
+  createController,
+  createWireSessionHub,
+  defineContract,
+  memoryTransportPair,
+} from '@emdash/wire/rpc';
+import { describe, expect, it, vi } from 'vitest';
+import { acpApiContract } from '../../api';
+import { makeAcpHarness, makeStartInput } from '../acp-test-support';
+import { AcpRuntime } from './runtime';
+
+describe('prompt acknowledgement over Wire', () => {
+  it.each([false, true])(
+    'keeps accepted execution alive after disconnect with lost acknowledgement: %s',
+    async (loseReply) => {
+      const turn = deferred<{ stopReason: 'end_turn' }>();
+      const acknowledged = deferred<void>();
+      const releaseReply = deferred<void>();
+      const h = makeAcpHarness();
+      h.agent.prompt.mockReturnValueOnce(turn.promise);
+      const runtime = new AcpRuntime(h.deps);
+      await runtime.attachSession(makeStartInput());
+      const contract = defineContract({ sendPrompt: acpApiContract.sendPrompt });
+      const hub = createWireSessionHub(
+        createController(contract, {
+          sendPrompt: async (input) => {
+            const result = await runtime.sendPrompt(
+              input.conversationId,
+              input.prompt,
+              input.placement,
+              input.promptId
+            );
+            acknowledged.resolve();
+            if (loseReply) await releaseReply.promise;
+            return result;
+          },
+        })
+      );
+      const pair = memoryTransportPair();
+      hub.open('desktop', pair.right);
+      const connection = connect(pair.left);
+      const promptId = randomUUID();
+      const request = client(contract, connection).sendPrompt({
+        conversationId: 'conv-1',
+        promptId,
+        prompt: { text: 'continue' },
+      });
+      const response = request.catch((error: unknown) => error);
+      try {
+        await acknowledged.promise;
+        if (!loseReply)
+          await expect(response).resolves.toEqual({ success: true, data: { queued: false } });
+        pair.disconnect();
+        if (loseReply) await expect(response).resolves.toMatchObject({ code: 'DISCONNECTED' });
+        expect(runtime.getSessionState('conv-1').isGenerating).toBe(true);
+        expect(h.agent.prompt).toHaveBeenCalledOnce();
+        expect(h.agent.cancel).not.toHaveBeenCalled();
+        turn.resolve({ stopReason: 'end_turn' });
+        await vi.waitFor(() => expect(runtime.getSessionState('conv-1').isGenerating).toBe(false));
+        expect(runtime.manager.getHistory('conv-1').turns[0].items[0]).toMatchObject({
+          text: 'continue',
+          promptId,
+        });
+      } finally {
+        releaseReply.resolve();
+        turn.resolve({ stopReason: 'end_turn' });
+        connection.dispose();
+        await hub.dispose();
+        await runtime.dispose();
+      }
+    }
+  );
+});

--- a/packages/core/src/runtimes/acp/node/runtime/runtime.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/runtime.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import type { Result } from '@emdash/shared';
 import { ok } from '@emdash/shared';
 import type { LiveLogSource } from '@emdash/wire/live';
@@ -96,9 +97,10 @@ export class AcpRuntime {
   sendPrompt(
     conversationId: string,
     prompt: PromptInput,
-    placement?: PromptPlacement
-  ): Promise<Result<{ queued: boolean }, AcpSendPromptError | AcpWakeFailure>> {
-    return this.manager.prompt({ conversationId, prompt, placement });
+    placement?: PromptPlacement,
+    promptId: string = randomUUID()
+  ): Promise<Result<{ queued: boolean }, AcpSendPromptError>> {
+    return this.manager.sendPrompt({ conversationId, prompt, placement, promptId });
   }
 
   editQueuedPrompt(

--- a/packages/core/src/runtimes/acp/node/runtime/session-manager.test.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/session-manager.test.ts
@@ -361,7 +361,7 @@ describe('AcpRuntime session manager', () => {
 
     expect(result).toMatchObject({
       success: false,
-      error: { kind: 'wake-failed', error: { type: 'new_session_failed' } },
+      error: { type: 'new_session_failed' },
     });
     expect(peek(live.states.state)).toMatchObject({ suspended: true, canSubmit: true });
     expect(peek(rt.sessionsListLiveModel().states.list)[input.conversationId]).toMatchObject({

--- a/packages/core/src/runtimes/acp/node/runtime/session-manager.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/session-manager.ts
@@ -293,8 +293,30 @@ export class SessionManager {
     return ok(record);
   }
 
-  async prompt(
-    input: SendPromptInput
+  sendPrompt(input: SendPromptInput): Promise<Result<{ queued: boolean }, AcpSendPromptError>> {
+    return new Promise((resolve, reject) => {
+      void this.runPrompt(input, (accepted) => resolve(ok(accepted))).then(
+        (result) => {
+          if (result.success) resolve(result);
+          else {
+            const error = result.error;
+            resolve(err(isAcpWakeFailure(error) ? error.error : error));
+          }
+        },
+        (error: unknown) => {
+          this.deps.logger.error('ACP prompt execution failed', {
+            conversationId: input.conversationId,
+            error,
+          });
+          reject(error);
+        }
+      );
+    });
+  }
+
+  private async runPrompt(
+    input: SendPromptInput,
+    onAccepted: (result: { queued: boolean }) => void
   ): Promise<Result<{ queued: boolean }, AcpSendPromptError | AcpWakeFailure>> {
     const entry = this.retained.get(input.conversationId);
     if (!entry || entry.deleted) return acpErr.conversationNotFound(input.conversationId);
@@ -305,17 +327,38 @@ export class SessionManager {
     if (!acquired.success) return this.mapWakeError(acquired.error);
     const lease = acquired.data;
     try {
+      let acceptance;
+      if (
+        !input.prompt.text.trim() &&
+        !input.prompt.hiddenContext?.trim() &&
+        !input.prompt.attachments?.length
+      )
+        return acpErr.invalidState('A prompt needs text or an attachment');
+      try {
+        acceptance = {
+          id: input.promptId,
+          onAccepted,
+          resolvedAttachments: await Promise.all(
+            (input.prompt.attachments ?? []).map((attachment) =>
+              this.deps.resolveAttachment(input.conversationId, attachment)
+            )
+          ),
+        };
+      } catch (error) {
+        return acpErr.promptFailed(toSerializedError(error));
+      }
       if (!entry.isCurrent()) return acpErr.conversationNotFound(input.conversationId);
       this.lifecycle.recordInput(input.conversationId);
       if (input.placement === 'queue') {
         const state = lease.value.cell.sessionState;
         if (state.lifecycle !== 'ready' || state.isGenerating || state.queuedPrompts.length > 0) {
-          const queued = lease.value.cell.queuePrompt(input.prompt);
+          const queued = lease.value.cell.queuePrompt(input.prompt, input.promptId);
           if (!queued.success) return queued;
+          onAccepted({ queued: true });
           return ok({ queued: true });
         }
       }
-      return await lease.value.cell.prompt(input.prompt);
+      return await lease.value.cell.prompt(input.prompt, acceptance);
     } finally {
       await lease.release();
     }

--- a/packages/core/src/runtimes/acp/node/runtime/types.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/types.ts
@@ -49,6 +49,7 @@ export interface AcpRuntimeDeps {
 
 export interface SendPromptInput {
   conversationId: string;
+  promptId: string;
   prompt: PromptInput;
   /** 'queue' always queues; 'auto' (default) delivers if idle and queues while a turn is active. */
   placement?: PromptPlacement;

--- a/packages/core/src/runtimes/acp/node/session/cell-deps.ts
+++ b/packages/core/src/runtimes/acp/node/session/cell-deps.ts
@@ -33,3 +33,9 @@ export interface SessionCellDeps {
 export interface SessionPromptResult {
   queued: boolean;
 }
+
+export interface PromptAcceptance {
+  id: string;
+  onAccepted(result: SessionPromptResult): void;
+  resolvedAttachments: readonly ResolvedPromptAttachment[];
+}

--- a/packages/core/src/runtimes/acp/node/session/cell.ts
+++ b/packages/core/src/runtimes/acp/node/session/cell.ts
@@ -42,7 +42,7 @@ import {
   type SessionMachineContext,
 } from '#runtimes/acp/node/machine/machine';
 import { createMachineEffectDriver, type MachineEffectDriver } from '../machine/primitive';
-import type { SessionCellDeps, SessionPromptResult } from './cell-deps';
+import type { PromptAcceptance, SessionCellDeps, SessionPromptResult } from './cell-deps';
 import { PermissionBroker } from './permission-broker';
 import { RawAcpLog, type RawAcpEvent } from './raw-log';
 
@@ -227,24 +227,33 @@ export class SessionCell {
     this.emitTranscriptChanged();
   }
 
-  async prompt(input: PromptInput): Promise<Result<SessionPromptResult, AcpSendPromptError>> {
+  async prompt(
+    input: PromptInput,
+    acceptance?: PromptAcceptance
+  ): Promise<Result<SessionPromptResult, AcpSendPromptError>> {
     const now = Date.now();
-    const result = await this.sendPromptInternal({
-      id: crypto.randomUUID(),
-      ...input,
-      createdAt: now,
-      updatedAt: now,
-    });
+    const result = await this.sendPromptInternal(
+      {
+        id: acceptance?.id ?? crypto.randomUUID(),
+        ...input,
+        createdAt: now,
+        updatedAt: now,
+      },
+      acceptance
+    );
     return result;
   }
 
-  queuePrompt(input: PromptInput): Result<void, InvalidStateError> {
+  queuePrompt(
+    input: PromptInput,
+    id: string = crypto.randomUUID()
+  ): Result<void, InvalidStateError> {
     const now = Date.now();
     const result = this.dispatchFor<InvalidStateError>(
       {
         type: 'QueuePrompt',
         prompt: {
-          id: crypto.randomUUID(),
+          id,
           ...input,
           createdAt: now,
           updatedAt: now,
@@ -491,7 +500,8 @@ export class SessionCell {
   }
 
   private async sendPromptInternal(
-    prompt: QueuedPrompt
+    prompt: QueuedPrompt,
+    acceptance?: PromptAcceptance
   ): Promise<Result<SessionPromptResult, AcpSendPromptError>> {
     const decision = this.dispatchFor<AcpSendPromptError>({ type: 'Prompt', prompt }, [
       'invalid_state',
@@ -500,13 +510,17 @@ export class SessionCell {
     const started = decision.data.some(
       (effect) => effect.type === 'agentEvent' && effect.phase === 'start'
     );
-    if (!started) return ok({ queued: true });
+    if (!started) {
+      acceptance?.onAccepted({ queued: true });
+      return ok({ queued: true });
+    }
 
     const messageId = `${this.conversationId}-${this.machine.nextTurnIndex}-user`;
     this.transcript.pushEvent({
       kind: 'message',
       role: 'user',
       messageId,
+      promptId: prompt.id,
       text: prompt.text,
       ...(prompt.attachments?.length
         ? {
@@ -521,11 +535,13 @@ export class SessionCell {
     this.emitTranscriptChanged();
 
     try {
-      const resolvedAttachments = await Promise.all(
-        (prompt.attachments ?? []).map((attachment) =>
-          this.deps.resolveAttachment(this.deps.conversationId, attachment)
-        )
-      );
+      const resolvedAttachments =
+        acceptance?.resolvedAttachments ??
+        (await Promise.all(
+          (prompt.attachments ?? []).map((attachment) =>
+            this.deps.resolveAttachment(this.deps.conversationId, attachment)
+          )
+        ));
       const promptRequest = {
         sessionId: this.acpSessionId,
         prompt: [
@@ -543,6 +559,7 @@ export class SessionCell {
         sessionId: this.acpSessionId,
         content: promptRequest.prompt,
       });
+      acceptance?.onAccepted({ queued: false });
       const response = await this.deps.agent.prompt(promptRequest);
       this.rawLog.record({
         kind: 'prompt_result',

--- a/packages/core/src/workspace-server/releases.test.ts
+++ b/packages/core/src/workspace-server/releases.test.ts
@@ -100,8 +100,8 @@ describe('workspace-server release contracts', () => {
   );
 
   it('extracts a protocol major and rejects invalid protocol versions', () => {
-    expect(PROTOCOL_VERSION).toBe('7.0.0');
-    expect(protocolMajor()).toBe(7);
+    expect(PROTOCOL_VERSION).toBe('8.0.0');
+    expect(protocolMajor()).toBe(8);
     expect(protocolMajor('2.3.4')).toBe(2);
     expect(() => protocolMajor('not-a-version')).toThrow(
       "Invalid protocol version 'not-a-version'"

--- a/packages/core/src/workspace-server/versions/index.ts
+++ b/packages/core/src/workspace-server/versions/index.ts
@@ -1,6 +1,6 @@
 import semver from 'semver';
 
-export const PROTOCOL_VERSION = '7.0.0';
+export const PROTOCOL_VERSION = '8.0.0';
 
 export function protocolMajor(version: string = PROTOCOL_VERSION): number {
   const parsed = semver.parse(version);

--- a/packages/core/src/workspace-server/versions/versions.test.ts
+++ b/packages/core/src/workspace-server/versions/versions.test.ts
@@ -81,11 +81,11 @@ describe('negotiateProtocol', () => {
     });
 
     it('rejects the previous protocol major with upgrade-client', () => {
-      expect(PROTOCOL_VERSION).toBe('7.0.0');
-      expect(negotiateProtocol('6.1.0')).toEqual({
+      expect(PROTOCOL_VERSION).toBe('8.0.0');
+      expect(negotiateProtocol('7.1.0')).toEqual({
         compatible: false,
         action: 'upgrade-client',
-        clientProtocolVersion: '6.1.0',
+        clientProtocolVersion: '7.1.0',
         serverProtocolVersion: PROTOCOL_VERSION,
       });
     });

--- a/packages/wire/src/api/connect.test.ts
+++ b/packages/wire/src/api/connect.test.ts
@@ -26,6 +26,7 @@ describe('connect', () => {
     expect(transport.closed).toBe(false);
     await expect(connection.call('health', undefined)).rejects.toMatchObject({
       code: 'DISCONNECTED',
+      delivery: 'not-sent',
     });
   });
 

--- a/packages/wire/src/api/connect.ts
+++ b/packages/wire/src/api/connect.ts
@@ -127,7 +127,12 @@ export function connect(transport: WireTransport, options: ConnectOptions = {}):
       if (message.ok) {
         pendingCall.resolve(message.value);
       } else {
-        pendingCall.reject(new WireError(message.code, message.message, { cause: message.cause }));
+        pendingCall.reject(
+          new WireError(message.code, message.message, {
+            cause: message.cause,
+            delivery: message.delivery,
+          })
+        );
       }
       return;
     }
@@ -234,7 +239,7 @@ export function connect(transport: WireTransport, options: ConnectOptions = {}):
     connected = false;
     for (const pendingCall of pending.values()) {
       pendingCall.cleanup();
-      pendingCall.reject(terminalFailureError());
+      pendingCall.reject(terminalFailureError(pendingCall.posted));
     }
     pending.clear();
     heldCallIds.length = 0;
@@ -260,11 +265,11 @@ export function connect(transport: WireTransport, options: ConnectOptions = {}):
     }
     return new Promise((resolve, reject) => {
       if (disposed) {
-        reject(new WireError('DISCONNECTED', 'Wire connection disposed'));
+        reject(new WireError('DISCONNECTED', 'Wire connection disposed', { delivery: 'not-sent' }));
         return;
       }
       if (terminal) {
-        reject(terminalFailureError());
+        reject(terminalFailureError(false));
         return;
       }
       if (options.signal?.aborted) {
@@ -280,7 +285,7 @@ export function connect(transport: WireTransport, options: ConnectOptions = {}):
             errorMessage: 'Wire call cancelled',
           });
         }
-        reject(new WireError('CANCELLED', 'Wire call cancelled'));
+        reject(new WireError('CANCELLED', 'Wire call cancelled', { delivery: 'not-sent' }));
         return;
       }
 
@@ -309,7 +314,11 @@ export function connect(transport: WireTransport, options: ConnectOptions = {}):
             errorMessage: 'Wire call cancelled',
           });
         }
-        reject(new WireError('CANCELLED', 'Wire call cancelled'));
+        reject(
+          new WireError('CANCELLED', 'Wire call cancelled', {
+            delivery: wasPosted ? undefined : 'not-sent',
+          })
+        );
       };
       const removeAbortListener = (): void => options.signal?.removeEventListener('abort', onAbort);
       options.signal?.addEventListener('abort', onAbort, { once: true });
@@ -383,7 +392,8 @@ export function connect(transport: WireTransport, options: ConnectOptions = {}):
     pendingCall.reject(
       new WireError(
         'TIMEOUT',
-        `Wire ${describeRequest(pendingCall.message)} timed out after ${deadlineMs}ms`
+        `Wire ${describeRequest(pendingCall.message)} timed out after ${deadlineMs}ms`,
+        { delivery: wasPosted ? undefined : 'not-sent' }
       )
     );
   }
@@ -393,7 +403,9 @@ export function connect(transport: WireTransport, options: ConnectOptions = {}):
       pending.delete(pendingCall.message.id);
       pendingCall.cleanup();
       pendingCall.reject(
-        new WireError('DISCONNECTED', 'Wire held-call buffer is full while disconnected')
+        new WireError('DISCONNECTED', 'Wire held-call buffer is full while disconnected', {
+          delivery: 'not-sent',
+        })
       );
       return;
     }
@@ -445,9 +457,10 @@ export function connect(transport: WireTransport, options: ConnectOptions = {}):
     return flushed;
   }
 
-  function terminalFailureError(): WireError {
+  function terminalFailureError(posted = true): WireError {
     return new WireError('DISCONNECTED', 'Wire transport failed permanently', {
       cause: terminalCause,
+      delivery: posted ? undefined : 'not-sent',
     });
   }
 
@@ -581,7 +594,11 @@ export function connect(transport: WireTransport, options: ConnectOptions = {}):
 
       for (const pendingCall of pending.values()) {
         pendingCall.cleanup();
-        pendingCall.reject(new WireError('DISCONNECTED', 'Wire connection disposed'));
+        pendingCall.reject(
+          new WireError('DISCONNECTED', 'Wire connection disposed', {
+            delivery: pendingCall.posted ? undefined : 'not-sent',
+          })
+        );
       }
       pending.clear();
 
@@ -777,12 +794,13 @@ function createPostError(message: WireMessage, error: unknown): WireError {
       : formatStructuredCloneFailure(message, 'message');
     return new WireError('SERIALIZATION', `${callContext} could not be serialized: ${diagnostic}`, {
       cause: error,
+      delivery: 'not-sent',
     });
   }
   return new WireError(
     'DISCONNECTED',
     error instanceof Error ? error.message : 'Wire transport disconnected',
-    { cause: error }
+    { cause: error, delivery: 'not-sent' }
   );
 }
 

--- a/packages/wire/src/api/connection-robustness.test.ts
+++ b/packages/wire/src/api/connection-robustness.test.ts
@@ -7,6 +7,34 @@ import { connect } from './connect';
 import { WireError, type WireMessage, type WireTransport } from './protocol';
 
 describe('connection call deadline', () => {
+  it.each(['timeout', 'cancel', 'dispose', 'terminal'] as const)(
+    'distinguishes held requests from posted requests on %s',
+    async (outcome) => {
+      for (const held of [false, true]) {
+        const clock = createManualClock();
+        const transport = scriptedTransport({ reconnectCapable: true });
+        const connection = connect(transport, { clock });
+        const abort = new AbortController();
+        if (held) transport.goDown();
+        const result = connection
+          .call('prompt', {}, { signal: abort.signal })
+          .catch((error: unknown) => error);
+        if (outcome === 'timeout') await clock.advanceBy(30_000);
+        if (outcome === 'cancel') abort.abort();
+        if (outcome === 'dispose') connection.dispose();
+        if (outcome === 'terminal') transport.failTerminally(new Error('failed'));
+        const error = await result;
+        expect(error).toBeInstanceOf(WireError);
+        expect((error as WireError).delivery).toBe(held ? 'not-sent' : undefined);
+        if (held) {
+          transport.goUp();
+          expect(transport.sent).toHaveLength(0);
+        }
+        connection.dispose();
+      }
+    }
+  );
+
   it('rejects a call with a TIMEOUT WireError when the peer never answers', async () => {
     const clock = createManualClock();
     const transport = scriptedTransport({ reconnectCapable: true });
@@ -119,7 +147,7 @@ describe('hold-until-deadline while disconnected', () => {
     const second = connection.call('held.second', {});
     const third = connection.call('held.third', {});
 
-    await expectWireError(third, 'DISCONNECTED');
+    expect(await expectWireError(third, 'DISCONNECTED')).toMatchObject({ delivery: 'not-sent' });
 
     transport.goUp();
     expect(transport.sent.map(callPath)).toEqual(['held.first', 'held.second']);
@@ -138,7 +166,7 @@ describe('hold-until-deadline while disconnected', () => {
     const inFlight = connection.call('posted.before', {});
     const inFlightRejection = expectWireError(inFlight, 'DISCONNECTED');
     transport.goDown();
-    await inFlightRejection;
+    expect((await inFlightRejection).delivery).toBeUndefined();
 
     const held = connection.call('issued.after', {});
     transport.goUp();
@@ -169,7 +197,9 @@ describe('hold-until-deadline while disconnected', () => {
     const connection = connect(transport, { clock });
 
     transport.goDown();
-    await expectWireError(connection.call('fails.fast', {}), 'DISCONNECTED');
+    expect(await expectWireError(connection.call('fails.fast', {}), 'DISCONNECTED')).toMatchObject({
+      delivery: 'not-sent',
+    });
     connection.dispose();
   });
 });
@@ -189,7 +219,10 @@ describe('terminal failure and disposal', () => {
     expect(await heldRejection).toMatchObject({ cause });
 
     const later = connection.call('after.terminal', {});
-    expect(await expectWireError(later, 'DISCONNECTED')).toMatchObject({ cause });
+    expect(await expectWireError(later, 'DISCONNECTED')).toMatchObject({
+      cause,
+      delivery: 'not-sent',
+    });
     connection.dispose();
   });
 

--- a/packages/wire/src/api/protocol.ts
+++ b/packages/wire/src/api/protocol.ts
@@ -61,6 +61,7 @@ export type WireResultMessage =
       code: WireErrorCode;
       message: string;
       cause?: SerializedError;
+      delivery?: 'not-sent';
     };
 
 export type WireUpdateMessage = {
@@ -156,13 +157,17 @@ export type WireTransport = {
 };
 
 export class WireError extends Error {
+  /** Present only when the failing request was never handed to its peer. */
+  readonly delivery?: 'not-sent';
+
   constructor(
     readonly code: WireErrorCode,
     message: string,
-    options: { cause?: unknown } = {}
+    options: { cause?: unknown; delivery?: 'not-sent' } = {}
   ) {
     super(message, options);
     this.name = 'WireError';
+    this.delivery = options.delivery;
   }
 }
 
@@ -170,6 +175,7 @@ export type SerializedWireError = {
   code: WireErrorCode;
   message: string;
   cause?: SerializedError;
+  delivery?: 'not-sent';
 };
 
 export function serializeWireError(error: unknown): SerializedWireError {
@@ -178,6 +184,7 @@ export function serializeWireError(error: unknown): SerializedWireError {
       code: error.code,
       message: error.message,
       cause: serializeCause(error.cause),
+      ...(error.delivery ? { delivery: error.delivery } : {}),
     };
   }
   if (error instanceof Error) {

--- a/packages/wire/src/rpc/wire.test.ts
+++ b/packages/wire/src/rpc/wire.test.ts
@@ -57,6 +57,31 @@ function structuredCloneTransport(transport: WireTransport): WireTransport {
 }
 
 describe('wire serve/connect', () => {
+  it('preserves non-delivery evidence when a gateway forwards a call to a disconnected worker', async () => {
+    const workerPair = memoryTransportPair();
+    const worker = connect(workerPair.left);
+    worker.dispose();
+    const gatewayPair = memoryTransportPair();
+    const gateway = connect(gatewayPair.left);
+    const stop = serve(
+      gatewayPair.right,
+      createController(contract, {
+        greet: (input) => worker.call('greet', input) as Promise<string>,
+        fail: () => {},
+        state: knownStateProvider(new LiveStateSource({ count: 0 })),
+      })
+    );
+    try {
+      await expect(gateway.call('greet', { name: 'wire' })).rejects.toMatchObject({
+        code: 'DISCONNECTED',
+        delivery: 'not-sent',
+      });
+    } finally {
+      gateway.dispose();
+      stop();
+    }
+  });
+
   it('calls procedures and propagates errors', async () => {
     const { connection } = setup();
     await expect(connection.call('greet', { name: 'wire' })).resolves.toBe('hello wire');
@@ -94,6 +119,7 @@ describe('wire serve/connect', () => {
       })
     ).rejects.toMatchObject({
       code: 'SERIALIZATION',
+      delivery: 'not-sent',
       message:
         "Wire call 'pullRequests.listPullRequests' could not be serialized: " +
         "'input.filters.labelNames' is an Array value that cannot be structured-cloned " +
@@ -114,6 +140,7 @@ describe('wire serve/connect', () => {
     await expect(connection.call('pullRequests.listPullRequests', undefined)).rejects.toMatchObject(
       {
         code: 'SERIALIZATION',
+        delivery: undefined,
         message:
           "Wire response for call 'pullRequests.listPullRequests' could not be serialized: " +
           "'value.filters.labelNames' is an Array value that cannot be structured-cloned " +


### PR DESCRIPTION
- acknowledge prompts after session activation and validation
- keep execution host-owned and publish progress through live state
- reconcile lost acknowledgements without restoring or resending accepted prompts
- remove healthy workspace status bars from task views
- align recovery status with the sidebar footer
- require workspace server protocol 8.0.0 without a compatibility fallback