### PR TITLE
feat(codex): add GPT-6 Astra to model options

### DIFF
--- a/packages/plugins/src/agents/impl/codex/index.ts
+++ b/packages/plugins/src/agents/impl/codex/index.ts
@@ -52,6 +52,12 @@ export const plugin = definePlugin(
     models: {
       kind: 'selectable',
       modelOptions: {
+        'gpt-6-astra': {
+          name: 'GPT-6 Astra',
+          description:
+            'Flagship GPT-6 model and Codex default for the most demanding agentic work.',
+          modelFeatures: { intelligence: 5, speed: 3 },
+        },
         'gpt-5.6-sol': {
           name: 'GPT-5.6 Sol',
           description: 'Flagship GPT-5.6 model for the hardest agentic coding workflows.',


### PR DESCRIPTION
Adds `gpt-6-astra` to the Codex provider model list. GPT-6 Astra launched Sept 3 and is the Codex CLI bundled default since v0.153.4; it was missing from the hardcoded picker used by the terminal/TUI path. The ACP chat path already discovers models dynamically and needs no change.

Checks: `pnpm run typecheck` and `pnpm run test` in `packages/plugins` (359 tests passing), `pnpm run format`.