### PR TITLE
open remote vscode windows with --new-window

### DIFF
--- a/apps/emdash-desktop/src/core/primitives/open-in-apps/api/open-in-apps.test.ts
+++ b/apps/emdash-desktop/src/core/primitives/open-in-apps/api/open-in-apps.test.ts
@@ -112,5 +112,6 @@ describe('OPEN_IN_APPS', () => {
       'rider {{path}}',
       'rider.sh {{path}}',
     ]);
+    expect(OPEN_IN_APPS.vscode.platforms.darwin?.openCommands?.[0]).toContain('code -n');
   });
 });

--- a/apps/emdash-desktop/src/core/primitives/open-in-apps/api/open-in-apps.ts
+++ b/apps/emdash-desktop/src/core/primitives/open-in-apps/api/open-in-apps.ts
@@ -94,16 +94,16 @@ const _OPEN_IN_APPS = {
     supportsRemote: true,
     platforms: {
       darwin: {
-        openCommands: ['command -v cursor >/dev/null 2>&1 && cursor .', 'open -a "Cursor" .'],
+        openCommands: ['command -v cursor >/dev/null 2>&1 && cursor -n .', 'open -n -a "Cursor" .'],
         checkCommands: ['cursor'],
         appNames: ['Cursor'],
       },
       win32: {
-        openCommands: ['cursor {{path}}'],
+        openCommands: ['cursor --new-window {{path}}'],
         checkCommands: ['cursor'],
       },
       linux: {
-        openCommands: ['cursor {{path}}'],
+        openCommands: ['cursor --new-window {{path}}'],
         checkCommands: ['cursor'],
       },
     },
@@ -117,7 +117,7 @@ const _OPEN_IN_APPS = {
     platforms: {
       darwin: {
         openCommands: [
-          'command -v code >/dev/null 2>&1 && code {{path}}',
+          'command -v code >/dev/null 2>&1 && code -n {{path}}',
           'open -n -b com.microsoft.VSCode --args {{path}}',
           'open -n -a "Visual Studio Code" {{path}}',
         ],
@@ -126,11 +126,11 @@ const _OPEN_IN_APPS = {
         appNames: ['Visual Studio Code'],
       },
       win32: {
-        openCommands: ['code {{path}}', 'code-insiders {{path}}'],
+        openCommands: ['code --new-window {{path}}', 'code-insiders --new-window {{path}}'],
         checkCommands: ['code', 'code-insiders'],
       },
       linux: {
-        openCommands: ['code {{path}}', 'code-insiders {{path}}'],
+        openCommands: ['code --new-window {{path}}', 'code-insiders --new-window {{path}}'],
         checkCommands: ['code', 'code-insiders'],
       },
     },
@@ -144,7 +144,7 @@ const _OPEN_IN_APPS = {
     platforms: {
       darwin: {
         openCommands: [
-          'command -v codium >/dev/null 2>&1 && codium {{path}}',
+          'command -v codium >/dev/null 2>&1 && codium -n {{path}}',
           'open -n -b com.vscodium --args {{path}}',
           'open -n -a "VSCodium" {{path}}',
         ],
@@ -153,11 +153,11 @@ const _OPEN_IN_APPS = {
         appNames: ['VSCodium'],
       },
       win32: {
-        openCommands: ['codium {{path}}'],
+        openCommands: ['codium --new-window {{path}}'],
         checkCommands: ['codium'],
       },
       linux: {
-        openCommands: ['codium {{path}}'],
+        openCommands: ['codium --new-window {{path}}'],
         checkCommands: ['codium'],
       },
     },

--- a/apps/emdash-desktop/src/main/core/app/service.ts
+++ b/apps/emdash-desktop/src/main/core/app/service.ts
@@ -23,6 +23,8 @@ import { getAppDb } from '@main/db/instance';
 import type { createDesktopWorkspaceRuntimeAcquirer } from '@main/gateway/workspace-runtime';
 import {
   buildRemoteEditorUrl,
+  buildRemoteEditorFolderUri,
+  buildRemoteEditorCli,
   buildRemoteSshCommand,
   buildRemoteTerminalExecArgs,
 } from '@main/host/remoteOpenIn';
@@ -404,7 +406,26 @@ class AppService implements Disposable {
 
     const { host, username, port } = connection;
 
-    if (appId === 'vscode' || appId === 'vscodium' || appId === 'cursor' || appId === 'zed') {
+    if (appId === 'vscode' || appId === 'vscodium' || appId === 'cursor') {
+      const folderUri = buildRemoteEditorFolderUri(host, username, target);
+      try {
+        await execFileCommand(buildRemoteEditorCli(appId), [
+          '--new-window',
+          '--folder-uri',
+          folderUri,
+        ]);
+        return;
+      } catch (error) {
+        log.warn('open-in: remote editor CLI failed, falling back to url', {
+          appId,
+          error: String(error),
+        });
+      }
+      await shell.openExternal(buildRemoteEditorUrl(appId, host, username, target, port));
+      return;
+    }
+
+    if (appId === 'zed') {
       await shell.openExternal(buildRemoteEditorUrl(appId, host, username, target, port));
       return;
     }

--- a/apps/emdash-desktop/src/main/host/remoteOpenIn.test.ts
+++ b/apps/emdash-desktop/src/main/host/remoteOpenIn.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildRemoteEditorUrl,
+  buildRemoteEditorFolderUri,
+  buildRemoteEditorCli,
   buildRemoteSshAuthority,
   buildRemoteTerminalExecArgs,
 } from './remoteOpenIn';
@@ -40,6 +42,15 @@ describe('remoteOpenIn', () => {
     it('encodes remote path segments in editor URLs', () => {
       expect(buildRemoteEditorUrl('zed', 'localhost', 'dev', '/repo with space/#1')).toBe(
         'zed://ssh/dev@localhost/repo%20with%20space/%231'
+      );
+    });
+  });
+
+  describe('buildRemoteEditorFolderUri', () => {
+    it('builds a vscode-remote folder uri for a new window', () => {
+      expect(buildRemoteEditorCli('vscode')).toBe('code');
+      expect(buildRemoteEditorFolderUri('localhost', 'dev', '/repo')).toBe(
+        'vscode-remote://ssh-remote+7b22686f73744e616d65223a226c6f63616c686f7374222c2275736572223a22646576227d/repo'
       );
     });
   });

--- a/apps/emdash-desktop/src/main/host/remoteOpenIn.ts
+++ b/apps/emdash-desktop/src/main/host/remoteOpenIn.ts
@@ -51,6 +51,21 @@ function buildVsCodeRemoteAuthority(host: string, username: string): string {
   ).toString('hex');
 }
 
+export function buildRemoteEditorFolderUri(
+  host: string,
+  username: string,
+  targetPath: string
+): string {
+  const vscodeAuthority = buildVsCodeRemoteAuthority(host, username);
+  return `vscode-remote://ssh-remote+${vscodeAuthority}${encodeRemotePath(targetPath)}`;
+}
+
+export function buildRemoteEditorCli(scheme: Exclude<RemoteEditorScheme, 'zed'>): string {
+  if (scheme === 'vscodium') return 'codium';
+  if (scheme === 'cursor') return 'cursor';
+  return 'code';
+}
+
 export function buildRemoteEditorUrl(
   scheme: RemoteEditorScheme,
   host: string,


### PR DESCRIPTION
## summary
opening a second remote workspace used `vscode://` which reuses the existing window. the cli now prefers `code --new-window --folder-uri vscode-remote://...` (and cursor/codium equivalents), with the url as fallback.

local vscode/cursor/codium launch commands also pass `-n` / `--new-window`.

closes #2904

## test plan
- [ ] open two remote workspaces in vs code and get two windows
- [ ] local "open in vs code" also opens a new window
- [ ] `pnpm --dir apps/emdash-desktop exec vitest run --project node src/main/host/remoteOpenIn.test.ts src/core/primitives/open-in-apps/api/open-in-apps.test.ts`
