### PR TITLE
show github check duration in seconds under one minute

### DIFF
--- a/apps/emdash-desktop/src/core/features/github/api/browser/checks/utils.test.ts
+++ b/apps/emdash-desktop/src/core/features/github/api/browser/checks/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { CheckRun } from './types';
-import { computeCheckBucket, sortCheckRunsByLatest } from './utils';
+import { computeCheckBucket, formatCheckDuration, sortCheckRunsByLatest } from './utils';
 
 function makeCheck(overrides: Partial<CheckRun> = {}): CheckRun {
   return {
@@ -31,6 +31,14 @@ describe('computeCheckBucket', () => {
     expect(
       computeCheckBucket(makeCheck({ status: 'COMPLETED', conclusion: 'STARTUP_FAILURE' }))
     ).toBe('fail');
+  });
+});
+
+describe('formatCheckDuration', () => {
+  it('shows seconds when the run is under a minute', () => {
+    expect(
+      formatCheckDuration('2026-07-18T09:00:00.000Z', '2026-07-18T09:00:12.000Z')
+    ).toBe('12s');
   });
 });
 

--- a/apps/emdash-desktop/src/core/features/github/api/browser/checks/utils.ts
+++ b/apps/emdash-desktop/src/core/features/github/api/browser/checks/utils.ts
@@ -95,5 +95,6 @@ export function formatCheckDuration(startedAt?: string, completedAt?: string): s
 
   if (hours > 0) return `${hours}h ${minutes}m`;
   if (minutes > 0) return `${minutes}m ${totalSeconds % 60}s`;
-  return '<1m';
+  if (totalSeconds > 0) return `${totalSeconds}s`;
+  return '<1s';
 }


### PR DESCRIPTION
## summary
checks that finished in under a minute always rendered as `<1m`, so a 12s job looked the same as a 50s one.

durations now show as `12s` / `Xm Ys` / `Xh Ym`.

## test plan
- [ ] open a pr with a short check run and confirm the duration shows seconds
- [ ] `pnpm --dir apps/emdash-desktop exec vitest run --project node src/core/features/github/api/browser/checks/utils.test.ts`
