### PR TITLE
always show the issue provider picker when jira and github are both installed

### DIFF
--- a/apps/emdash-desktop/src/core/features/tasks/browser/components/issue-selector/issue-selector.tsx
+++ b/apps/emdash-desktop/src/core/features/tasks/browser/components/issue-selector/issue-selector.tsx
@@ -182,7 +182,7 @@ export const IssueSelector = observer(function IssueSelector({
   );
 
   const leftAddon = issueProvider ? (
-    connectedProviderCount > 1 ? (
+    connectedProviderCount > 1 || issueProviderOrder.length > 1 ? (
       <Select.Root
         value={issueProvider}
         onValueChange={(v) => v && handleSelectIssueProvider(v as LinkedIssue['provider'])}


### PR DESCRIPTION
## summary
the provider dropdown only appeared when more than one provider counted as "connected/usable". github could stay selected (and fail listing) while jira was the working one, with no way to switch.

the select now shows whenever more than one issue integration is installed. unusable rows stay disabled.

closes #2983

## test plan
- [ ] with github + jira installed, open the issue picker and switch to jira even if github listing fails
- [ ] a single-provider install still shows only the logo
