### PR TITLE
fix(pull-requests): make manual refresh reliable

### DIFF
--- a/apps/emdash-desktop/src/core/features/source-control/api/browser/stores/pr-store.test.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/api/browser/stores/pr-store.test.ts
@@ -1,6 +1,6 @@
 import { createManualClock } from '@emdash/shared/testing';
 import { observable } from 'mobx';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ProjectHostAccessState } from '@core/features/projects/api/browser/stores/project-context';
 import type { PullRequest } from '@core/services/pull-requests/api';
 import type { GitCheckoutStore } from '../../../browser/stores/git-checkout-store';
@@ -8,13 +8,27 @@ import type { GitRepositoryStore } from './git-repository-store';
 import { PrStore } from './pr-store';
 import { TaskPrAssociationStore } from './task-pr-association-store';
 
+const mocks = vi.hoisted(() => ({
+  getPullRequestsRuntimeClient: vi.fn(),
+}));
+
+vi.mock('@core/services/pull-requests/api/client', () => ({
+  getPullRequestsRuntimeClient: mocks.getPullRequestsRuntimeClient,
+}));
+
 const pullRequest = {
   url: 'https://github.com/example/repo/pull/1',
+  identifier: '#1',
+  repositoryUrl: 'https://github.com/example/repo',
   status: 'open',
   title: 'Retained pull request',
 } as PullRequest;
 
 describe('PrStore Host observations', () => {
+  beforeEach(() => {
+    mocks.getPullRequestsRuntimeClient.mockReset();
+  });
+
   it('retains observed PRs as stale and distinguishes never-observed data', () => {
     const state = observable.box<ProjectHostAccessState>(
       { kind: 'ready', hostGeneration: 1 },
@@ -65,5 +79,38 @@ describe('PrStore Host observations', () => {
     );
     expect(neverObserved.pullRequestsObservation).toEqual({ kind: 'unavailable' });
     neverObserved.dispose();
+  });
+
+  it('relies on service-owned reconciliation after merge and mark-ready mutations', async () => {
+    const mergePullRequest = vi.fn(async () => ({
+      success: true as const,
+      data: { sha: 'abc', merged: true },
+    }));
+    const markReadyForReview = vi.fn(async () => ({ success: true as const, data: undefined }));
+    const syncSingle = vi.fn();
+    mocks.getPullRequestsRuntimeClient.mockResolvedValue({
+      mergePullRequest,
+      markReadyForReview,
+      syncSingle,
+    });
+    const association = new TaskPrAssociationStore(createManualClock(1_786_000_000_000));
+    association.setAssociation([pullRequest], { kind: 'unknown' });
+    const store = new PrStore(
+      'project-1',
+      'workspace-1',
+      {} as GitRepositoryStore,
+      {} as GitCheckoutStore,
+      association
+    );
+
+    await expect(store.mergePr(pullRequest.url, { strategy: 'merge' })).resolves.toEqual({
+      success: true,
+    });
+    await store.markReadyForReview(pullRequest.url);
+
+    expect(mergePullRequest).toHaveBeenCalledTimes(1);
+    expect(markReadyForReview).toHaveBeenCalledTimes(1);
+    expect(syncSingle).not.toHaveBeenCalled();
+    store.dispose();
   });
 });

--- a/apps/emdash-desktop/src/core/features/source-control/api/browser/stores/pr-store.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/api/browser/stores/pr-store.ts
@@ -178,7 +178,6 @@ export class PrStore {
       options,
     });
     if (result.success) {
-      await this._refreshPr(pr, client);
       captureTelemetry('pr_merged', {
         strategy: options.strategy,
         bypass_requirements: options.bypassRequirements ?? false,
@@ -206,11 +205,10 @@ export class PrStore {
     const prNumber = getPrNumber(pr);
     if (!prNumber) return;
     const client = await getPullRequestsRuntimeClient();
-    const result = await client.markReadyForReview({
+    await client.markReadyForReview({
       repositoryUrl: pr.repositoryUrl,
       number: prNumber,
     });
-    if (result.success) await this._refreshPr(pr, client);
   }
 
   /** Refresh the pull request and its check runs from GitHub. */

--- a/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/create-pr-modal.tsx
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/create-pr-modal.tsx
@@ -162,10 +162,6 @@ export const CreatePrModal = observer(function CreatePrModal({
       });
 
       if (result.success) {
-        await client.syncSingle({
-          repositoryUrl: targetRepositoryUrl,
-          number: result.data.number,
-        });
         complete();
       } else {
         setError(pullRequestErrorMessage(result.error));

--- a/apps/emdash-desktop/src/core/services/pull-requests/node/pull-request-service.db.test.ts
+++ b/apps/emdash-desktop/src/core/services/pull-requests/node/pull-request-service.db.test.ts
@@ -142,7 +142,7 @@ describe('PullRequestService lifecycle', () => {
     await scope.dispose();
   });
 
-  it('starts sync on registration and skips fresh incremental syncs', async () => {
+  it('starts sync on registration and always performs an explicitly requested sync', async () => {
     const scope = createScope({ label: 'pull-request-staleness-test' });
     const handle = await pullRequestSqliteStore.openTemp();
     scope.add(() => handle.close());
@@ -169,7 +169,17 @@ describe('PullRequestService lifecycle', () => {
       requestPriorities.background
     );
     await expect(service.sync(repositoryUrl)).resolves.toEqual(ok());
-    expect(sync).toHaveBeenCalledTimes(1);
+    expect(sync).toHaveBeenCalledTimes(2);
+    expect(sync).toHaveBeenLastCalledWith(
+      repositoryUrl,
+      expect.any(AbortSignal),
+      requestPriorities.task
+    );
+
+    await expect(
+      service['syncWithPriority'](repositoryUrl, requestPriorities.background)
+    ).resolves.toEqual(ok());
+    expect(sync).toHaveBeenCalledTimes(2);
 
     await expect(service.forceFullSync(repositoryUrl)).resolves.toEqual(ok());
     expect(forceFullSync).toHaveBeenCalledTimes(1);
@@ -179,6 +189,92 @@ describe('PullRequestService lifecycle', () => {
       requestPriorities.task
     );
     await scope.dispose();
+  });
+
+  it('does not let single-PR or check state postpone repository inventory syncs', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(0);
+      const scope = createScope({ label: 'pull-request-freshness-ownership-test' });
+      const handle = await pullRequestSqliteStore.openTemp();
+      scope.add(() => handle.close());
+      const store = new PullRequestStore(handle);
+      const sync = vi.fn(async () => ok());
+      const engine = { sync } as unknown as PullRequestEngine;
+      const { logger } = createStubLogger();
+      const service = new PullRequestService({
+        store,
+        githubAuth: fakeGitHubAuth(),
+        scope,
+        logger,
+        engine,
+        minSyncIntervalMs: 60_000,
+      });
+      const repositoryUrl = 'https://github.com/emdash/emdash';
+
+      expect(service.registerRepository(repositoryUrl)).toEqual(ok());
+      await vi.waitFor(() => expect(sync).toHaveBeenCalledTimes(1));
+      await vi.waitFor(() => expect(service['syncRuns'].size).toBe(0));
+      const lastRepositorySync = service['lastSuccessfulRepositorySyncs'].get(repositoryUrl)!;
+
+      vi.setSystemTime(lastRepositorySync + 59_000);
+      service['setSyncState'](repositoryUrl, {
+        phase: 'idle',
+        kind: 'single',
+        lastSyncedAt: Date.now(),
+      });
+      vi.setSystemTime(lastRepositorySync + 60_000);
+      await service['syncWithPriority'](repositoryUrl, requestPriorities.background);
+
+      expect(sync).toHaveBeenCalledTimes(2);
+      await scope.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('retains the last successful repository freshness after a failed explicit refresh', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(0);
+      const scope = createScope({ label: 'pull-request-failed-refresh-test' });
+      const handle = await pullRequestSqliteStore.openTemp();
+      scope.add(() => handle.close());
+      const store = new PullRequestStore(handle);
+      const sync = vi
+        .fn()
+        .mockResolvedValueOnce(ok())
+        .mockResolvedValueOnce(err({ type: 'sync_failed', message: 'GitHub unavailable' }));
+      const { logger } = createStubLogger();
+      const service = new PullRequestService({
+        store,
+        githubAuth: fakeGitHubAuth(),
+        scope,
+        logger,
+        engine: { sync } as unknown as PullRequestEngine,
+        minSyncIntervalMs: 60_000,
+      });
+      const repositoryUrl = 'https://github.com/emdash/emdash';
+
+      expect(service.registerRepository(repositoryUrl)).toEqual(ok());
+      await vi.waitFor(() => expect(sync).toHaveBeenCalledTimes(1));
+      await vi.waitFor(() => expect(service['syncRuns'].size).toBe(0));
+      const lastRepositorySync = service['lastSuccessfulRepositorySyncs'].get(repositoryUrl)!;
+
+      vi.setSystemTime(lastRepositorySync + 10_000);
+      await expect(service.sync(repositoryUrl)).resolves.toEqual(
+        err({ type: 'sync_failed', message: 'GitHub unavailable' })
+      );
+      await vi.waitFor(() => expect(service['syncRuns'].size).toBe(0));
+
+      vi.setSystemTime(lastRepositorySync + 20_000);
+      await service['syncWithPriority'](repositoryUrl, requestPriorities.background);
+
+      expect(sync).toHaveBeenCalledTimes(2);
+      await scope.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('validates canonical PR URLs against the cache scoped to one repository', async () => {

--- a/apps/emdash-desktop/src/core/services/pull-requests/node/pull-request-service.ts
+++ b/apps/emdash-desktop/src/core/services/pull-requests/node/pull-request-service.ts
@@ -46,7 +46,7 @@ export class PullRequestService {
   private readonly syncStateCells: Family<SyncStateKey, Cell<SyncState>>;
   private readonly syncStateValues = new Map<string, SyncState>();
   private readonly syncRuns = new Map<string, SyncRun>();
-  private readonly lastSuccessfulSyncs = new Map<string, number>();
+  private readonly lastSuccessfulRepositorySyncs = new Map<string, number>();
   private readonly engine: PullRequestEngine;
 
   constructor(private readonly options: PullRequestServiceOptions) {
@@ -215,14 +215,20 @@ export class PullRequestService {
     if (!normalized) return err({ type: 'invalid_repository', input: repositoryUrl });
     await this.cancelAndWait(normalized);
     this.options.store.unregisterRepository(normalized);
-    this.lastSuccessfulSyncs.delete(normalized);
+    this.lastSuccessfulRepositorySyncs.delete(normalized);
     this.syncStateCells.peekMember({ repositoryUrl: normalized })?.set(idleSyncState());
     this.syncStateValues.delete(normalized);
     return ok();
   }
 
   sync(repositoryUrl: string): Promise<SyncResult> {
-    return this.syncWithPriority(repositoryUrl, requestPriorities.task);
+    const normalized = normalizeRepositoryUrl(repositoryUrl);
+    if (!normalized) {
+      return Promise.resolve(err({ type: 'invalid_repository', input: repositoryUrl }));
+    }
+    return this.startSync(normalized, (signal) =>
+      this.engine.sync(normalized, signal, requestPriorities.task)
+    );
   }
 
   private syncWithPriority(repositoryUrl: string, priority: number): Promise<SyncResult> {
@@ -230,7 +236,7 @@ export class PullRequestService {
     if (!normalized) {
       return Promise.resolve(err({ type: 'invalid_repository', input: repositoryUrl }));
     }
-    const lastSuccessfulSync = this.lastSuccessfulSyncs.get(normalized);
+    const lastSuccessfulSync = this.lastSuccessfulRepositorySyncs.get(normalized);
     const minSyncIntervalMs = this.options.minSyncIntervalMs ?? DEFAULT_MIN_SYNC_INTERVAL_MS;
     if (lastSuccessfulSync !== undefined && Date.now() - lastSuccessfulSync < minSyncIntervalMs) {
       return Promise.resolve(ok());
@@ -369,9 +375,7 @@ export class PullRequestService {
     const run = this.options.scope.run(`sync:${repositoryUrl}`, async (signal) => {
       const result = await operation(signal);
       if (result.success) {
-        this.lastSuccessfulSyncs.set(repositoryUrl, Date.now());
-      } else {
-        this.lastSuccessfulSyncs.delete(repositoryUrl);
+        this.lastSuccessfulRepositorySyncs.set(repositoryUrl, Date.now());
       }
       return result;
     });
@@ -390,11 +394,6 @@ export class PullRequestService {
   }
 
   private setSyncState(repositoryUrl: string, state: SyncState): void {
-    if (state.phase === 'idle' && state.lastSyncedAt !== undefined) {
-      this.lastSuccessfulSyncs.set(repositoryUrl, state.lastSyncedAt);
-    } else if (state.phase === 'error') {
-      this.lastSuccessfulSyncs.delete(repositoryUrl);
-    }
     this.syncStateValues.set(repositoryUrl, state);
     this.syncStateCells.peekMember({ repositoryUrl })?.set(state);
   }


### PR DESCRIPTION
- make explicit repository refreshes bypass the local 60-second freshness gate while automatic syncs remain throttled
- keep repository inventory freshness owned by successful repository syncs so targeted updates and failed refreshes cannot distort polling state
- remove duplicate pr reads after create merge and mark-ready actions while preserving service-owned reconciliation