### PR TITLE
fix(browser): route localhost links through the external-link flow

### DIFF
--- a/apps/emdash-desktop/src/main/host/external-link-policy.test.ts
+++ b/apps/emdash-desktop/src/main/host/external-link-policy.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { isInternalAppUrl } from './external-link-policy';
+
+const DEV_RENDERER_URL = 'http://localhost:5173';
+const PACKAGED_RENDERER_URL = 'app://emdash/index.html';
+
+describe('isInternalAppUrl', () => {
+  describe('packaged app (app:// renderer)', () => {
+    it('treats the app origin as internal', () => {
+      expect(isInternalAppUrl('app://emdash/index.html', PACKAGED_RENDERER_URL)).toBe(true);
+      expect(isInternalAppUrl('app://emdash/assets/x.js', PACKAGED_RENDERER_URL)).toBe(true);
+    });
+
+    it('does not treat localhost dev servers as internal', () => {
+      expect(isInternalAppUrl('http://localhost:3000/', PACKAGED_RENDERER_URL)).toBe(false);
+      expect(isInternalAppUrl('http://localhost:3000', PACKAGED_RENDERER_URL)).toBe(false);
+      expect(isInternalAppUrl('http://127.0.0.1:5173/app', PACKAGED_RENDERER_URL)).toBe(false);
+      expect(isInternalAppUrl('http://LOCALHOST:8080/', PACKAGED_RENDERER_URL)).toBe(false);
+    });
+
+    it('does not treat file URLs or remote sites as internal', () => {
+      expect(isInternalAppUrl('file:///tmp/index.html', PACKAGED_RENDERER_URL)).toBe(false);
+      expect(isInternalAppUrl('https://github.com/x', PACKAGED_RENDERER_URL)).toBe(false);
+    });
+  });
+
+  describe('dev app (Vite renderer on localhost)', () => {
+    it('treats the Vite origin as internal', () => {
+      expect(isInternalAppUrl('http://localhost:5173/', DEV_RENDERER_URL)).toBe(true);
+      expect(isInternalAppUrl('http://localhost:5173/src/main.tsx', DEV_RENDERER_URL)).toBe(true);
+    });
+
+    it('does not treat other localhost ports or hosts as internal', () => {
+      expect(isInternalAppUrl('http://localhost:51730/', DEV_RENDERER_URL)).toBe(false);
+      expect(isInternalAppUrl('http://localhost:3000/', DEV_RENDERER_URL)).toBe(false);
+      expect(isInternalAppUrl('http://127.0.0.1:5173/', DEV_RENDERER_URL)).toBe(false);
+    });
+  });
+
+  it('rejects unparsable URLs', () => {
+    expect(isInternalAppUrl('not a url', PACKAGED_RENDERER_URL)).toBe(false);
+    expect(isInternalAppUrl('', PACKAGED_RENDERER_URL)).toBe(false);
+  });
+});

--- a/apps/emdash-desktop/src/main/host/external-link-policy.ts
+++ b/apps/emdash-desktop/src/main/host/external-link-policy.ts
@@ -1,0 +1,24 @@
+/**
+ * Whether `url` belongs to the origin the main window's renderer was loaded from.
+ *
+ * Only same-origin navigations may stay inside the main window. Everything else — including
+ * local dev servers on `localhost` / `127.0.0.1` — must go through the external-link flow so
+ * the user can pick an in-app browser tab or the system browser instead of getting a bare,
+ * unmanaged Electron window.
+ */
+export function isInternalAppUrl(url: string, rendererUrl: string): boolean {
+  const target = parseOrigin(url);
+  const app = parseOrigin(rendererUrl);
+  if (!target || !app) return false;
+  return target.protocol === app.protocol && target.host === app.host;
+}
+
+function parseOrigin(value: string): { protocol: string; host: string } | undefined {
+  try {
+    const parsed = new URL(value);
+    // `URL.origin` is "null" for custom schemes such as app://, so compare the parts directly.
+    return { protocol: parsed.protocol, host: parsed.host.toLowerCase() };
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/emdash-desktop/src/main/host/externalLinks.ts
+++ b/apps/emdash-desktop/src/main/host/externalLinks.ts
@@ -1,5 +1,6 @@
 import { shell, type BrowserWindow } from 'electron';
 import { desktopHostEvents } from '@core/features/workbench/node';
+import { isInternalAppUrl } from '@main/host/external-link-policy';
 import { getMainWindow } from '@main/host/window';
 import { log } from '@main/lib/logger';
 
@@ -21,17 +22,16 @@ function requestExternalLinkOpen(url: string) {
   });
 }
 
