### PR TITLE
fix(tui-agents): preserve captured session ids during resume recovery

### DIFF
--- a/apps/emdash-desktop/src/core/features/conversations/node/tui-conversation-provider.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/tui-conversation-provider.test.ts
@@ -1,6 +1,6 @@
+import type { Conversation } from '@core/primitives/conversations/api';
 import { ok } from '@emdash/shared';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Conversation } from '@core/primitives/conversations/api';
 import {
   TuiConversationProvider,
   type TuiConversationProviderOptions,
@@ -82,6 +82,33 @@ describe('TuiConversationProvider', () => {
       expect(resume).not.toHaveBeenCalled();
     }
   );
+
+  it('resumes claude with a hook-captured session id that differs from the conversation id', async () => {
+    const provider = createProvider();
+
+    await provider.ensureSession({
+      conversation: conversation({ providerId: 'claude', sessionId: 'native-session' }),
+      mode: 'resume',
+    });
+
+    expect(resume).toHaveBeenCalledWith(
+      expect.objectContaining({ providerId: 'claude', sessionId: 'native-session' })
+    );
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it('resumes claude with the conversation id when no other session id was captured', async () => {
+    const provider = createProvider();
+
+    await provider.ensureSession({
+      conversation: conversation({ providerId: 'claude', sessionId: 'conversation-1' }),
+      mode: 'resume',
+    });
+
+    expect(resume).toHaveBeenCalledWith(
+      expect.objectContaining({ providerId: 'claude', sessionId: 'conversation-1' })
+    );
+  });
 
   it.each([
     { label: 'local', host: { type: 'local', id: 'local' } as const },

--- a/apps/emdash-desktop/src/core/features/conversations/node/tui-conversation-provider.test.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/tui-conversation-provider.test.ts
@@ -1,6 +1,6 @@
-import type { Conversation } from '@core/primitives/conversations/api';
 import { ok } from '@emdash/shared';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Conversation } from '@core/primitives/conversations/api';
 import {
   TuiConversationProvider,
   type TuiConversationProviderOptions,

--- a/apps/emdash-desktop/src/core/features/conversations/node/tui-conversation-provider.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/node/tui-conversation-provider.ts
@@ -1,8 +1,3 @@
-import type { GitCredentialsSessionSpec } from '@emdash/core/primitives/git-credentials/api';
-import type { HostRef } from '@emdash/core/primitives/host/api';
-import type { TuiAgentStartInput } from '@emdash/core/runtimes/tui-agents/api';
-import { makeTmuxSessionName } from '@emdash/core/services/pty/api';
-import { and, eq } from 'drizzle-orm';
 import { conversationRegistryTable as conversations } from '@core/features/conversations/api/node/registry';
 import type {
   ConversationProvider,
@@ -15,6 +10,11 @@ import type { Conversation } from '@core/primitives/conversations/api';
 import { makePtySessionId } from '@core/primitives/pty/api';
 import type { AppDb } from '@core/services/app-db/node/db';
 import type { TuiAgentsRuntimeClient } from '@core/services/runtime-broker/api/clients';
+import type { GitCredentialsSessionSpec } from '@emdash/core/primitives/git-credentials/api';
+import type { HostRef } from '@emdash/core/primitives/host/api';
+import type { TuiAgentStartInput } from '@emdash/core/runtimes/tui-agents/api';
+import { makeTmuxSessionName } from '@emdash/core/services/pty/api';
+import { and, eq } from 'drizzle-orm';
 
 const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
@@ -182,13 +182,12 @@ function resolveAgentSession(
   mode: 'start' | 'resume'
 ): { sessionId: string; isResuming: boolean } {
   const isResuming = mode === 'resume';
+  const nativeSessionId = conversation.sessionId;
+  const hasNativeSessionId = Boolean(nativeSessionId) && nativeSessionId !== conversation.id;
   if (PROVIDER_SESSION_ID_REQUIRED_FOR_RESUME.has(conversation.providerId) && isResuming) {
-    const nativeSessionId = conversation.sessionId;
-    if (nativeSessionId && nativeSessionId !== conversation.id) {
-      return { sessionId: nativeSessionId, isResuming: true };
-    }
+    if (hasNativeSessionId) return { sessionId: nativeSessionId!, isResuming: true };
     return { sessionId: conversation.id, isResuming: false };
   }
-
+  if (isResuming && hasNativeSessionId) return { sessionId: nativeSessionId!, isResuming };
   return { sessionId: conversation.id, isResuming };
 }

--- a/packages/core/src/runtimes/tui-agents/node/hooks/hook-pipeline.test.ts
+++ b/packages/core/src/runtimes/tui-agents/node/hooks/hook-pipeline.test.ts
@@ -1,0 +1,58 @@
+import type { Logger } from '@emdash/shared/logger';
+import { describe, expect, it, vi } from 'vitest';
+import type { ResolvedTuiProvider } from '#services/agent-plugins/api/plugins';
+import { TuiHookPipeline } from './hook-pipeline';
+
+const logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+} as unknown as Logger;
+
+function createPipeline(validateSessionId?: (id: string) => boolean) {
+  const applyCanonicalEvent = vi.fn();
+  const provider = {
+    parseHookEvent: (type: string, body: Record<string, unknown>) =>
+      type === 'stop'
+        ? {
+            kind: 'status' as const,
+            type: 'stop' as const,
+            providerSessionId: typeof body.session_id === 'string' ? body.session_id : undefined,
+          }
+        : { kind: 'ignore' as const },
+    validateSessionId,
+  } as unknown as ResolvedTuiProvider;
+  const pipeline = new TuiHookPipeline({
+    getConversationConfig: () => ({ conversationId: 'conv-1', providerId: 'p' }),
+    getProvider: () => provider,
+    applyCanonicalEvent,
+    logger,
+  });
+  return { pipeline, applyCanonicalEvent };
+}
+
+describe('TuiHookPipeline', () => {
+  it('keeps a valid session id carried on a status event', async () => {
+    const { pipeline, applyCanonicalEvent } = createPipeline((id) => id.startsWith('ok-'));
+
+    await pipeline.handle({ ptyId: 'conv-1', type: 'stop', body: '{"session_id":"ok-1"}' });
+
+    expect(applyCanonicalEvent).toHaveBeenCalledWith('conv-1', 'p', {
+      kind: 'status',
+      type: 'stop',
+      providerSessionId: 'ok-1',
+    });
+  });
+
+  it('strips an invalid session id from a status event but still applies the status', async () => {
+    const { pipeline, applyCanonicalEvent } = createPipeline((id) => id.startsWith('ok-'));
+
+    await pipeline.handle({ ptyId: 'conv-1', type: 'stop', body: '{"session_id":"bad-1"}' });
+
+    expect(applyCanonicalEvent).toHaveBeenCalledTimes(1);
+    const event = applyCanonicalEvent.mock.calls[0]![2];
+    expect(event).toMatchObject({ kind: 'status', type: 'stop' });
+    expect(event.providerSessionId).toBeUndefined();
+  });
+});

--- a/packages/core/src/runtimes/tui-agents/node/hooks/hook-pipeline.ts
+++ b/packages/core/src/runtimes/tui-agents/node/hooks/hook-pipeline.ts
@@ -39,11 +39,18 @@ export class TuiHookPipeline {
     }
 
     const body = parseHookBody(raw.body);
-    const event =
-      provider.parseHookEvent?.(raw.type, body) ?? defaultHookEventParser(raw.type, body);
+    let event = provider.parseHookEvent?.(raw.type, body) ?? defaultHookEventParser(raw.type, body);
+    const validateSessionId = provider.validateSessionId;
     if (event.kind === 'session') {
-      const validateSessionId = provider.validateSessionId;
       if (validateSessionId && !validateSessionId(event.providerSessionId)) return;
+    } else if (
+      event.kind === 'status' &&
+      event.providerSessionId !== undefined &&
+      validateSessionId &&
+      !validateSessionId(event.providerSessionId)
+    ) {
+      const { providerSessionId: _invalid, ...rest } = event;
+      event = rest;
     }
 
     this.options.applyCanonicalEvent(config.conversationId, config.providerId, event);

--- a/packages/core/src/runtimes/tui-agents/node/runtime/agent-state.test.ts
+++ b/packages/core/src/runtimes/tui-agents/node/runtime/agent-state.test.ts
@@ -85,4 +85,59 @@ describe('TuiAgentStates', () => {
     expect(peek(sessions.states.list)['conv-1']?.sessionId).toBe('T-123');
     expect(onSessionIdChanged).toHaveBeenCalledWith('conv-1', 'T-123');
   });
+
+  it('adopts a provider session id carried on a status event', () => {
+    const { tracker, sessions, agentStates, onSessionIdChanged } = createTracker();
+    produceCell(sessions.states.list, (draft) => {
+      draft['conv-1'] = {
+        conversationId: 'conv-1',
+        providerId: 'claude',
+        sessionId: 'conv-1',
+        status: 'running',
+        cols: 120,
+        rows: 30,
+        resume: null,
+        startedAt: 1,
+      };
+    });
+
+    tracker.applyCanonicalEvent('conv-1', 'claude', {
+      kind: 'status',
+      type: 'start',
+      providerSessionId: 'resumed-session',
+    });
+
+    expect(peek(sessions.states.list)['conv-1']?.sessionId).toBe('resumed-session');
+    expect(onSessionIdChanged).toHaveBeenCalledWith('conv-1', 'resumed-session');
+    expect(peek(agentStates.states.list)['conv-1']?.status).toBe('working');
+  });
+
+  it('does not re-publish an unchanged session id carried on status events', () => {
+    const { tracker, sessions, onSessionIdChanged } = createTracker();
+    produceCell(sessions.states.list, (draft) => {
+      draft['conv-1'] = {
+        conversationId: 'conv-1',
+        providerId: 'claude',
+        sessionId: 'conv-1',
+        status: 'running',
+        cols: 120,
+        rows: 30,
+        resume: null,
+        startedAt: 1,
+      };
+    });
+
+    tracker.applyCanonicalEvent('conv-1', 'claude', {
+      kind: 'status',
+      type: 'start',
+      providerSessionId: 'conv-1',
+    });
+    tracker.applyCanonicalEvent('conv-1', 'claude', {
+      kind: 'status',
+      type: 'stop',
+      providerSessionId: 'conv-1',
+    });
+
+    expect(onSessionIdChanged).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/runtimes/tui-agents/node/runtime/agent-state.ts
+++ b/packages/core/src/runtimes/tui-agents/node/runtime/agent-state.ts
@@ -53,6 +53,10 @@ export class TuiAgentStates {
       return;
     }
 
+    if (event.providerSessionId) {
+      this.setProviderSessionId(conversationId, event.providerSessionId);
+    }
+
     if (event.type === 'start') {
       this.setStatus(conversationId, {
         providerId,

--- a/packages/core/src/runtimes/tui-agents/node/runtime/runtime.test.ts
+++ b/packages/core/src/runtimes/tui-agents/node/runtime/runtime.test.ts
@@ -111,6 +111,57 @@ function startInput(overrides: Partial<TuiAgentStartInput> = {}): TuiAgentStartI
 }
 
 describe('TuiAgentsRuntime', () => {
+  it.each(['fresh', 'resume'] as const)(
+    'recovers a %s launch using the session id captured after switching sessions',
+    async (mode) => {
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+      const clock = createManualClock();
+      const reports = createRecordingConversationLifecycleReporter();
+      const { runtime, spawner, agentHost } = createRuntime({
+        clock,
+        conversationReports: reports,
+      });
+      try {
+        if (mode === 'resume') {
+          await runtime.resumeSession(startInput({ sessionId: 'original-session' }));
+        } else {
+          await runtime.startSession(startInput());
+        }
+        runtime['agentStates'].applyCanonicalEvent('conversation-1', 'test', {
+          kind: 'status',
+          type: 'start',
+          providerSessionId: 'switched-session',
+        });
+        expect(reports.providerIds).toEqual([
+          { conversationId: 'conversation-1', providerSessionId: 'switched-session' },
+        ]);
+
+        // Crash outside the early-resume fallback window.
+        await clock.advanceBy(4_000);
+        spawner.processes[0]!.emitExit({ exitCode: 1, signal: null });
+        await vi.advanceTimersByTimeAsync(500);
+
+        expect(spawner.processes).toHaveLength(2);
+        expect(agentHost.buildPromptCommand).toHaveBeenLastCalledWith(
+          'test',
+          expect.objectContaining({
+            isResuming: true,
+            providerSessionId: 'switched-session',
+            initialPrompt: undefined,
+          })
+        );
+        expect(reports.started.at(-1)).toEqual({
+          conversationId: 'conversation-1',
+          providerSessionId: 'switched-session',
+          resumeOutcome: 'loaded',
+        });
+      } finally {
+        await runtime.dispose();
+        vi.useRealTimers();
+      }
+    }
+  );
+
   it('retains stopped output when replacement spawning fails', async () => {
     const { runtime, spawner } = createRuntime();
     await runtime.startSession(startInput());

--- a/packages/core/src/runtimes/tui-agents/node/runtime/runtime.ts
+++ b/packages/core/src/runtimes/tui-agents/node/runtime/runtime.ts
@@ -986,6 +986,17 @@ export class TuiAgentsRuntime {
       if (!active || active !== session || active.pty || !latest || latest.intent === 'stopped') {
         return;
       }
+      const sessionId = this.currentProviderSessionId(
+        config.input.conversationId,
+        latest.input.sessionId
+      );
+      if (sessionId) {
+        this.configs.set(config.input.conversationId, {
+          ...latest,
+          input: { ...latest.input, sessionId },
+          intent: 'resume',
+        });
+      }
       void this.launchCurrentConfig(config.input.conversationId);
     }, RESPAWN_DELAY_MS);
     return true;

--- a/packages/core/src/services/agent-plugins/api/plugins/capabilities/hooks-types.ts
+++ b/packages/core/src/services/agent-plugins/api/plugins/capabilities/hooks-types.ts
@@ -23,7 +23,10 @@ export type NotificationType =
 /**
  * Normalised hook event produced by a plugin's parseHookEvent method.
  *
- * - kind: 'status'  — maps to an agent lifecycle event (start/stop/error/notification)
+ * - kind: 'status'  — maps to an agent lifecycle event (start/stop/error/notification).
+ *   May also carry `providerSessionId` when the provider includes its session id in
+ *   every hook payload; the runtime adopts it whenever it differs from the stored id,
+ *   so an in-session switch (Claude's `/resume`) is tracked without a dedicated event.
  * - kind: 'session' — carries a provider session id to persist on the conversation
  * - kind: 'ignore'  — event should be silently dropped
  */
@@ -35,6 +38,7 @@ export type CanonicalHookEvent =
       title?: string;
       message?: string;
       lastAssistantMessage?: string;
+      providerSessionId?: string;
     }
   | { kind: 'session'; providerSessionId: string }
   | { kind: 'ignore' };

--- a/packages/core/src/services/agent-plugins/api/plugins/helpers/standard-command.test.ts
+++ b/packages/core/src/services/agent-plugins/api/plugins/helpers/standard-command.test.ts
@@ -42,6 +42,37 @@ describe('buildStandardCommand', () => {
     expect(result.args).toEqual(['threads', 'continue', 'T-thread-1']);
   });
 
+  it('resumes with the captured provider session id when it differs from the emdash id', () => {
+    const result = buildStandardCommand(
+      {
+        cli: 'claude',
+        autoApprove: false,
+        sessionId: 'conversation-1',
+        providerSessionId: 'native-1',
+        isResuming: true,
+        model: '',
+      },
+      { resumeFlag: '--resume', sessionIdFlag: '--session-id' }
+    );
+
+    expect(result.args).toEqual(['--resume', 'native-1']);
+  });
+
+  it('resumes with the emdash session id when no provider session id was captured', () => {
+    const result = buildStandardCommand(
+      {
+        cli: 'claude',
+        autoApprove: false,
+        sessionId: 'conversation-1',
+        isResuming: true,
+        model: '',
+      },
+      { resumeFlag: '--resume', sessionIdFlag: '--session-id' }
+    );
+
+    expect(result.args).toEqual(['--resume', 'conversation-1']);
+  });
+
   it('injects modelFlag when ctx.model is non-empty', () => {
     const result = buildStandardCommand(
       {

--- a/packages/core/src/services/agent-plugins/api/plugins/helpers/standard-command.ts
+++ b/packages/core/src/services/agent-plugins/api/plugins/helpers/standard-command.ts
@@ -82,8 +82,16 @@ export function buildStandardCommand(ctx: CommandContext, spec: StandardCommandS
   // Session / resume logic.
   // For sessionIdOnResumeOnly providers, use only the provider-native session id.
   // If providerSessionId is absent, validSessionId will be undefined → fallback flags apply.
-  // For all other providers, the emdash session UUID (sessionId) is used.
-  const rawSessionId = spec.sessionIdOnResumeOnly ? ctx.providerSessionId : ctx.sessionId;
+  // For all other providers, the emdash session UUID (sessionId) is used, unless a
+  // resume carries a provider-reported session id that differs from it (the process
+  // switched sessions, e.g. Claude's in-session `/resume`); then that id is resumed.
+  const capturedSessionId =
+    ctx.isResuming && ctx.providerSessionId && ctx.providerSessionId !== ctx.sessionId
+      ? ctx.providerSessionId
+      : undefined;
+  const rawSessionId = spec.sessionIdOnResumeOnly
+    ? ctx.providerSessionId
+    : (capturedSessionId ?? ctx.sessionId);
   const hasSessionId = !!rawSessionId;
   const validSessionId =
     hasSessionId && spec.validateSessionId

--- a/packages/plugins/src/agents/impl/claude/hooks.test.ts
+++ b/packages/plugins/src/agents/impl/claude/hooks.test.ts
@@ -1,0 +1,113 @@
+import type { PluginFs } from '@emdash/core/services/agent-plugins/api/plugins';
+import { makeStdinHookCommand } from '@emdash/core/services/agent-plugins/api/plugins/helpers';
+import { describe, expect, it } from 'vitest';
+import { CLAUDE_SETTINGS_PATH } from './hooks';
+import { provider } from './index';
+
+const RESUMED_SESSION_ID = 'b637979b-a4b6-43b5-90c2-a2fbe61321d8';
+
+function createMemoryFs(files = new Map<string, string>()): PluginFs {
+  return {
+    read: async (path) => files.get(path) ?? null,
+    write: async (path, content) => {
+      files.set(path, content);
+    },
+    delete: async (path) => {
+      files.delete(path);
+    },
+    exists: async (path) => files.has(path),
+    list: async () => [],
+  };
+}
+
+describe('claude hooks', () => {
+  const parse = provider.behavior.hooks!.parseHookEvent!;
+
+  it('carries the session id on start events so an in-session /resume is tracked', () => {
+    expect(
+      parse('start', {
+        session_id: RESUMED_SESSION_ID,
+        hook_event_name: 'UserPromptSubmit',
+        prompt: 'continue with the plan',
+      })
+    ).toEqual({
+      kind: 'status',
+      type: 'start',
+      providerSessionId: RESUMED_SESSION_ID,
+    });
+  });
+
+  it('carries the session id on stop events', () => {
+    expect(parse('stop', { session_id: RESUMED_SESSION_ID, hook_event_name: 'Stop' })).toEqual({
+      kind: 'status',
+      type: 'stop',
+      providerSessionId: RESUMED_SESSION_ID,
+    });
+  });
+
+  it('keeps notification classification and adds the session id', () => {
+    expect(
+      parse('notification', {
+        session_id: RESUMED_SESSION_ID,
+        hook_event_name: 'Notification',
+        message: 'Claude is waiting for your input',
+      })
+    ).toEqual({
+      kind: 'status',
+      type: 'notification',
+      notificationType: 'idle_prompt',
+      message: 'Claude is waiting for your input',
+      providerSessionId: RESUMED_SESSION_ID,
+    });
+  });
+
+  it('omits the session id when the payload has none', () => {
+    const event = parse('stop', { hook_event_name: 'Stop' });
+    expect(event).toEqual({ kind: 'status', type: 'stop' });
+    expect(event).not.toHaveProperty('providerSessionId');
+  });
+
+  it('maps SessionStart payloads to a session event', () => {
+    expect(
+      parse('session-start', {
+        session_id: RESUMED_SESSION_ID,
+        hook_event_name: 'SessionStart',
+        source: 'resume',
+      })
+    ).toEqual({ kind: 'session', providerSessionId: RESUMED_SESSION_ID });
+  });
+
+  it('resumes the tracked provider session id instead of the conversation id', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      cli: 'claude',
+      autoApprove: false,
+      initialPrompt: undefined,
+      sessionId: 'conversation-1',
+      providerSessionId: RESUMED_SESSION_ID,
+      isResuming: true,
+      model: '',
+    });
+
+    expect(command.args).toEqual(['--resume', RESUMED_SESSION_ID]);
+  });
+
+  it('declares session as a supported hook event', () => {
+    expect(provider.capabilities.hooks).toEqual({
+      kind: 'config',
+      scope: 'global',
+      supportedEvents: ['start', 'notification', 'stop', 'session'],
+    });
+  });
+
+  it('installs a SessionStart hook that reports the Claude session id', async () => {
+    const files = new Map<string, string>();
+    const fs = createMemoryFs(files);
+
+    await provider.behavior.hooks!.writeHooks(fs, []);
+
+    const settings = JSON.parse(files.get(CLAUDE_SETTINGS_PATH)!);
+    expect(settings.hooks.SessionStart).toEqual([
+      { hooks: [{ type: 'command', command: makeStdinHookCommand('session-start') }] },
+    ]);
+  });
+});

--- a/packages/plugins/src/agents/impl/claude/hooks.ts
+++ b/packages/plugins/src/agents/impl/claude/hooks.ts
@@ -4,6 +4,7 @@ import {
   configRoots,
   defaultHookEventParser,
   envConfigRoot,
+  extractProviderSessionId,
   makeStdinHookCommand,
 } from '@emdash/core/services/agent-plugins/api/plugins/helpers';
 
@@ -14,31 +15,42 @@ export const CLAUDE_SETTINGS_PATH = 'settings.json';
  * Classify by examining the message text:
  *   /permission|approval/i → permission_prompt
  *   everything else        → idle_prompt (agent waiting / done)
+ *
+ * Every Claude hook payload includes `session_id`, and it changes when the user
+ * switches sessions inside the TUI (`/resume`). Status events carry it so the
+ * runtime resumes the session Claude is actually in, not the one it launched with.
  */
 function parseClaudeHookEvent(
   eventType: string,
   body: Record<string, unknown>
 ): CanonicalHookEvent {
-  if (eventType === 'notification') {
-    const message = typeof body.message === 'string' ? body.message : '';
-    const notificationType = /permission|approval/i.test(message)
-      ? ('permission_prompt' as const)
-      : ('idle_prompt' as const);
-    return {
-      kind: 'status',
-      type: 'notification',
-      notificationType,
-      message: message || undefined,
-      title: typeof body.title === 'string' ? body.title : undefined,
-    };
-  }
+  const event =
+    eventType === 'notification'
+      ? parseClaudeNotification(body)
+      : defaultHookEventParser(eventType, body);
+  if (event.kind !== 'status') return event;
+  const providerSessionId = extractProviderSessionId(body);
+  return providerSessionId ? { ...event, providerSessionId } : event;
+}
 
-  return defaultHookEventParser(eventType, body);
+function parseClaudeNotification(body: Record<string, unknown>): CanonicalHookEvent {
+  const message = typeof body.message === 'string' ? body.message : '';
+  const notificationType = /permission|approval/i.test(message)
+    ? ('permission_prompt' as const)
+    : ('idle_prompt' as const);
+  return {
+    kind: 'status',
+    type: 'notification',
+    notificationType,
+    message: message || undefined,
+    title: typeof body.title === 'string' ? body.title : undefined,
+  };
 }
 
 export function buildClaudeHookConfig() {
   return {
     ...buildNestedJsonHookConfig(CLAUDE_SETTINGS_PATH, [
+      { hookKey: 'SessionStart', command: makeStdinHookCommand('session-start') },
       { hookKey: 'UserPromptSubmit', command: makeStdinHookCommand('start') },
       { hookKey: 'Notification', command: makeStdinHookCommand('notification') },
       { hookKey: 'Stop', command: makeStdinHookCommand('stop') },

--- a/packages/plugins/src/agents/impl/claude/index.ts
+++ b/packages/plugins/src/agents/impl/claude/index.ts
@@ -82,7 +82,7 @@ export const plugin = definePlugin(
     hooks: {
       kind: 'config',
       scope: 'global',
-      supportedEvents: ['start', 'notification', 'stop'],
+      supportedEvents: ['start', 'notification', 'stop', 'session'],
     },
     hostDependency: {
       id: 'claude',


### PR DESCRIPTION
- captures native claude session ids from hook events including in-session /resume changes
- persists captured ids and uses them for future resume commands
- recovers crashed tui sessions with the latest captured session id
- preserves fresh fallback behavior when no provider session id exists