### PR TITLE
allowlist common mcp credential env vars for agents

### DIFF
--- a/packages/core/src/primitives/agent-env/api/index.test.ts
+++ b/packages/core/src/primitives/agent-env/api/index.test.ts
@@ -92,6 +92,24 @@ describe('buildAllowlistedAgentEnv', () => {
     expect(env.PATH).toBe('/bin');
     expect(env.ANTHROPIC_API_KEY).toBe('included');
     expect(env.META_API_KEY).toBe('meta-secret');
+    expect(env.LINEAR_API_KEY).toBeUndefined();
+  });
+
+  it('passes through common MCP credentials and extra allowlisted keys', () => {
+    const env = buildAllowlistedAgentEnv(
+      {
+        LINEAR_API_KEY: 'lin',
+        SUPABASE_ACCESS_TOKEN: 'sb',
+        CUSTOM_MCP_TOKEN: 'custom',
+        UNSAFE_SECRET: 'nope',
+      },
+      { platform: 'posix', additionalKeys: ['CUSTOM_MCP_TOKEN'] }
+    );
+
+    expect(env.LINEAR_API_KEY).toBe('lin');
+    expect(env.SUPABASE_ACCESS_TOKEN).toBe('sb');
+    expect(env.CUSTOM_MCP_TOKEN).toBe('custom');
+    expect(env).not.toHaveProperty('UNSAFE_SECRET');
   });
 
   it('forwards all persistent XDG base-directory variables', () => {

--- a/packages/core/src/primitives/agent-env/api/index.ts
+++ b/packages/core/src/primitives/agent-env/api/index.ts
@@ -69,11 +69,16 @@ export const AGENT_ENV_VARS = [
   'KIMI_API_KEY',
   'KIMI_CODE_HOME',
   'KIRO_HOME',
+  'LANGSMITH_API_KEY',
+  'LINEAR_API_KEY',
+  'LINEAR_PAT',
   'META_API_KEY',
   'MISTRAL_API_KEY',
   'MIMOCODE_HOME',
   'MOONSHOT_API_KEY',
   'NO_PROXY',
+  'NOTION_API_KEY',
+  'NOTION_TOKEN',
   'OMP_AUTH_BROKER_SNAPSHOT_CACHE',
   'OMP_AUTH_BROKER_SNAPSHOT_TTL_MS',
   'OMP_AUTH_BROKER_URL',
@@ -116,6 +121,10 @@ export const AGENT_ENV_VARS = [
   'QWEN_RUNTIME_DIR',
   'QWEN_SANDBOX',
   'RLM_MAX_DEPTH',
+  'SUPABASE_ACCESS_TOKEN',
+  'SUPABASE_ANON_KEY',
+  'SUPABASE_SERVICE_ROLE_KEY',
+  'SUPABASE_URL',
   'VIBE_HOME',
   'XAI_API_KEY',
   'XDG_CACHE_HOME',
@@ -161,8 +170,7 @@ const CANONICAL_WINDOWS_ENV_NAMES = new Map(
     ...AGENT_ENV_VARS,
     ...WINDOWS_AGENT_ENV_VARS,
     'TMPDIR',
-    'SSH_AUTH_SOCK',
-    'SHELL',
+  'SSH_AUTH_SOCK',
   ].map((key) => [key.toLowerCase(), key] as const)
 );
 
@@ -171,6 +179,7 @@ export interface BuildAllowlistedAgentEnvOptions {
   username?: string;
   includeShellVar?: boolean;
   platform?: AgentEnvPlatform;
+  additionalKeys?: readonly string[];
 }
 
 export type AgentEnvPlatform = 'posix' | 'windows';
@@ -194,6 +203,9 @@ export function buildAllowlistedAgentEnv(
     ...getAllowlistedEnv(sourceEnv, GLOBAL_AGENT_ENV_VARS, platform),
     ...getAllowlistedEnv(sourceEnv, DISPLAY_ENV_VARS, platform),
     ...getAllowlistedEnv(sourceEnv, AGENT_ENV_VARS, platform),
+    ...(options.additionalKeys
+      ? getAllowlistedEnv(sourceEnv, options.additionalKeys, platform)
+      : {}),
   };
 
   if (platform === 'windows') {


### PR DESCRIPTION
## summary
mcp configs that expand `${LINEAR_API_KEY}` / `${SUPABASE_ACCESS_TOKEN}` / notion tokens were empty because those names were stripped by `buildAllowlistedAgentEnv`.

those keys are now on the default allowlist. callers can also pass `additionalKeys`.

closes #3103

## test plan
- [ ] with LINEAR_API_KEY in the login environment, start an agent whose mcp config references `${LINEAR_API_KEY}`
- [ ] `pnpm --dir packages/core exec vitest run src/primitives/agent-env/api/index.test.ts`
