### PR TITLE
fix(acp): allow queued prompts during active turns

### DIFF
--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-panel.tsx
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-panel.tsx
@@ -583,7 +583,7 @@ const ComposerForStore = observer(function ComposerForStore({
           canSubmit={a.canSubmit}
           onSubmit={handleSubmit}
           onInputChange={(text) => store.setDraftText(text)}
-          onSubmitWhileWorking={a.canSubmit ? handleSubmit : undefined}
+          onSubmitWhileWorking={store.liveActionsEnabled ? handleSubmit : undefined}
           onStop={a.canCancel ? handleStop : undefined}
           permissionRequest={permissionRequest}
           permissionQueueCount={store.permissionQueue.length}


### PR DESCRIPTION
- restores prompt queuing while an acp session is working
- gates queued submission on live host actions instead of ready-state submit affordance
- keeps disconnected sessions blocked from submitting queued prompts
- identifies the regression from the chat panel using canSubmit for onSubmitWhileWorking