### PR TITLE
fix(pty): add readable identity-backed tmux sessions

### DIFF
--- a/apps/emdash-desktop/src/core/features/conversations/node/tui-conversation-provider.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/tui-conversation-provider.test.ts
@@ -159,7 +159,6 @@ describe('TuiConversationProvider', () => {
           EMDASH_TASK_NAME: 'old-name',
         }),
         shellSetup: 'source old-profile',
-        tmuxSessionName: undefined,
       })
     );
     expect(start).toHaveBeenNthCalledWith(
@@ -170,7 +169,7 @@ describe('TuiConversationProvider', () => {
           EMDASH_TASK_NAME: 'new-name',
         }),
         shellSetup: 'source new-profile',
-        tmuxSessionName: expect.stringMatching(/^emdash-/),
+        tmux: { identity: expect.stringMatching(/:/) },
       })
     );
   });

--- a/apps/emdash-desktop/src/core/features/conversations/node/tui-conversation-provider.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/tui-conversation-provider.ts
@@ -1,7 +1,6 @@
 import type { GitCredentialsSessionSpec } from '@emdash/core/primitives/git-credentials/api';
 import type { HostRef } from '@emdash/core/primitives/host/api';
 import type { TuiAgentStartInput } from '@emdash/core/runtimes/tui-agents/api';
-import { makeTmuxSessionName } from '@emdash/core/services/pty/api';
 import { and, eq } from 'drizzle-orm';
 import { conversationRegistryTable as conversations } from '@core/features/conversations/api/node/registry';
 import type {
@@ -172,7 +171,7 @@ export class TuiConversationProvider implements ConversationProvider {
       cols: initialSize.cols,
       rows: initialSize.rows,
       shellSetup: launchContext.data.shellSetup,
-      tmuxSessionName: launchContext.data.tmux ? makeTmuxSessionName(sessionId) : undefined,
+      tmux: launchContext.data.tmux ? { identity: sessionId } : undefined,
     };
   }
 }

--- a/apps/emdash-desktop/src/core/features/projects/node/operations/deleteProject.db.test.ts
+++ b/apps/emdash-desktop/src/core/features/projects/node/operations/deleteProject.db.test.ts
@@ -126,7 +126,7 @@ describe('deleteProject', () => {
         acpConversationIds: [] as string[],
         tuiConversationIds: [] as string[],
         terminalSessionIds: [] as string[],
-        tmuxSessionNames: [] as string[],
+        tmuxSessionIdentities: [] as string[],
       })),
       killAcp: vi.fn(async () => {}),
       killTerminals: vi.fn(async () => {}),

