### PR TITLE
fix(acp): refresh transcript history after reconnect

### DIFF
--- a/agents/architecture/acp-runtime.md
+++ b/agents/architecture/acp-runtime.md
@@ -121,7 +121,11 @@ Startup/authentication failures are returned before acceptance. Provider failure
 are published through the existing session and transcript state. Callers that need completion
 observe that state; the send acknowledgement no longer means the turn has finished.
 
-The desktop subscribes before submission and refreshes snapshots after reattachment. A client
+The desktop subscribes before submission and refreshes both live snapshots and committed history
+after reattachment, even when no active turn was observed before the outage. History reads are
+fenced to the current attachment and retried after transient failure; a newly active turn defers
+history replacement until its completion. The optimistic row shares the submission's client prompt
+id, so history clears only the corresponding row and preserves newer submissions. A client
 prompt id follows the existing queue and synthesized user transcript message so a lost acknowledgement
 can be reconciled without matching text. Wire marks failures known to occur before posting as
 "not-sent", including held-call overflow and cancellation or disposal before posting. This evidence

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
@@ -120,6 +120,7 @@ export class AcpChatStore {
   private _submissionSequence = 0;
   private _historyRefreshRequested = false;
   private _historyRefreshTask: Promise<void> | null = null;
+  private _historyEpoch = 0;
   private _disposed = false;
   private _attachmentRecovery: Scope | null = null;
   private _attachedHostGeneration: number | undefined;
@@ -454,11 +455,12 @@ export class AcpChatStore {
     if (this.hostAccess?.liveAction.kind === 'disabled') return;
     const promptAttachments = attachments.map((attachment) => attachment.ref);
     const submissionSequence = ++this._submissionSequence;
+    const promptId = crypto.randomUUID();
     let optimisticId: string | undefined;
     this.draftText = '';
     this.draftAttachments = [];
     if (!this.affordances.isWorking) {
-      optimisticId = `optimistic:user:${Date.now()}`;
+      optimisticId = promptId;
       this.chatState.session.setPendingPrompt({
         id: optimisticId,
         text,
@@ -470,7 +472,7 @@ export class AcpChatStore {
       this.chatState.scroll.set(pinMode);
     }
 
-    void this._submitPrompt(text, promptAttachments, hiddenContext).then((outcome) => {
+    void this._submitPrompt(promptId, text, promptAttachments, hiddenContext).then((outcome) => {
       if (outcome !== 'rejected') return;
       runInAction(() => {
         if (this._disposed || submissionSequence !== this._submissionSequence) return;
@@ -712,6 +714,7 @@ export class AcpChatStore {
   }
 
   private _recoverAttachment(session: AcpLiveSession, generation: number | undefined): void {
+    this._historyEpoch++;
     void this._attachmentRecovery?.dispose();
     const scope = this._scope.child('attachment-recovery');
     this._attachmentRecovery = scope;
@@ -726,7 +729,10 @@ export class AcpChatStore {
             runInAction(() => {
               // Reattachment alone cannot recover a failed history/bootstrap load.
               if (this._bootstrapFailed) this.retry();
-              else this.loadError = null;
+              else {
+                this.loadError = null;
+                this._requestHistoryRefresh();
+              }
             });
             return;
           } catch (error) {
@@ -772,6 +778,7 @@ export class AcpChatStore {
   }
 
   private async _submitPrompt(
+    promptId: string,
     text: string,
     attachments: StoredPromptAttachment[],
     hiddenContext?: string | Promise<string | undefined>
@@ -794,11 +801,15 @@ export class AcpChatStore {
     }
 
     try {
-      const result = await session.sendPrompt({
-        text,
-        ...(resolvedHiddenContext ? { hiddenContext: resolvedHiddenContext } : {}),
-        ...(attachments.length > 0 ? { attachments } : {}),
-      });
+      const result = await session.sendPrompt(
+        {
+          text,
+          ...(resolvedHiddenContext ? { hiddenContext: resolvedHiddenContext } : {}),
+          ...(attachments.length > 0 ? { attachments } : {}),
+        },
+        undefined,
+        promptId
+      );
       if (!result.success) {
         this._toastError('Failed to send message', result.error);
         return 'rejected';
@@ -964,10 +975,21 @@ export class AcpChatStore {
 
     const task = Promise.resolve()
       .then(async () => {
+        let attempt = 0;
         while (this._historyRefreshRequested && !this._disposed) {
           this._historyRefreshRequested = false;
-          await this._refreshHistory();
+          if (await this._refreshHistory()) {
+            attempt = 0;
+          } else {
+            this._historyRefreshRequested = true;
+            await systemClock.sleep(Math.min(1_000 * 2 ** attempt++, 15_000), {
+              signal: this._scope.signal,
+            });
+          }
         }
+      })
+      .catch((error: unknown) => {
+        if (!this._disposed) getMementoClient().reportError(error);
       })
       .finally(() => {
         if (this._historyRefreshTask === task) this._historyRefreshTask = null;
@@ -976,30 +998,38 @@ export class AcpChatStore {
     this._historyRefreshTask = task;
   }
 
-  private async _refreshHistory(): Promise<void> {
+  private async _refreshHistory(): Promise<boolean> {
     const session = this.session;
-    if (!session) return;
+    const epoch = this._historyEpoch;
+    if (!session || !session.usable || this.hostAccess?.liveAction.kind === 'disabled') return true;
 
     try {
       const history = await session.loadHistory(undefined, 100);
-      if (!history.success || history.data.unavailable || this.session !== session) return;
+      if (this._disposed || this.session !== session || this._historyEpoch !== epoch) return true;
+      if (!history.success) throw new AcpStartError(history.error);
+      if (history.data.unavailable) return true;
       // A waking prompt may begin between replay completion and this response. Do not let a
       // replay-history seed reset the newly active turn; its normal completion refresh will seed
       // the authoritative history instead.
-      if (this.chatState.transcript.state.activeTurnSnapshot !== null) return;
+      if (this.chatState.transcript.state.activeTurnSnapshot !== null) return true;
       runInAction(() => {
         const pendingPrompt = this.chatState.session.state.pendingPrompt;
         this.chatState.transcript.history.seed(history.data.turns);
-        if (pendingPrompt && this.chatState.session.state.pendingPrompt === null) {
-          this.chatState.session.setPendingPrompt(pendingPrompt);
+        if (pendingPrompt) {
+          const committed = history.data.turns.some((turn) =>
+            turn.items.some((item) => item.kind === 'message' && item.promptId === pendingPrompt.id)
+          );
+          this.chatState.session.setPendingPrompt(committed ? null : pendingPrompt);
         }
         this._syncMessageCount();
       });
+      return true;
     } catch (error) {
       log.warn('Failed to refresh ACP history', {
         conversationId: this.conversationId,
         error,
       });
+      return error instanceof AcpStartError && error.errorType === 'auth_required';
     }
   }
 

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-live-session.ts
@@ -214,9 +214,9 @@ export class AcpLiveSession {
 
   async sendPrompt(
     prompt: PromptInput,
-    placement?: PromptPlacement
+    placement?: PromptPlacement,
+    promptId: string = crypto.randomUUID()
   ): Promise<Result<{ queued: boolean }, unknown>> {
-    const promptId = crypto.randomUUID();
     try {
       return await this.client.sendPrompt(
         { conversationId: this.conversationId, promptId, prompt, placement },

--- a/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-reconnect.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-reconnect.test.ts
@@ -1,0 +1,290 @@
+import * as chatUi from '@emdash/chat-ui';
+import type { HistoryPage, SessionState } from '@emdash/core/runtimes/acp/api/client';
+import { ok } from '@emdash/shared';
+import { deferred } from '@emdash/shared/testing';
+import {
+  client,
+  connect,
+  createController,
+  createWireSessionHub,
+  defineContract,
+  memoryTransportPair,
+  replaceableTransport,
+} from '@emdash/wire/rpc';
+import { cell, expose, flushStateTurn } from '@emdash/wire/state';
+import { observable, runInAction } from 'mobx';
+import { expect, it, vi } from 'vitest';
+import { conversationsContract } from '@core/features/conversations/api';
+import { installChatUiRuntime } from '@core/features/conversations/api/browser/chat/chat-ui-runtime';
+import { AcpChatStore } from '@core/features/conversations/browser/acp/acp-chat-store';
+import type { ProjectHostAccessState } from '@core/features/projects/api/browser/stores/project-context';
+
+const fixture = vi.hoisted(() => ({ client: undefined as unknown, context: undefined as unknown }));
+vi.mock('@core/features/conversations/api/browser/client', () => ({
+  getConversationsClient: async () => fixture.client,
+}));
+vi.mock('@core/features/conversations/api/browser/chat/shared-chat-context', () => ({
+  getSharedChatContext: () => fixture.context,
+}));
+vi.mock('@core/primitives/mementos/browser', () => ({
+  getMementoClient: () => ({
+    reportError: vi.fn(),
+    subject: () => ({
+      ready: Promise.resolve(),
+      release: async () => {},
+      handle: () => ({
+        value: { version: '1', text: '', attachments: [] },
+        autoPersist: () => () => {},
+      }),
+    }),
+  }),
+}));
+
+it.each([
+  'missed-active',
+  'observed-active',
+  'history-retry',
+  'new-prompt',
+  'new-active-turn',
+  'stale-reattach',
+  'disposed',
+] as const)('reloads completed history after reconnect: %s', async (mode) => {
+  installChatUiRuntime(chatUi);
+  const context = chatUi.createChatContext();
+  fixture.context = context;
+  const idle: SessionState = {
+    lifecycle: 'ready',
+    activeTurnId: null,
+    pendingPermissions: [],
+    lastStopReason: null,
+    lastTurnErrored: false,
+    queuedPrompts: [],
+    agentTurnActive: false,
+    backgroundAgentCount: 0,
+    isGenerating: false,
+    canSubmit: true,
+    canCancel: false,
+  };
+  const state = cell(idle);
+  const activeTurn = cell<HistoryPage['turns'][number] | null>(null);
+  const contract = defineContract({
+    acp: defineContract({
+      attach: conversationsContract.acp.attach,
+      session: conversationsContract.acp.session,
+      sendPrompt: conversationsContract.acp.sendPrompt,
+      loadHistory: conversationsContract.acp.loadHistory,
+    }),
+  });
+  const session = expose(contract.acp.session, {
+    state,
+    activeTurn,
+    config: cell({ modelOptions: null, efforts: null, modeOptions: null, availableCommands: [] }),
+    usage: cell(null),
+    plan: cell(null),
+    agents: cell([]),
+    terminals: cell([]),
+    mcpServers: cell([]),
+  });
+  let history: HistoryPage = { turns: [], nextCursor: null };
+  let acceptedPromptId = '';
+  const attach = vi.fn(async () => ok(undefined));
+  const loadHistory = vi.fn(async () => ok(history));
+  const sendPrompt = vi.fn(async ({ promptId }: { promptId: string }) => {
+    acceptedPromptId = promptId;
+    return ok({ queued: false });
+  });
+  const hub = createWireSessionHub(
+    createController(
+      contract,
+      {
+        acp: { attach, session, loadHistory, sendPrompt },
+      },
+      { validate: 'full' }
+    )
+  );
+  const transport = replaceableTransport();
+  const connection = connect(transport, { maxHeldCalls: 0 });
+  fixture.client = client(contract, connection);
+  const pair = memoryTransportPair();
+  hub.open('desktop-first', pair.right);
+  transport.install(pair.left);
+  const hostState = observable.box<ProjectHostAccessState>({ kind: 'ready', hostGeneration: 1 });
+  const store = new AcpChatStore('conversation-1', 'project-1', 'task-1', {
+    get state() {
+      return hostState.get();
+    },
+    get liveAction() {
+      return hostState.get().kind === 'ready' ? { kind: 'enabled' } : { kind: 'disabled' };
+    },
+  } as never);
+  const parent = document.createElement('div');
+  parent.style.cssText = 'width:800px;height:600px;position:relative';
+  document.body.append(parent);
+  const view = chatUi.createChatView({ context, state: store.chatState, parent });
+  const historyGate = deferred<void>();
+  let disposed = false;
+  try {
+    store.bootstrap();
+    await vi.waitFor(() => expect(store.historyLoading).toBe(false));
+    expect(store.loadError).toBeNull();
+    const live = store.session!;
+    const revalidate = vi.spyOn(live, 'revalidate');
+    const seed = vi.spyOn(store.chatState.transcript.history, 'seed');
+    const send = vi.spyOn(live, 'sendPrompt');
+    store.submitPrompt('continue');
+    await vi.waitFor(() => expect(send).toHaveResolvedWith(ok({ queued: false })));
+    expect(store.chatState.session.state.pendingPrompt?.text).toBe('continue');
+    const completed: HistoryPage['turns'][number] = {
+      id: 'completed-offline',
+      seq: 0,
+      initiator: 'user',
+      items: [
+        {
+          kind: 'message',
+          id: 'user',
+          seq: 0,
+          role: 'user',
+          text: 'continue',
+          promptId: acceptedPromptId,
+        },
+        { kind: 'message', id: 'agent', seq: 1, role: 'assistant', text: 'Completed remotely.' },
+      ],
+    };
+    if (mode === 'observed-active') {
+      activeTurn.set({ ...completed, items: [completed.items[0]] });
+      flushStateTurn();
+      await vi.waitFor(() => expect(live.activeTurn.current()?.id).toBe(completed.id));
+    }
+    transport.detach();
+    runInAction(() =>
+      hostState.set({ kind: 'degraded', situation: 'recovering', recovery: 'automatic' })
+    );
+    activeTurn.set(completed);
+    state.set({ ...idle, activeTurnId: completed.id, agentTurnActive: true, isGenerating: true });
+    flushStateTurn();
+    history = { turns: [completed], nextCursor: null };
+    activeTurn.set(null);
+    state.set({ ...idle, lastStopReason: 'end_turn' });
+    flushStateTurn();
+    if (mode === 'history-retry') {
+      loadHistory.mockRejectedValueOnce(new Error('History temporarily unavailable'));
+    }
+    if (
+      mode === 'new-prompt' ||
+      mode === 'new-active-turn' ||
+      mode === 'stale-reattach' ||
+      mode === 'disposed'
+    ) {
+      loadHistory.mockImplementationOnce(async () => {
+        const snapshot = history;
+        await historyGate.promise;
+        return ok(snapshot);
+      });
+    }
+    const replacement = memoryTransportPair();
+    hub.open('desktop-second', replacement.right);
+    transport.install(replacement.left);
+    runInAction(() => hostState.set({ kind: 'ready', hostGeneration: 2 }));
+    await vi.waitFor(() => expect(revalidate).toHaveResolved());
+    expect(live.usable).toBe(true);
+    expect(live.sessionState.current().lastStopReason).toBe('end_turn');
+    expect(live.activeTurn.current()).toBeNull();
+    expect(sendPrompt).toHaveBeenCalledOnce();
+    expect(attach).toHaveBeenCalledTimes(2);
+    if (mode === 'stale-reattach' || mode === 'disposed') {
+      await vi.waitFor(() => expect(loadHistory).toHaveBeenCalledTimes(2));
+      if (mode === 'disposed') {
+        view.dispose();
+        store.dispose();
+        disposed = true;
+        historyGate.resolve();
+        await vi.waitFor(() => expect(loadHistory).toHaveResolvedTimes(2));
+        expect(seed).not.toHaveBeenCalled();
+        return;
+      }
+      transport.detach();
+      runInAction(() =>
+        hostState.set({ kind: 'degraded', situation: 'recovering', recovery: 'automatic' })
+      );
+      // A replacement host snapshot must supersede the read from the previous attachment.
+      history = { turns: [{ ...completed, id: 'replacement-history' }], nextCursor: null };
+      const third = memoryTransportPair();
+      hub.open('desktop-third', third.right);
+      transport.install(third.left);
+      runInAction(() => hostState.set({ kind: 'ready', hostGeneration: 3 }));
+      await vi.waitFor(() => expect(revalidate).toHaveResolvedTimes(2));
+      historyGate.resolve();
+      await vi.waitFor(() => expect(seed).toHaveBeenCalledOnce());
+      expect(seed).toHaveBeenCalledWith(history.turns);
+      expect(store.chatState.transcript.state.committedTurns).toEqual(history.turns);
+      return;
+    }
+    if (mode === 'new-prompt' || mode === 'new-active-turn') {
+      await vi.waitFor(() => expect(loadHistory).toHaveBeenCalledTimes(2));
+      // Same text deliberately: only the prompt id distinguishes the new submission.
+      store.submitPrompt('continue');
+      await vi.waitFor(() => expect(sendPrompt).toHaveBeenCalledTimes(2));
+      const pending = store.chatState.session.state.pendingPrompt;
+      expect(pending?.id).toBe(acceptedPromptId);
+      store.setDraftText('a newer draft');
+      if (mode === 'new-active-turn') {
+        const nextTurn: HistoryPage['turns'][number] = {
+          id: 'next-turn',
+          seq: 1,
+          initiator: 'user',
+          items: [
+            {
+              kind: 'message',
+              id: 'next-user',
+              seq: 0,
+              role: 'user',
+              text: 'continue',
+              promptId: acceptedPromptId,
+            },
+          ],
+        };
+        activeTurn.set(nextTurn);
+        flushStateTurn();
+        await vi.waitFor(() => expect(live.activeTurn.current()?.id).toBe('next-turn'));
+        historyGate.resolve();
+        await vi.waitFor(() => expect(loadHistory).toHaveResolvedTimes(2));
+        expect(store.chatState.transcript.state.activeTurnSnapshot?.id).toBe('next-turn');
+        expect(store.chatState.transcript.state.committedTurns).toEqual([]);
+        history = { turns: [completed, nextTurn], nextCursor: null };
+        activeTurn.set(null);
+        flushStateTurn();
+        await vi.waitFor(() =>
+          expect(store.chatState.transcript.state.committedTurns).toEqual(history.turns)
+        );
+        expect(store.chatState.session.state.pendingPrompt).toBeNull();
+      } else {
+        historyGate.resolve();
+        await vi.waitFor(() =>
+          expect(store.chatState.transcript.state.committedTurns).toEqual([completed])
+        );
+        expect(store.chatState.session.state.pendingPrompt).toEqual(pending);
+      }
+      expect(store.draftText).toBe('a newer draft');
+      return;
+    }
+    await vi.waitFor(
+      () => expect(store.chatState.transcript.state.committedTurns).toHaveLength(1),
+      { timeout: 3_000 }
+    );
+    await vi.waitFor(() => expect(parent.textContent).toContain('Completed remotely.'));
+    expect.soft(store.chatState.transcript.state.committedTurns).toEqual([completed]);
+    expect.soft(store.chatState.session.state.pendingPrompt).toBeNull();
+  } finally {
+    historyGate.resolve();
+    if (!disposed) {
+      view.dispose();
+      store.dispose();
+    }
+    connection.dispose();
+    transport.close();
+    await hub.dispose();
+    await session.dispose();
+    context.dispose();
+    parent.remove();
+  }
+});

--- a/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
@@ -417,10 +417,14 @@ describe('AcpChatStore prompt submission', () => {
 
     resolveContext('resolved context');
     await vi.waitFor(() =>
-      expect(sendPrompt).toHaveBeenCalledWith({
-        text: 'hello',
-        hiddenContext: 'resolved context',
-      })
+      expect(sendPrompt).toHaveBeenCalledWith(
+        {
+          text: 'hello',
+          hiddenContext: 'resolved context',
+        },
+        undefined,
+        expect.any(String)
+      )
     );
   });
 
@@ -431,7 +435,9 @@ describe('AcpChatStore prompt submission', () => {
 
     store.submitPrompt('hello', [], Promise.reject(new Error('context unavailable')));
 
-    await vi.waitFor(() => expect(sendPrompt).toHaveBeenCalledWith({ text: 'hello' }));
+    await vi.waitFor(() =>
+      expect(sendPrompt).toHaveBeenCalledWith({ text: 'hello' }, undefined, expect.any(String))
+    );
     expect(store.draftText).toBe('');
   });
 
@@ -550,10 +556,14 @@ describe('AcpChatStore prompt submission', () => {
     expect(store.draftText).toBe('');
     expect(store.draftAttachments).toEqual([]);
     await vi.waitFor(() =>
-      expect(sendPrompt).toHaveBeenCalledWith({
-        text: 'hello',
-        attachments: [attachment.ref],
-      })
+      expect(sendPrompt).toHaveBeenCalledWith(
+        {
+          text: 'hello',
+          attachments: [attachment.ref],
+        },
+        undefined,
+        expect.any(String)
+      )
     );
   });
 


### PR DESCRIPTION
- refresh authoritative transcript history after an acp session reconnects
- reconcile optimistic prompts with their submitted prompt ids so completed prompts clear correctly
- retry transient history refresh failures and ignore stale attachment responses
- preserve newer prompts and active turns while history refreshes