### PR TITLE
fix(pull-requests): poll active checks until completion

### DIFF
--- a/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/checks-list.tsx
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/checks-list.tsx
@@ -11,7 +11,6 @@ import {
 } from '@core/features/github/api/browser/checks';
 import { openExternal } from '@core/primitives/desktop-host/browser/host-client';
 import type { PullRequest, PullRequestComment } from '@core/services/pull-requests/api';
-import { useSyncCheckRuns } from '../../../state/use-check-runs';
 import { CommentsList } from './comments-list';
 import { buildPullRequestConversationItems } from './pull-request-conversation';
 import { usePullRequestComments } from './use-pull-request-comments';
@@ -96,11 +95,12 @@ export function ChecksList({ checks }: { checks: CheckRun[] }) {
 export const PrChecksList = observer(function PrChecksList({
   projectId,
   pr,
+  checks,
 }: {
   projectId: string;
   pr: PullRequest;
+  checks: CheckRun[];
 }) {
-  const { checks } = useSyncCheckRuns(pr);
   const commentsQuery = usePullRequestComments(projectId, pr);
   const comments = commentsQuery.data ?? EMPTY_COMMENTS;
   const conversationItems = useMemo(

--- a/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/pr-entry.tsx
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/changes-panel/components/pr-entry/pr-entry.tsx
@@ -11,6 +11,7 @@ import { PrMergeLine } from '@root/src/core/services/pull-requests/browser/compo
 import { PrNumberBadge } from '@root/src/core/services/pull-requests/browser/components/pr-number-badge';
 import { StatusIcon } from '@root/src/core/services/pull-requests/browser/components/pr-status-icon';
 import { PrUrlCopyButton } from '@root/src/core/services/pull-requests/browser/components/pr-url-copy-button';
+import { useSyncCheckRuns } from '../../../state/use-check-runs';
 import { PrCheckoutDriftLine } from './checkout-drift-line';
 import { PrChecksList } from './checks-list';
 import { CommitRangeCommitsList } from './commits-list';
@@ -55,6 +56,7 @@ export const PullRequestEntry = observer(function PullRequestEntry({ pr }: { pr:
   const [isMarkingReady, setIsMarkingReady] = useState(false);
   const [bypassRequirements, setBypassRequirements] = useState(false);
   const [isUpdatingCheckout, setIsUpdatingCheckout] = useState(false);
+  const { checks } = useSyncCheckRuns(pr);
   if (!diffView) return null;
   const tab = diffView.effectivePrTab;
   const isOpen = pr.status === 'open';
@@ -164,7 +166,7 @@ export const PullRequestEntry = observer(function PullRequestEntry({ pr }: { pr:
         <div className="min-h-0 flex-1 overflow-y-auto">
           {tab === 'files' && <PrFilesList pr={pr} />}
           {tab === 'commits' && <CommitRangeCommitsList range={commitRangeForPullRequest(pr)} />}
-          {tab === 'checks' && <PrChecksList projectId={projectId} pr={pr} />}
+          {tab === 'checks' && <PrChecksList projectId={projectId} pr={pr} checks={checks} />}
         </div>
       </div>
       {pr.status === 'open' && (

--- a/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/state/use-check-runs.test.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/state/use-check-runs.test.ts
@@ -205,11 +205,72 @@ describe('useSyncCheckRuns', () => {
     expect(syncChecks).toHaveBeenCalledTimes(3);
   });
 
-  it('keeps the current checks when a refresh fails without starting a retry loop', async () => {
+  it('waits to sync when the pull request view mounts hidden', async () => {
     const syncChecks = vi.fn().mockResolvedValue({
-      success: false,
-      error: { type: 'refresh_failed', message: 'GitHub is unavailable' },
+      success: true,
+      data: { hasRunning: false },
     });
+    mocks.getPullRequestsRuntimeClient.mockResolvedValue({ syncChecks });
+    Object.defineProperty(document, 'hidden', { configurable: true, value: true });
+
+    await act(async () => {
+      root.render(React.createElement(Probe));
+      await flushAsyncWork();
+    });
+    expect(syncChecks).not.toHaveBeenCalled();
+
+    Object.defineProperty(document, 'hidden', { configurable: true, value: false });
+    await act(async () => {
+      document.dispatchEvent(new dom.window.Event('visibilitychange'));
+      await flushAsyncWork();
+    });
+    expect(syncChecks).toHaveBeenCalledOnce();
+  });
+
+  it('does not sync when the client resolves after the view is hidden', async () => {
+    const syncChecks = vi.fn().mockResolvedValue({
+      success: true,
+      data: { hasRunning: false },
+    });
+    let resolveClient: ((value: { syncChecks: typeof syncChecks }) => void) | null = null;
+    mocks.getPullRequestsRuntimeClient.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveClient = resolve;
+        })
+    );
+
+    await act(async () => {
+      root.render(React.createElement(Probe));
+      await flushAsyncWork();
+    });
+
+    Object.defineProperty(document, 'hidden', { configurable: true, value: true });
+    document.dispatchEvent(new dom.window.Event('visibilitychange'));
+    await act(async () => {
+      resolveClient?.({ syncChecks });
+      await flushAsyncWork();
+    });
+    expect(syncChecks).not.toHaveBeenCalled();
+
+    Object.defineProperty(document, 'hidden', { configurable: true, value: false });
+    await act(async () => {
+      document.dispatchEvent(new dom.window.Event('visibilitychange'));
+      await flushAsyncWork();
+    });
+    expect(syncChecks).toHaveBeenCalledOnce();
+  });
+
+  it('keeps polling through refresh failures until checks complete', async () => {
+    const syncChecks = vi
+      .fn()
+      .mockResolvedValueOnce({
+        success: false,
+        error: { type: 'checks_failed', message: 'GitHub is unavailable' },
+      })
+      .mockResolvedValueOnce({ success: true, data: { hasRunning: true } })
+      .mockRejectedValueOnce(new Error('The connection was interrupted'))
+      .mockResolvedValueOnce({ success: true, data: { hasRunning: false } });
     mocks.getPullRequestsRuntimeClient.mockResolvedValue({ syncChecks });
 
     await act(async () => {
@@ -217,6 +278,31 @@ describe('useSyncCheckRuns', () => {
       await flushAsyncWork();
     });
     await act(async () => {
+      await vi.advanceTimersByTimeAsync(CHECK_RUN_POLL_INTERVAL_MS * 3);
+    });
+
+    expect(syncChecks).toHaveBeenCalledTimes(4);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(CHECK_RUN_POLL_INTERVAL_MS * 2);
+    });
+    expect(syncChecks).toHaveBeenCalledTimes(4);
+  });
+
+  it('stops polling after a non-retryable refresh error', async () => {
+    const syncChecks = vi.fn().mockResolvedValue({
+      success: false,
+      error: {
+        type: 'github_auth_required',
+        host: 'github.com',
+        hint: 'Connect GitHub from account settings.',
+      },
+    });
+    mocks.getPullRequestsRuntimeClient.mockResolvedValue({ syncChecks });
+
+    await act(async () => {
+      root.render(React.createElement(Probe));
+      await flushAsyncWork();
       await vi.advanceTimersByTimeAsync(CHECK_RUN_POLL_INTERVAL_MS * 2);
     });
 

--- a/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/state/use-check-runs.test.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/state/use-check-runs.test.ts
@@ -1,0 +1,225 @@
+import { JSDOM } from 'jsdom';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PullRequest } from '@core/services/pull-requests/api';
+import { CHECK_RUN_POLL_INTERVAL_MS, useSyncCheckRuns } from './use-check-runs';
+
+const mocks = vi.hoisted(() => ({
+  getPullRequestsRuntimeClient: vi.fn(),
+}));
+
+vi.mock('@core/services/pull-requests/api/client', () => ({
+  getPullRequestsRuntimeClient: mocks.getPullRequestsRuntimeClient,
+}));
+
+const pullRequest = {
+  repositoryUrl: 'https://github.com/generalaction/emdash',
+  url: 'https://github.com/generalaction/emdash/pull/1',
+  headRefOid: 'head-1',
+  checks: [],
+} as unknown as PullRequest;
+
+async function flushAsyncWork() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('useSyncCheckRuns', () => {
+  let dom: JSDOM;
+  let root: Root;
+
+  beforeEach(() => {
+    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>');
+    Object.defineProperty(dom.window.document, 'hidden', { configurable: true, value: false });
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.useFakeTimers();
+    root = createRoot(dom.window.document.getElementById('root') as HTMLDivElement);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    dom.window.close();
+  });
+
+  function Probe({ pr = pullRequest }: { pr?: PullRequest }) {
+    useSyncCheckRuns(pr);
+    return null;
+  }
+
+  it('polls active checks until they complete', async () => {
+    const syncChecks = vi
+      .fn()
+      .mockResolvedValueOnce({ success: true, data: { hasRunning: true } })
+      .mockResolvedValueOnce({ success: true, data: { hasRunning: true } })
+      .mockResolvedValueOnce({ success: true, data: { hasRunning: false } });
+    mocks.getPullRequestsRuntimeClient.mockResolvedValue({ syncChecks });
+
+    await act(async () => {
+      root.render(React.createElement(Probe));
+      await flushAsyncWork();
+    });
+
+    expect(syncChecks).toHaveBeenCalledOnce();
+    expect(syncChecks).toHaveBeenCalledWith(
+      {
+        repositoryUrl: pullRequest.repositoryUrl,
+        pullRequestUrl: pullRequest.url,
+        headRefOid: pullRequest.headRefOid,
+      },
+      { signal: expect.any(AbortSignal) }
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(CHECK_RUN_POLL_INTERVAL_MS);
+    });
+    expect(syncChecks).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(CHECK_RUN_POLL_INTERVAL_MS);
+    });
+    expect(syncChecks).toHaveBeenCalledTimes(3);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(CHECK_RUN_POLL_INTERVAL_MS * 2);
+    });
+    expect(syncChecks).toHaveBeenCalledTimes(3);
+  });
+
+  it('cancels an in-flight refresh when the pull request view unmounts', async () => {
+    let resolveInFlight:
+      | ((value: { success: true; data: { hasRunning: boolean } }) => void)
+      | null = null;
+    const syncChecks = vi
+      .fn()
+      .mockResolvedValueOnce({ success: true, data: { hasRunning: true } })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveInFlight = resolve;
+          })
+      );
+    mocks.getPullRequestsRuntimeClient.mockResolvedValue({ syncChecks });
+
+    await act(async () => {
+      root.render(React.createElement(Probe));
+      await flushAsyncWork();
+    });
+    expect(syncChecks).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(CHECK_RUN_POLL_INTERVAL_MS);
+    });
+    expect(syncChecks).toHaveBeenCalledTimes(2);
+    const signal = syncChecks.mock.calls[1]?.[1]?.signal as AbortSignal;
+    expect(signal.aborted).toBe(false);
+
+    await act(async () => root.render(null));
+    expect(signal.aborted).toBe(true);
+
+    await act(async () => {
+      resolveInFlight?.({ success: true, data: { hasRunning: true } });
+      await flushAsyncWork();
+      await vi.advanceTimersByTimeAsync(CHECK_RUN_POLL_INTERVAL_MS);
+    });
+
+    expect(syncChecks).toHaveBeenCalledTimes(2);
+  });
+
+  it('aborts the old refresh before syncing a new head', async () => {
+    let resolveOldHead: ((value: { success: true; data: { hasRunning: boolean } }) => void) | null =
+      null;
+    const syncChecks = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveOldHead = resolve;
+          })
+      )
+      .mockResolvedValueOnce({ success: true, data: { hasRunning: false } });
+    mocks.getPullRequestsRuntimeClient.mockResolvedValue({ syncChecks });
+
+    await act(async () => {
+      root.render(React.createElement(Probe));
+      await flushAsyncWork();
+    });
+    const oldSignal = syncChecks.mock.calls[0]?.[1]?.signal as AbortSignal;
+    expect(oldSignal.aborted).toBe(false);
+
+    const newHead = { ...pullRequest, headRefOid: 'head-2' };
+    await act(async () => {
+      root.render(React.createElement(Probe, { pr: newHead }));
+      await flushAsyncWork();
+    });
+
+    expect(oldSignal.aborted).toBe(true);
+    expect(syncChecks).toHaveBeenCalledTimes(2);
+    expect(syncChecks.mock.calls[1]?.[0]).toMatchObject({ headRefOid: 'head-2' });
+
+    await act(async () => {
+      resolveOldHead?.({ success: true, data: { hasRunning: true } });
+      await flushAsyncWork();
+      await vi.advanceTimersByTimeAsync(CHECK_RUN_POLL_INTERVAL_MS);
+    });
+    expect(syncChecks).toHaveBeenCalledTimes(2);
+  });
+
+  it('pauses polling while hidden and refreshes on return', async () => {
+    const syncChecks = vi
+      .fn()
+      .mockResolvedValueOnce({ success: true, data: { hasRunning: true } })
+      .mockResolvedValueOnce({ success: true, data: { hasRunning: true } })
+      .mockResolvedValueOnce({ success: true, data: { hasRunning: false } });
+    mocks.getPullRequestsRuntimeClient.mockResolvedValue({ syncChecks });
+
+    await act(async () => {
+      root.render(React.createElement(Probe));
+      await flushAsyncWork();
+    });
+    expect(syncChecks).toHaveBeenCalledOnce();
+
+    Object.defineProperty(document, 'hidden', { configurable: true, value: true });
+    document.dispatchEvent(new dom.window.Event('visibilitychange'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(CHECK_RUN_POLL_INTERVAL_MS * 2);
+    });
+    expect(syncChecks).toHaveBeenCalledOnce();
+
+    Object.defineProperty(document, 'hidden', { configurable: true, value: false });
+    await act(async () => {
+      document.dispatchEvent(new dom.window.Event('visibilitychange'));
+      await flushAsyncWork();
+    });
+    expect(syncChecks).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(CHECK_RUN_POLL_INTERVAL_MS);
+    });
+    expect(syncChecks).toHaveBeenCalledTimes(3);
+  });
+
+  it('keeps the current checks when a refresh fails without starting a retry loop', async () => {
+    const syncChecks = vi.fn().mockResolvedValue({
+      success: false,
+      error: { type: 'refresh_failed', message: 'GitHub is unavailable' },
+    });
+    mocks.getPullRequestsRuntimeClient.mockResolvedValue({ syncChecks });
+
+    await act(async () => {
+      root.render(React.createElement(Probe));
+      await flushAsyncWork();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(CHECK_RUN_POLL_INTERVAL_MS * 2);
+    });
+
+    expect(syncChecks).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/state/use-check-runs.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/state/use-check-runs.ts
@@ -1,9 +1,15 @@
 import { useEffect, useMemo } from 'react';
 import { computeCheckRunsSummary, type CheckRun } from '@core/features/github/api/browser/checks';
-import type { PullRequest } from '@core/services/pull-requests/api';
+import type { PullRequest, PullRequestError } from '@core/services/pull-requests/api';
 import { getPullRequestsRuntimeClient } from '@core/services/pull-requests/api/client';
 
 export const CHECK_RUN_POLL_INTERVAL_MS = 10_000;
+
+const retryableCheckSyncErrors = new Set<PullRequestError['type']>([
+  'host_unreachable',
+  'github_rate_limited',
+  'checks_failed',
+]);
 
 export function useSyncCheckRuns(pr: PullRequest) {
   const checks = useMemo(() => pr.checks as CheckRun[], [pr.checks]);
@@ -32,7 +38,7 @@ export function useSyncCheckRuns(pr: PullRequest) {
     };
 
     const sync = async () => {
-      if (disposed || inFlight || !client) return;
+      if (disposed || document.hidden || inFlight || !client) return;
       inFlight = true;
       try {
         const result = await client.syncChecks(
@@ -43,10 +49,13 @@ export function useSyncCheckRuns(pr: PullRequest) {
           },
           { signal: controller.signal }
         );
-        hasRunning = result.success && result.data.hasRunning;
+        if (result.success) {
+          hasRunning = result.data.hasRunning;
+        } else if (!retryableCheckSyncErrors.has(result.error.type)) {
+          hasRunning = false;
+        }
       } catch {
-        hasRunning = false;
-        // The existing checks remain renderable when a background refresh fails.
+        // A failed refresh does not prove that active checks have completed.
       } finally {
         inFlight = false;
         schedulePoll();

--- a/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/state/use-check-runs.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/diff-view/state/use-check-runs.ts
@@ -3,22 +3,82 @@ import { computeCheckRunsSummary, type CheckRun } from '@core/features/github/ap
 import type { PullRequest } from '@core/services/pull-requests/api';
 import { getPullRequestsRuntimeClient } from '@core/services/pull-requests/api/client';
 
+export const CHECK_RUN_POLL_INTERVAL_MS = 10_000;
+
 export function useSyncCheckRuns(pr: PullRequest) {
   const checks = useMemo(() => pr.checks as CheckRun[], [pr.checks]);
   const summary = useMemo(() => computeCheckRunsSummary(checks), [checks]);
 
   useEffect(() => {
+    let disposed = false;
+    let hasRunning = true;
+    let inFlight = false;
+    let pollTimer: ReturnType<typeof setTimeout> | undefined;
+    let client: Awaited<ReturnType<typeof getPullRequestsRuntimeClient>> | undefined;
+    const controller = new AbortController();
+
+    const clearPollTimer = () => {
+      if (pollTimer !== undefined) clearTimeout(pollTimer);
+      pollTimer = undefined;
+    };
+
+    const schedulePoll = () => {
+      clearPollTimer();
+      if (disposed || document.hidden || !hasRunning) return;
+      pollTimer = setTimeout(() => {
+        pollTimer = undefined;
+        void sync();
+      }, CHECK_RUN_POLL_INTERVAL_MS);
+    };
+
+    const sync = async () => {
+      if (disposed || inFlight || !client) return;
+      inFlight = true;
+      try {
+        const result = await client.syncChecks(
+          {
+            repositoryUrl: pr.repositoryUrl,
+            pullRequestUrl: pr.url,
+            headRefOid: pr.headRefOid,
+          },
+          { signal: controller.signal }
+        );
+        hasRunning = result.success && result.data.hasRunning;
+      } catch {
+        hasRunning = false;
+        // The existing checks remain renderable when a background refresh fails.
+      } finally {
+        inFlight = false;
+        schedulePoll();
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        clearPollTimer();
+      } else if (hasRunning) {
+        void sync();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
     void getPullRequestsRuntimeClient()
-      .then(async (client) => {
-        await client.syncChecks({
-          repositoryUrl: pr.repositoryUrl,
-          pullRequestUrl: pr.url,
-          headRefOid: pr.headRefOid,
-        });
+      .then((runtimeClient) => {
+        if (disposed) return;
+        client = runtimeClient;
+        void sync();
       })
       .catch(() => {
+        hasRunning = false;
         // The existing checks remain renderable when a background refresh fails.
       });
+
+    return () => {
+      disposed = true;
+      controller.abort();
+      clearPollTimer();
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
   }, [pr.headRefOid, pr.repositoryUrl, pr.url]);
 
   return {


### PR DESCRIPTION
### Description

GitHub checks can still be queued or running after the pull request view loads. Emdash currently fetches them once, so the checks list and merge status can stay stale until the view is reopened.

This change keeps refreshing while a check is active and stops after all checks finish. Polling continues when moving between pull request tabs, pauses while the window is hidden, and cancels cleanly when the pull request head changes or the view closes.

### Related issues

Fixes #3164

### Testing

- Focused `use-check-runs.test.ts` Vitest suite: 5 passed
- `oxfmt --check` on the four touched files
- `oxlint` on the four touched files

### Screenshot/Recording (if applicable)

Not applicable; behavior is covered by the hook tests.

<details>
<summary>Checklist</summary>

- [ ] I kept this PR small and focused
- [ ] I ran a self-review before opening this PR
- [ ] I ran the relevant local checks or explained why not
- [ ] I updated docs when behavior or setup changed
- [ ] I added or updated tests when behavior changed, or explained why not
- [ ] I only added comments where the logic is not obvious
- [ ] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>