### PR TITLE
stop serializing slash commands as //name

### DIFF
--- a/packages/ui/src/react/components/prompt-editor/extensions/slash-command.ts
+++ b/packages/ui/src/react/components/prompt-editor/extensions/slash-command.ts
@@ -20,6 +20,10 @@ import type { CommandItem } from '../types';
 
 const slashCommandPluginKey = new PluginKey('slashCommand');
 
+function slashCommandName(value: string | null | undefined): string {
+  return (value ?? '').replace(/^\/+/, '');
+}
+
 function plainTextInsertContent(text: string) {
   const lines = text.length > 0 ? text.split(/\r?\n/) : [''];
   return lines.map((line) => ({
@@ -46,7 +50,9 @@ export function buildSlashCommandExtension(
   }).configure({
     HTMLAttributes: { class: 'slash-command-chip' },
     renderText({ node }) {
-      return `/${(node.attrs.name as string | null) ?? (node.attrs.id as string | null) ?? ''}`;
+      return `/${slashCommandName(
+        (node.attrs.name as string | null) ?? (node.attrs.id as string | null)
+      )}`;
     },
     renderHTML({ node }) {
       return [
@@ -57,7 +63,9 @@ export function buildSlashCommandExtension(
           'data-name': node.attrs.name as string,
           class: 'slash-command-chip',
         },
-        `/${(node.attrs.name as string | null) ?? (node.attrs.id as string | null) ?? ''}`,
+        `/${slashCommandName(
+          (node.attrs.name as string | null) ?? (node.attrs.id as string | null)
+        )}`,
       ];
     },
     suggestion: {
@@ -86,7 +94,7 @@ export function buildSlashCommandExtension(
             .insertContentAt(range.from, [
               {
                 type: 'slashCommand',
-                attrs: { id: item.id, name: item.name ?? item.id },
+                attrs: { id: item.id, name: slashCommandName(item.name ?? item.id) },
               },
               { type: 'text', text: ' ' },
             ])

--- a/packages/ui/src/react/components/prompt-editor/serialize.test.ts
+++ b/packages/ui/src/react/components/prompt-editor/serialize.test.ts
@@ -98,6 +98,11 @@ describe('serializeDoc', () => {
     expect(serializeDoc(doc)).toBe('/review this');
   });
 
+  it('strips a leading slash from slash command names', () => {
+    const doc = makeDoc(paragraph(slashCommandNode('/settings')));
+    expect(serializeDoc(doc)).toBe('/settings');
+  });
+
   it('serializes a hard break as \\n within a paragraph', () => {
     const doc = makeDoc(paragraph(textNode('line1'), hardBreakNode(), textNode('line2')));
     expect(serializeDoc(doc)).toBe('line1\nline2');

--- a/packages/ui/src/react/components/prompt-editor/serialize.ts
+++ b/packages/ui/src/react/components/prompt-editor/serialize.ts
@@ -51,7 +51,8 @@ export function serializeNode(node: Node): string {
   }
 
   if (node.type.name === 'slashCommand') {
-    const name = (node.attrs.name as string | null) ?? (node.attrs.id as string | null) ?? '';
+    const name = ((node.attrs.name as string | null) ?? (node.attrs.id as string | null) ?? '')
+      .replace(/^\/+/, '');
     return `/${name}`;
   }
 


### PR DESCRIPTION
## summary
if a harness advertises a command as `/settings`, the chip stored that name and serialize prepended another `/`.

names are normalized by stripping leading slashes on insert and on serialize.

closes #3126

## test plan
- [ ] pick a slash command whose advertised name includes `/` and confirm the sent prompt is `/name` once
- [ ] `pnpm --dir packages/ui exec vitest run src/react/components/prompt-editor/serialize.test.ts`
