### PR TITLE
fix(files): follow external symlink targets

### DIFF
--- a/apps/emdash-desktop/src/core/features/editor/api/browser/facet-binder/monaco-facet-binder.browser.test.ts
+++ b/apps/emdash-desktop/src/core/features/editor/api/browser/facet-binder/monaco-facet-binder.browser.test.ts
@@ -224,6 +224,35 @@ describe('MonacoFacetBinder handles', () => {
     expect(editor.getOption(monaco.editor.EditorOption.readOnly)).toBe(false);
   });
 
+  it('updates read-only state in attached editors and preserves the buffer and undo stack', async () => {
+    const binder = newBinder();
+    const ref = fileRef('repo', 'permissions.txt');
+    const handle = await createHandle(binder, descriptor(ref, BUFFER, 'text'));
+    const uri = encodeFacetUri(ref, BUFFER);
+    const editor = createEditor();
+    const otherEditor = createEditor();
+    binder.attach(editor, uri);
+    binder.attach(otherEditor, uri);
+    editor.setPosition({ lineNumber: 1, column: 5 });
+    editor.trigger('keyboard', 'type', { text: '!' });
+    const model = editor.getModel()!;
+
+    handle.setReadOnly(true);
+    expect(editor.getOption(monaco.editor.EditorOption.readOnly)).toBe(true);
+    expect(otherEditor.getOption(monaco.editor.EditorOption.readOnly)).toBe(true);
+    binder.detach(otherEditor, uri);
+    binder.attach(otherEditor, uri);
+    expect(otherEditor.getOption(monaco.editor.EditorOption.readOnly)).toBe(true);
+    expect(handle.getText()).toBe('text!');
+
+    handle.setReadOnly(false);
+    expect(editor.getOption(monaco.editor.EditorOption.readOnly)).toBe(false);
+    expect(otherEditor.getOption(monaco.editor.EditorOption.readOnly)).toBe(false);
+    expect(editor.getModel()).toBe(model);
+    await model.undo();
+    expect(handle.getText()).toBe('text');
+  });
+
   it('applies setText to read-only facets (store-driven updates)', async () => {
     const binder = newBinder();
     const ref = fileRef('repo', 'mirror.txt');

--- a/apps/emdash-desktop/src/core/features/editor/api/browser/facet-binder/monaco-facet-binder.ts
+++ b/apps/emdash-desktop/src/core/features/editor/api/browser/facet-binder/monaco-facet-binder.ts
@@ -7,7 +7,7 @@ import type {
   FacetHandleBinder,
 } from '@core/features/editor/api/browser/open-file-store/facet-handle';
 import { log } from '@core/primitives/logging/browser/logger';
-import { decodeFacetUri, encodeFacetUri } from './facet-uri';
+import { encodeFacetUri } from './facet-uri';
 
 /**
  * The Monaco-side projection of OpenFileStore (spec §7): implements
@@ -23,8 +23,12 @@ import { decodeFacetUri, encodeFacetUri } from './facet-uri';
  * wedging the stack.
  */
 export class MonacoFacetBinder implements FacetHandleBinder {
+  private monaco: typeof monaco | undefined;
   /** Live models keyed by facet URI string; refs count live handles. */
-  private readonly models = new Map<string, { model: monaco.editor.ITextModel; refs: number }>();
+  private readonly models = new Map<
+    string,
+    { model: monaco.editor.ITextModel; refs: number; readonly: boolean }
+  >();
   /** Cursor/scroll/folding state per facet URI, saved between attaches. */
   private readonly viewStates = new Map<string, monaco.editor.ICodeEditorViewState>();
   /** Diff-editor view states keyed by `${originalUri}::${modifiedUri}`. */
@@ -43,6 +47,7 @@ export class MonacoFacetBinder implements FacetHandleBinder {
     }
     const uri = encodeFacetUri(decoded.data, descriptor.facet);
     const m = await this.loadMonaco();
+    this.monaco = m;
 
     let entry = this.models.get(uri);
     if (entry) {
@@ -65,10 +70,10 @@ export class MonacoFacetBinder implements FacetHandleBinder {
           monacoUri
         );
       }
-      entry = { model, refs: 1 };
+      entry = { model, refs: 1, readonly: descriptor.readonly };
       this.models.set(uri, entry);
     }
-    return new MonacoFacetHandle(this, uri, entry.model, descriptor.readonly);
+    return new MonacoFacetHandle(this, uri, entry.model, descriptor.facet.kind !== 'buffer');
   }
 
   // ---------------------------------------------------------------------------
@@ -78,6 +83,15 @@ export class MonacoFacetBinder implements FacetHandleBinder {
   /** The live ITextModel at a codec-produced facet URI, if any. */
   modelFor(uri: string): monaco.editor.ITextModel | undefined {
     return this.models.get(uri)?.model;
+  }
+
+  setReadOnly(uri: string, readOnly: boolean): void {
+    const entry = this.models.get(uri);
+    if (!entry || entry.readonly === readOnly) return;
+    entry.readonly = readOnly;
+    for (const editor of this.monaco?.editor.getEditors() ?? []) {
+      if (editor.getModel() === entry.model) editor.updateOptions({ readOnly });
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -95,10 +109,7 @@ export class MonacoFacetBinder implements FacetHandleBinder {
     const entry = this.models.get(uri);
     if (!entry) return;
     editor.setModel(entry.model);
-    const decoded = decodeFacetUri(uri);
-    if (decoded.success) {
-      editor.updateOptions({ readOnly: decoded.data.facet.kind !== 'buffer' });
-    }
+    editor.updateOptions({ readOnly: entry.readonly });
     const viewState = this.viewStates.get(uri);
     if (viewState) editor.restoreViewState(viewState);
   }
@@ -199,6 +210,11 @@ class MonacoFacetHandle implements FacetHandle {
 
   getText(): string {
     return this.model.getValue();
+  }
+
+  setReadOnly(readOnly: boolean): void {
+    if (this.disposed) return;
+    this.binder.setReadOnly(this.uri, this.readonlyFacet || readOnly);
   }
 
   setText(text: string): void {

--- a/apps/emdash-desktop/src/core/features/editor/api/browser/open-file-store/facet-handle.ts
+++ b/apps/emdash-desktop/src/core/features/editor/api/browser/open-file-store/facet-handle.ts
@@ -28,6 +28,8 @@ export interface FacetHandle {
    * own programmatic writes from user edits.
    */
   setText(text: string): void;
+  /** Update editor editability without replacing the model or its undo history. */
+  setReadOnly(readOnly: boolean): void;
   /** Subscribe to text changes. Returns an unsubscribe function. */
   onDidChange(listener: () => void): () => void;
   dispose(): void;
@@ -44,7 +46,7 @@ export type FacetDescriptor = Readonly<{
   facet: Facet;
   /** Text the handle must start with (disk content, or the buffer seed). */
   initialText: string;
-  /** True for disk-mirror and git-snapshot facets; false for the buffer. */
+  /** True for snapshots and buffers that filesystem permissions make read-only. */
   readonly: boolean;
 }>;
 

--- a/apps/emdash-desktop/src/core/features/editor/api/browser/open-file-store/open-file-store.test.ts
+++ b/apps/emdash-desktop/src/core/features/editor/api/browser/open-file-store/open-file-store.test.ts
@@ -87,17 +87,23 @@ function createManualClock(): ManualClock {
 
 class FakeFacetHandle implements FacetHandle {
   readonly descriptor: FacetDescriptor;
+  readOnly: boolean;
   disposed = false;
   private text: string;
   private readonly listeners = new Set<() => void>();
 
   constructor(descriptor: FacetDescriptor) {
     this.descriptor = descriptor;
+    this.readOnly = descriptor.readonly;
     this.text = descriptor.initialText;
   }
 
   getText(): string {
     return this.text;
+  }
+
+  setReadOnly(readOnly: boolean): void {
+    this.readOnly = readOnly;
   }
 
   setText(text: string): void {
@@ -317,6 +323,47 @@ describe('OpenFileStore', () => {
       expect(entry.dirty).toBe(false);
       expect(entry.conflicted).toBe(false);
       expect(entry.saving).toBe(false);
+    });
+
+    it('honors filesystem read-only state', async () => {
+      const h = start();
+      const ref = hostFileRefFromNativePath('/repo/linked/file.ts');
+      const bufferLease = h.store.acquire(ref, BUFFER);
+      const diskLease = h.store.acquire(ref, DISK);
+      h.publish(h.diskKey('/repo/linked/file.ts'), {
+        ...textContent('external', 'e1'),
+        readonly: true,
+      });
+
+      await waitFor(() => bufferLease.entry.handleFor(BUFFER) !== undefined);
+      expect(bufferLease.entry.status).toEqual({ kind: 'ready' });
+      expect(bufferLease.entry.readOnly).toBe(true);
+      expect(bufferHandle(bufferLease.entry).getText()).toBe('external');
+      expect(bufferHandle(bufferLease.entry).descriptor.readonly).toBe(true);
+      expect(await h.store.save(bufferLease.entry)).toEqual(err({ type: 'readonly' }));
+
+      bufferLease.release();
+      diskLease.release();
+    });
+
+    it('updates existing handles when filesystem permissions change without losing edits', async () => {
+      const h = start();
+      const filePath = '/repo/permissions.ts';
+      const { entry } = await openReady(h, filePath, 'disk');
+      const buffer = bufferHandle(entry);
+      buffer.setText('unsaved');
+      h.publish(h.diskKey(filePath), { ...textContent('disk', 'e1'), readonly: true });
+      await waitFor(() => entry.readOnly);
+      expect(buffer.readOnly).toBe(true);
+      expect(entry.handleFor(BUFFER)).toBe(buffer);
+      expect(buffer.getText()).toBe('unsaved');
+      expect(await h.store.save(entry)).toEqual(err({ type: 'readonly' }));
+
+      h.publish(h.diskKey(filePath), textContent('disk', 'e1'));
+      await waitFor(() => !entry.readOnly);
+      expect(buffer.readOnly).toBe(false);
+      expect((entry.handleFor(DISK) as FakeFacetHandle).readOnly).toBe(true);
+      expect(await h.store.save(entry)).toEqual(ok(undefined));
     });
 
     it('shares one entry and one in-flight load across spellings of the same ResourceKey', async () => {

--- a/apps/emdash-desktop/src/core/features/editor/api/browser/open-file-store/open-file-store.ts
+++ b/apps/emdash-desktop/src/core/features/editor/api/browser/open-file-store/open-file-store.ts
@@ -51,6 +51,7 @@ export type ContentStatus =
 
 export type SaveFileError =
   | { type: 'not-open' }
+  | { type: 'readonly' }
   | { type: 'no-etag' }
   | { type: 'conflict' }
   | { type: 'write-failed'; message: string };
@@ -69,6 +70,7 @@ export interface OpenFileEntry {
   readonly dirty: boolean;
   readonly conflicted: boolean;
   readonly saving: boolean;
+  readonly readOnly: boolean;
   handleFor(facet: Facet): FacetHandle | undefined;
   /** Per-ref readiness of a git snapshot facet (spec §6). */
   gitStatus(ref: GitRef): ContentStatus | undefined;
@@ -120,6 +122,7 @@ class OpenFileEntryImpl implements OpenFileEntry {
   dirty = false;
   conflicted = false;
   saving = false;
+  readOnly = false;
 
   readonly facetHandles = observable.map<string, FacetHandle>([], { deep: false });
   readonly gitStatuses = observable.map<string, ContentStatus>([], { deep: false });
@@ -151,6 +154,7 @@ class OpenFileEntryImpl implements OpenFileEntry {
       dirty: observable,
       conflicted: observable,
       saving: observable,
+      readOnly: observable,
     });
   }
 
@@ -313,6 +317,7 @@ export class OpenFileStore {
   ): Promise<Result<void, SaveFileError>> {
     const impl = this.entries.get(entry.key);
     if (!impl || impl !== entry) return err({ type: 'not-open' as const });
+    if (impl.readOnly) return err({ type: 'readonly' as const });
     const slot = impl.slots.get(BUFFER_SLOT);
     const handle = slot?.handle;
     const binding = impl.diskSource;
@@ -697,12 +702,15 @@ export class OpenFileStore {
         entry.lastDiskText = content.content;
         entry.lastDiskEtag = content.etag;
         entry.everReady = true;
+        entry.readOnly = content.readonly;
+        entry.handleFor({ kind: 'buffer' })?.setReadOnly(content.readonly);
         this.setStatus(entry, READY);
         this.ensureDiskFacetHandles(entry);
         this.applyDiskText(entry);
         return;
       }
       case 'binary':
+        entry.readOnly = content.readonly;
         this.transitionError(entry, 'binary');
         return;
       case 'too-large':
@@ -803,7 +811,7 @@ export class OpenFileStore {
       uri: entry.uri,
       facet: slot.facet,
       initialText,
-      readonly: slot.facet.kind !== 'buffer',
+      readonly: slot.facet.kind !== 'buffer' || entry.readOnly,
     };
     void this.withBinder()
       .then((binder) => binder.createHandle(descriptor))
@@ -814,6 +822,7 @@ export class OpenFileStore {
         }
         slot.pendingHandle = false;
         slot.handle = handle;
+        handle.setReadOnly(slot.facet.kind !== 'buffer' || entry.readOnly);
         runInAction(() => {
           entry.facetHandles.set(slotKey, handle);
         });

--- a/apps/emdash-desktop/src/core/features/editor/api/browser/task-editor/stores/file-tab-resource.ts
+++ b/apps/emdash-desktop/src/core/features/editor/api/browser/task-editor/stores/file-tab-resource.ts
@@ -159,6 +159,10 @@ export class FileTabResource implements TabResource {
     return this.entry?.dirty ?? false;
   }
 
+  get readOnly(): boolean {
+    return this.entry?.readOnly ?? false;
+  }
+
   /** Current buffer text; touch {@link bufferVersion} first in observers. */
   bufferText(): string {
     return this.entry?.handleFor(BUFFER)?.getText() ?? '';

--- a/apps/emdash-desktop/src/core/features/editor/browser/task-editor/editor-provider.tsx
+++ b/apps/emdash-desktop/src/core/features/editor/browser/task-editor/editor-provider.tsx
@@ -18,10 +18,7 @@ import { monacoBootstrap } from '../monaco/monaco-bootstrap';
 import { addMonacoKeyboardShortcuts, configureMonacoEditor } from '../monaco/monaco-config';
 import { registerActiveCodeEditor } from '../renderers/activeCodeEditor';
 import { DEFAULT_EDITOR_OPTIONS } from '../renderers/utils';
-import {
-  activeFilePath as getActiveFilePath,
-  activeFileResource as getActiveFileResource,
-} from './pane-selectors';
+import { activeFileResource as getActiveFileResource } from './pane-selectors';
 
 const BUFFER = { kind: 'buffer' } as const;
 
@@ -55,15 +52,15 @@ export const EditorProvider = observer(function EditorProvider({
   const liveActionDisabledReason = projectAvailabilityUi.getLiveActionDisabledReason(projectId);
   const editorScopeImplementation = {
     'editor.save': () => ({
-      availability: () =>
-        liveActionDisabledReason
-          ? disabled(liveActionDisabledReason)
-          : getActiveFilePath(paneTabManager)
-            ? enabled
-            : hidden,
+      availability: () => {
+        if (liveActionDisabledReason) return disabled(liveActionDisabledReason);
+        const resource = getActiveFileResource(paneTabManager);
+        if (!resource) return hidden;
+        return resource.readOnly ? disabled('File is read-only') : enabled;
+      },
       execute: () => {
-        const path = getActiveFilePath(paneTabManager);
-        if (path) void editorView.saveFile(path);
+        const resource = getActiveFileResource(paneTabManager);
+        if (resource && !resource.readOnly) void editorView.saveFile(resource.path);
       },
     }),
     'editor.saveAll': () => ({
@@ -126,8 +123,8 @@ export const EditorProvider = observer(function EditorProvider({
 
     addMonacoKeyboardShortcuts(editor, m, {
       onSave: () => {
-        const path = getActiveFilePath(paneTabManager);
-        if (path) void editorView.saveFile(path);
+        const resource = getActiveFileResource(paneTabManager);
+        if (resource && !resource.readOnly) void editorView.saveFile(resource.path);
       },
       onSaveAll: () => {
         void editorView.saveAllFiles();

--- a/apps/emdash-desktop/src/core/features/editor/contributions/browser/monaco/sticky-diff-editor.browser.test.tsx
+++ b/apps/emdash-desktop/src/core/features/editor/contributions/browser/monaco/sticky-diff-editor.browser.test.tsx
@@ -1,0 +1,131 @@
+import { encodeResourceUri, resourceKeyFromFileRef } from '@emdash/core/primitives/path/api';
+import { observable, runInAction } from 'mobx';
+import * as monaco from 'monaco-editor';
+import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeAll, expect, it, vi } from 'vitest';
+import { encodeFacetUri } from '@core/features/editor/api/browser/facet-binder/facet-uri';
+import { MonacoFacetBinder } from '@core/features/editor/api/browser/facet-binder/monaco-facet-binder';
+import type { OpenFileEntry } from '@core/features/editor/api/browser/open-file-store/open-file-store';
+import { hostFileRefFromNativePath } from '@core/primitives/desktop-runtime/api';
+import { StickyDiffEditor, type DiffSideModel } from './sticky-diff-editor';
+
+const runtime = vi.hoisted(() => ({ binder: null as MonacoFacetBinder | null }));
+vi.mock('@core/features/editor/browser/monaco/install-monaco-facet-binder', () => ({
+  installMonacoFacetBinder: () => runtime.binder,
+}));
+vi.mock('@core/features/editor/browser/monaco/monaco-bootstrap', () => ({
+  monacoBootstrap: { getMonaco: () => monaco, setTheme: vi.fn() },
+}));
+vi.mock('@core/features/editor/api/browser/open-file-store/open-file-store', () => ({
+  openFileStore: { save: vi.fn() },
+}));
+vi.mock('@core/manifests/browser/modal-api', () => ({ openModal: vi.fn() }));
+vi.mock('@core/primitives/theme/browser', () => ({
+  useTheme: () => ({ effectiveTheme: 'dark' }),
+}));
+
+self.MonacoEnvironment = { getWorker: () => new editorWorker() };
+const cleanups: Array<() => void | Promise<void>> = [];
+beforeAll(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+  runtime.binder = null;
+});
+
+it.each([true, false])(
+  'observes filesystem permissions with initial read-only state %s',
+  async (initialReadOnly) => {
+    const binder = new MonacoFacetBinder(async () => monaco);
+    runtime.binder = binder;
+    const ref = hostFileRefFromNativePath('/repo/permissions.txt');
+    const facet = { kind: 'buffer' } as const;
+    const handle = await binder.createHandle({
+      uri: encodeResourceUri(ref),
+      facet,
+      initialText: 'text',
+      readonly: initialReadOnly,
+    });
+    cleanups.push(() => handle.dispose());
+    const permissions = observable.object({ readOnly: initialReadOnly });
+    const entry: OpenFileEntry = {
+      key: resourceKeyFromFileRef(ref),
+      uri: encodeResourceUri(ref),
+      status: { kind: 'ready' },
+      dirty: false,
+      conflicted: false,
+      saving: false,
+      get readOnly() {
+        return permissions.readOnly;
+      },
+      handleFor: () => handle,
+      gitStatus: () => undefined,
+    };
+    const modified: DiffSideModel = {
+      kind: 'facet',
+      entry,
+      facet,
+      uri: encodeFacetUri(ref, facet),
+    };
+    const host = document.createElement('div');
+    host.style.cssText = 'width: 800px; height: 400px';
+    document.body.append(host);
+    cleanups.push(() => host.remove());
+    const root = createRoot(host);
+    cleanups.push(async () => {
+      await act(async () => {
+        root.unmount();
+      });
+    });
+    let editor: monaco.editor.IStandaloneDiffEditor | null = null;
+    await act(async () => {
+      root.render(
+        <StickyDiffEditor
+          original={{ kind: 'empty' }}
+          modified={modified}
+          filePath="permissions.txt"
+          diffStyle="split"
+          onEditorChange={(value) => {
+            editor = value;
+          }}
+        />
+      );
+    });
+    const diff = editor as monaco.editor.IStandaloneDiffEditor | null;
+    if (!diff) throw new Error('diff editor missing');
+    const right = diff.getModifiedEditor();
+    const model = right.getModel();
+    expect(right.getOption(monaco.editor.EditorOption.readOnly)).toBe(initialReadOnly);
+    const setReadOnly = async (readOnly: boolean) => {
+      await act(async () => {
+        runInAction(() => {
+          permissions.readOnly = readOnly;
+        });
+      });
+      expect(right.getOption(monaco.editor.EditorOption.readOnly)).toBe(readOnly);
+      expect(right.getModel()).toBe(model);
+      expect(diff.getOriginalEditor().getOption(monaco.editor.EditorOption.readOnly)).toBe(true);
+    };
+    await setReadOnly(false);
+    const diffUpdated = new Promise<void>((resolve) => {
+      const subscription = diff.onDidUpdateDiff(() => {
+        subscription.dispose();
+        resolve();
+      });
+      cleanups.push(() => subscription.dispose());
+    });
+    right.setPosition({ lineNumber: 1, column: 5 });
+    right.trigger('keyboard', 'type', { text: '!' });
+    expect(handle.getText()).toBe('text!');
+    await setReadOnly(true);
+    await setReadOnly(false);
+    expect(handle.getText()).toBe('text!');
+    // Finish the worker diff before unmounting its editor and models.
+    await diffUpdated;
+  }
+);

--- a/apps/emdash-desktop/src/core/features/editor/contributions/browser/monaco/sticky-diff-editor.tsx
+++ b/apps/emdash-desktop/src/core/features/editor/contributions/browser/monaco/sticky-diff-editor.tsx
@@ -26,7 +26,7 @@ export type DiffSideModel =
 export interface StickyDiffEditorProps {
   /** The old/original (left) side; null while leases are being acquired. */
   original: DiffSideModel | null;
-  /** The new/modified (right) side; editable when it is a buffer facet. */
+  /** The new/modified (right) side; editable when it is a writable buffer facet. */
   modified: DiffSideModel | null;
   /** Checkout-relative path, used by the save-conflict dialog. */
   filePath: string;
@@ -230,19 +230,19 @@ export function StickyDiffEditor({
       const modModel = modResolved.type === 'model' ? modResolved.model : emptyModel('modified');
       if (!origModel || !modModel) return;
 
+      const editable =
+        modified.kind === 'facet' &&
+        modified.facet.kind === 'buffer' &&
+        !modified.entry.readOnly &&
+        modResolved.type === 'model';
+      editor.updateOptions({ readOnly: !editable });
+
       const attached = editor.getModel();
       if (attached?.original === origModel && attached?.modified === modModel) return;
       if (attached) editor.setModel(null);
 
       editor.setModel({ original: origModel, modified: modModel });
       attachedUrisRef.current = { original: sideUri(original), modified: sideUri(modified) };
-      // Edits are only meaningful on a live buffer facet; empty stand-ins and
-      // git snapshots stay read-only.
-      const editable =
-        modified.kind === 'facet' &&
-        modified.facet.kind === 'buffer' &&
-        modResolved.type === 'model';
-      editor.updateOptions({ readOnly: !editable });
       editor.layout();
       // Restore scroll/cursor for the incoming side pair.
       installMonacoFacetBinder().restoreDiffViewState(sideUri(original), sideUri(modified), editor);

--- a/packages/core/src/runtimes/files/api/tree/state.ts
+++ b/packages/core/src/runtimes/files/api/tree/state.ts
@@ -23,6 +23,7 @@ export const fileEntrySchema = z.object({
   mtimeMs: z.number().optional(),
   symlinkTarget: z.string().nullable().optional(),
   symlinkTargetKind: symlinkTargetKindSchema.optional(),
+  symlinkTargetOutsideRoot: z.boolean().optional(),
 });
 
 export const fileTreeModelSchema = z
@@ -59,7 +60,7 @@ export const fileTreeModelSchema = z
         context.addIssue({
           code: 'custom',
           path: ['entries', entryPath, 'childrenLoaded'],
-          message: 'Only directories and in-root directory symlinks can load children',
+          message: 'Only directories and directory symlinks can load children',
         });
       }
       if (entry.kind === 'symlink' && entry.symlinkTargetKind === undefined) {
@@ -74,6 +75,13 @@ export const fileTreeModelSchema = z
           code: 'custom',
           path: ['entries', entryPath, 'symlinkTargetKind'],
           message: 'Only symlink entries can describe a symlink target kind',
+        });
+      }
+      if (entry.kind !== 'symlink' && entry.symlinkTargetOutsideRoot !== undefined) {
+        context.addIssue({
+          code: 'custom',
+          path: ['entries', entryPath, 'symlinkTargetOutsideRoot'],
+          message: 'Only symlink entries can describe target containment',
         });
       }
       if (new Set(entry.children).size !== entry.children.length) {

--- a/packages/core/src/runtimes/files/node/api/absolute-path-mutations.test.ts
+++ b/packages/core/src/runtimes/files/node/api/absolute-path-mutations.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, realpath, rm, stat, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { ok } from '@emdash/shared';
@@ -192,6 +192,72 @@ describe('files runtime fs mutations', () => {
           }
         )
       ).resolves.toMatchObject({ success: false, error: { type: 'already-exists' } });
+    } finally {
+      await dispose();
+    }
+  });
+
+  it('mutates external directory contents but deletes only the symlink entry', async () => {
+    const workspace = await makeDir();
+    const outside = await makeDir();
+    const outsideFile = path.join(outside, 'existing.txt');
+    await writeFile(outsideFile, 'keep\n');
+    try {
+      await symlink(outside, path.join(workspace, 'linked'), 'dir');
+    } catch {
+      return;
+    }
+    const { connection, dispose } = await makeRuntime();
+    const linkedPath = (name: string) => runtimeRoot(path.join(workspace, 'linked', name));
+
+    try {
+      await expect(
+        connection.api.fs.createFile({
+          path: linkedPath('created.txt'),
+        })
+      ).resolves.toMatchObject({ success: true });
+      await expect(
+        connection.api.fs.writeFile({
+          path: linkedPath('existing.txt'),
+          content: 'changed\n',
+          precondition: { kind: 'overwrite' },
+        })
+      ).resolves.toMatchObject({ success: true });
+      await expect(readFile(outsideFile, 'utf8')).resolves.toBe('changed\n');
+      await expect(
+        connection.api.fs.createDirectory({ path: linkedPath('folder') })
+      ).resolves.toMatchObject({ success: true });
+      await expect(
+        connection.api.fs.rename({ from: linkedPath('created.txt'), to: linkedPath('renamed.txt') })
+      ).resolves.toMatchObject({ success: true });
+      await expect(
+        connection.api.fs.move({
+          from: linkedPath('renamed.txt'),
+          to: linkedPath('folder/moved.txt'),
+        })
+      ).resolves.toMatchObject({ success: true });
+      const copied = path.join(workspace, 'copied.txt');
+      await expect(
+        connection.api.fs.copy({ from: linkedPath('existing.txt'), to: runtimeRoot(copied) })
+      ).resolves.toMatchObject({ success: true });
+      await expect(readFile(copied, 'utf8')).resolves.toBe('changed\n');
+      await expect(
+        connection.api.fs.delete({
+          path: linkedPath('folder/moved.txt'),
+        })
+      ).resolves.toMatchObject({ success: true });
+
+      await expect(stat(path.join(outside, 'folder/moved.txt'))).rejects.toMatchObject({
+        code: 'ENOENT',
+      });
+
+      // Removing the workspace entry itself is safe: it removes the link, not its target.
+      await expect(
+        connection.api.fs.delete({
+          path: runtimeRoot(path.join(workspace, 'linked')),
+        })
+      ).resolves.toEqual({ success: true, data: undefined });
+      await expect(readFile(outsideFile, 'utf8')).resolves.toBe('changed\n');
     } finally {
       await dispose();
     }

--- a/packages/core/src/runtimes/files/node/api/absolute-path.test.ts
+++ b/packages/core/src/runtimes/files/node/api/absolute-path.test.ts
@@ -1,4 +1,13 @@
-import { chmod, mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises';
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { ok } from '@emdash/shared';
@@ -266,6 +275,58 @@ describe('files runtime absolute-path content', () => {
       await dispose();
     }
   });
+
+  it.each(['directory', 'file'] as const)(
+    'reads and edits an external %s symlink',
+    async (kind) => {
+      const workspace = await makeDir();
+      const outside = await makeDir();
+      const outsideFile = path.join(outside, 'target.txt');
+      await writeFile(outsideFile, 'outside\n');
+      try {
+        await symlink(
+          kind === 'directory' ? outside : outsideFile,
+          path.join(workspace, 'linked'),
+          kind === 'directory' ? 'dir' : 'file'
+        );
+      } catch {
+        return;
+      }
+      const { connection, dispose } = await makeRuntime();
+      const key = {
+        path: runtimeRoot(
+          path.join(workspace, 'linked', ...(kind === 'directory' ? ['target.txt'] : []))
+        ),
+      };
+
+      try {
+        const snapshot = await connection.api.content.state(key, 'content').snapshot();
+        expect(snapshot.data).toMatchObject({
+          kind: 'text',
+          content: 'outside\n',
+          readonly: false,
+        });
+        if (snapshot.data.kind !== 'text') throw new Error('Expected text content');
+
+        await expect(
+          connection.api.content.mutate('write', {
+            key,
+            input: {
+              content: 'changed\n',
+              precondition: { kind: 'etag', etag: snapshot.data.etag },
+            },
+          })
+        ).resolves.toMatchObject({ success: true });
+        await expect(readFile(outsideFile, 'utf8')).resolves.toBe('changed\n');
+        await expect(connection.api.fs.readText(key)).resolves.toMatchObject({
+          success: true,
+          data: { content: 'changed\n' },
+        });
+      } finally {
+        await dispose();
+      }
+    }
+  );
 
   it('rejects the filesystem root itself as an absolute file key', async () => {
     const { connection, dispose } = await makeRuntime();

--- a/packages/core/src/runtimes/files/node/api/controller.test.ts
+++ b/packages/core/src/runtimes/files/node/api/controller.test.ts
@@ -197,7 +197,7 @@ describe('createFilesController', () => {
     }
   });
 
-  it('cannot follow an outside-parent symlink but deletes the link itself', async () => {
+  it('reads an outside-parent symlink and deletes only the link itself', async () => {
     const root = await makeRoot();
     const outside = await makeRoot();
     const outsideFile = path.join(outside, 'outside.txt');
@@ -213,7 +213,7 @@ describe('createFilesController', () => {
     try {
       await expect(
         connection.api.fs.readText({ path: runtimeRoot(path.join(root, 'outside-link')) })
-      ).resolves.toMatchObject({ success: false, error: { type: 'invalid-path' } });
+      ).resolves.toMatchObject({ success: true, data: { content: 'keep' } });
       await expect(
         connection.api.fs.delete({ path: runtimeRoot(path.join(root, 'outside-link')) })
       ).resolves.toMatchObject({ success: true });

--- a/packages/core/src/runtimes/files/node/fs/path-policy.test.ts
+++ b/packages/core/src/runtimes/files/node/fs/path-policy.test.ts
@@ -28,7 +28,7 @@ describe('RootPathPolicy', () => {
     expect(normalizeRelativePath('src\\file').success).toBe(path.sep !== '\\');
   });
 
-  it('rejects followed paths that escape through a symlink', async () => {
+  it('follows external symlinks while reporting target containment', async () => {
     const root = await makeRoot();
     const outside = await makeRoot();
     await mkdir(path.join(outside, 'target'));
@@ -40,8 +40,8 @@ describe('RootPathPolicy', () => {
 
     const policy = new RootPathPolicy(root);
     await expect(policy.resolveFollowed('linked')).resolves.toMatchObject({
-      success: false,
-      error: { type: 'invalid-path' },
+      success: true,
+      data: { realPath: path.join(outside, 'target'), outsideRoot: true },
     });
     expect(policy.resolveEntry('linked')).toMatchObject({ success: true });
   });

--- a/packages/core/src/runtimes/files/node/fs/path-policy.ts
+++ b/packages/core/src/runtimes/files/node/fs/path-policy.ts
@@ -16,6 +16,7 @@ export type ResolvedEntryPath = {
 
 export type ResolvedFollowedPath = ResolvedEntryPath & {
   realPath: string;
+  outsideRoot: boolean;
 };
 
 export type ResolvedExistingEntryPath = ResolvedEntryPath & {
@@ -39,15 +40,17 @@ export class RootPathPolicy {
     return ok({ path: normalized.data, absolutePath });
   }
 
+  /** The root anchors the path; following an explicit symlink uses OS permissions. */
   async resolveFollowed(entryPath: string): Promise<Result<ResolvedFollowedPath, FsError>> {
     const entry = this.resolveEntry(entryPath);
     if (!entry.success) return entry;
     try {
       const canonical = await realpath(entry.data.absolutePath);
-      if (!containsPath(this.rootPath, canonical)) {
-        return err(invalidPath(entry.data.path, 'Path resolves outside the workspace root'));
-      }
-      return ok({ ...entry.data, realPath: canonical });
+      return ok({
+        ...entry.data,
+        realPath: canonical,
+        outsideRoot: !containsPath(this.rootPath, canonical),
+      });
     } catch (error) {
       return err(toFsError(error, entry.data.path));
     }

--- a/packages/core/src/runtimes/files/node/tree/directory-reader.test.ts
+++ b/packages/core/src/runtimes/files/node/tree/directory-reader.test.ts
@@ -18,10 +18,13 @@ describe('TreeDirectoryReader', () => {
     const root = await makeRoot();
     const outside = await makeRoot();
     await mkdir(path.join(root, 'z-directory'));
+    await mkdir(path.join(outside, 'nested'));
     await writeFile(path.join(root, 'a.txt'), 'a');
     await writeFile(path.join(outside, 'outside.txt'), 'outside');
+    await writeFile(path.join(outside, 'nested', 'child.txt'), 'child');
     try {
       await symlink('z-directory', path.join(root, 'linked-directory'), 'dir');
+      await symlink(path.join(outside, 'nested'), path.join(root, 'outside-directory'), 'dir');
       await symlink(path.join(outside, 'outside.txt'), path.join(root, 'outside-file'), 'file');
       await symlink('missing', path.join(root, 'missing-link'), 'file');
     } catch {
@@ -35,6 +38,7 @@ describe('TreeDirectoryReader', () => {
     if (!result.success) return;
     expect(result.data.map((entry) => entry.name)).toEqual([
       'linked-directory',
+      'outside-directory',
       'z-directory',
       'a.txt',
       'missing-link',
@@ -45,7 +49,8 @@ describe('TreeDirectoryReader', () => {
       symlinkTargetKind: 'directory',
     });
     expect(result.data.find((entry) => entry.name === 'outside-file')).toMatchObject({
-      symlinkTargetKind: 'outside-root',
+      symlinkTargetKind: 'file',
+      symlinkTargetOutsideRoot: true,
     });
     expect(result.data.find((entry) => entry.name === 'missing-link')).toMatchObject({
       symlinkTargetKind: 'missing',
@@ -53,6 +58,22 @@ describe('TreeDirectoryReader', () => {
     const linked = result.data.find((entry) => entry.name === 'linked-directory');
     expect(linked && isExpandableFileEntry(linked)).toBe(true);
     expect(linked && 'expandable' in linked).toBe(false);
+
+    const outsideDirectory = result.data.find((entry) => entry.name === 'outside-directory');
+    expect(outsideDirectory).toMatchObject({
+      kind: 'symlink',
+      symlinkTargetKind: 'directory',
+      symlinkTargetOutsideRoot: true,
+    });
+    expect(outsideDirectory && isExpandableFileEntry(outsideDirectory)).toBe(true);
+
+    const outsideChildren = await new TreeDirectoryReader(new RootPathPolicy(root)).readChildren(
+      relativePath('outside-directory')
+    );
+    expect(outsideChildren).toMatchObject({
+      success: true,
+      data: [{ path: 'outside-directory/child.txt', kind: 'file' }],
+    });
   });
 });
 

--- a/packages/core/src/runtimes/files/node/tree/directory-reader.ts
+++ b/packages/core/src/runtimes/files/node/tree/directory-reader.ts
@@ -77,6 +77,7 @@ export class TreeDirectoryReader {
           kind: 'symlink',
           symlinkTarget: target.target,
           symlinkTargetKind: target.kind,
+          symlinkTargetOutsideRoot: target.outsideRoot,
           ...(target.stat && target.kind === 'file' ? { etag: etagForStat(target.stat) } : {}),
         });
       }
@@ -95,6 +96,7 @@ async function classifySymlink(
 ): Promise<{
   target: string | null;
   kind: SymlinkTargetKind;
+  outsideRoot: boolean;
   stat?: { mtimeMs: number; size: number };
 }> {
   let target: string | null = null;
@@ -105,17 +107,20 @@ async function classifySymlink(
   }
 
   try {
-    const canonical = await realpath(absolutePath);
-    if (!containsPath(rootPath, canonical)) return { target, kind: 'outside-root' };
     const metadata = await stat(absolutePath);
+    const canonical = await realpath(absolutePath);
     const statMetadata = { mtimeMs: Number(metadata.mtimeMs), size: Number(metadata.size) };
-    if (metadata.isDirectory()) return { target, kind: 'directory', stat: statMetadata };
-    if (metadata.isFile()) return { target, kind: 'file', stat: statMetadata };
-    return { target, kind: 'other', stat: statMetadata };
+    const outsideRoot = !containsPath(rootPath, canonical);
+    if (metadata.isDirectory()) {
+      return { target, kind: 'directory', outsideRoot, stat: statMetadata };
+    }
+    if (metadata.isFile()) return { target, kind: 'file', outsideRoot, stat: statMetadata };
+    return { target, kind: 'other', outsideRoot, stat: statMetadata };
   } catch (error) {
     return {
       target,
       kind: (error as NodeJS.ErrnoException).code === 'ENOENT' ? 'missing' : 'other',
+      outsideRoot: false,
     };
   }
 }

--- a/packages/ui/src/react/components/file-tree/file-tree-utils.test.ts
+++ b/packages/ui/src/react/components/file-tree/file-tree-utils.test.ts
@@ -133,6 +133,9 @@ describe('file-tree utils', () => {
     expect(isOpenableFileTreeNode(directoryLink)).toBe(false);
     expect(isExpandableFileTreeNode(fileLink)).toBe(false);
     expect(isOpenableFileTreeNode(fileLink)).toBe(true);
+    for (const symlinkTargetKind of ['missing', 'other', 'outside-root'] as const) {
+      expect(isOpenableFileTreeNode({ ...fileLink, symlinkTargetKind })).toBe(false);
+    }
   });
 
   it('resolves drop targets for directories, files, and root space', () => {

--- a/packages/ui/src/react/components/file-tree/file-tree-utils.ts
+++ b/packages/ui/src/react/components/file-tree/file-tree-utils.ts
@@ -62,9 +62,7 @@ export function isExpandableFileTreeNode(node: FileTreeNode): boolean {
 }
 
 export function isOpenableFileTreeNode(node: FileTreeNode): boolean {
-  return (
-    node.type === 'file' || (node.type === 'symlink' && node.symlinkTargetKind !== 'directory')
-  );
+  return node.type === 'file' || (node.type === 'symlink' && node.symlinkTargetKind === 'file');
 }
 
 export function normalizeFileTreePath(path: string): string {


### PR DESCRIPTION
- allow file tree browsing and edits through symlinks whose targets live outside the workspace
- classify external symlink targets by their real file type so directories expand and files open
- preserve safe symlink deletion by removing the link without deleting its target
- synchronize filesystem read-only state with open editor buffers and save actions
- update attached Monaco editors without replacing models or losing undo history