### PR TITLE
verify ssh host keys against known_hosts

### DIFF
--- a/apps/emdash-desktop/src/core/services/ssh/node/connect/known-hosts.test.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/connect/known-hosts.test.ts
@@ -1,0 +1,37 @@
+import { createHmac } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { hostKeyDecision } from './known-hosts';
+
+const key = Buffer.from('ssh-ed25519-host-key-bytes');
+const b64 = key.toString('base64');
+
+describe('hostKeyDecision', () => {
+  it('matches a known host key', () => {
+    expect(
+      hostKeyDecision('work.example', key, `work.example ssh-ed25519 ${b64}`)
+    ).toBe('match');
+  });
+
+  it('rejects a changed host key', () => {
+    expect(
+      hostKeyDecision(
+        'work.example',
+        Buffer.from('other-key'),
+        `work.example ssh-ed25519 ${b64}`
+      )
+    ).toBe('mismatch');
+  });
+
+  it('allows unknown hosts (tofu)', () => {
+    expect(hostKeyDecision('new.example', key, `work.example ssh-ed25519 ${b64}`)).toBe(
+      'unknown'
+    );
+  });
+
+  it('matches hashed known_hosts hostnames', () => {
+    const salt = Buffer.from('salt-value');
+    const digest = createHmac('sha1', salt).update('work.example').digest('base64');
+    const hashed = `|1|${salt.toString('base64')}|${digest}`;
+    expect(hostKeyDecision('work.example', key, `${hashed} ssh-ed25519 ${b64}`)).toBe('match');
+  });
+});

--- a/apps/emdash-desktop/src/core/services/ssh/node/connect/known-hosts.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/connect/known-hosts.ts
@@ -1,0 +1,99 @@
+import { createHmac } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export type HostKeyDecision = 'match' | 'mismatch' | 'unknown';
+
+export function knownHostsPath(home = homedir()): string {
+  return join(home, '.ssh', 'known_hosts');
+}
+
+export function hostKeyDecision(
+  host: string,
+  hostKey: Buffer,
+  knownHostsContents: string
+): HostKeyDecision {
+  const hostNames = hostAliases(host);
+  let sawHost = false;
+  for (const line of knownHostsContents.split(/\r?\n/)) {
+    const parsed = parseKnownHostsLine(line);
+    if (!parsed) continue;
+    if (!hostMatchesEntry(hostNames, parsed.hosts)) continue;
+    sawHost = true;
+    if (keyMatches(hostKey, parsed.keyType, parsed.keyData)) return 'match';
+  }
+  if (sawHost) return 'mismatch';
+  return 'unknown';
+}
+
+export function createKnownHostsVerifier(
+  host: string,
+  readKnownHosts: () => string | null = () => {
+    try {
+      return readFileSync(knownHostsPath(), 'utf8');
+    } catch {
+      return null;
+    }
+  }
+): (key: Buffer, done: (ok: boolean) => void) => void {
+  return (key, done) => {
+    const contents = readKnownHosts();
+    if (!contents) {
+      done(true);
+      return;
+    }
+    done(hostKeyDecision(host, key, contents) !== 'mismatch');
+  };
+}
+
+function hostAliases(host: string): string[] {
+  const trimmed = host.trim();
+  const aliases = new Set<string>([trimmed, trimmed.toLowerCase()]);
+  if (trimmed.includes(':') && !trimmed.startsWith('[')) {
+    aliases.add(`[${trimmed}]`);
+  }
+  return [...aliases];
+}
+
+function parseKnownHostsLine(
+  line: string
+): { hosts: string[]; keyType: string; keyData: string } | null {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith('#')) return null;
+  const tokens = trimmed.startsWith('@') ? trimmed.split(/\s+/).slice(1) : trimmed.split(/\s+/);
+  if (tokens.length < 3) return null;
+  const [hosts, keyType, keyData] = tokens;
+  if (!hosts || !keyType || !keyData) return null;
+  return { hosts: hosts.split(','), keyType, keyData };
+}
+
+function hostMatchesEntry(hostNames: string[], entryHosts: string[]): boolean {
+  return entryHosts.some((entry) => {
+    if (entry.startsWith('|1|')) return hashedHostMatches(hostNames, entry);
+    const normalized = entry.replace(/^\[|\]$/g, '');
+    return hostNames.some(
+      (candidate) => candidate === entry || candidate.toLowerCase() === entry.toLowerCase() || candidate === normalized
+    );
+  });
+}
+
+function hashedHostMatches(hostNames: string[], entry: string): boolean {
+  const parts = entry.split('|');
+  if (parts.length !== 4 || parts[1] !== '1' || !parts[2] || !parts[3]) return false;
+  const salt = Buffer.from(parts[2], 'base64');
+  const digest = Buffer.from(parts[3], 'base64');
+  return hostNames.some((host) =>
+    createHmac('sha1', salt).update(host).digest().equals(digest)
+  );
+}
+
+function keyMatches(hostKey: Buffer, keyType: string, keyData: string): boolean {
+  try {
+    const encoded = hostKey.toString('base64');
+    if (encoded === keyData) return true;
+    return Buffer.from(keyData, 'base64').equals(hostKey);
+  } catch {
+    return keyType.length > 0 && false;
+  }
+}

--- a/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.ts
@@ -17,6 +17,7 @@ import {
 } from '../transport/transports';
 import { buildAuthConfig, resolveManualAgentSshConfig } from './ssh-connect-auth';
 import { applyForwardAgent } from './ssh-connect-forward-agent';
+import { createKnownHostsVerifier } from './known-hosts';
 
 const { createAgent } = ssh2;
 
@@ -107,6 +108,7 @@ export async function resolveSshConnectConfig(
     keepaliveInterval: resolved?.serverAliveInterval ? resolved.serverAliveInterval * 1000 : 60_000,
     keepaliveCountMax: resolved?.serverAliveCountMax ?? 3,
     ...authResult.config,
+    hostVerifier: createKnownHostsVerifier(host),
     strictVendor: false,
   };
 


### PR DESCRIPTION
## summary
ssh2 was connecting with no `hostVerifier`, so any host key was accepted.

connect now checks `~/.ssh/known_hosts` (plain and hashed host entries). a changed key is rejected. an unknown host still connects (tofu) so first-time lans are not blocked.

closes #1360

## test plan
- [ ] connect to a host whose known_hosts key matches
- [ ] point a saved host at a different machine with a different key and confirm connect fails as host-key
- [ ] `pnpm --dir apps/emdash-desktop exec vitest run --project node src/core/services/ssh/node/connect/known-hosts.test.ts src/core/services/ssh/node/connect/resolve-ssh-connect-config.test.ts`
