### PR TITLE
run workspace teardown after a runtime restart

### DIFF
--- a/packages/core/src/runtimes/workspace-registry/node/activation.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/activation.ts
@@ -47,8 +47,8 @@ export type WorkspaceActivationManagerOptions = {
    * single step-writer (spec: activation-scripts-via-terminals).
    */
   recordScriptStep: (id: string, script: ScriptStepScript, state: WorkspaceScriptStepState) => void;
-  /** Persists lastActivatedAt — the only durable trace of an activation. */
-  recordActivated: (id: string, at: number) => Promise<void>;
+  /** Persists lastActivatedAt — the only durable trace of an activation. Null clears it after teardown. */
+  recordActivated: (id: string, at: number | null) => Promise<void>;
   /**
    * The artifact gate (dependency gating): resolves once the background artifact copy
    * settled. Awaited only where scripts consume dependencies — before prepare and
@@ -184,22 +184,28 @@ export class WorkspaceActivationManager {
   }
 
   /**
-   * Aborts in-flight scripts and runs teardown, time-boxed and never throwing. No-op
-   * when the workspace is not active — teardown runs at most once per activation.
-   * Session killing is the caller's step; this owns only the script plane. A teardown
-   * failure is reported to the caller: notice-only for plain deactivation, a removal
-   * stage for the delete verbs (ADR 0006).
+   * Aborts in-flight scripts and runs teardown, time-boxed and never throwing.
+   * After a process restart the in-memory activation is gone but lastActivatedAt
+   * remains; teardown still runs once, then lastActivatedAt is cleared so a later
+   * deactivate is a no-op. Session killing is the caller's step.
    */
-  async deactivate(id: string): Promise<WorkspaceDeactivationResult> {
+  async deactivate(
+    id: string,
+    record?: { path: string; lastActivatedAt: number | null }
+  ): Promise<WorkspaceDeactivationResult> {
     const state = this.active.get(id);
-    if (!state) return { teardownFailure: null };
-    this.active.delete(id);
+    const workspacePath = state?.workspacePath ?? record?.path;
+    const shouldTeardown = Boolean(state) || (record?.lastActivatedAt ?? null) !== null;
+    if (!shouldTeardown || !workspacePath) return { teardownFailure: null };
 
-    state.controller.abort();
-    await state.background;
+    if (state) {
+      this.active.delete(id);
+      state.controller.abort();
+      await state.background;
+    }
 
     let teardownFailure: { message: string } | null = null;
-    const policy = await this.resolveLifecycleConfig(id, state.workspacePath);
+    const policy = await this.resolveLifecycleConfig(id, workspacePath);
     const scripts = policy.scripts;
     if (scripts.teardown) {
       const outcome = await this.runner.run({
@@ -207,7 +213,7 @@ export class WorkspaceActivationManager {
         command: scripts.teardown,
         shellSetup: policy.shellSetup,
         env: policy.env,
-        cwd: state.workspacePath,
+        cwd: workspacePath,
         timeoutMs: this.teardownTimeoutMs,
       });
       if (outcome.status === 'succeeded') {
@@ -218,6 +224,7 @@ export class WorkspaceActivationManager {
       }
     }
     this.options.publishActivation(id, null);
+    await this.options.recordActivated(id, null);
     return { teardownFailure };
   }
 

--- a/packages/core/src/runtimes/workspace-registry/node/api/activation.contract.test.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/api/activation.contract.test.ts
@@ -243,6 +243,32 @@ describe('workspace registry activation lifecycle', () => {
     );
   });
 
+  it('runs teardown after a runtime restart when lastActivatedAt is still set', async () => {
+    const workspacePath = await makeWorkspace('cold-teardown', {
+      teardown: 'echo teardown >> teardown-log',
+    });
+
+    const activated = await wire.client.activateWorkspace({ workspaceId: 'ws-cold-teardown' });
+    expect(activated.success).toBe(true);
+
+    wire.dispose();
+    runtime.dispose();
+    runtime = createRegistryRuntime();
+    wire = createTestWire(workspaceRegistryContract, createWorkspaceRegistryController(runtime));
+
+    const deactivated = await wire.client.deactivateWorkspace({ workspaceId: 'ws-cold-teardown' });
+    expect(deactivated.success).toBe(true);
+    await expect(fs.readFile(path.join(workspacePath, 'teardown-log'), 'utf8')).resolves.toBe(
+      'teardown\n'
+    );
+
+    const again = await wire.client.deactivateWorkspace({ workspaceId: 'ws-cold-teardown' });
+    expect(again.success).toBe(true);
+    await expect(fs.readFile(path.join(workspacePath, 'teardown-log'), 'utf8')).resolves.toBe(
+      'teardown\n'
+    );
+  });
+
   it('a hanging teardown is cut off at the time-box and deactivation still succeeds', async () => {
     await makeWorkspace('hanging', { teardown: 'sleep 30' });
     const activated = await wire.client.activateWorkspace({ workspaceId: 'ws-hanging' });

--- a/packages/core/src/runtimes/workspace-registry/node/runtime.ts
+++ b/packages/core/src/runtimes/workspace-registry/node/runtime.ts
@@ -306,7 +306,11 @@ export class WorkspaceRegistryRuntime {
         this.enqueue(async () => {
           const record = this.store.get(id);
           if (!record) return;
-          const updated: DurableWorkspaceRecord = { ...record, lastActivatedAt: at, updatedAt: at };
+          const updated: DurableWorkspaceRecord = {
+            ...record,
+            lastActivatedAt: at,
+            updatedAt: this.clock.now(),
+          };
           this.store.update(updated);
           this.publish(updated);
         }),
@@ -902,7 +906,10 @@ export class WorkspaceRegistryRuntime {
   ): Promise<WorkspaceDeactivationResult> {
     // Stop and await script-plane runs first. Killing their terminal sessions first
     // can make an intentional Stop look like a failed process exit.
-    const deactivation = await this.activationManager.deactivate(record.id);
+    const deactivation = await this.activationManager.deactivate(record.id, {
+      path: record.path,
+      lastActivatedAt: record.lastActivatedAt,
+    });
     try {
       await this.killSessions(record.path);
     } catch (error) {


### PR DESCRIPTION
## summary
archive/delete only ran the `.emdash.json` teardown script while the workspace was still in the in-memory activation map. after an app restart that map is empty, so archived then deleted tasks skipped teardown and leaked simulators / other setup resources.

deactivate now runs teardown once whenever `lastActivatedAt` is set, then clears it so a second deactivate stays a no-op.

closes #2886

## test plan
- [ ] activate a workspace with a teardown script, restart emdash, archive/delete the task, confirm the script ran
- [ ] live archive still runs teardown once
- [ ] `pnpm --dir packages/core exec vitest run src/runtimes/workspace-registry/node/api/activation.contract.test.ts`