-export function registerExternalLinkHandlers(win: BrowserWindow, isDev: boolean) {
+/**
+ * `rendererUrl` is the URL the main window was loaded from; only navigations to that origin
+ * stay in-window. Local dev servers on other localhost ports are external links like any other.
+ */
+export function registerExternalLinkHandlers(win: BrowserWindow, rendererUrl: string) {
   const wc = win.webContents;
-
-  const isInternalAppUrl = (url: string) => {
-    if (isDev) return url.startsWith(process.env.ELECTRON_RENDERER_URL!);
-    return url.startsWith('file://') || /^http:\/\/(127\.0\.0\.1|localhost):\d+(?:\/|$)/i.test(url);
-  };
 
   // Handle window.open and target="_blank"
   wc.setWindowOpenHandler(({ url }) => {
-    if (!isInternalAppUrl(url) && /^https?:\/\//i.test(url)) {
+    if (!isInternalAppUrl(url, rendererUrl) && /^https?:\/\//i.test(url)) {
       requestExternalLinkOpen(url);
       return { action: 'deny' };
     }
@@ -40,7 +40,7 @@ export function registerExternalLinkHandlers(win: BrowserWindow, isDev: boolean)
 
   // Intercept navigations that would leave the app
   wc.on('will-navigate', (event, url) => {
-    if (!isInternalAppUrl(url) && /^https?:\/\//i.test(url)) {
+    if (!isInternalAppUrl(url, rendererUrl) && /^https?:\/\//i.test(url)) {
       event.preventDefault();
       requestExternalLinkOpen(url);
     }

--- a/apps/emdash-desktop/src/main/host/window.ts
+++ b/apps/emdash-desktop/src/main/host/window.ts
@@ -84,14 +84,13 @@ export function createMainWindow(): BrowserWindow {
     mainWindow.setMenuBarVisibility(false);
   }
 
-  if (import.meta.env.DEV) {
-    void mainWindow.loadURL(process.env.ELECTRON_RENDERER_URL!);
-  } else {
-    void mainWindow.loadURL(`${APP_ORIGIN}/index.html`);
-  }
+  const rendererUrl = import.meta.env.DEV
+    ? process.env.ELECTRON_RENDERER_URL!
+    : `${APP_ORIGIN}/index.html`;
+  void mainWindow.loadURL(rendererUrl);
 
-  // Route external links to the user’s default browser
-  registerExternalLinkHandlers(mainWindow, import.meta.env.DEV);
+  // Route anything outside the renderer origin through the external-link flow
+  registerExternalLinkHandlers(mainWindow, rendererUrl);
   registerBrowserWebviewHandlers(mainWindow);
 
   // Window-first: show immediately with the theme-matching background instead


### PR DESCRIPTION
### Description

Clicking a `http://localhost:PORT` link in a task (chat transcript links, resource links, any `target="_blank"` anchor) opened a bare, unmanaged Electron window instead of the usual "Open in Emdash / Open in Browser" dialog, so the page could never land as an in-app browser tab in the workspace.

**Root cause.** `registerExternalLinkHandlers` decided what counts as "the app itself" with a hard-coded rule: in the packaged build, `file://` plus any `http://localhost:PORT` / `http://127.0.0.1:PORT`. That rule dates from when the packaged renderer was served over http; the renderer now loads from the `app://` origin, so the localhost carve-out only ever matched the user's own dev servers. Those URLs got `{ action: 'allow' }` from `setWindowOpenHandler`, which makes Electron spawn a new `BrowserWindow`. Every other http(s) link got `deny` plus the dialog. The same stale rule sat in the `will-navigate` handler, where a top-level localhost navigation would have replaced the app window instead of being intercepted.

**Fix.** Compare the target against the origin the main window was actually loaded from (`ELECTRON_RENDERER_URL` in dev, `app://emdash` in production) instead of pattern-matching hosts. The check lives in a small pure module, `external-link-policy.ts`, so it is unit-testable without Electron. Localhost dev servers now take the same path as every other link and can open as a browser tab in the current task.

Only `window.ts` calls `registerExternalLinkHandlers`, so its signature change (`isDev` → `rendererUrl`) has no other callers.

### Related issues

None filed.

### Testing

- `pnpm run format`, `pnpm run lint` (pre-existing warnings only), `pnpm run typecheck` from `apps/emdash-desktop`
- `pnpm exec vitest run --project node src/main/host/external-link-policy.test.ts` (6 tests: app origin vs. localhost ports, dev origin vs. other localhost ports, file/https/unparsable input)
- Manual, dev app on the isolated profile with a throwaway `python3 -m http.server 8899`: started a Claude Code chat-UI conversation in a task, asked it to reply with `http://localhost:8899/`, and clicked that link in the transcript with the mouse. Ran once with the old packaged-app rule temporarily forced on (the bug only shows in packaged builds, since the dev check compares against the Vite URL), and once with this fix.

### Screenshot/Recording

**Before** (old packaged-app rule forced on in dev): clicking the link in the chat transcript shows no dialog in the main window; the page lands in a separate 800×600 `BrowserWindow` (default Electron size) with nothing but the page.

| Main window after the click, nothing happens | The stray window (packaged app) |
|---|---|
| ![before main](https://raw.githubusercontent.com/tkohout/emdash/cb7626ec83475363e69f5844cbcec695ee1d28c1/browser-localhost-open/before-main.png) | ![before stray window](https://raw.githubusercontent.com/tkohout/emdash/d12dfae1088697d5e3384f155194935101809eff/browser-localhost-open/before-stray-window-native.png) |

**After:** the same click goes through the regular dialog, and "Open in Emdash" opens the page as a browser tab in the task.

| Dialog | Browser tab in the workspace |
|---|---|
| ![after dialog](https://raw.githubusercontent.com/tkohout/emdash/cb7626ec83475363e69f5844cbcec695ee1d28c1/browser-localhost-open/after-dialog.png) | ![after tab](https://raw.githubusercontent.com/tkohout/emdash/cb7626ec83475363e69f5844cbcec695ee1d28c1/browser-localhost-open/after-tab.png) |

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed (no docs describe this rule)
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)




