### PR TITLE
fix(conversations): preserve ACP drafts across tab navigation

### DIFF
--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-panel.tsx
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-panel.tsx
@@ -214,12 +214,6 @@ const ComposerForStore = observer(function ComposerForStore({
     editorApiRef.current?.focus();
   }, []);
 
-  useEffect(() => {
-    const editor = editorApiRef.current;
-    if (!editor || editor.getText() === store.draftText) return;
-    editor.setText(store.draftText);
-  }, [store, store.draftText]);
-
   const buildHiddenIssueContext = useCallback(
     (value: string) =>
       buildIssueMentionHiddenContext(value, async (target) => {
@@ -581,6 +575,7 @@ const ComposerForStore = observer(function ComposerForStore({
         <ChatComposer
           isWorking={a.isWorking}
           canSubmit={a.canSubmit}
+          value={store.draftText}
           onSubmit={handleSubmit}
           onInputChange={(text) => store.setDraftText(text)}
           onSubmitWhileWorking={a.canSubmit ? handleSubmit : undefined}

--- a/packages/ui/src/react/components/chat-composer/chat-composer-controlled.test.tsx
+++ b/packages/ui/src/react/components/chat-composer/chat-composer-controlled.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, cleanup, render, waitFor } from '@testing-library/react';
+import { useState, type RefObject } from 'react';
+import { createPortal } from 'react-dom';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { PromptEditorRef } from '../prompt-editor/types';
+import { ChatComposer } from './index';
+
+afterEach(() => {
+  cleanup();
+  document.body.replaceChildren();
+});
+
+function ControlledPortalComposer({
+  slot,
+  editorRef,
+}: {
+  slot: HTMLElement;
+  editorRef: RefObject<PromptEditorRef | null>;
+}) {
+  const [draft, setDraft] = useState('');
+
+  return createPortal(
+    <ChatComposer
+      value={draft}
+      onInputChange={setDraft}
+      editorApiRef={editorRef}
+      onSubmit={() => {}}
+    />,
+    slot
+  );
+}
+
+describe('ChatComposer controlled value', () => {
+  it('restores the host-owned draft when its portal target changes', async () => {
+    const firstSlot = document.createElement('div');
+    const secondSlot = document.createElement('div');
+    document.body.append(firstSlot, secondSlot);
+    const editorRef = { current: null } as RefObject<PromptEditorRef | null>;
+    const result = render(<ControlledPortalComposer slot={firstSlot} editorRef={editorRef} />);
+
+    await waitFor(() => expect(editorRef.current).not.toBeNull());
+    act(() => editorRef.current?.setText('retained across navigation'));
+    await waitFor(() => expect(editorRef.current?.getText()).toBe('retained across navigation'));
+
+    result.rerender(<ControlledPortalComposer slot={secondSlot} editorRef={editorRef} />);
+
+    await waitFor(() => expect(editorRef.current?.getText()).toBe('retained across navigation'));
+  });
+});

--- a/packages/ui/src/react/components/chat-composer/index.tsx
+++ b/packages/ui/src/react/components/chat-composer/index.tsx
@@ -195,6 +195,8 @@ export interface ChatComposerProps {
   canSubmit?: boolean;
   /** Hide the submit/stop control for draft-only composer surfaces. */
   showSubmitButton?: boolean;
+  /** Host-owned serialized editor value. Omit to keep the editor internally managed. */
+  value?: string;
   /** Override the idle editor placeholder. Disabled/working placeholders still take precedence. */
   placeholder?: string;
 
@@ -652,6 +654,7 @@ export function ChatComposer({
   isWorking = false,
   canSubmit = true,
   showSubmitButton = true,
+  value,
   placeholder,
   agentOptions,
   selectedAgent,
@@ -947,6 +950,7 @@ export function ChatComposer({
                 }
               }
             }}
+            value={value}
             placeholder={resolvedPlaceholder}
             disabled={disabled}
             onChange={onInputChange}


### PR DESCRIPTION
- adds controlled value support to ChatComposer
- keeps ACP draft text in host-owned state across tab navigation
- restores draft content when the composer portal target changes
- replaces the unreliable imperative editor restoration flow