### PR TITLE
fix(tui-agents): distinguish missing tmux from dead sessions in sweep and reconcile

### DIFF
--- a/packages/core/src/runtimes/tui-agents/node/runtime/runtime.test.ts
+++ b/packages/core/src/runtimes/tui-agents/node/runtime/runtime.test.ts
@@ -825,6 +825,43 @@ describe('TuiAgentsRuntime', () => {
     await runtime.dispose();
   });
 
+  it('resumes non-tmux intents when tmux is unavailable without vetoing the run', async () => {
+    const intents = createMemorySessionIntentStore();
+    await intents.saveActive({
+      conversationId: 'conversation-1',
+      sessionId: 'provider-session',
+      payload: { ...startInput({ sessionId: 'provider-session' }) },
+    });
+    await intents.saveActive({
+      conversationId: 'conversation-2',
+      sessionId: 'tmux-session',
+      payload: {
+        ...startInput({ conversationId: 'conversation-2', sessionId: 'tmux-session' }),
+        tmuxSessionName: makeLegacyTmuxSessionName('project:task:conversation-2'),
+      },
+    });
+    const exec = vi.fn(() => Promise.reject(missingTmuxError()));
+    const { runtime, spawner } = createRuntime({ intents, exec: { exec }, platform: 'linux' });
+
+    await runtime.reconcile();
+    await flushIntentWrites();
+
+    expect(spawner.specs).toHaveLength(1);
+    expect(peek(runtime.sessionsLiveModel.get(undefined)!.states.list)).toHaveProperty(
+      'conversation-1'
+    );
+    expect(peek(runtime.sessionsLiveModel.get(undefined)!.states.list)).not.toHaveProperty(
+      'conversation-2'
+    );
+    expect(intents.snapshot()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ conversationId: 'conversation-1', status: 'active' }),
+        expect.objectContaining({ conversationId: 'conversation-2', status: 'active' }),
+      ])
+    );
+    await runtime.dispose();
+  });
+
   it('keeps tmux sessions across sweeps when the tmux binary is missing', async () => {
     const clock = createManualClock(0);
     const exec = vi.fn(() => Promise.reject(missingTmuxError()));

--- a/packages/core/src/runtimes/tui-agents/node/runtime/runtime.test.ts
+++ b/packages/core/src/runtimes/tui-agents/node/runtime/runtime.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { ok } from '@emdash/shared';
 import { noopLogger } from '@emdash/shared/logger';
 import { createManualClock, type ManualClock } from '@emdash/shared/testing';
@@ -109,6 +110,20 @@ function startInput(overrides: Partial<TuiAgentStartInput> = {}): TuiAgentStartI
     rows: 30,
     ...overrides,
   };
+}
+
+/** Mirrors the BoundExec spawn failure when the tmux executable is not on PATH. */
+function missingTmuxError(): Error {
+  return Object.assign(new Error('spawn tmux ENOENT'), {
+    exitCode: null,
+    stderr: 'spawn tmux ENOENT',
+    cause: Object.assign(new Error('spawn tmux ENOENT'), { code: 'ENOENT' }),
+  });
+}
+
+/** Lifecycle intent writes are queued behind promise microtasks; let them land. */
+function flushIntentWrites(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 50));
 }
 
 describe('TuiAgentsRuntime', () => {
@@ -372,7 +387,7 @@ describe('TuiAgentsRuntime', () => {
       startInput({ conversationId: 'conversation-2', trustWorkspace: true })
     );
     expect(trustWorkspace).toHaveBeenCalledWith(expect.any(Object), {
-      workspacePath: '/workspace',
+      workspacePath: path.normalize('/workspace'),
     });
   });
 
@@ -416,7 +431,7 @@ describe('TuiAgentsRuntime', () => {
   });
 
   it('wraps command execution with shellSetup and tmux', async () => {
-    const { runtime, spawner } = createRuntime();
+    const { runtime, spawner } = createRuntime({ platform: 'linux' });
 
     await runtime.startSession(
       startInput({
@@ -437,7 +452,7 @@ describe('TuiAgentsRuntime', () => {
   });
 
   it('resolves a readable metadata-backed tmux session from its stable identity', async () => {
-    const { runtime, spawner, exec } = createRuntime();
+    const { runtime, spawner, exec } = createRuntime({ platform: 'linux' });
 
     await runtime.startSession(
       startInput({
@@ -555,7 +570,7 @@ describe('TuiAgentsRuntime', () => {
       stdout: `${sessionName}\t42\tv1:${encodedIdentity}\n`,
       stderr: '',
     }));
-    const { runtime, spawner } = createRuntime({ exec: { exec } });
+    const { runtime, spawner } = createRuntime({ exec: { exec }, platform: 'linux' });
 
     await runtime.startSession(startInput({ tmux: { identity } }));
     await runtime.stopSession('conversation-1');
@@ -638,6 +653,7 @@ describe('TuiAgentsRuntime', () => {
       clock,
       lifecycle: { session: { kind: 'idle-after', outputMs: 1_000 }, sweepIntervalMs: 1_100 },
       exec: { exec },
+      platform: 'linux',
     });
 
     const identity = 'project:task:conversation-1';
@@ -682,6 +698,7 @@ describe('TuiAgentsRuntime', () => {
     const { runtime, spawner } = createRuntime({
       intents,
       exec: { exec },
+      platform: 'linux',
     });
 
     await runtime.reconcile();
@@ -698,7 +715,7 @@ describe('TuiAgentsRuntime', () => {
       conversationId: 'conversation-1',
       payload: { ...startInput(), tmuxSessionName: makeLegacyTmuxSessionName('missing') },
     });
-    const { runtime } = createRuntime({ intents });
+    const { runtime } = createRuntime({ intents, platform: 'linux' });
 
     await runtime.reconcile();
 
@@ -754,7 +771,7 @@ describe('TuiAgentsRuntime', () => {
       payload: { ...startInput(), tmuxSessionName: makeLegacyTmuxSessionName('legacy') },
     });
     const exec = vi.fn(() => Promise.reject(new Error('tmux unavailable')));
-    const { runtime, spawner } = createRuntime({ intents, exec: { exec } });
+    const { runtime, spawner } = createRuntime({ intents, exec: { exec }, platform: 'linux' });
 
     await runtime.reconcile();
 
@@ -763,6 +780,69 @@ describe('TuiAgentsRuntime', () => {
       conversationId: 'conversation-1',
       status: 'active',
     });
+  });
+
+  it('resumes non-tmux active intents without consulting tmux liveness', async () => {
+    const intents = createMemorySessionIntentStore();
+    await intents.saveActive({
+      conversationId: 'conversation-1',
+      sessionId: 'provider-session',
+      payload: { ...startInput({ sessionId: 'provider-session' }) },
+    });
+    const { runtime, spawner } = createRuntime({ intents, platform: 'linux' });
+
+    await runtime.reconcile();
+
+    expect(spawner.specs).toHaveLength(1);
+    expect(peek(runtime.sessionsLiveModel.get(undefined)!.states.list)).toHaveProperty(
+      'conversation-1'
+    );
+    await runtime.dispose();
+  });
+
+  it('leaves tmux-backed intents active when the tmux binary is missing', async () => {
+    const identity = 'project:task:conversation-1';
+    const intents = createMemorySessionIntentStore();
+    await intents.saveActive({
+      conversationId: 'conversation-1',
+      sessionId: 'provider-session',
+      payload: {
+        ...startInput({ sessionId: 'provider-session' }),
+        tmuxSessionName: makeLegacyTmuxSessionName(identity),
+      },
+    });
+    const exec = vi.fn(() => Promise.reject(missingTmuxError()));
+    const { runtime, spawner } = createRuntime({ intents, exec: { exec }, platform: 'linux' });
+
+    await runtime.reconcile();
+    await flushIntentWrites();
+
+    expect(spawner.specs).toHaveLength(0);
+    expect(intents.snapshot()[0]).toMatchObject({
+      conversationId: 'conversation-1',
+      status: 'active',
+    });
+    await runtime.dispose();
+  });
+
+  it('keeps tmux sessions across sweeps when the tmux binary is missing', async () => {
+    const clock = createManualClock(0);
+    const exec = vi.fn(() => Promise.reject(missingTmuxError()));
+    const { runtime, spawner } = createRuntime({
+      clock,
+      lifecycle: { session: { kind: 'idle-after', outputMs: 1_000 }, sweepIntervalMs: 1_100 },
+      exec: { exec },
+      platform: 'linux',
+    });
+
+    await runtime.startSession(startInput({ tmux: { identity: 'project:task:conversation-1' } }));
+    await clock.advanceBy(1_200);
+
+    expect(peek(runtime.sessionsLiveModel.get(undefined)!.states.list)).toHaveProperty(
+      'conversation-1'
+    );
+    expect(spawner.processes[0]?.killCount ?? 0).toBe(0);
+    await runtime.dispose();
   });
 
   it('removes persisted TUI intent when a session is killed', async () => {

--- a/packages/core/src/runtimes/tui-agents/node/runtime/runtime.ts
+++ b/packages/core/src/runtimes/tui-agents/node/runtime/runtime.ts
@@ -40,6 +40,7 @@ import {
 } from '#services/conversation-reports/node';
 import {
   decodeLegacyTmuxSessionName,
+  isTmuxMissingError,
   killTmuxSession,
   listTmuxSessionActivity,
   logLocalPtySpawnWarnings,
@@ -102,6 +103,12 @@ export class TuiAgentsRuntime {
   private readonly clock: Clock;
   private readonly lifecycle: ConversationSessionLifecycle;
   private tmuxActivity = new Map<string, number>();
+  /**
+   * True when the last tmux listing failed because the executable is
+   * unavailable. Liveness is then unknown: tmux-backed sessions are kept
+   * (sweep) or deferred (reconcile) instead of being mistaken for dead.
+   */
+  private tmuxUnknown = false;
   private readonly unexpectedRespawns = new Map<string, number>();
   private readonly promptSpills = new Map<string, PromptSpillResult>();
   /**
@@ -166,15 +173,28 @@ export class TuiAgentsRuntime {
         if (sessionPolicy.kind === 'always') return;
         if ((this.deps.platform ?? process.platform) === 'win32') {
           this.tmuxActivity = new Map();
+          this.tmuxUnknown = false;
           return;
         }
         // Skip the tmux subprocess entirely when nothing is tracked; the sweep
         // below iterates the same (empty) config set.
         if (this.configs.size === 0) {
           this.tmuxActivity = new Map();
+          this.tmuxUnknown = false;
           return;
         }
-        this.tmuxActivity = await listTmuxSessionActivity(this.deps.exec);
+        try {
+          this.tmuxActivity = await listTmuxSessionActivity(this.deps.exec);
+          this.tmuxUnknown = false;
+        } catch (error) {
+          if (!isTmuxMissingError(error)) throw error;
+          // The dependency is gone, not the sessions: keep the previous table
+          // and let the snapshot treat tmux-backed sessions as unknown.
+          this.tmuxUnknown = true;
+          this.deps.logger.debug('TuiAgentsRuntime: tmux unavailable; skipping activity refresh', {
+            error: String(error),
+          });
+        }
       },
       entries: () => this.configs.keys(),
       snapshot: (conversationId, activity) => this.lifecycleSnapshot(conversationId, activity),
@@ -258,14 +278,29 @@ export class TuiAgentsRuntime {
           precheck: async () => {
             if ((this.deps.platform ?? process.platform) === 'win32') {
               this.tmuxActivity = new Map();
+              this.tmuxUnknown = false;
               return { ctx: undefined };
             }
             try {
               // The prefetch doubles as the gate's liveness table; a listing
               // failure vetoes the whole run (intents stay untouched).
               this.tmuxActivity = await listTmuxSessionActivity(this.deps.exec);
+              this.tmuxUnknown = false;
               return { ctx: undefined };
             } catch (error) {
+              if (isTmuxMissingError(error)) {
+                // Missing dependency, not missing sessions: proceed so
+                // tmux-independent intents still resume; the gate defers the
+                // tmux-backed ones.
+                this.tmuxUnknown = true;
+                this.deps.logger.debug(
+                  'TuiAgentsRuntime: tmux unavailable; deferring tmux intents',
+                  {
+                    error: String(error),
+                  }
+                );
+                return { ctx: undefined };
+              }
               return { veto: true as const, error };
             }
           },
@@ -278,6 +313,11 @@ export class TuiAgentsRuntime {
             return { input: this.normalizePersistedInput(parsed.data) };
           },
           gate: (input) => {
+            // Sessions without tmux never depended on it; their liveness is
+            // the runtime's own PTY state, so they always resume.
+            if (!input.tmux) return { ok: true as const };
+            // Unqueryable tmux means unknown liveness: defer, don't suspend.
+            if (this.tmuxUnknown) return { defer: true as const };
             if (tmuxActivityForInput(this.tmuxActivity, input) === undefined) {
               return { suspend: 'process-lost' };
             }
@@ -876,9 +916,12 @@ export class TuiAgentsRuntime {
     // Interactive busy window, plus tmux-side liveness: recent output inside the
     // tmux session must keep the key alive exactly as long as the idle policy's
     // output window would (it previously enriched the policy's lastOutputAt).
+    // When tmux is unqueryable its sessions are unknown, not dead: keep them
+    // until a successful listing can judge them again.
     const busy =
       (lastOutputAt !== null && now - lastOutputAt < BUSY_OUTPUT_WINDOW_MS) ||
-      (tmuxLastOutputAt !== undefined && now - tmuxLastOutputAt < this.tmuxKeepAliveMs);
+      (tmuxLastOutputAt !== undefined && now - tmuxLastOutputAt < this.tmuxKeepAliveMs) ||
+      (this.tmuxUnknown && config.input.tmux !== undefined);
     return { running: state?.status === 'running', busy };
   }
 

--- a/packages/core/src/services/pty/api/index.ts
+++ b/packages/core/src/services/pty/api/index.ts
@@ -33,8 +33,10 @@ export { PtySession } from './pty-session';
 export type { PtySessionOptions } from './pty-session';
 export {
   buildTmuxShellLine,
+  isTmuxMissingError,
   killTmuxSession,
   listTmuxSessions,
+  TmuxUnavailableError,
   type TmuxSessionInventoryEntry,
 } from './tmux-commands';
 export {

--- a/packages/core/src/services/pty/api/tmux-commands.ts
+++ b/packages/core/src/services/pty/api/tmux-commands.ts
@@ -10,6 +10,27 @@ export type TmuxSessionInventoryEntry = {
   identity: string | null;
 };
 
+/**
+ * Thrown when tmux cannot be queried because the executable is unavailable
+ * (missing from PATH, unresolvable, or a shell command-not-found exit). This
+ * is distinct from a successful enumeration that finds zero sessions: unknown
+ * liveness must not be mistaken for dead sessions.
+ */
+export class TmuxUnavailableError extends Error {
+  constructor(message = 'tmux is not available', options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'TmuxUnavailableError';
+  }
+}
+
+/** Reusable capability check: is this failure just a missing tmux executable? */
+export function isTmuxMissingError(error: unknown): boolean {
+  const failure = readExecFailure(error);
+  if (!failure) return false;
+  if (failure.executableMissing) return true;
+  return failure.exitCode === 127;
+}
+
 export function buildTmuxShellLine(
   sessionName: string,
   commandLine: string,
@@ -42,7 +63,12 @@ export async function listTmuxSessions(
     const result = await ctx.exec('tmux', ['list-sessions', '-F', TMUX_LIST_FORMAT]);
     return parseTmuxSessionInventory(result.stdout);
   } catch (error) {
-    if (isExpectedTmuxListFailure(error)) return [];
+    if (isNoTmuxServerFailure(error)) return [];
+    if (isTmuxMissingError(error)) {
+      throw new TmuxUnavailableError('tmux list-sessions: tmux executable is not available', {
+        cause: error,
+      });
+    }
     throw error;
   }
 }
@@ -76,10 +102,10 @@ export function parseTmuxSessionInventory(output: string): TmuxSessionInventoryE
   return sessions;
 }
 
-function isExpectedTmuxListFailure(error: unknown): boolean {
+/** A running tmux client that reports no server: successful enumeration, zero sessions. */
+function isNoTmuxServerFailure(error: unknown): boolean {
   const failure = readExecFailure(error);
   if (!failure) return false;
-  if (failure.executableMissing) return true;
   if (
     failure.exitCode === 1 &&
     /no server running|failed to connect to server|error connecting to .*\(no such file or directory\)/i.test(
@@ -88,7 +114,7 @@ function isExpectedTmuxListFailure(error: unknown): boolean {
   ) {
     return true;
   }
-  return failure.exitCode === 127;
+  return false;
 }
 
 /** Normalize the two execution-error shapes currently exposed by IExecutionContext. */

--- a/packages/core/src/services/pty/api/tmux-commands.ts
+++ b/packages/core/src/services/pty/api/tmux-commands.ts
@@ -25,6 +25,7 @@ export class TmuxUnavailableError extends Error {
 
 /** Reusable capability check: is this failure just a missing tmux executable? */
 export function isTmuxMissingError(error: unknown): boolean {
+  if (error instanceof TmuxUnavailableError) return true;
   const failure = readExecFailure(error);
   if (!failure) return false;
   if (failure.executableMissing) return true;

--- a/packages/core/src/services/pty/api/tmux.test.ts
+++ b/packages/core/src/services/pty/api/tmux.test.ts
@@ -14,7 +14,7 @@ import {
   resolveTmuxSession,
   tmuxIdentityActivityKey,
 } from './tmux';
-import { buildTmuxShellLine } from './tmux-commands';
+import { buildTmuxShellLine, TmuxUnavailableError } from './tmux-commands';
 import {
   decodeLegacyTmuxSessionName,
   makeLegacyTmuxSessionName,
@@ -81,6 +81,17 @@ describe('resolveTmuxSession', () => {
     await expect(
       resolveTmuxSession(stubExecContext(exec), { identity, label: 'workspace' })
     ).resolves.toEqual({ name: legacyName, exists: true, writeIdentity: false });
+  });
+
+  it('treats a missing tmux executable as a not-yet-existing session', async () => {
+    const identity = 'project:task:terminal';
+    const exec = vi.fn(async () => {
+      throw Object.assign(new Error('spawn tmux ENOENT'), { code: 'ENOENT' });
+    });
+
+    await expect(
+      resolveTmuxSession(stubExecContext(exec), { identity, label: 'workspace' })
+    ).resolves.toMatchObject({ exists: false, writeIdentity: true });
   });
 });
 
@@ -229,32 +240,36 @@ describe('listTmuxSessionActivity', () => {
     await expect(listTmuxSessionActivity(stubExecContext(exec))).resolves.toEqual(new Map());
   });
 
-  it('returns an empty map when tmux is not installed (spawn failure)', async () => {
+  it('reports tmux as unavailable when tmux is not installed (spawn failure)', async () => {
     const exec = vi.fn(async () => {
       throw Object.assign(new Error('spawn tmux ENOENT'), { code: 'ENOENT' });
     });
 
-    await expect(listTmuxSessionActivity(stubExecContext(exec))).resolves.toEqual(new Map());
+    await expect(listTmuxSessionActivity(stubExecContext(exec))).rejects.toBeInstanceOf(
+      TmuxUnavailableError
+    );
   });
 
-  it('returns an empty map when BoundExec wraps a missing tmux executable', async () => {
+  it('reports tmux as unavailable when BoundExec wraps a missing tmux executable', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'emdash-tmux-missing-'));
     try {
       const bound = createBoundExec({ file: join(cwd, 'missing-tmux'), cwd });
       const ctx = stubExecContext((_file, args) => bound.exec(args ?? []));
 
-      await expect(listTmuxSessionActivity(ctx)).resolves.toEqual(new Map());
+      await expect(listTmuxSessionActivity(ctx)).rejects.toBeInstanceOf(TmuxUnavailableError);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });
 
-  it('returns an empty map for a shell command-not-found exit', async () => {
+  it('reports tmux as unavailable for a shell command-not-found exit', async () => {
     const exec = vi.fn(async () => {
       throw new ExecError('tmux', [], 127, '', 'tmux: command not found');
     });
 
-    await expect(listTmuxSessionActivity(stubExecContext(exec))).resolves.toEqual(new Map());
+    await expect(listTmuxSessionActivity(stubExecContext(exec))).rejects.toBeInstanceOf(
+      TmuxUnavailableError
+    );
   });
 
   it.each([

--- a/packages/core/src/services/pty/api/tmux.test.ts
+++ b/packages/core/src/services/pty/api/tmux.test.ts
@@ -14,7 +14,7 @@ import {
   resolveTmuxSession,
   tmuxIdentityActivityKey,
 } from './tmux';
-import { buildTmuxShellLine, TmuxUnavailableError } from './tmux-commands';
+import { buildTmuxShellLine, isTmuxMissingError, TmuxUnavailableError } from './tmux-commands';
 import {
   decodeLegacyTmuxSessionName,
   makeLegacyTmuxSessionName,
@@ -270,6 +270,10 @@ describe('listTmuxSessionActivity', () => {
     await expect(listTmuxSessionActivity(stubExecContext(exec))).rejects.toBeInstanceOf(
       TmuxUnavailableError
     );
+  });
+
+  it('classifies a wrapped TmuxUnavailableError as a missing-tmux failure', () => {
+    expect(isTmuxMissingError(new TmuxUnavailableError())).toBe(true);
   });
 
   it.each([

--- a/packages/core/src/services/pty/api/tmux.ts
+++ b/packages/core/src/services/pty/api/tmux.ts
@@ -1,5 +1,5 @@
 import type { IExecutionContext } from '#primitives/exec/api';
-import { listTmuxSessions, parseTmuxSessionInventory } from './tmux-commands';
+import { listTmuxSessions, parseTmuxSessionInventory, TmuxUnavailableError } from './tmux-commands';
 import { makeLegacyTmuxSessionName, makeTmuxSessionName } from './tmux-identity';
 
 export type ResolvedTmuxSession = {
@@ -12,7 +12,7 @@ export async function resolveTmuxSession(
   ctx: IExecutionContext,
   input: { identity: string; label: string }
 ): Promise<ResolvedTmuxSession> {
-  const sessions = await listTmuxSessions(ctx);
+  const sessions = await listTmuxSessionsOrEmpty(ctx);
   const metadataMatch = sessions.find((session) => session.identity === input.identity);
   if (metadataMatch) {
     return { name: metadataMatch.name, exists: true, writeIdentity: true };
@@ -34,7 +34,7 @@ export async function findTmuxSessionNamesByIdentity(
 ): Promise<Map<string, string>> {
   const requested = new Set(identities);
   const found = new Map<string, string>();
-  for (const session of await listTmuxSessions(ctx)) {
+  for (const session of await listTmuxSessionsOrEmpty(ctx)) {
     if (!session.identity || !requested.has(session.identity)) continue;
     if (!found.has(session.identity)) found.set(session.identity, session.name);
   }
@@ -53,6 +53,21 @@ export function parseTmuxSessionActivity(output: string): Map<string, number> {
 
 export function tmuxIdentityActivityKey(identity: string): string {
   return `identity:${identity}`;
+}
+
+/**
+ * Creation/discovery paths treat an unqueryable tmux as "nothing found": a
+ * missing executable surfaces honestly when the spawned session fails, so
+ * these callers need no liveness distinction. Only `listTmuxSessionActivity`
+ * propagates `TmuxUnavailableError` for sweep/reconcile judgments.
+ */
+async function listTmuxSessionsOrEmpty(ctx: IExecutionContext) {
+  try {
+    return await listTmuxSessions(ctx);
+  } catch (error) {
+    if (error instanceof TmuxUnavailableError) return [];
+    throw error;
+  }
 }
 
 function activityByHandle(

--- a/packages/core/src/services/session-lifecycle/api/index.ts
+++ b/packages/core/src/services/session-lifecycle/api/index.ts
@@ -64,7 +64,11 @@ export interface ReconcileOptions<TResume, TCtx> {
   /** Run-vetoing pre-scan; a veto (or throw) aborts the whole reconcile. */
   precheck?: () => Promise<{ ctx: TCtx } | { veto: true; error?: unknown }>;
   parse: (intent: SessionIntent, ctx: TCtx) => { input: TResume } | { suspend: string };
-  gate?: (input: TResume) => { ok: true } | { suspend: string };
+  /**
+   * Per-intent verdict: resume it, suspend it with a cause, or defer it
+   * (leave the intent untouched when liveness is currently unknowable).
+   */
+  gate?: (input: TResume) => { ok: true } | { suspend: string } | { defer: true };
   resume: (input: TResume) => Promise<Result<unknown, unknown>>;
 }
 

--- a/packages/core/src/services/session-lifecycle/node/session-lifecycle.test.ts
+++ b/packages/core/src/services/session-lifecycle/node/session-lifecycle.test.ts
@@ -921,7 +921,7 @@ describe('createSessionLifecycle', () => {
     function reconcileHarness(options: {
       intents: SessionIntentStore;
       precheck?: () => Promise<{ ctx: void } | { veto: true; error?: unknown }>;
-      gate?: (input: ResumeInput) => { ok: true } | { suspend: string };
+      gate?: (input: ResumeInput) => { ok: true } | { suspend: string } | { defer: true };
       resume?: (input: ResumeInput) => Promise<Result<unknown, unknown>>;
     }) {
       const harness = makeHarness();
@@ -1025,6 +1025,21 @@ describe('createSessionLifecycle', () => {
         status: 'suspended',
         suspendedCause: 'process-lost',
       });
+    });
+
+    it('leaves deferred intents untouched without resuming', async () => {
+      const intents = createMemorySessionIntentStore();
+      await intents.saveActive({ conversationId: 'unknown', payload: {} });
+      const { lifecycle, resumed } = reconcileHarness({
+        intents,
+        gate: () => ({ defer: true as const }),
+      });
+
+      await lifecycle.reconcile();
+      await settle();
+
+      expect(resumed).toEqual([]);
+      expect(intents.snapshot()[0]).toMatchObject({ status: 'active' });
     });
 
     it("warns and suspends 'reconcile-failed' when resume fails", async () => {

--- a/packages/core/src/services/session-lifecycle/node/session-lifecycle.ts
+++ b/packages/core/src/services/session-lifecycle/node/session-lifecycle.ts
@@ -392,6 +392,7 @@ export function createSessionLifecycle<TResume, TCtx>(
           writeSuspendedIntent(intent.conversationId, gated.suspend);
           continue;
         }
+        if ('defer' in gated) continue;
       }
 
       try {


### PR DESCRIPTION
Fixes #3109.

## Problem
On machines without tmux, \listTmuxSessions\ collapsed capability-unavailable (ENOENT, exit 127) into an empty activity map. Consequences in \TuiAgentsRuntime\:
- sweep treated tmux-backed sessions as idle-dead and evicted them (scrollback reseeded, terminal blank on reopen),
- the reconcile gate suspended every active intent as \process-lost\, including non-tmux sessions whose liveness never depended on tmux, so nothing auto-resumed after a worker restart.

## Change
- pty service boundary (\	mux-commands.ts\): new \TmuxUnavailableError\ + reusable \isTmuxMissingError\. Successful empty enumeration (no-server exit 1) still means zero live sessions; a missing executable is unknown liveness and now throws typed.
- \esolveTmuxSession\/\indTmuxSessionNamesByIdentity\ (creation/discovery): treat unknown as not-found, so spawn surfaces the honest failure downstream. Only \listTmuxSessionActivity\ propagates for sweep/reconcile judgments.
- \TuiAgentsRuntime\: tracks \	muxUnknown\. Sweep keeps tmux-backed sessions while unknown (reaped once tmux is queryable again); reconcile proceeds instead of vetoing, defers tmux-backed intents via a new gate \defer\ verdict, and always resumes non-tmux intents.
- session-lifecycle: gate gains \{ defer: true }\ (intent left untouched).

## Verification
- 3 new deterministic RED tests (failed on \810e17f3\, green after): non-tmux intent resumes on reconcile, tmux intent stays active when the binary is missing, sweep keeps tmux sessions when the binary is missing.
- Updated \	mux.test.ts\ missing-binary cases to the new contract; added resolve-missing and gate-defer tests.
- \pnpm --filter @emdash/core\ targeted suites green (\untime.test.ts\ 38/38; pty, session-lifecycle green); \pnpm run typecheck\ green for all 9 projects.
- Pre-existing Windows-host failures (prompt-spill, workspace-trust file test, terminals tmux tests) verified identical on clean HEAD; tmux-assuming TUI tests pinned to \platform: linux\ for hermeticity (test-only).
- Not run per author request: \pnpm run lint\, full \pnpm run test\.