### PR TITLE
do not yank chat scroll when the user has scrolled up

### DIFF
--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
@@ -467,9 +467,12 @@ export class AcpChatStore {
         attachments: attachments.map(toPendingAttachment),
       });
       this._syncMessageCount();
-      const pinMode = getChatUiRuntime().pinTopMode(optimisticId);
-      this._view?.setScrollMode(pinMode);
-      this.chatState.scroll.set(pinMode);
+      const currentScroll = this.chatState.scroll.get?.() ?? { kind: 'tail' as const };
+      if (currentScroll.kind !== 'anchor') {
+        const pinMode = getChatUiRuntime().pinTopMode(optimisticId);
+        this._view?.setScrollMode(pinMode);
+        this.chatState.scroll.set(pinMode);
+      }
     }
 
     void this._submitPrompt(promptId, text, promptAttachments, hiddenContext).then((outcome) => {

--- a/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
@@ -373,7 +373,7 @@ describe('AcpChatStore prompt submission', () => {
             state: transcriptTestState,
             history: { seed: historySeed },
           },
-          scroll: { set: vi.fn() },
+          scroll: { get: () => ({ kind: 'tail' }), set: vi.fn() },
           dispose: vi.fn(),
         }) as never,
       createChatView: vi.fn() as never,


### PR DESCRIPTION
## summary
every non-busy submit forced `pinTopMode`, which rewrote scroll intent even if the user had parked the transcript.

pin-on-send now only runs when the current intent is not already an anchor (user scrolled away).

closes #2006

## test plan
- [ ] scroll up in an agent transcript, send another message, confirm the viewport stays put
- [ ] sending while already at the bottom still pins the new prompt
