### PR TITLE
fix(pull-requests): fence checks to current head

### DIFF
--- a/apps/emdash-desktop/src/core/services/pull-requests/node/engine/pull-request-engine.db.test.ts
+++ b/apps/emdash-desktop/src/core/services/pull-requests/node/engine/pull-request-engine.db.test.ts
@@ -8,7 +8,7 @@ import {
   type ScheduledRequest,
 } from '@emdash/shared/requests';
 import { retrySchedules } from '@emdash/shared/scheduling';
-import { createStubLogger } from '@emdash/shared/testing';
+import { createStubLogger, deferred } from '@emdash/shared/testing';
 import type { ContractClient } from '@emdash/wire/rpc';
 import type { Octokit } from '@octokit/rest';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -633,7 +633,7 @@ describe('PullRequestEngine', () => {
     expect(github.paginate).not.toHaveBeenCalled();
   });
 
-  it('keeps check IDs stable across refreshes', async () => {
+  it('uses the returned head for stable check IDs across refreshes', async () => {
     const handle = await pullRequestSqliteStore.openTemp();
     closeHandles.push(() => handle.close());
     const store = new PullRequestStore(handle);
@@ -641,37 +641,7 @@ describe('PullRequestEngine', () => {
     const pullRequestUrl = `${repositoryUrl}/pull/42`;
     store.registerRepository(repositoryUrl);
     store.savePullRequest(pullRequestFixture());
-    const graphql = vi.fn(async () => ({
-      repository: {
-        pullRequest: {
-          commits: {
-            nodes: [
-              {
-                commit: {
-                  statusCheckRollup: {
-                    contexts: {
-                      pageInfo: { hasNextPage: false, endCursor: null },
-                      nodes: [
-                        {
-                          __typename: 'CheckRun',
-                          name: 'CI',
-                          status: 'COMPLETED',
-                          conclusion: 'SUCCESS',
-                          detailsUrl: 'https://github.com/checks/1',
-                          startedAt: '2026-01-01T00:00:00.000Z',
-                          completedAt: '2026-01-01T00:01:00.000Z',
-                          checkSuite: null,
-                        },
-                      ],
-                    },
-                  },
-                },
-              },
-            ],
-          },
-        },
-      },
-    }));
+    const graphql = vi.fn(async () => gqlCheckRunsResponse('head'));
     const { logger } = createStubLogger();
     const states: SyncState[] = [];
     const engine = createEngine({
@@ -682,13 +652,23 @@ describe('PullRequestEngine', () => {
       onSyncState: (_repositoryUrl, state) => states.push(state),
     });
 
-    await engine.syncChecks(repositoryUrl, pullRequestUrl, 'head', new AbortController().signal);
+    await engine.syncChecks(
+      repositoryUrl,
+      pullRequestUrl,
+      'caller-head',
+      new AbortController().signal
+    );
     const firstId = store.listPullRequests({
       repositoryUrls: [repositoryUrl],
       cursor: null,
       limit: 10,
     }).prs[0]?.checks[0]?.id;
-    await engine.syncChecks(repositoryUrl, pullRequestUrl, 'head', new AbortController().signal);
+    await engine.syncChecks(
+      repositoryUrl,
+      pullRequestUrl,
+      'caller-head',
+      new AbortController().signal
+    );
     const secondId = store.listPullRequests({
       repositoryUrls: [repositoryUrl],
       cursor: null,
@@ -712,37 +692,9 @@ describe('PullRequestEngine', () => {
     const pullRequestUrl = `${repositoryUrl}/pull/42`;
     store.registerRepository(repositoryUrl);
     store.savePullRequest(pullRequestFixture());
-    const graphql = vi.fn(async () => ({
-      repository: {
-        pullRequest: {
-          commits: {
-            nodes: [
-              {
-                commit: {
-                  statusCheckRollup: {
-                    contexts: {
-                      pageInfo: { hasNextPage: false, endCursor: null },
-                      nodes: [
-                        {
-                          __typename: 'CheckRun',
-                          name: 'CI',
-                          status: 'REQUESTED',
-                          conclusion: null,
-                          detailsUrl: 'https://github.com/checks/1',
-                          startedAt: null,
-                          completedAt: null,
-                          checkSuite: null,
-                        },
-                      ],
-                    },
-                  },
-                },
-              },
-            ],
-          },
-        },
-      },
-    }));
+    const graphql = vi.fn(async () =>
+      gqlCheckRunsResponse('head', { status: 'REQUESTED', conclusion: null })
+    );
     const { logger } = createStubLogger();
     const engine = createEngine({
       store,
@@ -754,6 +706,348 @@ describe('PullRequestEngine', () => {
     await expect(
       engine.syncChecks(repositoryUrl, pullRequestUrl, 'head', new AbortController().signal)
     ).resolves.toEqual(ok(true));
+  });
+
+  it('invalidates cached checks when the pull request head changes', async () => {
+    const handle = await pullRequestSqliteStore.openTemp();
+    closeHandles.push(() => handle.close());
+    const store = new PullRequestStore(handle);
+    const repositoryUrl = 'https://github.com/emdash/emdash';
+    const pullRequestUrl = `${repositoryUrl}/pull/42`;
+    store.registerRepository(repositoryUrl);
+    store.savePullRequest(pullRequestFixture());
+    const graphql = vi.fn(async () => gqlCheckRunsResponse('head', { name: 'Old CI' }));
+    const { logger } = createStubLogger();
+    const engine = createEngine({
+      store,
+      githubAuth: fakeGitHubAuth(),
+      logger,
+      createOctokit: () => fakeOctokit(graphql),
+    });
+
+    await expect(
+      engine.syncChecks(repositoryUrl, pullRequestUrl, 'head', new AbortController().signal)
+    ).resolves.toEqual(ok(false));
+    expect(
+      store.listPullRequests({ repositoryUrls: [repositoryUrl], cursor: null, limit: 10 }).prs[0]
+        ?.checks
+    ).toHaveLength(1);
+
+    store.savePullRequest({ ...pullRequestFixture(), title: 'Refreshed feature' });
+    expect(
+      store.listPullRequests({ repositoryUrls: [repositoryUrl], cursor: null, limit: 10 }).prs[0]
+        ?.checks
+    ).toHaveLength(1);
+
+    store.savePullRequest({ ...pullRequestFixture(), headRefOid: 'new-head' });
+
+    expect(
+      store.listPullRequests({ repositoryUrls: [repositoryUrl], cursor: null, limit: 10 }).prs[0]
+        ?.checks
+    ).toEqual([]);
+    await expect(
+      engine.syncChecks(repositoryUrl, pullRequestUrl, 'head', new AbortController().signal)
+    ).resolves.toMatchObject({ success: false, error: { type: 'checks_failed' } });
+  });
+
+  it('rejects check pages from different pull request heads', async () => {
+    const handle = await pullRequestSqliteStore.openTemp();
+    closeHandles.push(() => handle.close());
+    const store = new PullRequestStore(handle);
+    const repositoryUrl = 'https://github.com/emdash/emdash';
+    const pullRequestUrl = `${repositoryUrl}/pull/42`;
+    store.registerRepository(repositoryUrl);
+    store.savePullRequest(pullRequestFixture());
+    const graphql = vi
+      .fn()
+      .mockResolvedValueOnce(
+        gqlCheckRunsResponse('head', {
+          name: 'First page',
+          hasNextPage: true,
+          endCursor: 'next',
+        })
+      )
+      .mockResolvedValueOnce(gqlCheckRunsResponse('new-head', { name: 'Second page' }));
+    const { logger } = createStubLogger();
+    const engine = createEngine({
+      store,
+      githubAuth: fakeGitHubAuth(),
+      logger,
+      createOctokit: () => fakeOctokit(graphql),
+    });
+
+    const result = await engine.syncChecks(
+      repositoryUrl,
+      pullRequestUrl,
+      'head',
+      new AbortController().signal
+    );
+
+    expect(result).toMatchObject({ success: false, error: { type: 'checks_failed' } });
+    expect(
+      store.listPullRequests({ repositoryUrls: [repositoryUrl], cursor: null, limit: 10 }).prs[0]
+        ?.checks
+    ).toEqual([]);
+  });
+
+  it('rejects check results without a pull request head', async () => {
+    const handle = await pullRequestSqliteStore.openTemp();
+    closeHandles.push(() => handle.close());
+    const store = new PullRequestStore(handle);
+    const repositoryUrl = 'https://github.com/emdash/emdash';
+    const pullRequestUrl = `${repositoryUrl}/pull/42`;
+    store.registerRepository(repositoryUrl);
+    store.savePullRequest(pullRequestFixture());
+    const graphql = vi.fn(async () => ({ repository: { pullRequest: null } }));
+    const { logger } = createStubLogger();
+    const engine = createEngine({
+      store,
+      githubAuth: fakeGitHubAuth(),
+      logger,
+      createOctokit: () => fakeOctokit(graphql),
+    });
+
+    await expect(
+      engine.syncChecks(repositoryUrl, pullRequestUrl, 'head', new AbortController().signal)
+    ).resolves.toMatchObject({ success: false, error: { type: 'checks_failed' } });
+  });
+
+  it('rejects check results requested for a different repository', async () => {
+    const handle = await pullRequestSqliteStore.openTemp();
+    closeHandles.push(() => handle.close());
+    const store = new PullRequestStore(handle);
+    const repositoryUrl = 'https://github.com/emdash/emdash';
+    const pullRequestUrl = `${repositoryUrl}/pull/42`;
+    store.registerRepository(repositoryUrl);
+    store.savePullRequest(pullRequestFixture());
+    const graphql = vi.fn(async () => gqlCheckRunsResponse('head'));
+    const { logger } = createStubLogger();
+    const engine = createEngine({
+      store,
+      githubAuth: fakeGitHubAuth(),
+      logger,
+      createOctokit: () => fakeOctokit(graphql),
+    });
+
+    await expect(
+      engine.syncChecks(
+        'https://github.com/other/project',
+        pullRequestUrl,
+        'head',
+        new AbortController().signal
+      )
+    ).resolves.toMatchObject({ success: false, error: { type: 'checks_failed' } });
+    expect(graphql).not.toHaveBeenCalled();
+  });
+
+  it('accepts matching repository URLs with different casing', async () => {
+    const handle = await pullRequestSqliteStore.openTemp();
+    closeHandles.push(() => handle.close());
+    const store = new PullRequestStore(handle);
+    const repositoryUrl = 'https://github.com/emdash/emdash';
+    const pullRequestUrl = `${repositoryUrl}/pull/42`;
+    store.registerRepository(repositoryUrl);
+    store.savePullRequest(pullRequestFixture());
+    const graphql = vi.fn(async () => gqlCheckRunsResponse('head'));
+    const { logger } = createStubLogger();
+    const engine = createEngine({
+      store,
+      githubAuth: fakeGitHubAuth(),
+      logger,
+      createOctokit: () => fakeOctokit(graphql),
+    });
+
+    await expect(
+      engine.syncChecks(
+        'https://github.com/Emdash/Emdash',
+        pullRequestUrl,
+        'head',
+        new AbortController().signal
+      )
+    ).resolves.toEqual(ok(false));
+    expect(graphql).toHaveBeenCalledOnce();
+  });
+
+  it('does not let an older check sync overwrite newer results', async () => {
+    const handle = await pullRequestSqliteStore.openTemp();
+    closeHandles.push(() => handle.close());
+    const store = new PullRequestStore(handle);
+    const repositoryUrl = 'https://github.com/emdash/emdash';
+    const pullRequestUrl = `${repositoryUrl}/pull/42`;
+    store.registerRepository(repositoryUrl);
+    store.savePullRequest({ ...pullRequestFixture(), headRefOid: 'new-head' });
+    const oldResponse = deferred<ReturnType<typeof gqlCheckRunsResponse>>();
+    const oldRequestStarted = deferred<void>();
+    let requestCount = 0;
+    const graphql = vi.fn(async () => {
+      requestCount += 1;
+      if (requestCount === 1) {
+        oldRequestStarted.resolve(undefined);
+        return await oldResponse.promise;
+      }
+      return gqlCheckRunsResponse('new-head');
+    });
+    const { logger } = createStubLogger();
+    const engine = createEngine({
+      store,
+      githubAuth: fakeGitHubAuth(),
+      logger,
+      createOctokit: () => fakeOctokit(graphql),
+    });
+
+    const oldSync = engine.syncChecks(
+      repositoryUrl,
+      pullRequestUrl,
+      'old-caller-head',
+      new AbortController().signal
+    );
+    await oldRequestStarted.promise;
+    await expect(
+      engine.syncChecks(repositoryUrl, pullRequestUrl, 'new-head', new AbortController().signal)
+    ).resolves.toEqual(ok(false));
+    oldResponse.resolve(
+      gqlCheckRunsResponse('new-head', { status: 'IN_PROGRESS', conclusion: null })
+    );
+
+    await expect(oldSync).resolves.toMatchObject({
+      success: false,
+      error: { type: 'checks_failed' },
+    });
+    const pullRequest = store.listPullRequests({
+      repositoryUrls: [repositoryUrl],
+      cursor: null,
+      limit: 10,
+    }).prs[0];
+    expect(pullRequest).toMatchObject({
+      headRefOid: 'new-head',
+      checks: [{ name: 'CI', status: 'COMPLETED', commitSha: 'new-head' }],
+    });
+  });
+
+  it('keeps an older valid check sync when a newer attempt fails', async () => {
+    const handle = await pullRequestSqliteStore.openTemp();
+    closeHandles.push(() => handle.close());
+    const store = new PullRequestStore(handle);
+    const repositoryUrl = 'https://github.com/emdash/emdash';
+    const pullRequestUrl = `${repositoryUrl}/pull/42`;
+    store.registerRepository(repositoryUrl);
+    store.savePullRequest(pullRequestFixture());
+    const oldResponse = deferred<ReturnType<typeof gqlCheckRunsResponse>>();
+    const oldRequestStarted = deferred<void>();
+    const graphql = vi.fn(async () => {
+      oldRequestStarted.resolve(undefined);
+      return await oldResponse.promise;
+    });
+    let authCalls = 0;
+    const githubAuth: ContractClient<GitHubAuthContract> = {
+      resolveAuth: async () => {
+        authCalls += 1;
+        return authCalls === 1
+          ? ok({
+              token: 'test-token',
+              host: 'github.com',
+              apiBaseUrl: 'https://api.github.com',
+            })
+          : err({
+              type: 'account_unresolvable',
+              host: 'github.com',
+              message: 'The GitHub account is unavailable.',
+            });
+      },
+    };
+    const { logger } = createStubLogger();
+    const engine = createEngine({
+      store,
+      githubAuth,
+      logger,
+      createOctokit: () => fakeOctokit(graphql),
+    });
+
+    const oldSync = engine.syncChecks(
+      repositoryUrl,
+      pullRequestUrl,
+      'head',
+      new AbortController().signal
+    );
+    await oldRequestStarted.promise;
+    await expect(
+      engine.syncChecks(repositoryUrl, pullRequestUrl, 'head', new AbortController().signal)
+    ).resolves.toMatchObject({ success: false });
+    oldResponse.resolve(gqlCheckRunsResponse('head'));
+
+    await expect(oldSync).resolves.toEqual(ok(false));
+    expect(
+      store.listPullRequests({ repositoryUrls: [repositoryUrl], cursor: null, limit: 10 }).prs[0]
+        ?.checks
+    ).toHaveLength(1);
+  });
+
+  it('tracks successful check syncs separately for each pull request head', async () => {
+    const handle = await pullRequestSqliteStore.openTemp();
+    closeHandles.push(() => handle.close());
+    const store = new PullRequestStore(handle);
+    const repositoryUrl = 'https://github.com/emdash/emdash';
+    const pullRequestUrl = `${repositoryUrl}/pull/42`;
+    store.registerRepository(repositoryUrl);
+    store.savePullRequest({ ...pullRequestFixture(), headRefOid: 'head-a' });
+    const firstHeadResponse = deferred<ReturnType<typeof gqlCheckRunsResponse>>();
+    const firstRequestStarted = deferred<void>();
+    let graphqlCalls = 0;
+    const graphql = vi.fn(async () => {
+      graphqlCalls += 1;
+      if (graphqlCalls === 1) {
+        firstRequestStarted.resolve(undefined);
+        return await firstHeadResponse.promise;
+      }
+      return gqlCheckRunsResponse('head-b', { name: 'Head B CI' });
+    });
+    let authCalls = 0;
+    const githubAuth: ContractClient<GitHubAuthContract> = {
+      resolveAuth: async () => {
+        authCalls += 1;
+        return authCalls < 3
+          ? ok({
+              token: 'test-token',
+              host: 'github.com',
+              apiBaseUrl: 'https://api.github.com',
+            })
+          : err({
+              type: 'account_unresolvable',
+              host: 'github.com',
+              message: 'The GitHub account is unavailable.',
+            });
+      },
+    };
+    const { logger } = createStubLogger();
+    const engine = createEngine({
+      store,
+      githubAuth,
+      logger,
+      createOctokit: () => fakeOctokit(graphql),
+    });
+
+    const firstHeadSync = engine.syncChecks(
+      repositoryUrl,
+      pullRequestUrl,
+      'head-a',
+      new AbortController().signal
+    );
+    await firstRequestStarted.promise;
+    store.savePullRequest({ ...pullRequestFixture(), headRefOid: 'head-b' });
+    await expect(
+      engine.syncChecks(repositoryUrl, pullRequestUrl, 'head-b', new AbortController().signal)
+    ).resolves.toEqual(ok(false));
+    store.savePullRequest({ ...pullRequestFixture(), headRefOid: 'head-a' });
+    await expect(
+      engine.syncChecks(repositoryUrl, pullRequestUrl, 'head-a', new AbortController().signal)
+    ).resolves.toMatchObject({ success: false });
+    firstHeadResponse.resolve(gqlCheckRunsResponse('head-a', { name: 'Head A CI' }));
+
+    await expect(firstHeadSync).resolves.toEqual(ok(false));
+    expect(
+      store.listPullRequests({ repositoryUrls: [repositoryUrl], cursor: null, limit: 10 }).prs[0]
+        ?.checks
+    ).toEqual([expect.objectContaining({ name: 'Head A CI', commitSha: 'head-a' })]);
   });
 
   it('schedules background sync pages with retry through one account lane', async () => {
@@ -964,6 +1258,57 @@ function fakeOctokit(graphql: (...args: never[]) => Promise<unknown>): Octokit {
     rest: {},
     paginate: vi.fn(),
   } as unknown as Octokit;
+}
+
+function gqlCheckRunsResponse(
+  headRefOid: string,
+  options: {
+    name?: string;
+    status?: string;
+    conclusion?: string | null;
+    hasNextPage?: boolean;
+    endCursor?: string | null;
+  } = {}
+) {
+  const {
+    name = 'CI',
+    status = 'COMPLETED',
+    conclusion = 'SUCCESS',
+    hasNextPage = false,
+    endCursor = null,
+  } = options;
+  return {
+    repository: {
+      pullRequest: {
+        commits: {
+          nodes: [
+            {
+              commit: {
+                oid: headRefOid,
+                statusCheckRollup: {
+                  contexts: {
+                    pageInfo: { hasNextPage, endCursor },
+                    nodes: [
+                      {
+                        __typename: 'CheckRun',
+                        name,
+                        status,
+                        conclusion,
+                        detailsUrl: 'https://github.com/checks/1',
+                        startedAt: '2026-01-01T00:00:00.000Z',
+                        completedAt: status === 'COMPLETED' ? '2026-01-01T00:01:00.000Z' : null,
+                        checkSuite: null,
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
 }
 
 function fakeCommentsOctokit(options: {

--- a/apps/emdash-desktop/src/core/services/pull-requests/node/engine/pull-request-engine.ts
+++ b/apps/emdash-desktop/src/core/services/pull-requests/node/engine/pull-request-engine.ts
@@ -74,6 +74,12 @@ type RequestLane = {
   gates: Record<GitHubRateResource, RateGate>;
 };
 
+type CheckSyncState = {
+  nextGeneration: number;
+  latestStoredGenerations: Map<string, number>;
+  active: number;
+};
+
 type GitHubRateResource = 'graphql' | 'rest';
 
 type GitHubClient = {
@@ -173,6 +179,7 @@ type GqlCheckNode = GqlCheckRunNode | GqlStatusContextNode;
 
 export class PullRequestEngine {
   private readonly requestLanes = new Map<string, RequestLane>();
+  private readonly checkSyncStates = new Map<string, CheckSyncState>();
   /**
    * Last identity each repository was accessed as, keyed by repository URL and
    * held in memory only — the store no longer persists an account binding.
@@ -301,21 +308,38 @@ export class PullRequestEngine {
     headRefOid: string,
     signal: AbortSignal
   ): Promise<Result<boolean, PullRequestError>> {
-    const repository = this.parseRepository(repositoryUrl);
-    if (!repository.success) return repository;
+    const requestedRepository = this.parseRepository(repositoryUrl);
+    if (!requestedRepository.success) return requestedRepository;
     const identity = this.options.store.getPullRequestIdentity(pullRequestUrl);
-    const number = identity?.identifier
+    if (!identity) return ok(false);
+    const repository = parseRepositoryRef(identity.repositoryUrl);
+    if (
+      repository?.repositoryUrl.toLowerCase() !==
+      requestedRepository.data.repositoryUrl.toLowerCase()
+    ) {
+      return err({
+        type: 'checks_failed',
+        message: 'The pull request does not belong to the requested repository.',
+      });
+    }
+    const number = identity.identifier
       ? Number.parseInt(identity.identifier.replace('#', ''), 10)
       : Number.NaN;
     if (!Number.isFinite(number)) return ok(false);
-    if (this.options.store.getChecksCommitSha(pullRequestUrl) !== headRefOid) {
-      this.options.store.clearChecks(pullRequestUrl);
-    }
-    const github = await this.getOctokit(repository.data, signal);
-    if (!github.success) return github;
-    const { lane, octokit } = github.data;
+    const syncState = this.checkSyncStates.get(pullRequestUrl) ?? {
+      nextGeneration: 0,
+      latestStoredGenerations: new Map<string, number>(),
+      active: 0,
+    };
+    this.checkSyncStates.set(pullRequestUrl, syncState);
+    const syncGeneration = ++syncState.nextGeneration;
+    syncState.active += 1;
     try {
+      const github = await this.getOctokit(repository, signal);
+      if (!github.success) return github;
+      const { lane, octokit } = github.data;
       const nodes: GqlCheckNode[] = [];
+      let checksHeadRefOid: string | undefined;
       let cursor: string | undefined;
       for (;;) {
         const response = await this.request(
@@ -323,7 +347,7 @@ export class PullRequestEngine {
           signal,
           {
             priority: requestPriorities.interactive,
-            key: `checks:${repository.data.repositoryUrl}:${number}:${headRefOid}:${cursor ?? ''}`,
+            key: `checks:${repository.repositoryUrl}:${number}:${headRefOid}:${cursor ?? ''}`,
           },
           (requestSignal) =>
             octokit.graphql<{
@@ -332,6 +356,7 @@ export class PullRequestEngine {
                   commits: {
                     nodes: Array<{
                       commit: {
+                        oid: string;
                         statusCheckRollup: {
                           contexts: {
                             pageInfo: { hasNextPage: boolean; endCursor: string | null };
@@ -345,28 +370,56 @@ export class PullRequestEngine {
               };
               rateLimit?: GraphQlRateLimit;
             }>(GET_PR_CHECK_RUNS_BY_URL_QUERY, {
-              owner: repository.data.owner,
-              repo: repository.data.repo,
+              owner: repository.owner,
+              repo: repository.repo,
               number,
               cursor: cursor ?? null,
               request: { signal: requestSignal },
             })
         );
         lane.gates.graphql.observe(graphQlRateFeedback(response.rateLimit));
-        const contexts =
-          response.repository.pullRequest?.commits.nodes[0]?.commit.statusCheckRollup?.contexts;
+        const commit = response.repository.pullRequest?.commits.nodes[0]?.commit;
+        if (!commit) {
+          return err({
+            type: 'checks_failed',
+            message: 'GitHub did not return a pull request head for the check runs.',
+          });
+        }
+        if (checksHeadRefOid && commit.oid !== checksHeadRefOid) {
+          return err({
+            type: 'checks_failed',
+            message: 'The pull request head changed while check runs were loading.',
+          });
+        }
+        checksHeadRefOid = commit.oid;
+        const contexts = commit.statusCheckRollup?.contexts;
         if (!contexts) break;
         nodes.push(...contexts.nodes);
         if (!contexts.pageInfo.hasNextPage) break;
         cursor = contexts.pageInfo.endCursor ?? undefined;
       }
-      this.options.store.replaceChecks(
+      if (!checksHeadRefOid) return ok(false);
+      if ((syncState.latestStoredGenerations.get(checksHeadRefOid) ?? 0) > syncGeneration) {
+        return err({
+          type: 'checks_failed',
+          message: 'A newer check run sync completed before this one.',
+        });
+      }
+      const replaced = this.options.store.replaceChecksForHead(
         pullRequestUrl,
+        checksHeadRefOid,
         nodes.map((node, index) =>
-          checkNodeToPullRequestCheck(node, pullRequestUrl, headRefOid, index)
+          checkNodeToPullRequestCheck(node, pullRequestUrl, checksHeadRefOid, index)
         )
       );
-      this.emit(repositoryUrl, {
+      if (!replaced) {
+        return err({
+          type: 'checks_failed',
+          message: 'The pull request head changed while check runs were loading.',
+        });
+      }
+      syncState.latestStoredGenerations.set(checksHeadRefOid, syncGeneration);
+      this.emit(repository.repositoryUrl, {
         phase: 'idle',
         kind: 'single',
         lastSyncedAt: Date.now(),
@@ -379,7 +432,12 @@ export class PullRequestEngine {
         )
       );
     } catch (error) {
-      return this.handleError(error, repository.data, 'Unable to sync check runs', 'checks_failed');
+      return this.handleError(error, repository, 'Unable to sync check runs', 'checks_failed');
+    } finally {
+      syncState.active -= 1;
+      if (syncState.active === 0 && this.checkSyncStates.get(pullRequestUrl) === syncState) {
+        this.checkSyncStates.delete(pullRequestUrl);
+      }
     }
   }
 

--- a/apps/emdash-desktop/src/core/services/pull-requests/node/store/pull-request-store.ts
+++ b/apps/emdash-desktop/src/core/services/pull-requests/node/store/pull-request-store.ts
@@ -443,20 +443,19 @@ export class PullRequestStore {
     );
   }
 
-  getChecksCommitSha(pullRequestUrl: string): string | null {
-    return (
-      this.handle.connection.get<{ commitSha: string }>(
-        `SELECT commit_sha AS commitSha
-        FROM pull_request_checks
-        WHERE pull_request_url = ?
-        LIMIT 1`,
+  replaceChecksForHead(
+    pullRequestUrl: string,
+    headRefOid: string,
+    checks: PullRequestCheck[]
+  ): boolean {
+    return this.handle.transaction(() => {
+      const current = this.handle.connection.get<{ headRefOid: string }>(
+        `SELECT head_ref_oid AS headRefOid
+        FROM pull_requests
+        WHERE url = ?`,
         [pullRequestUrl]
-      )?.commitSha ?? null
-    );
-  }
-
-  replaceChecks(pullRequestUrl: string, checks: PullRequestCheck[]): void {
-    this.handle.transaction(() => {
+      );
+      if (current?.headRefOid !== headRefOid) return false;
       this.handle.connection.run('DELETE FROM pull_request_checks WHERE pull_request_url = ?', [
         pullRequestUrl,
       ]);
@@ -482,13 +481,8 @@ export class PullRequestStore {
           ]
         );
       }
+      return true;
     });
-  }
-
-  clearChecks(pullRequestUrl: string): void {
-    this.handle.connection.run('DELETE FROM pull_request_checks WHERE pull_request_url = ?', [
-      pullRequestUrl,
-    ]);
   }
 
   replaceComments(pullRequestUrl: string, comments: PullRequestComment[]): void {
@@ -695,9 +689,9 @@ export class PullRequestStore {
           app_name AS appName,
           app_logo_url AS appLogoUrl
         FROM pull_request_checks
-        WHERE pull_request_url = ?
+        WHERE pull_request_url = ? AND commit_sha = ?
         ORDER BY name`,
-        [row.url]
+        [row.url, row.headRefOid]
       );
       return {
         url: row.url,


### PR DESCRIPTION
### Description

A pull request can move to a new head while its checks are still loading. Emdash currently drops the head OID returned by GitHub and stores those checks using the caller's SHA, which can attach fresh results to an older commit.

This change keeps GitHub's returned OID, rejects pages from different heads, and only replaces checks when that OID still matches the pull request's stored head. Cached checks from an older head stay hidden, and a newer sync cannot be overwritten by an older one that finishes later.

It also verifies that the repository and pull request URL belong together before requesting checks.

### Related issues

Fixes #3175.

### Testing

- `pnpm exec vitest run --project main-db src/core/services/pull-requests/node/engine/pull-request-engine.db.test.ts`
- `pnpm exec vitest run --project main-db src/core/services/pull-requests/node/store/pull-request-store.db.test.ts`
- `pnpm exec vitest run --project main-db src/core/services/pull-requests/node/pull-request-service.db.test.ts`
- `pnpm exec oxfmt --check src/core/services/pull-requests/node/engine/pull-request-engine.ts src/core/services/pull-requests/node/engine/pull-request-engine.db.test.ts src/core/services/pull-requests/node/store/pull-request-store.ts`
- `pnpm exec oxlint src/core/services/pull-requests/node/engine/pull-request-engine.ts src/core/services/pull-requests/node/engine/pull-request-engine.db.test.ts src/core/services/pull-requests/node/store/pull-request-store.ts`
- `pnpm exec tsgo --noEmit -p tsconfig.node.json`

### Screenshot/Recording (if applicable)

Not applicable. This changes the pull request service and database behavior, with no UI changes.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed (not applicable; no user-facing docs changed)
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>