--- a/apps/emdash-desktop/src/core/features/tasks/api/node/task-session-cleanup.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/api/node/task-session-cleanup.ts
@@ -17,7 +17,7 @@ export type TaskSessionTargets = {
   acpConversationIds: string[];
   tuiConversationIds: string[];
   terminalSessionIds: string[];
-  tmuxSessionNames: string[];
+  tmuxSessionIdentities: string[];
 };
 
 export type TaskSessionScope = {
@@ -65,7 +65,7 @@ export async function killTaskSessions(
     if (
       targets.tuiConversationIds.length > 0 ||
       targets.terminalSessionIds.length > 0 ||
-      targets.tmuxSessionNames.length > 0
+      targets.tmuxSessionIdentities.length > 0
     ) {
       await sessionCleanup.killTerminals(db, scope, context, targets);
     }

--- a/apps/emdash-desktop/src/core/features/tasks/api/node/task-session-manager.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/api/node/task-session-manager.ts
@@ -1,6 +1,5 @@
 import { hostRefKey, type SerializedHostRef } from '@emdash/core/primitives/host/api';
 import type { HostFileRef } from '@emdash/core/primitives/path/api';
-import { makeTmuxSessionName } from '@emdash/core/services/pty/api';
 import {
   runtimeResolveErrorAsError,
   type RuntimeBroker,
@@ -131,11 +130,14 @@ async function cleanupDetachedSessions(
     return;
   }
   const { conversationIds, terminalIds } = await getTaskSessionLeafIds(db, projectId, taskId);
-  const sessionNames = [...conversationIds, ...terminalIds].map((leafId) =>
-    makeTmuxSessionName(makePtySessionId(projectId, taskId, leafId))
+  const sessionIdentities = [...conversationIds, ...terminalIds].map((leafId) =>
+    makePtySessionId(projectId, taskId, leafId)
   );
-  if (sessionNames.length > 0) {
-    await runtime.data.terminals.killTmuxSessions({ sessionNames });
+  if (sessionIdentities.length > 0) {
+    await runtime.data.terminals.killTmuxSessions({
+      sessionIdentities,
+      workspaceLabel: runtimeWorkspace.path.segments.at(-1) ?? 'workspace',
+    });
   }
 }
 

--- a/apps/emdash-desktop/src/core/features/tasks/node/operations/deleteTask.db.test.ts
+++ b/apps/emdash-desktop/src/core/features/tasks/node/operations/deleteTask.db.test.ts
@@ -120,7 +120,7 @@ describe('deleteTask', () => {
         acpConversationIds: [] as string[],
         tuiConversationIds: [] as string[],
         terminalSessionIds: [] as string[],
-        tmuxSessionNames: [] as string[],
+        tmuxSessionIdentities: [] as string[],
       })),
       killAcp: vi.fn(async () => {}),
       killTerminals: vi.fn(async () => {}),

--- a/apps/emdash-desktop/src/main/core/runtime/operations/session-cleanup.ts
+++ b/apps/emdash-desktop/src/main/core/runtime/operations/session-cleanup.ts
@@ -3,7 +3,6 @@ import {
   sshConnectionIdOf,
   type SerializedHostRef,
 } from '@emdash/core/primitives/host/api';
-import { makeTmuxSessionName } from '@emdash/core/services/pty/api';
 import { and, eq, inArray, isNull, ne, or } from 'drizzle-orm';
 import { hostFileRefFromNativePath } from '@core/primitives/desktop-runtime/api';
 import { makePtySessionId } from '@core/primitives/pty/api';
@@ -19,7 +18,7 @@ export type LifecycleSessionTargets = {
   acpConversationIds: string[];
   tuiConversationIds: string[];
   terminalSessionIds: string[];
-  tmuxSessionNames: string[];
+  tmuxSessionIdentities: string[];
 };
 
 /** The task being deleted plus the host its sessions live on — all this module needs. */
@@ -62,7 +61,7 @@ export async function resolveLifecycleSessionTargets(
     acpConversationIds: new Set(),
     tuiConversationIds: new Set(),
     terminalSessionIds: new Set(),
-    tmuxSessionNames: new Set(),
+    tmuxSessionIdentities: new Set(),
   };
   const taskIds = operation.taskId ? [operation.taskId] : [];
   if (taskIds.length > 0) {
@@ -101,9 +100,8 @@ export async function resolveLifecycleSessionTargets(
     }
     for (const row of [...acpRows, ...tuiRows, ...terminalRows]) {
       if (row.projectId === null || row.taskId === null) continue;
-      targets.tmuxSessionNames.add(
-        makeTmuxSessionName(makePtySessionId(row.projectId, row.taskId, row.id))
-      );
+      const identity = makePtySessionId(row.projectId, row.taskId, row.id);
+      targets.tmuxSessionIdentities.add(identity);
     }
   }
 
@@ -157,10 +155,17 @@ export async function killLifecycleTerminalSessions(
     }
   }
 
-  if (!operation.projectId || targets.tmuxSessionNames.length === 0) return;
+  if (!operation.projectId || targets.tmuxSessionIdentities.length === 0) return;
   const projectTerminals = dependencies.getProjectTerminals(operation.projectId);
   if (!projectTerminals) return;
-  await projectTerminals.killTmuxSessions({ sessionNames: targets.tmuxSessionNames });
+  await projectTerminals.killTmuxSessions({
+    sessionIdentities: targets.tmuxSessionIdentities,
+    workspaceLabel: context.workspacePath ? workspaceLabel(context.workspacePath) : undefined,
+  });
+}
+
+function workspaceLabel(path: string): string {
+  return path.split(/[\\/]/u).filter(Boolean).at(-1) ?? 'workspace';
 }
 
 function toArrays(targets: SessionTargetSets): LifecycleSessionTargets {
@@ -168,7 +173,7 @@ function toArrays(targets: SessionTargetSets): LifecycleSessionTargets {
     acpConversationIds: [...targets.acpConversationIds],
     tuiConversationIds: [...targets.tuiConversationIds],
     terminalSessionIds: [...targets.terminalSessionIds],
-    tmuxSessionNames: [...targets.tmuxSessionNames],
+    tmuxSessionIdentities: [...targets.tmuxSessionIdentities],
   };
 }
 

--- a/apps/emdash-desktop/src/main/db/legacy-port/importers/relational/conversations.ts
+++ b/apps/emdash-desktop/src/main/db/legacy-port/importers/relational/conversations.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { makeTmuxSessionName } from '@emdash/core/services/pty/api';
+import { makeLegacyTmuxSessionName } from '@emdash/core/services/pty/api';
 import { createConversationRegistry } from '@core/features/conversations/api/node/registry';
 import type { CommandRunner } from '@core/primitives/command-runner/api/command-runner';
 import { makePtySessionId } from '@core/primitives/pty/api';
@@ -182,7 +182,7 @@ function legacyPtyLookupKey(providerId: string, suffix: string): string {
   return `${providerId}:${suffix}`;
 }
 
-function makeLegacyTmuxSessionName(legacyPtyId: string): string {
+function makeV0TmuxSessionName(legacyPtyId: string): string {
   return `emdash-${legacyPtyId.replace(/[^a-zA-Z0-9._-]/g, '-')}`;
 }
 
@@ -323,27 +323,27 @@ async function renameLegacyTmuxSession(params: {
   const { tmuxExec, legacyPtyId, mappedProjectId, mappedTaskId, conversationId } = params;
   if (!tmuxExec || !legacyPtyId) return;
 
-  const oldName = makeLegacyTmuxSessionName(legacyPtyId);
-  const newName = makeTmuxSessionName(
+  const oldName = makeV0TmuxSessionName(legacyPtyId);
+  const newName = makeLegacyTmuxSessionName(
     makePtySessionId(mappedProjectId, mappedTaskId, conversationId)
   );
   if (oldName === newName) return;
 
   try {
-    await tmuxExec('tmux', ['has-session', '-t', oldName]);
+    await tmuxExec('tmux', ['has-session', '-t', `=${oldName}`]);
   } catch {
     return;
   }
 
   try {
-    await tmuxExec('tmux', ['has-session', '-t', newName]);
+    await tmuxExec('tmux', ['has-session', '-t', `=${newName}`]);
     return;
   } catch {
     // Expected when the v1 session name has not been created yet.
   }
 
   try {
-    await tmuxExec('tmux', ['rename-session', '-t', oldName, newName]);
+    await tmuxExec('tmux', ['rename-session', '-t', `=${oldName}`, newName]);
   } catch (error) {
     log.debug('legacy-port: conversations: failed to rename legacy tmux session', {
       legacyPtyId,

--- a/apps/emdash-desktop/src/main/db/legacy-port/importers/relational/relational.test.ts
+++ b/apps/emdash-desktop/src/main/db/legacy-port/importers/relational/relational.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { makeTmuxSessionName } from '@emdash/core/services/pty/api';
+import { makeLegacyTmuxSessionName } from '@emdash/core/services/pty/api';
 import Database from 'better-sqlite3';
 import { afterEach, describe, expect, it } from 'vitest';
 import { makePtySessionId } from '@core/primitives/pty/api';
@@ -868,7 +868,7 @@ describe('legacy-port table passes', () => {
       if (
         command === 'tmux' &&
         args?.[0] === 'has-session' &&
-        args[2] !== 'emdash-claude-chat-conv-legacy-chat'
+        args[2] !== '=emdash-claude-chat-conv-legacy-chat'
       ) {
         throw new Error('missing');
       }
@@ -889,22 +889,22 @@ describe('legacy-port table passes', () => {
       tmuxExec,
     });
 
-    const newTmuxName = makeTmuxSessionName(
+    const newTmuxName = makeLegacyTmuxSessionName(
       makePtySessionId('proj-legacy-tmux', 'task-legacy-tmux', mappedChatUuid)
     );
 
     expect(calls).toEqual([
       {
         command: 'tmux',
-        args: ['has-session', '-t', 'emdash-claude-chat-conv-legacy-chat'],
+        args: ['has-session', '-t', '=emdash-claude-chat-conv-legacy-chat'],
       },
       {
         command: 'tmux',
-        args: ['has-session', '-t', newTmuxName],
+        args: ['has-session', '-t', `=${newTmuxName}`],
       },
       {
         command: 'tmux',
-        args: ['rename-session', '-t', 'emdash-claude-chat-conv-legacy-chat', newTmuxName],
+        args: ['rename-session', '-t', '=emdash-claude-chat-conv-legacy-chat', newTmuxName],
       },
     ]);
   });

--- a/packages/core/src/runtimes/terminals/api/schemas.ts
+++ b/packages/core/src/runtimes/terminals/api/schemas.ts
@@ -137,7 +137,8 @@ export const terminalControlInputSchema = z.object({
 });
 
 export const killTmuxSessionsInputSchema = z.object({
-  sessionNames: z.array(z.string().min(1)),
+  sessionIdentities: z.array(z.string().min(1)),
+  workspaceLabel: z.string().min(1).optional(),
 });
 
 export type KillTmuxSessionsInput = z.infer<typeof killTmuxSessionsInputSchema>;

--- a/packages/core/src/runtimes/terminals/node/runtime/runtime.test.ts
+++ b/packages/core/src/runtimes/terminals/node/runtime/runtime.test.ts
@@ -410,10 +410,23 @@ describe('TerminalsRuntime', () => {
       scope,
     });
 
-    const result = await runtime.killTmuxSessions({ sessionIdentities: [identity] });
+    const result = await runtime.killTmuxSessions({
+      sessionIdentities: [identity],
+      workspaceLabel: 'workspace',
+    });
 
     expect(result).toEqual({ success: true, data: undefined });
-    expect(exec.exec).toHaveBeenLastCalledWith('tmux', ['kill-session', '-t', '=manually-renamed']);
+    expect(exec.exec).toHaveBeenCalledWith('tmux', ['kill-session', '-t', '=manually-renamed']);
+    expect(exec.exec).toHaveBeenCalledWith('tmux', [
+      'kill-session',
+      '-t',
+      `=${makeTmuxSessionName(identity, 'workspace')}`,
+    ]);
+    expect(exec.exec).toHaveBeenCalledWith('tmux', [
+      'kill-session',
+      '-t',
+      `=${makeLegacyTmuxSessionName(identity)}`,
+    ]);
     await scope.dispose();
   });
 
@@ -445,6 +458,41 @@ describe('TerminalsRuntime', () => {
       '-t',
       `=${makeLegacyTmuxSessionName(identity)}`,
     ]);
+    await scope.dispose();
+  });
+
+  it('killTmuxSessions uses deterministic names when identity discovery fails', async () => {
+    const exec = fakeExec();
+    exec.exec.mockRejectedValueOnce(new Error('inventory failed'));
+    const logger = { ...noopLogger, warn: vi.fn() };
+    const spawner = new FakePtySpawner();
+    const scope = createScope({ label: 'test-terminals' });
+    const runtime = new TerminalsRuntime({
+      spawner,
+      userEnv: async () => testUserEnv(),
+      exec,
+      logger,
+      scope,
+    });
+    const identity = 'project:task:terminal';
+
+    const result = await runtime.killTmuxSessions({
+      sessionIdentities: [identity],
+      workspaceLabel: 'workspace',
+    });
+
+    expect(result).toEqual({ success: true, data: undefined });
+    expect(exec.exec).toHaveBeenCalledWith('tmux', [
+      'kill-session',
+      '-t',
+      `=${makeTmuxSessionName(identity, 'workspace')}`,
+    ]);
+    expect(exec.exec).toHaveBeenCalledWith('tmux', [
+      'kill-session',
+      '-t',
+      `=${makeLegacyTmuxSessionName(identity)}`,
+    ]);
+    expect(logger.warn).toHaveBeenCalledOnce();
     await scope.dispose();
   });
 

--- a/packages/core/src/runtimes/terminals/node/runtime/runtime.test.ts
+++ b/packages/core/src/runtimes/terminals/node/runtime/runtime.test.ts
@@ -18,6 +18,7 @@ import type {
   TerminalShellResolver,
 } from '#primitives/terminal-shell/api';
 import type { TerminalSessionState } from '#runtimes/terminals/api';
+import { makeLegacyTmuxSessionName, makeTmuxSessionName } from '#services/pty/api';
 import { FakePtySpawner } from '#services/pty/testing';
 import {
   expectNoSessionResidue,
@@ -360,7 +361,7 @@ describe('TerminalsRuntime', () => {
     await scope.dispose();
   });
 
-  it('killTmuxSessions calls killTmuxSession for each session name', async () => {
+  it('killTmuxSessions falls back to each legacy name when metadata is absent', async () => {
     const exec = fakeExec();
     const spawner = new FakePtySpawner();
     const scope = createScope({ label: 'test-terminals' });
@@ -372,19 +373,85 @@ describe('TerminalsRuntime', () => {
     });
 
     const result = await runtime.killTmuxSessions({
-      sessionNames: ['emdash-session1', 'emdash-session2'],
+      sessionIdentities: ['session1', 'session2'],
     });
 
     expect(result).toEqual({ success: true, data: undefined });
-    expect(exec.exec).toHaveBeenCalledTimes(2);
-    expect(exec.exec).toHaveBeenCalledWith('tmux', ['kill-session', '-t', 'emdash-session1']);
-    expect(exec.exec).toHaveBeenCalledWith('tmux', ['kill-session', '-t', 'emdash-session2']);
+    expect(exec.exec).toHaveBeenCalledTimes(3);
+    expect(exec.exec).toHaveBeenCalledWith('tmux', [
+      'kill-session',
+      '-t',
+      `=${makeLegacyTmuxSessionName('session1')}`,
+    ]);
+    expect(exec.exec).toHaveBeenCalledWith('tmux', [
+      'kill-session',
+      '-t',
+      `=${makeLegacyTmuxSessionName('session2')}`,
+    ]);
+    await scope.dispose();
+  });
+
+  it('killTmuxSessions discovers a renamed session by identity metadata', async () => {
+    const identity = 'project:task:terminal';
+    const encodedIdentity = Buffer.from(JSON.stringify({ version: 1, identity }), 'utf8').toString(
+      'base64url'
+    );
+    const exec = fakeExec();
+    exec.exec.mockResolvedValueOnce({
+      stdout: `manually-renamed\t42\tv1:${encodedIdentity}\n`,
+      stderr: '',
+    });
+    const spawner = new FakePtySpawner();
+    const scope = createScope({ label: 'test-terminals' });
+    const runtime = new TerminalsRuntime({
+      spawner,
+      userEnv: async () => testUserEnv(),
+      exec,
+      scope,
+    });
+
+    const result = await runtime.killTmuxSessions({ sessionIdentities: [identity] });
+
+    expect(result).toEqual({ success: true, data: undefined });
+    expect(exec.exec).toHaveBeenLastCalledWith('tmux', ['kill-session', '-t', '=manually-renamed']);
+    await scope.dispose();
+  });
+
+  it('killTmuxSessions tries readable and legacy names when metadata is unavailable', async () => {
+    const exec = fakeExec();
+    const spawner = new FakePtySpawner();
+    const scope = createScope({ label: 'test-terminals' });
+    const runtime = new TerminalsRuntime({
+      spawner,
+      userEnv: async () => testUserEnv(),
+      exec,
+      scope,
+    });
+    const identity = 'project:task:terminal';
+
+    const result = await runtime.killTmuxSessions({
+      sessionIdentities: [identity],
+      workspaceLabel: 'Fix login',
+    });
+
+    expect(result).toEqual({ success: true, data: undefined });
+    expect(exec.exec).toHaveBeenCalledWith('tmux', [
+      'kill-session',
+      '-t',
+      `=${makeTmuxSessionName(identity, 'Fix login')}`,
+    ]);
+    expect(exec.exec).toHaveBeenCalledWith('tmux', [
+      'kill-session',
+      '-t',
+      `=${makeLegacyTmuxSessionName(identity)}`,
+    ]);
     await scope.dispose();
   });
 
   it('killTmuxSessions succeeds even when sessions are missing', async () => {
     const exec = fakeExec();
-    exec.exec.mockRejectedValue(new Error('no session'));
+    exec.exec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    exec.exec.mockRejectedValueOnce(new Error('no session'));
     const spawner = new FakePtySpawner();
     const scope = createScope({ label: 'test-terminals' });
     const runtime = new TerminalsRuntime({
@@ -395,7 +462,7 @@ describe('TerminalsRuntime', () => {
     });
 
     const result = await runtime.killTmuxSessions({
-      sessionNames: ['emdash-missing'],
+      sessionIdentities: ['missing'],
     });
 
     expect(result).toEqual({ success: true, data: undefined });
@@ -408,10 +475,39 @@ describe('TerminalsRuntime', () => {
     const runtime = new TerminalsRuntime({ spawner, userEnv: async () => testUserEnv(), scope });
 
     const result = await runtime.killTmuxSessions({
-      sessionNames: ['emdash-session1'],
+      sessionIdentities: ['session1'],
     });
 
     expect(result).toEqual({ success: true, data: undefined });
+    await scope.dispose();
+  });
+
+  it('starts tmux terminals with a readable name and stable identity metadata', async () => {
+    const exec = fakeExec();
+    const spawner = new FakePtySpawner();
+    const scope = createScope({ label: 'test-terminals-readable-tmux' });
+    const runtime = new TerminalsRuntime({
+      spawner,
+      userEnv: async () => testUserEnv(),
+      exec,
+      scope,
+    });
+
+    await runtime.start({
+      key: { workspace: testWorkspace(), id: 'terminal-1' },
+      spec: { cwd: '/repo/Fix login', env: {}, tmux: true },
+    });
+
+    const { invocation } = spawner.specs[0]!;
+    expect(invocation.kind).toBe('argv');
+    if (invocation.kind !== 'argv') throw new Error('Expected argv invocation');
+    expect(invocation.argv[1]).toMatch(/fix-login-[a-f0-9]{10}/u);
+    expect(invocation.argv[1]).toContain('@emdash_identity');
+    expect(exec.exec).toHaveBeenCalledWith('tmux', [
+      'list-sessions',
+      '-F',
+      '#{session_name}\t#{session_activity}\t#{@emdash_identity}',
+    ]);
     await scope.dispose();
   });
 

--- a/packages/core/src/runtimes/terminals/node/runtime/runtime.ts
+++ b/packages/core/src/runtimes/terminals/node/runtime/runtime.ts
@@ -287,18 +287,20 @@ export class TerminalsRuntime {
   ): Promise<Result<void, TerminalRuntimeError>> {
     if (process.platform === 'win32') return ok(undefined);
     await this.withExecutionContext(async (exec) => {
-      const discovered = await findTmuxSessionNamesByIdentity(exec, input.sessionIdentities);
       const names = new Set<string>();
       for (const identity of input.sessionIdentities) {
-        const discoveredName = discovered.get(identity);
-        if (discoveredName) {
-          names.add(discoveredName);
-          continue;
-        }
         if (input.workspaceLabel) {
           names.add(makeTmuxSessionName(identity, input.workspaceLabel));
         }
         names.add(makeLegacyTmuxSessionName(identity));
+      }
+      try {
+        const discovered = await findTmuxSessionNamesByIdentity(exec, input.sessionIdentities);
+        for (const name of discovered.values()) names.add(name);
+      } catch (error) {
+        this.logger.warn('terminals: failed to discover tmux sessions; using deterministic names', {
+          error: String(error),
+        });
       }
       for (const name of names) await killTmuxSession(exec, name);
     });

--- a/packages/core/src/runtimes/terminals/node/runtime/runtime.ts
+++ b/packages/core/src/runtimes/terminals/node/runtime/runtime.ts
@@ -33,8 +33,11 @@ import {
 } from '#services/preview-detection/node';
 import {
   buildTerminalEnv,
+  findTmuxSessionNamesByIdentity,
   killTmuxSession,
+  makeLegacyTmuxSessionName,
   makeTmuxSessionName,
+  resolveTmuxSession,
   resolveLocalPtySpawn,
   PtyRegistry,
   type PtySession,
@@ -284,7 +287,20 @@ export class TerminalsRuntime {
   ): Promise<Result<void, TerminalRuntimeError>> {
     if (process.platform === 'win32') return ok(undefined);
     await this.withExecutionContext(async (exec) => {
-      for (const name of input.sessionNames) await killTmuxSession(exec, name);
+      const discovered = await findTmuxSessionNamesByIdentity(exec, input.sessionIdentities);
+      const names = new Set<string>();
+      for (const identity of input.sessionIdentities) {
+        const discoveredName = discovered.get(identity);
+        if (discoveredName) {
+          names.add(discoveredName);
+          continue;
+        }
+        if (input.workspaceLabel) {
+          names.add(makeTmuxSessionName(identity, input.workspaceLabel));
+        }
+        names.add(makeLegacyTmuxSessionName(identity));
+      }
+      for (const name of names) await killTmuxSession(exec, name);
     });
     return ok(undefined);
   }
@@ -328,13 +344,26 @@ export class TerminalsRuntime {
       overrides: spec.env,
       gitCredentials: spec.gitCredentials,
     });
+    let tmux: { name: string; identity?: string } | undefined;
+    if (spec.tmux && process.platform === 'win32') {
+      tmux = { name: makeTmuxSessionName(sessionKey, workspaceLabel(spec.cwd)) };
+    } else if (spec.tmux) {
+      const resolvedTmux = await this.withExecutionContext((exec) =>
+        resolveTmuxSession(exec, { identity: sessionKey, label: workspaceLabel(spec.cwd) })
+      );
+      if (!resolvedTmux) throw new Error('No tmux execution context is available');
+      tmux = {
+        name: resolvedTmux.name,
+        identity: resolvedTmux.writeIdentity ? sessionKey : undefined,
+      };
+    }
     const resolved = resolveLocalPtySpawn({
       intent: {
         kind: 'interactive-shell',
         cwd: spec.cwd,
         shellProfile,
         shellSetup: spec.shellSetup,
-        tmuxSessionName: spec.tmux ? makeTmuxSessionName(sessionKey) : undefined,
+        tmux,
       },
       platform: process.platform,
       env,
@@ -385,9 +414,13 @@ export class TerminalsRuntime {
   private async killTmuxForSession(sessionKey: string): Promise<void> {
     const config = this.interactiveConfigs.get(sessionKey);
     if (!config?.spec.tmux || process.platform === 'win32') return;
-    await this.withExecutionContext((exec) =>
-      killTmuxSession(exec, makeTmuxSessionName(sessionKey))
-    );
+    await this.withExecutionContext(async (exec) => {
+      const resolved = await resolveTmuxSession(exec, {
+        identity: sessionKey,
+        label: workspaceLabel(config.spec.cwd),
+      });
+      if (resolved.exists) await killTmuxSession(exec, resolved.name);
+    });
   }
 
   private async shellResolverFor(
@@ -399,18 +432,17 @@ export class TerminalsRuntime {
     return this.shellResolver;
   }
 
-  private async withExecutionContext(
-    operation: (exec: IExecutionContext) => Promise<void>
-  ): Promise<void> {
+  private async withExecutionContext<T>(
+    operation: (exec: IExecutionContext) => Promise<T>
+  ): Promise<T | undefined> {
     if (this.exec) {
-      await operation(this.exec);
-      return;
+      return await operation(this.exec);
     }
     if (!this.createExecutionContext) return;
 
     const exec = this.createExecutionContext(await this.loadUserEnv());
     try {
-      await operation(exec);
+      return await operation(exec);
     } finally {
       exec.dispose();
     }
@@ -574,6 +606,10 @@ export class TerminalsRuntime {
       Object.fromEntries(Object.entries(previous).filter(([id]) => !id.startsWith(prefix)))
     );
   }
+}
+
+function workspaceLabel(path: string): string {
+  return path.split(/[\\/]/u).filter(Boolean).at(-1) ?? 'workspace';
 }
 
 function scopeKeyFor(workspace: HostFileRef): string {

--- a/packages/core/src/runtimes/tui-agents/api/schemas.ts
+++ b/packages/core/src/runtimes/tui-agents/api/schemas.ts
@@ -29,7 +29,7 @@ export const tuiAgentStartInputSchema = z.object({
   cols: z.number().int(),
   rows: z.number().int(),
   shellSetup: z.string().optional(),
-  tmuxSessionName: z.string().optional(),
+  tmux: z.object({ identity: z.string().min(1) }).optional(),
 });
 
 export type TuiAgentStartInput = z.infer<typeof tuiAgentStartInputSchema>;
@@ -155,6 +155,7 @@ export type TuiAgentStateList = z.infer<typeof tuiAgentStateListSchema>;
 
 export const persistedTuiAgentStartInputSchema = tuiAgentStartInputSchema.extend({
   lastAgentState: tuiAgentStateSchema.optional(),
+  tmuxSessionName: z.string().optional(),
 });
 
 export type PersistedTuiAgentStartInput = z.infer<typeof persistedTuiAgentStartInputSchema>;

--- a/packages/core/src/runtimes/tui-agents/node/runtime/runtime.test.ts
+++ b/packages/core/src/runtimes/tui-agents/node/runtime/runtime.test.ts
@@ -16,6 +16,7 @@ import type {
 import type { ConversationLifecycleReporter } from '#services/conversation-reports/node';
 import { createRecordingConversationLifecycleReporter } from '#services/conversation-reports/node/testing';
 import type { IExecutionContext } from '#services/exec/api';
+import { makeLegacyTmuxSessionName, makeTmuxSessionName } from '#services/pty/api';
 import { FakePtySpawner } from '#services/pty/testing';
 import { createMemorySessionIntentStore } from '#services/session-intents/api';
 import {
@@ -369,7 +370,7 @@ describe('TuiAgentsRuntime', () => {
     await runtime.startSession(
       startInput({
         shellSetup: 'source ~/.profile',
-        tmuxSessionName: 'emdash-test',
+        tmux: { identity: 'project:task:conversation-1' },
       })
     );
 
@@ -379,8 +380,31 @@ describe('TuiAgentsRuntime', () => {
     expect(invocation.executable).toBe('/bin/bash');
     expect(invocation.argv[0]).toBe('-lc');
     expect(invocation.argv[1]).toContain('tmux -u attach-session');
-    expect(invocation.argv[1]).toContain('emdash-test');
-    expect(invocation.argv[1]).toContain("source ~/.profile && agent run 'hello world'");
+    expect(invocation.argv[1]).toMatch(/workspace-[a-f0-9]{10}/u);
+    expect(invocation.argv[1]).toContain('source ~/.profile && agent run');
+    expect(invocation.argv[1]).toContain('hello world');
+  });
+
+  it('resolves a readable metadata-backed tmux session from its stable identity', async () => {
+    const { runtime, spawner, exec } = createRuntime();
+
+    await runtime.startSession(
+      startInput({
+        cwd: '/workspace/Fix login',
+        tmux: { identity: 'project:task:conversation-1' },
+      })
+    );
+
+    const { invocation } = spawner.specs[0]!;
+    expect(invocation.kind).toBe('argv');
+    if (invocation.kind !== 'argv') throw new Error('Expected argv invocation');
+    expect(invocation.argv[1]).toMatch(/fix-login-[a-f0-9]{10}/u);
+    expect(invocation.argv[1]).toContain('@emdash_identity');
+    expect(exec.exec).toHaveBeenCalledWith('tmux', [
+      'list-sessions',
+      '-F',
+      '#{session_name}\t#{session_activity}\t#{@emdash_identity}',
+    ]);
   });
 
   it('resolves the Windows default shell, applies setup, and removes tmux intent', async () => {
@@ -390,7 +414,7 @@ describe('TuiAgentsRuntime', () => {
       startInput({
         cwd: 'C:\\workspace',
         shellSetup: 'set READY=1',
-        tmuxSessionName: 'must-not-run',
+        tmux: { identity: 'must-not-run' },
       })
     );
 
@@ -471,22 +495,30 @@ describe('TuiAgentsRuntime', () => {
   });
 
   it('stops and deletes sessions while cleaning up tmux', async () => {
-    const { runtime, spawner, exec } = createRuntime();
+    const identity = 'project:task:conversation-1';
+    const sessionName = makeTmuxSessionName(identity, 'workspace');
+    const encodedIdentity = Buffer.from(JSON.stringify({ version: 1, identity }), 'utf8').toString(
+      'base64url'
+    );
+    const exec = vi.fn(async () => ({
+      stdout: `${sessionName}\t42\tv1:${encodedIdentity}\n`,
+      stderr: '',
+    }));
+    const { runtime, spawner } = createRuntime({ exec: { exec } });
 
-    await runtime.startSession(startInput({ tmuxSessionName: 'emdash-test' }));
+    await runtime.startSession(startInput({ tmux: { identity } }));
     await runtime.stopSession('conversation-1');
 
     expect(spawner.processes[0]!.killCount).toBeGreaterThan(0);
     await vi.waitFor(() => {
-      expect(exec.exec).toHaveBeenCalledWith('tmux', ['kill-session', '-t', 'emdash-test']);
+      expect(exec).toHaveBeenCalledWith('tmux', ['kill-session', '-t', `=${sessionName}`]);
     });
 
-    await runtime.startSession(startInput({ tmuxSessionName: 'emdash-test' }));
+    await runtime.startSession(startInput({ tmux: { identity } }));
     await runtime.deleteSession('conversation-1');
-
-    await vi.waitFor(() => {
-      expect(exec.exec).toHaveBeenCalledTimes(2);
-    });
+    await vi.waitFor(() =>
+      expect(exec).toHaveBeenCalledWith('tmux', ['kill-session', '-t', `=${sessionName}`])
+    );
   });
 
   it('falls back to a fresh session when resume exits immediately', async () => {
@@ -547,7 +579,7 @@ describe('TuiAgentsRuntime', () => {
     const clock = createManualClock(1_000_000);
     const exec = vi.fn(() =>
       Promise.resolve({
-        stdout: `emdash-test\t${Math.floor(clock.now() / 1000)}\n`,
+        stdout: `emdash-test\t${Math.floor(clock.now() / 1000)}\t\n`,
         stderr: '',
       })
     );
@@ -557,14 +589,20 @@ describe('TuiAgentsRuntime', () => {
       exec: { exec },
     });
 
-    await runtime.startSession(startInput({ tmuxSessionName: 'emdash-test' }));
+    const identity = 'project:task:conversation-1';
+    const readableName = makeTmuxSessionName(identity, 'workspace');
+    exec.mockResolvedValue({
+      stdout: `${readableName}\t${Math.floor(clock.now() / 1000)}\t\n`,
+      stderr: '',
+    });
+    await runtime.startSession(startInput({ tmux: { identity } }));
 
     await clock.advanceBy(1_200);
 
     expect(exec).toHaveBeenCalledWith('tmux', [
       'list-sessions',
       '-F',
-      '#{session_name}\t#{session_activity}',
+      '#{session_name}\t#{session_activity}\t#{@emdash_identity}',
     ]);
     expect(spawner.processes[0]!.killCount).toBe(0);
     expect(peek(runtime.sessionsLiveModel.get(undefined)!.states.list)).toHaveProperty(
@@ -573,18 +611,20 @@ describe('TuiAgentsRuntime', () => {
   });
 
   it('reconciles active intents only when their tmux session exists', async () => {
+    const identity = 'project:task:conversation-1';
+    const legacyName = makeLegacyTmuxSessionName(identity);
     const intents = createMemorySessionIntentStore();
     await intents.saveActive({
       conversationId: 'conversation-1',
       sessionId: 'provider-session',
-      payload: startInput({
-        sessionId: 'provider-session',
-        tmuxSessionName: 'emdash-test',
-      }),
+      payload: {
+        ...startInput({ sessionId: 'provider-session' }),
+        tmuxSessionName: legacyName,
+      },
     });
     const exec = vi.fn(() =>
       Promise.resolve({
-        stdout: 'emdash-test\t42\n',
+        stdout: `${legacyName}\t42\t\n`,
         stderr: '',
       })
     );
@@ -605,7 +645,7 @@ describe('TuiAgentsRuntime', () => {
     const intents = createMemorySessionIntentStore();
     await intents.saveActive({
       conversationId: 'conversation-1',
-      payload: startInput({ tmuxSessionName: 'emdash-missing' }),
+      payload: { ...startInput(), tmuxSessionName: makeLegacyTmuxSessionName('missing') },
     });
     const { runtime } = createRuntime({ intents });
 
@@ -660,7 +700,7 @@ describe('TuiAgentsRuntime', () => {
     const intents = createMemorySessionIntentStore();
     await intents.saveActive({
       conversationId: 'conversation-1',
-      payload: startInput({ tmuxSessionName: 'emdash-test' }),
+      payload: { ...startInput(), tmuxSessionName: makeLegacyTmuxSessionName('legacy') },
     });
     const exec = vi.fn(() => Promise.reject(new Error('tmux unavailable')));
     const { runtime, spawner } = createRuntime({ intents, exec: { exec } });
@@ -678,7 +718,7 @@ describe('TuiAgentsRuntime', () => {
     const intents = createMemorySessionIntentStore();
     const { runtime, spawner } = createRuntime({ intents });
 
-    await runtime.startSession(startInput({ tmuxSessionName: 'emdash-test' }));
+    await runtime.startSession(startInput({ tmux: { identity: 'project:task:conversation-1' } }));
     await vi.waitFor(() => expect(intents.snapshot()).toHaveLength(1));
 
     await runtime.killSession('conversation-1');

--- a/packages/core/src/runtimes/tui-agents/node/runtime/runtime.ts
+++ b/packages/core/src/runtimes/tui-agents/node/runtime/runtime.ts
@@ -39,11 +39,16 @@ import {
   type ConversationLifecycleReporter,
 } from '#services/conversation-reports/node';
 import {
+  decodeLegacyTmuxSessionName,
   killTmuxSession,
   listTmuxSessionActivity,
   logLocalPtySpawnWarnings,
+  makeLegacyTmuxSessionName,
+  makeTmuxSessionName,
   PtyRegistry,
   resolveLocalPtySpawn,
+  resolveTmuxSession,
+  tmuxIdentityActivityKey,
   type PtyExitInfo,
   type PtySession,
   type PtySpawnSpec,
@@ -270,10 +275,10 @@ export class TuiAgentsRuntime {
             if (parsed.data.lastAgentState) {
               this.agentStates.restore(parsed.data.lastAgentState);
             }
-            return { input: this.normalizePlatformInput(parsed.data) };
+            return { input: this.normalizePersistedInput(parsed.data) };
           },
           gate: (input) => {
-            if (!input.tmuxSessionName || !this.tmuxActivity.has(input.tmuxSessionName)) {
+            if (tmuxActivityForInput(this.tmuxActivity, input) === undefined) {
               return { suspend: 'process-lost' };
             }
             return { ok: true as const };
@@ -866,9 +871,7 @@ export class TuiAgentsRuntime {
     if (!config || config.intent === 'stopped') return null;
     const state = peek(this.sessionsList.states.list)[conversationId];
     const now = this.clock.now();
-    const tmuxLastOutputAt = config.input.tmuxSessionName
-      ? this.tmuxActivity.get(config.input.tmuxSessionName)
-      : undefined;
+    const tmuxLastOutputAt = tmuxActivityForInput(this.tmuxActivity, config.input);
     const lastOutputAt = maxNullable(activity.lastOutputAt, tmuxLastOutputAt);
     // Interactive busy window, plus tmux-side liveness: recent output inside the
     // tmux session must keep the key alive exactly as long as the idle policy's
@@ -944,6 +947,17 @@ export class TuiAgentsRuntime {
       platform,
       env: await this.deps.env(),
     });
+    let tmux: { name: string; identity?: string } | undefined;
+    if (input.tmux) {
+      const resolvedTmux = await resolveTmuxSession(this.deps.exec, {
+        identity: input.tmux.identity,
+        label: workspaceLabel(input.cwd),
+      });
+      tmux = {
+        name: resolvedTmux.name,
+        identity: resolvedTmux.writeIdentity ? input.tmux.identity : undefined,
+      };
+    }
     const resolved = resolveLocalPtySpawn({
       intent: {
         kind: 'run-command',
@@ -951,7 +965,7 @@ export class TuiAgentsRuntime {
         command: { kind: 'argv', command: command.command, args: command.args },
         shellSetup: input.shellSetup,
         shellProfile,
-        tmuxSessionName: input.tmuxSessionName,
+        tmux,
       },
       platform,
       env,
@@ -971,7 +985,7 @@ export class TuiAgentsRuntime {
     generation: number,
     info: PtyExitInfo
   ): boolean {
-    if (config.input.tmuxSessionName || config.intent === 'stopped') return false;
+    if (config.input.tmux || config.intent === 'stopped') return false;
     if (!this.isUnexpectedExit(info)) return false;
     const current = this.configs.get(config.input.conversationId);
     if (!current || current.intent === 'stopped') return false;
@@ -997,7 +1011,14 @@ export class TuiAgentsRuntime {
 
   private async killTmuxForConfig(config: TuiSessionConfig | undefined): Promise<void> {
     if ((this.deps.platform ?? process.platform) === 'win32') return;
-    const sessionName = config?.input.tmuxSessionName;
+    let sessionName: string | undefined;
+    if (config?.input.tmux) {
+      const resolved = await resolveTmuxSession(this.deps.exec, {
+        identity: config.input.tmux.identity,
+        label: workspaceLabel(config.input.cwd),
+      });
+      sessionName = resolved.exists ? resolved.name : undefined;
+    }
     if (!sessionName) return;
     await killTmuxSession(this.deps.exec, sessionName, (error) => {
       this.deps.logger.debug('TuiAgentsRuntime: tmux session not found or already stopped', {
@@ -1007,12 +1028,35 @@ export class TuiAgentsRuntime {
     });
   }
 
-  private normalizePlatformInput<T extends TuiAgentStartInput>(input: T): T {
-    if ((this.deps.platform ?? process.platform) !== 'win32' || !input.tmuxSessionName)
-      return input;
-    const { tmuxSessionName: _tmuxSessionName, ...normalized } = input;
-    return normalized as T;
+  private normalizePlatformInput(input: TuiAgentStartInput): TuiAgentStartInput {
+    if ((this.deps.platform ?? process.platform) !== 'win32' || !input.tmux) return input;
+    const { tmux: _tmux, ...normalized } = input;
+    return normalized;
   }
+
+  private normalizePersistedInput(input: PersistedTuiAgentStartInput): TuiAgentStartInput {
+    const { tmuxSessionName, ...current } = input;
+    if (current.tmux || !tmuxSessionName) return this.normalizePlatformInput(current);
+    const identity = decodeLegacyTmuxSessionName(tmuxSessionName);
+    return this.normalizePlatformInput(identity ? { ...current, tmux: { identity } } : current);
+  }
+}
+
+function workspaceLabel(path: string): string {
+  return path.split(/[\\/]/u).filter(Boolean).at(-1) ?? 'workspace';
+}
+
+function tmuxActivityForInput(
+  activity: ReadonlyMap<string, number>,
+  input: Pick<TuiAgentStartInput, 'cwd' | 'tmux'>
+): number | undefined {
+  if (!input.tmux) return undefined;
+  const byIdentity = activity.get(tmuxIdentityActivityKey(input.tmux.identity));
+  return (
+    byIdentity ??
+    activity.get(makeTmuxSessionName(input.tmux.identity, workspaceLabel(input.cwd))) ??
+    activity.get(makeLegacyTmuxSessionName(input.tmux.identity))
+  );
 }
 
 function maxNullable(a: number | null, b: number | null | undefined): number | null {

--- a/packages/core/src/services/pty/api/index.ts
+++ b/packages/core/src/services/pty/api/index.ts
@@ -33,12 +33,24 @@ export { PtySession } from './pty-session';
 export type { PtySessionOptions } from './pty-session';
 export {
   buildTmuxShellLine,
-  decodeTmuxSessionName,
   killTmuxSession,
-  listTmuxSessionActivity,
+  listTmuxSessions,
+  type TmuxSessionInventoryEntry,
+} from './tmux-commands';
+export {
+  decodeLegacyTmuxSessionName,
+  LEGACY_TMUX_SESSION_PREFIX,
+  makeLegacyTmuxSessionName,
   makeTmuxSessionName,
+  TMUX_IDENTITY_OPTION,
+} from './tmux-identity';
+export {
+  findTmuxSessionNamesByIdentity,
+  listTmuxSessionActivity,
   parseTmuxSessionActivity,
-  TMUX_SESSION_PREFIX,
+  resolveTmuxSession,
+  tmuxIdentityActivityKey,
+  type ResolvedTmuxSession,
 } from './tmux';
 export { buildTerminalEnv } from './terminal-env';
 export type { PtyDimensions, PtyExitInfo, PtyProcess, PtySpawner, PtySpawnSpec } from './types';

--- a/packages/core/src/services/pty/api/local-spawn.ts
+++ b/packages/core/src/services/pty/api/local-spawn.ts
@@ -1,7 +1,7 @@
 import { getWindowsEnvValue } from '#primitives/agent-env/api';
 import { formatCommandLine, quoteArg, type NativeInvocation } from '#primitives/exec/api';
 import { planExecutableLaunch, type FileExists } from '#primitives/exec/node';
-import { buildTmuxShellLine } from './tmux';
+import { buildTmuxShellLine } from './tmux-commands';
 
 export type ResolvedPtyShellProfile = {
   id: string;
@@ -27,7 +27,7 @@ export type PtySpawnIntent =
       cwd: string;
       shellProfile?: ResolvedPtyShellProfile;
       shellSetup?: string;
-      tmuxSessionName?: string;
+      tmux?: { name: string; identity?: string };
     }
   | {
       kind: 'run-command';
@@ -35,7 +35,7 @@ export type PtySpawnIntent =
       command: PtyCommandSpec;
       shellProfile?: ResolvedPtyShellProfile;
       shellSetup?: string;
-      tmuxSessionName?: string;
+      tmux?: { name: string; identity?: string };
     };
 
 export type LocalPtySpawnWarning = 'tmux_unsupported_on_windows';
@@ -106,7 +106,7 @@ function wrapCmdExeCommandLine(commandLine: string): string {
 
 function windowsWarnings(intent: PtySpawnIntent): LocalPtySpawnWarning[] {
   const warnings: LocalPtySpawnWarning[] = [];
-  if (intent.tmuxSessionName) warnings.push('tmux_unsupported_on_windows');
+  if (intent.tmux) warnings.push('tmux_unsupported_on_windows');
   return warnings;
 }
 
@@ -249,14 +249,14 @@ function resolvePosixSpawn(
   const setupWrapperArgs = getSetupWrapperArgs(intent);
 
   if (intent.kind === 'interactive-shell') {
-    if (intent.tmuxSessionName) {
+    if (intent.tmux) {
       const commandLine = intent.shellSetup
         ? `${intent.shellSetup} && exec ${quoteArg(shell, 'posix')} ${interactiveArgs.join(' ')}`
         : `exec ${quoteArg(shell, 'posix')} ${interactiveArgs.join(' ')}`;
       return {
         invocation: argvInvocation(shell, [
           ...(intent.shellSetup ? setupWrapperArgs : commandArgs),
-          buildTmuxShellLine(intent.tmuxSessionName, commandLine),
+          buildTmuxShellLine(intent.tmux.name, commandLine, intent.tmux.identity),
         ]),
         cwd: intent.cwd,
         warnings: [],
@@ -291,7 +291,7 @@ function resolvePosixSpawn(
     );
   }
 
-  if (intent.command.kind === 'argv' && !intent.shellSetup && !intent.tmuxSessionName) {
+  if (intent.command.kind === 'argv' && !intent.shellSetup && !intent.tmux) {
     const plan = planExecutableLaunch({
       platform,
       command: intent.command.command,
@@ -310,11 +310,11 @@ function resolvePosixSpawn(
     ? `${intent.shellSetup} && ${commandLine}`
     : commandLine;
 
-  if (intent.tmuxSessionName) {
+  if (intent.tmux) {
     return {
       invocation: argvInvocation(shell, [
         ...commandArgs,
-        buildTmuxShellLine(intent.tmuxSessionName, fullCommandLine),
+        buildTmuxShellLine(intent.tmux.name, fullCommandLine, intent.tmux.identity),
       ]),
       cwd: intent.cwd,
       warnings: [],

--- a/packages/core/src/services/pty/api/tmux-commands.ts
+++ b/packages/core/src/services/pty/api/tmux-commands.ts
@@ -1,0 +1,117 @@
+import { quoteArg, type IExecutionContext } from '#primitives/exec/api';
+import { decodeTmuxIdentity, encodeTmuxIdentity, TMUX_IDENTITY_OPTION } from './tmux-identity';
+
+const TMUX_HISTORY_LIMIT = 100_000;
+const TMUX_LIST_FORMAT = `#{session_name}\t#{session_activity}\t#{${TMUX_IDENTITY_OPTION}}`;
+
+export type TmuxSessionInventoryEntry = {
+  name: string;
+  activity: number;
+  identity: string | null;
+};
+
+export function buildTmuxShellLine(
+  sessionName: string,
+  commandLine: string,
+  identity?: string
+): string {
+  const exactTarget = quoteArg(`=${sessionName}`, 'posix');
+  const exactOptionTarget = quoteArg(`=${sessionName}:`, 'posix');
+  const quotedName = quoteArg(sessionName, 'posix');
+  const quotedCmd = quoteArg(commandLine, 'posix');
+  const checkExists = `tmux has-session -t ${exactTarget} 2>/dev/null`;
+  const newSession = `tmux -u new-session -d -s ${quotedName} ${quotedCmd}`;
+  const setIdentity = identity
+    ? `tmux set-option -t ${exactOptionTarget} ${TMUX_IDENTITY_OPTION} ${quoteArg(encodeTmuxIdentity(identity), 'posix')} 2>/dev/null || true`
+    : null;
+  const enableMouse = `tmux set-option -t ${exactOptionTarget} mouse on 2>/dev/null || true`;
+  const setHistoryLimit = `tmux set-option -t ${exactOptionTarget} history-limit ${TMUX_HISTORY_LIMIT} 2>/dev/null || true`;
+  const ensureSession = `(${checkExists} || ${newSession})`;
+  const configure = [setIdentity, enableMouse, setHistoryLimit]
+    .filter((command): command is string => command !== null)
+    .map((command) => `(${command})`)
+    .join(' && ');
+  const attach = `tmux -u attach-session -t ${exactTarget}`;
+  return `/bin/sh -c ${quoteArg(`${ensureSession} && ${configure} && ${attach}`, 'posix')}`;
+}
+
+export async function listTmuxSessions(
+  ctx: IExecutionContext
+): Promise<TmuxSessionInventoryEntry[]> {
+  try {
+    const result = await ctx.exec('tmux', ['list-sessions', '-F', TMUX_LIST_FORMAT]);
+    return parseTmuxSessionInventory(result.stdout);
+  } catch (error) {
+    if (isExpectedTmuxListFailure(error)) return [];
+    throw error;
+  }
+}
+
+export async function killTmuxSession(
+  ctx: IExecutionContext,
+  sessionName: string,
+  onError?: (error: unknown) => void
+): Promise<void> {
+  try {
+    await ctx.exec('tmux', ['kill-session', '-t', `=${sessionName}`]);
+  } catch (error) {
+    onError?.(error);
+  }
+}
+
+export function parseTmuxSessionInventory(output: string): TmuxSessionInventoryEntry[] {
+  const sessions: TmuxSessionInventoryEntry[] = [];
+  for (const line of output.split('\n')) {
+    if (!line.trim()) continue;
+    const [name, seconds, encodedIdentity = ''] = line.split('\t');
+    if (!name || !seconds) continue;
+    const parsed = Number(seconds);
+    if (!Number.isFinite(parsed)) continue;
+    sessions.push({
+      name,
+      activity: parsed * 1_000,
+      identity: decodeTmuxIdentity(encodedIdentity),
+    });
+  }
+  return sessions;
+}
+
+function isExpectedTmuxListFailure(error: unknown): boolean {
+  const failure = readExecFailure(error);
+  if (!failure) return false;
+  if (failure.executableMissing) return true;
+  if (
+    failure.exitCode === 1 &&
+    /no server running|failed to connect to server|error connecting to .*\(no such file or directory\)/i.test(
+      failure.stderr
+    )
+  ) {
+    return true;
+  }
+  return failure.exitCode === 127;
+}
+
+/** Normalize the two execution-error shapes currently exposed by IExecutionContext. */
+function readExecFailure(
+  error: unknown
+): { exitCode: number | null; stderr: string; executableMissing: boolean } | null {
+  if (typeof error !== 'object' || error === null) return null;
+  const stderr = 'stderr' in error && typeof error.stderr === 'string' ? error.stderr : '';
+  if ('exitCode' in error && (typeof error.exitCode === 'number' || error.exitCode === null)) {
+    const cause = 'cause' in error ? error.cause : undefined;
+    const executableMissing =
+      error.exitCode === null &&
+      typeof cause === 'object' &&
+      cause !== null &&
+      'code' in cause &&
+      cause.code === 'ENOENT';
+    return { exitCode: error.exitCode, stderr, executableMissing };
+  }
+  if ('code' in error) {
+    if (error.code === 'ENOENT') return { exitCode: null, stderr, executableMissing: true };
+    if (typeof error.code === 'number') {
+      return { exitCode: error.code, stderr, executableMissing: false };
+    }
+  }
+  return null;
+}

--- a/packages/core/src/services/pty/api/tmux-identity.ts
+++ b/packages/core/src/services/pty/api/tmux-identity.ts
@@ -1,0 +1,74 @@
+import { createHash } from 'node:crypto';
+
+export const LEGACY_TMUX_SESSION_PREFIX = 'emdash-';
+export const TMUX_IDENTITY_OPTION = '@emdash_identity';
+const TMUX_NAME_MAX_LENGTH = 48;
+const TMUX_HASH_LENGTH = 10;
+
+export function makeTmuxSessionName(identity: string, label = 'session'): string {
+  const hash = createHash('sha256').update(identity).digest('hex').slice(0, TMUX_HASH_LENGTH);
+  const sanitized = sanitizeTmuxSessionLabel(label);
+  const maxLabelLength = TMUX_NAME_MAX_LENGTH - TMUX_HASH_LENGTH - 1;
+  const graphemes = Array.from(
+    new Intl.Segmenter('en', { granularity: 'grapheme' }).segment(sanitized),
+    ({ segment }) => segment
+  );
+  return `${graphemes.slice(0, maxLabelLength).join('')}-${hash}`;
+}
+
+export function makeLegacyTmuxSessionName(identity: string): string {
+  return `${LEGACY_TMUX_SESSION_PREFIX}${Buffer.from(identity, 'utf8').toString('base64url')}`;
+}
+
+export function decodeLegacyTmuxSessionName(sessionName: string): string | null {
+  if (!sessionName.startsWith(LEGACY_TMUX_SESSION_PREFIX)) return null;
+  const encoded = sessionName.slice(LEGACY_TMUX_SESSION_PREFIX.length);
+  if (!encoded) return null;
+  try {
+    const identity = Buffer.from(encoded, 'base64url').toString('utf8');
+    return makeLegacyTmuxSessionName(identity) === sessionName ? identity : null;
+  } catch {
+    return null;
+  }
+}
+
+export function encodeTmuxIdentity(identity: string): string {
+  const encoded = Buffer.from(JSON.stringify({ version: 1, identity }), 'utf8').toString(
+    'base64url'
+  );
+  return `v1:${encoded}`;
+}
+
+export function decodeTmuxIdentity(value: string): string | null {
+  if (!value.startsWith('v1:')) return null;
+  try {
+    const parsed: unknown = JSON.parse(
+      Buffer.from(value.slice('v1:'.length), 'base64url').toString('utf8')
+    );
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      !('version' in parsed) ||
+      parsed.version !== 1 ||
+      !('identity' in parsed) ||
+      typeof parsed.identity !== 'string' ||
+      !parsed.identity
+    ) {
+      return null;
+    }
+    return parsed.identity;
+  } catch {
+    return null;
+  }
+}
+
+function sanitizeTmuxSessionLabel(label: string): string {
+  const sanitized = label
+    .normalize('NFKC')
+    .toLocaleLowerCase('en-US')
+    .replaceAll(/[.:]+/gu, '-')
+    .replaceAll(/[^\p{Letter}\p{Number}_-]+/gu, '-')
+    .replaceAll(/-+/gu, '-')
+    .replaceAll(/^[-_]+|[-_]+$/gu, '');
+  return sanitized || 'session';
+}

--- a/packages/core/src/services/pty/api/tmux.test.ts
+++ b/packages/core/src/services/pty/api/tmux.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -7,15 +8,179 @@ import type { IExecutionContext } from '#primitives/exec/api';
 import { createBoundExec } from '#services/exec/api/bound-exec';
 // oxlint-disable-next-line emdash/core-module-boundaries -- tests distinguish wrapped execution errors from raw execFile errors at the same primitive boundary
 import { ExecError } from '#services/exec/api/types';
-import { listTmuxSessionActivity, parseTmuxSessionActivity } from './tmux';
+import {
+  listTmuxSessionActivity,
+  parseTmuxSessionActivity,
+  resolveTmuxSession,
+  tmuxIdentityActivityKey,
+} from './tmux';
+import { buildTmuxShellLine } from './tmux-commands';
+import {
+  decodeLegacyTmuxSessionName,
+  makeLegacyTmuxSessionName,
+  makeTmuxSessionName,
+} from './tmux-identity';
+
+const TMUX_AVAILABLE = spawnSync('tmux', ['-V']).status === 0;
+
+describe('tmux session naming', () => {
+  it('creates deterministic readable names while preserving the legacy codec', () => {
+    const identity = 'project:task:terminal';
+    const name = makeTmuxSessionName(identity, 'Fix login.flow: now');
+
+    expect(name).toBe(makeTmuxSessionName(identity, 'Fix login.flow: now'));
+    expect(name).not.toBe(makeTmuxSessionName('other:task:terminal', 'Fix login.flow: now'));
+    expect(name).toMatch(/^fix-login-flow-now-[a-f0-9]{10}$/);
+    expect(makeTmuxSessionName(identity, ':...:')).toMatch(/^session-[a-f0-9]{10}$/);
+
+    const legacyName = makeLegacyTmuxSessionName(identity);
+    expect(decodeLegacyTmuxSessionName(legacyName)).toBe(identity);
+    expect(decodeLegacyTmuxSessionName(name)).toBeNull();
+  });
+
+  it('keeps the hash suffix when a long label is truncated', () => {
+    const identity = 'project:task:terminal';
+    const short = makeTmuxSessionName(identity, 'short');
+    const long = makeTmuxSessionName(identity, 'x'.repeat(200));
+
+    expect(long.length).toBeLessThanOrEqual(48);
+    expect(long.slice(-10)).toBe(short.slice(-10));
+  });
+
+  it('keeps readable Unicode while stripping tmux separators', () => {
+    expect(makeTmuxSessionName('identity', 'Über café.日本: ready')).toMatch(
+      /^über-café-日本-ready-[a-f0-9]{10}$/u
+    );
+  });
+});
+
+describe('resolveTmuxSession', () => {
+  it('prefers metadata so a renamed session remains attachable', async () => {
+    const identity = 'project:task:terminal';
+    const encoded = Buffer.from(JSON.stringify({ version: 1, identity }), 'utf8').toString(
+      'base64url'
+    );
+    const exec = vi.fn(async () => ({
+      stdout: `renamed\t42\tv1:${encoded}\n`,
+      stderr: '',
+    }));
+
+    await expect(
+      resolveTmuxSession(stubExecContext(exec), { identity, label: 'new-label' })
+    ).resolves.toEqual({ name: 'renamed', exists: true, writeIdentity: true });
+  });
+
+  it('falls back to the exact legacy name without backfilling metadata', async () => {
+    const identity = 'project:task:terminal';
+    const legacyName = makeLegacyTmuxSessionName(identity);
+    const exec = vi.fn(async () => ({
+      stdout: `${legacyName}\t42\t\n${legacyName}-sibling\t43\t\n`,
+      stderr: '',
+    }));
+
+    await expect(
+      resolveTmuxSession(stubExecContext(exec), { identity, label: 'workspace' })
+    ).resolves.toEqual({ name: legacyName, exists: true, writeIdentity: false });
+  });
+});
+
+describe('buildTmuxShellLine', () => {
+  it('uses exact targets and POSIX quoting', () => {
+    const line = buildTmuxShellLine('workspace-$12', 'printf "$HOME"', 'project:task:leaf');
+
+    expect(line).toContain('has-session -t');
+    expect(line).toContain('attach-session -t');
+    expect(line).toContain('new-session -d -s');
+    expect(line).toContain('=workspace-$12');
+    expect(line).not.toContain('"workspace-$12"');
+  });
+
+  it.skipIf(!TMUX_AVAILABLE)(
+    'creates metadata-backed sessions and reattaches legacy sessions without replacing them',
+    async () => {
+      const cwd = await mkdtemp('/tmp/emdash-tmux-');
+      const env = { ...process.env, TMUX_TMPDIR: cwd };
+      const shell = createBoundExec({ file: '/bin/sh', cwd, env });
+      const tmux = createBoundExec({ file: 'tmux', cwd, env });
+      const ctx = stubExecContext((_file, args) => tmux.exec(args ?? []));
+      const identity = 'project:task:terminal';
+
+      try {
+        const created = await resolveTmuxSession(ctx, { identity, label: 'Fix login' });
+        await shell
+          .exec(['-c', buildTmuxShellLine(created.name, 'sleep 30', identity)])
+          .catch(() => {});
+
+        await expect(
+          resolveTmuxSession(ctx, { identity, label: 'renamed-workspace' })
+        ).resolves.toMatchObject({ name: created.name, exists: true });
+        await tmux.exec(['rename-session', '-t', `=${created.name}`, 'manually-renamed']);
+        await expect(
+          resolveTmuxSession(ctx, { identity, label: 'renamed-workspace' })
+        ).resolves.toMatchObject({ name: 'manually-renamed', exists: true });
+        await tmux.exec(['kill-session', '-t', '=manually-renamed']);
+
+        const legacyName = makeLegacyTmuxSessionName(identity);
+        await tmux.exec(['new-session', '-d', '-s', legacyName, 'sleep 30']);
+        const before = await tmux.exec([
+          'display-message',
+          '-p',
+          '-t',
+          `=${legacyName}`,
+          '#{pane_pid}',
+        ]);
+        const legacy = await resolveTmuxSession(ctx, { identity, label: 'Fix login' });
+        await shell.exec(['-c', buildTmuxShellLine(legacy.name, 'exit 99')]).catch(() => {});
+        const after = await tmux.exec([
+          'display-message',
+          '-p',
+          '-t',
+          `=${legacyName}`,
+          '#{pane_pid}',
+        ]);
+        const sessions = await tmux.exec(['list-sessions', '-F', '#{session_name}']);
+
+        expect(legacy).toEqual({ name: legacyName, exists: true, writeIdentity: false });
+        expect(after.stdout).toBe(before.stdout);
+        expect(sessions.stdout.trim().split('\n')).toEqual([legacyName]);
+
+        await tmux.exec(['kill-session', '-t', `=${legacyName}`]);
+        const prefixIdentity = 'project:task:prefix-target';
+        const prefixName = makeTmuxSessionName(prefixIdentity, 'prefix');
+        await tmux.exec(['new-session', '-d', '-s', `${prefixName}-sibling`, 'sleep 30']);
+        const missingExact = await resolveTmuxSession(ctx, {
+          identity: prefixIdentity,
+          label: 'prefix',
+        });
+        await shell
+          .exec(['-c', buildTmuxShellLine(missingExact.name, 'sleep 30', prefixIdentity)])
+          .catch(() => {});
+        const exactSessions = await tmux.exec(['list-sessions', '-F', '#{session_name}']);
+        expect(exactSessions.stdout.trim().split('\n').sort()).toEqual(
+          [prefixName, `${prefixName}-sibling`].sort()
+        );
+      } finally {
+        await tmux.exec(['kill-server']).catch(() => {});
+        await rm(cwd, { recursive: true, force: true });
+      }
+    }
+  );
+});
 
 describe('parseTmuxSessionActivity', () => {
   it('parses session activity timestamps as milliseconds', () => {
-    const parsed = parseTmuxSessionActivity('one\t1710000000\ntwo\t1710000005\ninvalid\n');
+    const identity = 'project:task:leaf';
+    const encoded = Buffer.from(JSON.stringify({ version: 1, identity }), 'utf8').toString(
+      'base64url'
+    );
+    const parsed = parseTmuxSessionActivity(
+      `one\t1710000000\tv1:${encoded}\ntwo\t1710000005\t\ninvalid\n`
+    );
 
     expect(parsed).toEqual(
       new Map([
         ['one', 1_710_000_000_000],
+        [tmuxIdentityActivityKey(identity), 1_710_000_000_000],
         ['two', 1_710_000_005_000],
       ])
     );
@@ -24,7 +189,7 @@ describe('parseTmuxSessionActivity', () => {
 
 describe('listTmuxSessionActivity', () => {
   it('runs one tmux list-sessions command', async () => {
-    const exec = vi.fn(async () => ({ stdout: 'name\t42\n', stderr: '' }));
+    const exec = vi.fn(async () => ({ stdout: 'name\t42\t\n', stderr: '' }));
     const ctx = stubExecContext(exec);
 
     const activity = await listTmuxSessionActivity(ctx);
@@ -32,7 +197,7 @@ describe('listTmuxSessionActivity', () => {
     expect(exec).toHaveBeenCalledWith('tmux', [
       'list-sessions',
       '-F',
-      '#{session_name}\t#{session_activity}',
+      '#{session_name}\t#{session_activity}\t#{@emdash_identity}',
     ]);
     expect(activity).toEqual(new Map([['name', 42_000]]));
   });

--- a/packages/core/src/services/pty/api/tmux.ts
+++ b/packages/core/src/services/pty/api/tmux.ts
@@ -1,121 +1,67 @@
 import type { IExecutionContext } from '#primitives/exec/api';
+import { listTmuxSessions, parseTmuxSessionInventory } from './tmux-commands';
+import { makeLegacyTmuxSessionName, makeTmuxSessionName } from './tmux-identity';
 
-export const TMUX_SESSION_PREFIX = 'emdash-';
-const TMUX_HISTORY_LIMIT = 100_000;
+export type ResolvedTmuxSession = {
+  name: string;
+  exists: boolean;
+  writeIdentity: boolean;
+};
 
-export function buildTmuxShellLine(sessionName: string, commandLine: string): string {
-  const quotedName = JSON.stringify(sessionName);
-  const quotedCmd = JSON.stringify(commandLine);
-  const checkExists = `tmux has-session -t ${quotedName} 2>/dev/null`;
-  const newSession = `tmux -u new-session -d -s ${quotedName} ${quotedCmd}`;
-  const enableMouse = `tmux set-option -t ${quotedName} mouse on 2>/dev/null || true`;
-  const setHistoryLimit = `tmux set-option -t ${quotedName} history-limit ${TMUX_HISTORY_LIMIT} 2>/dev/null || true`;
-  const configure = `(${enableMouse}) && (${setHistoryLimit})`;
-  const attach = `tmux -u attach-session -t ${quotedName}`;
-  const script = `(${checkExists} || ${newSession}) && ${configure} && ${attach}`;
-  return `/bin/sh -c ${JSON.stringify(script)}`;
-}
-
-export function makeTmuxSessionName(sessionId: string): string {
-  const encoded = Buffer.from(sessionId, 'utf8').toString('base64url');
-  return `${TMUX_SESSION_PREFIX}${encoded}`;
-}
-
-export function decodeTmuxSessionName(sessionName: string): string | null {
-  if (!sessionName.startsWith(TMUX_SESSION_PREFIX)) return null;
-  const encoded = sessionName.slice(TMUX_SESSION_PREFIX.length);
-  if (!encoded) return null;
-  try {
-    const sessionId = Buffer.from(encoded, 'base64url').toString('utf8');
-    if (makeTmuxSessionName(sessionId) !== sessionName) return null;
-    return sessionId;
-  } catch {
-    return null;
+export async function resolveTmuxSession(
+  ctx: IExecutionContext,
+  input: { identity: string; label: string }
+): Promise<ResolvedTmuxSession> {
+  const sessions = await listTmuxSessions(ctx);
+  const metadataMatch = sessions.find((session) => session.identity === input.identity);
+  if (metadataMatch) {
+    return { name: metadataMatch.name, exists: true, writeIdentity: true };
   }
+
+  const legacyName = makeLegacyTmuxSessionName(input.identity);
+  if (sessions.some((session) => session.name === legacyName)) {
+    return { name: legacyName, exists: true, writeIdentity: false };
+  }
+
+  const name = makeTmuxSessionName(input.identity, input.label);
+  const namedSession = sessions.find((session) => session.name === name);
+  return { name, exists: namedSession !== undefined, writeIdentity: true };
+}
+
+export async function findTmuxSessionNamesByIdentity(
+  ctx: IExecutionContext,
+  identities: readonly string[]
+): Promise<Map<string, string>> {
+  const requested = new Set(identities);
+  const found = new Map<string, string>();
+  for (const session of await listTmuxSessions(ctx)) {
+    if (!session.identity || !requested.has(session.identity)) continue;
+    if (!found.has(session.identity)) found.set(session.identity, session.name);
+  }
+  return found;
 }
 
 export async function listTmuxSessionActivity(
   ctx: IExecutionContext
 ): Promise<Map<string, number>> {
-  try {
-    const result = await ctx.exec('tmux', [
-      'list-sessions',
-      '-F',
-      '#{session_name}\t#{session_activity}',
-    ]);
-    return parseTmuxSessionActivity(result.stdout);
-  } catch (error) {
-    if (isExpectedTmuxListFailure(error)) return new Map();
-    throw error;
-  }
+  return activityByHandle(await listTmuxSessions(ctx));
 }
 
 export function parseTmuxSessionActivity(output: string): Map<string, number> {
+  return activityByHandle(parseTmuxSessionInventory(output));
+}
+
+export function tmuxIdentityActivityKey(identity: string): string {
+  return `identity:${identity}`;
+}
+
+function activityByHandle(
+  sessions: readonly { name: string; activity: number; identity: string | null }[]
+): Map<string, number> {
   const activity = new Map<string, number>();
-  for (const line of output.split('\n')) {
-    if (!line.trim()) continue;
-    const [name, seconds] = line.split('\t');
-    if (!name || !seconds) continue;
-    const parsed = Number(seconds);
-    if (!Number.isFinite(parsed)) continue;
-    activity.set(name, parsed * 1_000);
+  for (const session of sessions) {
+    activity.set(session.name, session.activity);
+    if (session.identity) activity.set(tmuxIdentityActivityKey(session.identity), session.activity);
   }
   return activity;
-}
-
-export async function killTmuxSession(
-  ctx: IExecutionContext,
-  sessionName: string,
-  onError?: (error: unknown) => void
-): Promise<void> {
-  try {
-    await ctx.exec('tmux', ['kill-session', '-t', sessionName]);
-  } catch (error) {
-    onError?.(error);
-  }
-}
-
-function isExpectedTmuxListFailure(error: unknown): boolean {
-  const failure = readExecFailure(error);
-  if (!failure) return false;
-  if (failure.executableMissing) return true;
-  if (
-    failure.exitCode === 1 &&
-    /no server running|failed to connect to server|error connecting to .*\(no such file or directory\)/i.test(
-      failure.stderr
-    )
-  ) {
-    return true;
-  }
-  return failure.exitCode === 127;
-}
-
-/**
- * IExecutionContext does not declare its error mode yet, so two shapes flow
- * through it: BoundExec's ExecError ({ exitCode, stderr, cause }) and
- * NodeExecutionContext's raw promisified-execFile errors ({ code, stderr },
- * where code is 'ENOENT' when the binary is missing). Accept both until the
- * unified ExecError lands (.scratch/exec-and-layering/map.md).
- */
-function readExecFailure(
-  error: unknown
-): { exitCode: number | null; stderr: string; executableMissing: boolean } | null {
-  if (typeof error !== 'object' || error === null) return null;
-  const stderr = 'stderr' in error && typeof error.stderr === 'string' ? error.stderr : '';
-  if ('exitCode' in error && (typeof error.exitCode === 'number' || error.exitCode === null)) {
-    const cause = 'cause' in error ? error.cause : undefined;
-    const executableMissing =
-      error.exitCode === null &&
-      typeof cause === 'object' &&
-      cause !== null &&
-      'code' in cause &&
-      cause.code === 'ENOENT';
-    return { exitCode: error.exitCode, stderr, executableMissing };
-  }
-  if ('code' in error) {
-    if (error.code === 'ENOENT') return { exitCode: null, stderr, executableMissing: true };
-    if (typeof error.code === 'number')
-      return { exitCode: error.code, stderr, executableMissing: false };
-  }
-  return null;
 }


### PR DESCRIPTION
- generates deterministic readable tmux names from workspace labels and stable identity hashes
- stores stable emdash identities in @emdash_identity so renamed sessions remain discoverable
- reattaches pre-fix base64url sessions and normalizes legacy persisted tui recovery records
- uses exact tmux targets and posix-safe quoting to prevent prefix matches and shell expansion
- simplifies workspace server inputs to pass session identity instead of resolved tmux names
- separates tmux identity command construction and resolution into focused modules