### PR TITLE
fix(agents): honor custom CLI and path overrides

### DIFF
--- a/agents/architecture/workspace-server.md
+++ b/agents/architecture/workspace-server.md
@@ -121,7 +121,7 @@ The wire contract is versioned with a single [semver](https://semver.org) string
 [`packages/core/src/workspace-server/versions/index.ts`](../../packages/core/src/workspace-server/versions/index.ts):
 
 ```ts
-export const PROTOCOL_VERSION = '8.0.0';
+export const PROTOCOL_VERSION = '9.0.0';
 ```
 
 ### What each component means

--- a/agents/integrations/providers.md
+++ b/agents/integrations/providers.md
@@ -83,6 +83,14 @@ you select an OrcaRouter model from the OpenCode model picker.
   interpolated shell command and no uninstall/install lifecycle in provider metadata. Future managed
   sources such as Nix should add new source and selection variants without changing runtime spawn
   injection.
+- Executable selection belongs to the host-dependency runtime. Auto follows the plugin's binary
+  names on the host PATH; a saved path or CLI-name override resolves independently of discovery.
+  The resolver accepts an optional proposed selection, so validation and startup share one
+  operation and implementation. Invalid overrides block launch and
+  never fall back to Auto. Settings save only after validation, and failed saves retain the previous
+  selection. Existing path-selection JSON remains valid; CLI selections add a `kind: 'cli'` variant
+  with a `command` field. Overrides accept executable files or PATH names; use a wrapper script for
+  commands with arguments, such as `srt claude`.
 - Claude uses deterministic `--session-id` values for conversation isolation.
 - Codex ACP exposes collaboration mode separately from permission mode. The ACP runtime maps the
   provider-owned `collaboration_mode` config category to the chat composer's Default/Plan selector

--- a/apps/emdash-desktop/src/core/features/agents/api/browser/client.ts
+++ b/apps/emdash-desktop/src/core/features/agents/api/browser/client.ts
@@ -11,8 +11,8 @@ export function getAgentsClient(): Promise<AgentsRpcClient> {
   return domainClient<AgentsRpcClient>(agentsDomain, agentsContract);
 }
 
-export async function unwrapAgentsResult<T>(
-  result: Promise<Result<T, RuntimeResolveError>>
+export async function unwrapAgentsResult<T, E = RuntimeResolveError>(
+  result: Promise<Result<T, E>>
 ): Promise<T> {
   const resolved = await result;
   if (!resolved.success) throw resolved.error;

--- a/apps/emdash-desktop/src/core/features/agents/api/browser/use-agent-installation-statuses.ts
+++ b/apps/emdash-desktop/src/core/features/agents/api/browser/use-agent-installation-statuses.ts
@@ -1,3 +1,7 @@
+import type {
+  HostDependencyError,
+  ResolvedHostDependency,
+} from '@emdash/core/primitives/host-dependencies/api';
 import { hostRefKey, type HostRef } from '@emdash/core/primitives/host/api';
 import {
   isRuntimeResolveError,
@@ -9,7 +13,7 @@ import { toast } from '@emdash/ui/react/primitives';
 import { useMutation, useMutationState, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo } from 'react';
 import { getAgentsClient, unwrapAgentsResult } from '@core/features/agents/api/browser/client';
-import { useAgents } from '@core/features/agents/api/browser/use-agents';
+import { AGENTS_METADATA_QUERY_KEY, useAgents } from '@core/features/agents/api/browser/use-agents';
 import type {
   AgentInstallationStatus,
   AgentInstallError,
@@ -158,12 +162,19 @@ export function useAgentInstallationStatuses(host: HostRef) {
 
   const setUsedMutation = useMutation<
     void,
-    RuntimeResolveError,
+    RuntimeResolveError | HostDependencyError,
     { id: string; selection: HostDependencySelection }
   >({
     mutationFn: async ({ id, selection }) =>
       unwrapAgentsResult((await getAgentsClient()).setUsedInstallation({ host, id, selection })),
-    onSuccess: invalidate,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: key }),
+        queryClient.invalidateQueries({
+          queryKey: [...AGENTS_METADATA_QUERY_KEY, hostRefKey(host)],
+        }),
+      ]);
+    },
   });
 
   const refreshLatestMutation = useMutation<void, RuntimeResolveError, string>({
@@ -186,7 +197,7 @@ export function useAgentInstallationStatuses(host: HostRef) {
     updateFailures: updateFailureMap.failures,
     dismissInstallFailure: installFailureMap.clearFailure,
     dismissUpdateFailure: updateFailureMap.clearFailure,
-    setUsedInstallation: setUsedMutation.mutate,
+    setUsedInstallation: setUsedMutation.mutateAsync,
     refreshLatestVersion: refreshLatestMutation.mutate,
     probeAll: probeAllMutation.mutate,
     isInstalling: installMutation.isPending,
@@ -222,7 +233,7 @@ export type HostDependencyInstallation = {
   setUsed(selection: HostDependencySelection): Promise<void>;
   refresh(): Promise<void>;
   fetchLatestVersion(): Promise<void>;
-  probeOverride(selection: { path?: string; cli?: string }): Promise<Installation | null>;
+  resolve(selection?: HostDependencySelection): Promise<ResolvedHostDependency>;
 };
 
 export function useAgentInstallationStatus(
@@ -310,10 +321,7 @@ export function useAgentInstallationStatus(
   );
 
   const setUsed = useCallback(
-    (selection: HostDependencySelection) =>
-      new Promise<void>((resolve) => {
-        setUsedInstallation({ id, selection }, { onSettled: () => resolve() });
-      }),
+    (selection: HostDependencySelection) => setUsedInstallation({ id, selection }),
     [setUsedInstallation, id]
   );
 
@@ -333,10 +341,10 @@ export function useAgentInstallationStatus(
     [refreshLatestVersion, id]
   );
 
-  const probeOverride = useCallback(
-    async (selection: { path?: string; cli?: string }) =>
+  const resolve = useCallback(
+    async (selection?: HostDependencySelection) =>
       unwrapAgentsResult(
-        (await getAgentsClient()).probeOverride({
+        (await getAgentsClient()).resolveInstallation({
           host,
           id: id as AgentProviderId,
           selection,
@@ -367,7 +375,7 @@ export function useAgentInstallationStatus(
     setUsed,
     refresh,
     fetchLatestVersion,
-    probeOverride,
+    resolve,
   };
 }
 

--- a/apps/emdash-desktop/src/core/features/agents/api/contract.ts
+++ b/apps/emdash-desktop/src/core/features/agents/api/contract.ts
@@ -1,3 +1,8 @@
+import {
+  hostDependencyErrorSchema,
+  hostDependencySelectionSchema,
+  resolvedHostDependencySchema,
+} from '@emdash/core/primitives/host-dependencies/api';
 import { hostRefSchema } from '@emdash/core/primitives/host/api';
 import {
   agentConfigAuthErrorSchema,
@@ -97,16 +102,14 @@ export const agentsContract = defineContract({
     error: runtimeResolveErrorSchema,
   }),
   setUsedInstallation: fallible({
-    input: agentInputSchema.extend({ selection: z.unknown().optional() }),
+    input: agentInputSchema.extend({ selection: hostDependencySelectionSchema }),
     data: z.void(),
-    error: runtimeResolveErrorSchema,
+    error: z.union([hostDependencyErrorSchema, runtimeResolveErrorSchema]),
   }),
-  probeOverride: fallible({
-    input: agentInputSchema.extend({
-      selection: z.object({ path: z.string().optional(), cli: z.string().optional() }),
-    }),
-    data: z.null(),
-    error: runtimeResolveErrorSchema,
+  resolveInstallation: fallible({
+    input: agentInputSchema.extend({ selection: hostDependencySelectionSchema.optional() }),
+    data: resolvedHostDependencySchema,
+    error: z.union([hostDependencyErrorSchema, runtimeResolveErrorSchema]),
   }),
   refreshLatestVersion: fallible({
     input: agentInputSchema,

--- a/apps/emdash-desktop/src/core/features/agents/node/agent-payload-builder.ts
+++ b/apps/emdash-desktop/src/core/features/agents/node/agent-payload-builder.ts
@@ -150,11 +150,11 @@ export function toAgentInstallationStatus(
 }
 
 function installationsFromView(view: HostDependencyView): Installation[] {
-  return view.candidates.map((candidate) => ({
+  const installations: Installation[] = view.candidates.map((candidate) => ({
     id: candidate.realpath,
     realpath: candidate.realpath,
     pathEntry: candidate.path,
-    isActive: candidate.isPathDefault,
+    isActive: !view.selection && candidate.isPathDefault,
     manageable: false,
     provenance: { kind: 'unknown', confidence: 'inferred' },
     status: 'available',
@@ -162,6 +162,22 @@ function installationsFromView(view: HostDependencyView): Installation[] {
     latestVersion: null,
     updateAvailable: false,
   }));
+  if (view.selection) {
+    const value = view.selection.kind === 'path' ? view.selection.path : view.selection.command;
+    installations.push({
+      id: view.selection.kind,
+      realpath: view.resolved?.realpath ?? value,
+      pathEntry: value,
+      isActive: true,
+      manageable: false,
+      provenance: { kind: 'manual', confidence: 'confirmed' },
+      status: view.status,
+      version: null,
+      latestVersion: null,
+      updateAvailable: false,
+    });
+  }
+  return installations;
 }
 
 function sourceKey(source: SelectedSource): string {

--- a/apps/emdash-desktop/src/core/features/agents/node/controller.test.ts
+++ b/apps/emdash-desktop/src/core/features/agents/node/controller.test.ts
@@ -1,5 +1,5 @@
 import { hostDependenciesContract } from '@emdash/core/services/host-dependencies/node';
-import { err } from '@emdash/shared';
+import { err, ok } from '@emdash/shared';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createAgentOperations } from './controller';
 
@@ -81,3 +81,51 @@ function createOperations() {
     providerOverrideSettings: {} as never,
   });
 }
+
+describe('executable overrides', () => {
+  it('probes through the supplied host client without persisting', async () => {
+    const resolved = {
+      id: 'claude',
+      command: 'wrapper',
+      path: '/remote/bin/wrapper',
+      realpath: '/remote/bin/wrapper',
+      source: { kind: 'cli', command: 'wrapper' },
+    };
+    const resolve = vi.fn(async () => ok(resolved));
+    const mutate = vi.fn();
+    const operations = createOperations();
+    expect(
+      await operations.resolveInstallation(
+        'claude',
+        { kind: 'cli', command: 'wrapper' },
+        'remote',
+        {
+          resolver: { resolve },
+          snapshot: { mutate },
+        } as never
+      )
+    ).toEqual(ok(resolved));
+    expect(resolve).toHaveBeenCalledWith({
+      id: 'claude',
+      selection: { kind: 'cli', command: 'wrapper' },
+    });
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it('preserves command names and propagates save errors', async () => {
+    const failure = err({ type: 'io', message: 'disk full' });
+    const mutate = vi.fn(async () => failure);
+    expect(
+      await createOperations().setUsedInstallation(
+        'claude',
+        undefined,
+        { kind: 'cli', command: 'wrapper' },
+        { snapshot: { mutate } } as never
+      )
+    ).toEqual(failure);
+    expect(mutate).toHaveBeenCalledWith('setSelection', {
+      key: undefined,
+      input: { id: 'claude', selection: { kind: 'cli', command: 'wrapper' } },
+    });
+  });
+});

--- a/apps/emdash-desktop/src/core/features/agents/node/controller.ts
+++ b/apps/emdash-desktop/src/core/features/agents/node/controller.ts
@@ -1,4 +1,8 @@
 import type {
+  HostDependencyError,
+  HostDependencySelection,
+} from '@emdash/core/primitives/host-dependencies/api';
+import type {
   DependencyId,
   HostDependencyOperationProgress,
   HostDependencySnapshot,
@@ -7,7 +11,7 @@ import { hostDependenciesContract } from '@emdash/core/services/host-dependencie
 import type { HostDependenciesContract } from '@emdash/core/services/host-dependencies/node';
 import { runtimeResolveErrorAsError } from '@emdash/core/services/runtime-broker/api';
 import type { AgentProviderId } from '@emdash/plugins/agents/types';
-import type { Result } from '@emdash/shared';
+import { err, ok, type Result } from '@emdash/shared';
 import type { ContractClient } from '@emdash/wire/rpc';
 import type { InstallMethod } from '@core/primitives/agents/api';
 import type { ProviderCustomConfig } from '@core/primitives/app-settings/api';
@@ -157,17 +161,16 @@ export function createAgentOperations(dependencies: {
 
     setUsedInstallation: async (
       id: DependencyId,
-      connectionId?: string,
-      selection?: unknown,
+      connectionId: string | undefined,
+      selection: HostDependencySelection,
       manager?: HostDependenciesClient
-    ): Promise<void> => {
-      // undefined = no-op; null = explicit auto (clear override)
-      if (selection === undefined) return;
+    ): Promise<Result<void, HostDependencyError>> => {
       const mgr = await resolveDependencyManager(getDependencyManager, connectionId, manager);
-      await mgr.snapshot.mutate('setSelection', {
+      const result = await mgr.snapshot.mutate('setSelection', {
         key: undefined,
-        input: { id, selection: normalizeSelection(selection) },
+        input: { id, selection },
       });
+      return result.success ? ok() : err(result.error);
     },
 
     probe: async (id: DependencyId, connectionId?: string, manager?: HostDependenciesClient) => {
@@ -179,11 +182,15 @@ export function createAgentOperations(dependencies: {
       return result.success ? result.data.data.dependencies[id] : result;
     },
 
-    probeOverride: async (
-      _id: DependencyId,
-      _selection: { path?: string; cli?: string },
-      _connectionId?: string
-    ) => null,
+    resolveInstallation: async (
+      id: DependencyId,
+      selection: HostDependencySelection | undefined,
+      connectionId?: string,
+      manager?: HostDependenciesClient
+    ) => {
+      const mgr = await resolveDependencyManager(getDependencyManager, connectionId, manager);
+      return mgr.resolver.resolve(selection === undefined ? { id } : { id, selection });
+    },
 
     refreshLatestVersion: async (_id: DependencyId, _connectionId?: string): Promise<void> => {},
 
@@ -220,29 +227,4 @@ async function snapshotFor(
   await ensureProbed(manager);
   const snapshot = await manager.snapshot.state(undefined, 'current').snapshot();
   return snapshot.data;
-}
-
-function normalizeSelection(selection: unknown): { kind: 'path'; path: string } | null {
-  if (selection === null) return null;
-  if (typeof selection !== 'object' || selection === null) return null;
-  const candidate = selection as {
-    kind?: unknown;
-    path?: unknown;
-    realpath?: unknown;
-    command?: unknown;
-  };
-  if (candidate.kind === 'path' && typeof candidate.path === 'string') {
-    return { kind: 'path', path: candidate.path };
-  }
-  if (candidate.kind === 'pinned' && typeof candidate.realpath === 'string') {
-    return { kind: 'path', path: candidate.realpath };
-  }
-  if (
-    candidate.kind === 'cli' &&
-    typeof candidate.command === 'string' &&
-    candidate.command.startsWith('/')
-  ) {
-    return { kind: 'path', path: candidate.command };
-  }
-  return null;
 }

--- a/apps/emdash-desktop/src/core/features/agents/node/override-launch.test.ts
+++ b/apps/emdash-desktop/src/core/features/agents/node/override-launch.test.ts
@@ -1,0 +1,92 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { createMemoryKeyValueStore } from '@emdash/core/primitives/kv/api';
+import {
+  AgentPluginHost,
+  createPluginRegistry,
+  type CLIAgentPluginProvider,
+} from '@emdash/core/services/agent-plugins/api/plugins';
+import { createLocalPluginFs } from '@emdash/core/services/agent-plugins/api/plugins/helpers';
+import { NodeExecutionContext } from '@emdash/core/services/exec/api';
+import { HostDependenciesRuntime } from '@emdash/core/services/host-dependencies/node';
+import { createScope } from '@emdash/shared/concurrency';
+import { describe, expect, it } from 'vitest';
+import { getPlugin } from '@core/features/agents/api/node/plugin-registry';
+import { toAgentInstallationStatus } from './agent-payload-builder';
+
+describe.skipIf(process.platform === 'win32')('Claude executable override launch', () => {
+  it('uses the saved wrapper for TUI and Claude ACP without changing provider arguments', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'emdash-override-launch-'));
+    const wrapper = join(directory, 'sandbox wrapper');
+    await writeFile(wrapper, '#!/bin/sh\nprintf "wrapper:%s\\n" "$@"\n', { mode: 0o755 });
+    const scope = createScope({ label: 'override-launch-test' });
+    const exec = new NodeExecutionContext({ env: { PATH: process.env.PATH } });
+    const runtime = new HostDependenciesRuntime({
+      hostId: 'local',
+      store: createMemoryKeyValueStore(),
+      exec,
+      definitions: [
+        {
+          id: 'claude',
+          name: 'Claude',
+          category: 'agent',
+          binaryNames: ['claude'],
+          status: 'active',
+        },
+      ],
+    });
+    const registry = createPluginRegistry<CLIAgentPluginProvider>();
+    registry.register(getPlugin('claude'));
+    const host = new AgentPluginHost({
+      scope,
+      registry,
+      exec,
+      dependencies: runtime,
+      fs: createLocalPluginFs(directory),
+      env: async () => ({ HOME: directory, PATH: process.env.PATH }),
+      homeDir: directory,
+    });
+    try {
+      const selected = await runtime.setSelection('claude', { kind: 'path', path: wrapper });
+      expect(selected.success).toBe(true);
+      if (!selected.success) throw new Error('Wrapper selection failed');
+      const status = toAgentInstallationStatus('claude', undefined, selected.data);
+      expect(status).toMatchObject({ used: { kind: 'path', path: wrapper }, command: wrapper });
+      expect(status.installations.find((installation) => installation.id === 'path')).toMatchObject(
+        { pathEntry: wrapper, isActive: true, status: 'available' }
+      );
+
+      const tui = await host.buildPromptCommand('claude', {
+        model: 'sonnet',
+        autoApprove: false,
+        initialPrompt: 'hello',
+      });
+      expect(tui).toMatchObject({ success: true, data: { command: wrapper } });
+      if (!tui.success) throw new Error('TUI invocation failed');
+      const output = await promisify(execFile)(tui.data.command, tui.data.args);
+      expect(output.stdout).toContain('wrapper:hello');
+
+      const acp = await host.buildAcpSpawn('claude', { cwd: directory });
+      expect(acp).toMatchObject({
+        success: true,
+        data: { command: process.execPath, env: { CLAUDE_CODE_EXECUTABLE: wrapper } },
+      });
+      await rm(wrapper);
+      expect(
+        await host.buildPromptCommand('claude', { model: 'sonnet', autoApprove: false })
+      ).toMatchObject({ success: false, error: { type: 'cli-not-found' } });
+      expect(await host.buildAcpSpawn('claude', { cwd: directory })).toMatchObject({
+        success: false,
+        error: { type: 'cli-not-found' },
+      });
+    } finally {
+      await host.dispose();
+      runtime.dispose();
+      await scope.dispose();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/emdash-desktop/src/core/features/agents/node/wire-controller.test.ts
+++ b/apps/emdash-desktop/src/core/features/agents/node/wire-controller.test.ts
@@ -15,6 +15,48 @@ const legacyOperations = vi.hoisted(() => ({
 const remoteHost = hostRef('remote', 'ssh-1');
 
 describe('createAgentsWireController', () => {
+  it('carries override validation results and errors across Wire on the selected host', async () => {
+    const resolved = {
+      id: 'claude',
+      command: 'wrapper',
+      path: '/remote/wrapper',
+      realpath: '/remote/wrapper',
+      source: { kind: 'cli' as const, command: 'wrapper' },
+    };
+    const resolveInstallation = vi.fn(async () => ok(resolved));
+    const failure = { type: 'invalid-selection' as const, id: 'claude', message: 'Not executable' };
+    const setUsedInstallation = vi.fn(async () => err(failure));
+    const hostDependencies = {};
+    const controller = createAgentsWireController({
+      operations: { resolveInstallation, setUsedInstallation } as never,
+      runtimes: { client: async () => ok({ hostDependencies }) } as never,
+    });
+    const wire = createTestWire(agentsContract, controller);
+    try {
+      expect(
+        await wire.client.resolveInstallation({
+          host: remoteHost,
+          id: 'claude',
+          selection: { kind: 'cli', command: 'wrapper' },
+        })
+      ).toEqual(ok(resolved));
+      expect(resolveInstallation).toHaveBeenCalledWith(
+        'claude',
+        { kind: 'cli', command: 'wrapper' },
+        'ssh-1',
+        hostDependencies
+      );
+      expect(
+        await wire.client.setUsedInstallation({
+          host: remoteHost,
+          id: 'claude',
+          selection: { kind: 'cli', command: 'wrapper' },
+        })
+      ).toEqual(err(failure));
+    } finally {
+      await wire.dispose();
+    }
+  });
   it('maps a remote HostRef to the existing SSH connection identity', async () => {
     const hostDependencies = {};
     const client = vi.fn(async () => ok({ hostDependencies }));

--- a/apps/emdash-desktop/src/core/features/agents/node/wire-controller.ts
+++ b/apps/emdash-desktop/src/core/features/agents/node/wire-controller.ts
@@ -79,7 +79,7 @@ export function createAgentsWireController(options: CreateAgentsWireControllerOp
     updateSettings: ({ host, id, config }) =>
       withHostRuntime(options.runtimes, host, () => agentOperations.updateSettings(id, config)),
     setUsedInstallation: ({ host, id, selection }) =>
-      withHostRuntime(options.runtimes, host, (runtime) =>
+      withHostResult(options.runtimes, host, (runtime) =>
         agentOperations.setUsedInstallation(
           id as DependencyId,
           sshConnectionIdOf(host),
@@ -87,9 +87,14 @@ export function createAgentsWireController(options: CreateAgentsWireControllerOp
           runtime.hostDependencies
         )
       ),
-    probeOverride: ({ host, id, selection }) =>
-      withHostRuntime(options.runtimes, host, () =>
-        agentOperations.probeOverride(id as DependencyId, selection, sshConnectionIdOf(host))
+    resolveInstallation: ({ host, id, selection }) =>
+      withHostResult(options.runtimes, host, (runtime) =>
+        agentOperations.resolveInstallation(
+          id as DependencyId,
+          selection,
+          sshConnectionIdOf(host),
+          runtime.hostDependencies
+        )
       ),
     refreshLatestVersion: ({ host, id }) =>
       withHostRuntime(options.runtimes, host, () =>
@@ -154,6 +159,16 @@ async function withHostRuntime<T>(
   const runtime = await runtimes.client(host);
   if (!runtime.success) return err(runtime.error);
   return ok(await work(runtime.data));
+}
+
+async function withHostResult<T, E>(
+  runtimes: AgentsRuntimeBroker,
+  host: HostRef,
+  work: (client: HostRuntimesClient) => Promise<Result<T, E>>
+): Promise<Result<T, E | RuntimeResolveError>> {
+  const runtime = await runtimes.client(host);
+  if (!runtime.success) return err(runtime.error);
+  return work(runtime.data);
 }
 
 async function withAgentConfigResult<T, E>(

--- a/apps/emdash-desktop/src/core/features/settings/browser/agents-page/DependencyInstallationStatusCard.tsx
+++ b/apps/emdash-desktop/src/core/features/settings/browser/agents-page/DependencyInstallationStatusCard.tsx
@@ -105,6 +105,7 @@ export const DependencyInstallationStatusCard = observer(function DependencyInst
 
         <DropdownMenu.Root>
           <DropdownMenu.Trigger
+            disabled={state === 'checking'}
             className="shrink-0 rounded p-1 text-foreground-passive hover:bg-background-2 hover:text-foreground"
             aria-label="Installation options"
           >

--- a/apps/emdash-desktop/src/core/features/settings/browser/agents-page/InstallationOverrideCard.tsx
+++ b/apps/emdash-desktop/src/core/features/settings/browser/agents-page/InstallationOverrideCard.tsx
@@ -1,9 +1,7 @@
-import { Alert, Input } from '@emdash/ui/react/primitives';
+import { Alert, Button, Input, toast } from '@emdash/ui/react/primitives';
 import { Loader2 } from 'lucide-react';
 import { useState } from 'react';
 import type { HostDependencyInstallation } from '@core/features/agents/api/browser/use-agent-installation-statuses';
-import type { Installation } from '@core/primitives/agents/api';
-import { CommandActionButton } from '@core/primitives/agents/browser/install-command-row';
 
 export type InstallationOverrideCardProps = {
   vm: HostDependencyInstallation;
@@ -12,8 +10,7 @@ export type InstallationOverrideCardProps = {
   initialValue?: string;
   /** Called when checking state changes (for parent to derive 'checking' state). */
   onChecking: (isChecking: boolean) => void;
-  /** Called with the probe result once Validate completes (null means probeOverride returned nothing). */
-  onResolved: (installation: Installation | null) => void;
+  onSaved: () => void;
 };
 
 export function InstallationOverrideCard({
@@ -21,18 +18,28 @@ export function InstallationOverrideCard({
   kind,
   initialValue = '',
   onChecking,
-  onResolved,
+  onSaved,
 }: InstallationOverrideCardProps) {
   const [value, setValue] = useState(initialValue);
   const [isChecking, setIsChecking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleValidate = async () => {
     setIsChecking(true);
+    setError(null);
     onChecking(true);
     try {
-      const selection = kind === 'path' ? { path: value } : { cli: value };
-      const result = await vm.probeOverride(selection);
-      onResolved(result ?? null);
+      const selection = kind === 'path' ? { kind, path: value } : { kind, command: value };
+      await vm.resolve(selection);
+      await vm.setUsed(selection);
+      toast('Executable override saved');
+      onSaved();
+    } catch (error) {
+      setError(
+        error && typeof error === 'object' && 'message' in error
+          ? String(error.message)
+          : 'Could not validate or save this executable.'
+      );
     } finally {
       setIsChecking(false);
       onChecking(false);
@@ -44,8 +51,12 @@ export function InstallationOverrideCard({
   return (
     <div className="space-y-2 rounded-lg border p-3">
       <Input
+        aria-label={kind === 'path' ? 'Executable path' : 'Command name'}
         value={value}
-        onChange={(e) => setValue(e.target.value)}
+        onChange={(e) => {
+          setValue(e.target.value);
+          setError(null);
+        }}
         placeholder={
           kind === 'path' ? '/usr/local/bin/claude' : kind === 'cli' ? 'claude' : undefined
         }
@@ -57,11 +68,18 @@ export function InstallationOverrideCard({
           ? "Using an absolute path to the agent binary overrides auto-resolution and disables emdash's ability to update the agent."
           : "Enter the command name or binary resolved on PATH. This overrides auto-resolution and disables emdash's ability to update the agent."}
       </Alert.Root>
+      {error && <Alert.Root status="destructive">{error}</Alert.Root>}
       {hasValue && (
         <div className="flex justify-end">
-          <CommandActionButton disabled={isChecking} onClick={() => void handleValidate()}>
-            {isChecking ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : 'Validate'}
-          </CommandActionButton>
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={isChecking}
+            onClick={() => void handleValidate()}
+          >
+            {isChecking && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+            Validate
+          </Button>
         </div>
       )}
     </div>

--- a/apps/emdash-desktop/src/core/features/settings/browser/agents-page/installation-overrides.browser.test.tsx
+++ b/apps/emdash-desktop/src/core/features/settings/browser/agents-page/installation-overrides.browser.test.tsx
@@ -1,0 +1,154 @@
+import '@emdash/ui/style.css';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import type { HostDependencyInstallation } from '@core/features/agents/api/browser/use-agent-installation-statuses';
+import { InstallSection } from '@core/features/settings/contributions/browser/agents-page/InstallSection';
+
+const hooks = vi.hoisted(() => ({ useAgentInstallationStatus: vi.fn() }));
+vi.mock('@core/features/agents/api/browser/use-agent-installation-statuses', () => hooks);
+
+beforeAll(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+describe('installation override settings', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+  let vm: HostDependencyInstallation;
+
+  beforeEach(() => {
+    vm = {
+      runtimeError: null,
+      data: null,
+      used: { kind: 'auto' },
+      status: 'available',
+      installations: [
+        {
+          id: '/bin/claude',
+          realpath: '/bin/claude',
+          pathEntry: '/bin/claude',
+          isActive: true,
+          manageable: false,
+          provenance: { kind: 'unknown', confidence: 'inferred' },
+          status: 'available',
+          version: null,
+          latestVersion: null,
+          updateAvailable: false,
+        },
+      ],
+      isInstalling: false,
+      isUpdating: false,
+      isUninstalling: false,
+      installingMethod: undefined,
+      updatingMethod: undefined,
+      uninstallingMethod: undefined,
+      installFailure: null,
+      updateFailure: null,
+      install: vi.fn(),
+      update: vi.fn(),
+      uninstall: vi.fn(),
+      dismissInstallFailure: vi.fn(),
+      dismissUpdateFailure: vi.fn(),
+      refresh: vi.fn(),
+      fetchLatestVersion: vi.fn(),
+      setUsed: vi.fn(async () => {}),
+      resolve: vi.fn(async () => ({
+        id: 'claude',
+        command: '/custom/wrapper',
+        path: '/custom/wrapper',
+        realpath: '/custom/wrapper',
+        source: { kind: 'path' as const, path: '/custom/wrapper' },
+      })),
+    };
+    hooks.useAgentInstallationStatus.mockReturnValue(vm);
+    host = document.createElement('div');
+    host.style.width = '480px';
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    host.remove();
+  });
+
+  async function render() {
+    await act(async () =>
+      root.render(<InstallSection agentId="claude" agentPayload={undefined} installOptions={[]} />)
+    );
+  }
+
+  async function choosePathOverride() {
+    await page.getByRole('button', { name: 'Installation options' }).click();
+    await page.getByRole('menuitem', { name: 'Change source' }).click();
+    await page.getByRole('menuitem', { name: /^Path Override/ }).click();
+  }
+
+  it('keeps a new override as a draft until validation succeeds', async () => {
+    vi.mocked(vm.setUsed).mockImplementation(async (selection) => {
+      if (selection?.kind !== 'path') throw new Error('Expected a path');
+      vm.used = selection;
+      vm.installations.push({
+        id: 'path',
+        realpath: selection.path,
+        pathEntry: selection.path,
+        isActive: true,
+        manageable: false,
+        provenance: { kind: 'manual', confidence: 'confirmed' },
+        status: 'available',
+        version: null,
+        latestVersion: null,
+        updateAvailable: false,
+      });
+    });
+    await render();
+    await choosePathOverride();
+    expect(vm.setUsed).not.toHaveBeenCalled();
+    await page.getByRole('textbox', { name: 'Executable path' }).fill('/custom/wrapper');
+    // A background status render must not discard the draft.
+    vm.used = { kind: 'auto' };
+    await render();
+    await expect
+      .element(page.getByRole('textbox', { name: 'Executable path' }))
+      .toHaveValue('/custom/wrapper');
+    await page.getByRole('button', { name: 'Validate' }).click();
+    await expect
+      .poll(() => vi.mocked(vm.setUsed).mock.calls)
+      .toEqual([[{ kind: 'path', path: '/custom/wrapper' }]]);
+    expect(vm.resolve).toHaveBeenCalledWith({ kind: 'path', path: '/custom/wrapper' });
+    await expect.element(page.getByText('Found', { exact: true })).toBeVisible();
+    await expect
+      .element(page.getByRole('textbox', { name: 'Executable path' }))
+      .toHaveValue('/custom/wrapper');
+  });
+
+  it('shows validation failures and leaves the active selection untouched', async () => {
+    vi.mocked(vm.resolve).mockRejectedValue({
+      type: 'invalid-selection',
+      message: 'File is not executable',
+    });
+    await render();
+    await choosePathOverride();
+    await page.getByRole('textbox', { name: 'Executable path' }).fill('/bad/wrapper');
+    await page.getByRole('button', { name: 'Validate' }).click();
+    await expect.element(page.getByText('File is not executable')).toBeVisible();
+    expect(vm.setUsed).not.toHaveBeenCalled();
+  });
+
+  it('restores saved values and displays save failures', async () => {
+    vm.used = { kind: 'cli', command: 'sandbox-claude' };
+    vi.mocked(vm.setUsed).mockRejectedValue({ type: 'io', message: 'disk full' });
+    await render();
+    await expect
+      .element(page.getByRole('textbox', { name: 'Command name' }))
+      .toHaveValue('sandbox-claude');
+    await page.getByRole('button', { name: 'Validate' }).click();
+    await expect.element(page.getByText('disk full')).toBeVisible();
+    expect(vm.resolve).toHaveBeenCalledWith({ kind: 'cli', command: 'sandbox-claude' });
+    expect(vm.setUsed).toHaveBeenCalledWith({ kind: 'cli', command: 'sandbox-claude' });
+  });
+});

--- a/apps/emdash-desktop/src/core/features/settings/browser/agents-page/installation-sources.test.ts
+++ b/apps/emdash-desktop/src/core/features/settings/browser/agents-page/installation-sources.test.ts
@@ -125,10 +125,10 @@ describe('findInstallation', () => {
 // ---------------------------------------------------------------------------
 
 describe('toSelection', () => {
-  it('builds pinned selection', () => {
+  it('normalizes a pinned source to a path selection', () => {
     expect(toSelection({ kind: 'pinned', realpath: '/opt/homebrew/bin/tool' })).toEqual({
-      kind: 'pinned',
-      realpath: '/opt/homebrew/bin/tool',
+      kind: 'path',
+      path: '/opt/homebrew/bin/tool',
     });
   });
 
@@ -146,11 +146,8 @@ describe('toSelection', () => {
     });
   });
 
-  it('builds method selection', () => {
-    expect(toSelection({ kind: 'method', method: 'npm' })).toEqual({
-      kind: 'method',
-      method: 'npm',
-    });
+  it('does not persist an install method as an executable selection', () => {
+    expect(toSelection({ kind: 'method', method: 'npm' })).toBeNull();
   });
 
   it('returns null for auto (clear override)', () => {
@@ -163,6 +160,16 @@ describe('toSelection', () => {
 // ---------------------------------------------------------------------------
 
 describe('buildSourceRows', () => {
+  it('shows the discovered default in Auto even while an override is active', () => {
+    const discovered = makeInstall({ realpath: '/bin/claude', isActive: false });
+    const override = makeInstall({ id: 'path', realpath: '/custom/wrapper', isActive: true });
+    expect(buildSourceRows(installOptions, [discovered, override])[0]).toMatchObject({
+      ref: { kind: 'auto' },
+      displayPath: '/bin/claude',
+      status: 'available',
+    });
+    expect(buildSourceRows(installOptions, [override])[0]?.status).toBe('missing');
+  });
   it('includes auto as the first row', () => {
     const rows = buildSourceRows(installOptions, []);
     expect(rows[0]?.ref.kind).toBe('auto');

--- a/apps/emdash-desktop/src/core/features/settings/browser/agents-page/installation-sources.ts
+++ b/apps/emdash-desktop/src/core/features/settings/browser/agents-page/installation-sources.ts
@@ -25,10 +25,10 @@ export function toSelection(
   ref: SelectedSource,
   overrideValues: { path?: string; cli?: string } = {}
 ): HostDependencySelection {
-  if (ref.kind === 'pinned') return { kind: 'pinned', realpath: ref.realpath };
+  if (ref.kind === 'pinned') return { kind: 'path', path: ref.realpath };
   if (ref.kind === 'path') return { kind: 'path', path: overrideValues.path ?? '' };
   if (ref.kind === 'cli') return { kind: 'cli', command: overrideValues.cli ?? '' };
-  if (ref.kind === 'method') return { kind: 'method', method: ref.method };
+  if (ref.kind === 'method') return null;
   // auto → null (clear override)
   return null;
 }
@@ -135,12 +135,12 @@ export function buildSourceRows(
   // 1. Auto row — a policy ("follow the PATH winner"), not a concrete install.
   // It never carries an "Installed" badge; instead the sublabel shows what it
   // currently resolves to so the user can see where auto points.
-  const activeInst = installations.find((i) => i.isActive);
+  const autoInst = installations.find((i) => i.id !== 'path' && i.id !== 'cli');
   rows.push({
     ref: { kind: 'auto' },
     label: 'Auto',
-    status: activeInst?.status ?? 'missing',
-    displayPath: activeInst ? shortPath(activeInst.pathEntry ?? activeInst.realpath) : undefined,
+    status: autoInst?.status ?? 'missing',
+    displayPath: autoInst ? shortPath(autoInst.pathEntry ?? autoInst.realpath) : undefined,
   });
 
   // 2. Detected installations

--- a/apps/emdash-desktop/src/core/features/settings/contributions/browser/agents-page/InstallSection.tsx
+++ b/apps/emdash-desktop/src/core/features/settings/contributions/browser/agents-page/InstallSection.tsx
@@ -1,3 +1,4 @@
+import { toast } from '@emdash/ui/react/primitives';
 import { observer } from 'mobx-react-lite';
 import { useEffect, useMemo, useState } from 'react';
 import { hostRefFromConnectionId } from '@core/features/agents/api/browser/client';
@@ -14,12 +15,10 @@ import { InstallationOverrideCard } from '@core/features/settings/browser/agents
 import { InstallDependencyCard } from '@core/features/settings/browser/agents-page/InstallDependencyCard';
 import type {
   AgentPayload,
-  Installation,
   InstallMethod,
   InstallOption,
   SelectedSource,
 } from '@core/primitives/agents/api';
-import { sourceKey } from '@core/primitives/agents/api';
 
 export type InstallSectionProps = {
   agentId: string;
@@ -64,7 +63,7 @@ function seedSource(
 
 /**
  * Status-driven composer that owns the renderer-local `selectedSource` (UI intent).
- * Selection is always persisted immediately — `used` and `selectedSource` are kept in sync.
+ * Override drafts are persisted only after validation succeeds.
  * Uninstalled agents with no prior override default to the recommended install method.
  */
 export const InstallSection = observer(function InstallSection({
@@ -104,37 +103,25 @@ const LocalInstallSection = observer(function LocalInstallSection({
     agentPayload
   );
 
-  const [selectedSource, setSelectedSource] = useState<SelectedSource>(() =>
-    seedSource(vm.used, vm.status, installOptions)
-  );
+  const [sourceDraft, setSourceDraft] = useState<SelectedSource | null>(null);
+  const selectedSource = sourceDraft ?? seedSource(vm.used, vm.status, installOptions);
   const [isChecking, setIsChecking] = useState(false);
 
-  // Follow vm.used changes from background probes / post-install updates.
-  // When vm.used is auto and the agent is not installed, keep the recommended
-  // default instead of resetting — the user hasn't persisted a choice yet.
+  // A completed install returns to the active source; background probes leave override drafts alone.
   useEffect(() => {
-    if (vm.isInstalling || vm.isUpdating || !vm.used) return;
-    const liveRef = refFromUsed(vm.used);
-    if (liveRef.kind !== 'auto') {
-      // Explicit persisted selection — always follow it
-      setSelectedSource((prev) => (sourceKey(prev) !== sourceKey(liveRef) ? liveRef : prev));
-    } else if (vm.status === 'available') {
-      // Installed via auto (no explicit method) — reset to auto
-      setSelectedSource((prev) => (prev.kind !== 'auto' ? { kind: 'auto' } : prev));
+    if (vm.status === 'available' && !vm.isInstalling && !vm.isUpdating) {
+      setSourceDraft((draft) => (draft?.kind === 'method' ? null : draft));
     }
-    // Uninstalled + auto → keep the recommended pre-selection
   }, [vm.used, vm.status, vm.isInstalling, vm.isUpdating]);
 
   // Persisted override values used as initial inputs for the override card.
   const initialPath = useMemo(() => {
-    const inst = vm.installations.find((i) => i.id === 'path');
-    return inst?.pathEntry ?? '';
-  }, [vm.installations]);
+    return vm.used?.kind === 'path' ? vm.used.path : '';
+  }, [vm.used]);
 
   const initialCli = useMemo(() => {
-    const inst = vm.installations.find((i) => i.id === 'cli');
-    return inst?.pathEntry ?? '';
-  }, [vm.installations]);
+    return vm.used?.kind === 'cli' ? vm.used.command : '';
+  }, [vm.used]);
 
   const selectedInstall = findInstallation(vm.installations, selectedSource);
 
@@ -151,24 +138,21 @@ const LocalInstallSection = observer(function LocalInstallSection({
   })();
 
   const onSelectSource = (ref: SelectedSource) => {
-    // Persist every selection immediately so `used` always tracks `selected`,
-    // including path/cli overrides. Empty overrides persist harmlessly —
-    // resolveAgentExecutable falls back to auto-resolution when a path/cli
-    // selection does not resolve, and onOverrideResolved re-persists the
-    // concrete value once the user validates it.
-    void vm.setUsed(toSelection(ref, { path: initialPath, cli: initialCli }));
-    setSelectedSource(ref);
-  };
-
-  const onOverrideResolved = (installation: Installation | null) => {
-    if (installation?.status === 'available') {
-      void vm.setUsed(
-        toSelection(selectedSource, {
-          path: installation.id === 'path' ? (installation.pathEntry ?? '') : undefined,
-          cli: installation.id === 'cli' ? (installation.pathEntry ?? '') : undefined,
-        })
-      );
+    if (isOverrideRef(ref) || ref.kind === 'method') {
+      setSourceDraft(ref);
+      return;
     }
+    void vm
+      .setUsed(toSelection(ref))
+      .then(() => setSourceDraft(null))
+      .catch((error: unknown) => {
+        toast.error('Could not change executable', {
+          description:
+            error && typeof error === 'object' && 'message' in error
+              ? String(error.message)
+              : 'Please try again.',
+        });
+      });
   };
 
   // For the install command card, narrow to the selected method when concrete.
@@ -224,13 +208,14 @@ const LocalInstallSection = observer(function LocalInstallSection({
         />
       )}
 
-      {state !== 'found' && isOverrideRef(selectedSource) && (
+      {isOverrideRef(selectedSource) && (
         <InstallationOverrideCard
+          key={`${selectedSource.kind}:${selectedSource.kind === 'path' ? initialPath : initialCli}`}
           vm={vm}
           kind={selectedSource.kind}
           initialValue={selectedSource.kind === 'path' ? initialPath : initialCli}
           onChecking={setIsChecking}
-          onResolved={onOverrideResolved}
+          onSaved={() => setSourceDraft(null)}
         />
       )}
     </div>

--- a/apps/emdash-desktop/src/core/primitives/agents/api/agent-payload.ts
+++ b/apps/emdash-desktop/src/core/primitives/agents/api/agent-payload.ts
@@ -110,8 +110,11 @@ export function resolveActiveInstallation(
   return undefined;
 }
 
-/** Persisted user preference for which installation to use on a specific host. */
-export type HostDependencySelection = InstallOverride | null;
+/** Canonical persisted executable selection for one host. */
+export type HostDependencySelection =
+  | { kind: 'path'; path: string }
+  | { kind: 'cli'; command: string }
+  | null;
 
 // ---------------------------------------------------------------------------
 // Host dependency operation errors

--- a/apps/emdash-desktop/src/main/core/dependencies/host-dependency-store.ts
+++ b/apps/emdash-desktop/src/main/core/dependencies/host-dependency-store.ts
@@ -72,8 +72,8 @@ function normalizeSelection(selection: unknown): HostDependencySelection | null 
   if (value.kind === 'pinned' && typeof value.realpath === 'string') {
     return { kind: 'path', path: value.realpath };
   }
-  if (value.kind === 'cli' && typeof value.command === 'string' && value.command.startsWith('/')) {
-    return { kind: 'path', path: value.command };
+  if (value.kind === 'cli' && typeof value.command === 'string') {
+    return { kind: 'cli', command: value.command };
   }
   if (typeof value.path === 'string') return { kind: 'path', path: value.path };
   return null;

--- a/packages/core/src/primitives/host-dependencies/api/types.ts
+++ b/packages/core/src/primitives/host-dependencies/api/types.ts
@@ -31,10 +31,10 @@ export const hostDependencyDefinitionSchema = hostDependencyDescriptorSchema.ext
 export type HostDependencyDefinition = z.output<typeof hostDependencyDefinitionSchema>;
 
 export const hostDependencySelectionSchema = z
-  .object({
-    kind: z.literal('path'),
-    path: z.string().min(1),
-  })
+  .discriminatedUnion('kind', [
+    z.object({ kind: z.literal('path'), path: z.string().min(1) }),
+    z.object({ kind: z.literal('cli'), command: z.string().min(1) }),
+  ])
   .nullable();
 export type HostDependencySelection = z.output<typeof hostDependencySelectionSchema>;
 
@@ -54,6 +54,7 @@ export const resolvedHostDependencySchema = z.object({
   source: z.discriminatedUnion('kind', [
     z.object({ kind: z.literal('auto') }),
     z.object({ kind: z.literal('path'), path: z.string() }),
+    z.object({ kind: z.literal('cli'), command: z.string() }),
   ]),
 });
 export type ResolvedHostDependency = z.output<typeof resolvedHostDependencySchema>;
@@ -132,7 +133,10 @@ export const hostDependencyViewResultSchema = resultSchema(
 export type HostDependencyViewResult = Result<HostDependencyView, HostDependencyError>;
 
 export interface HostDependencyResolver {
-  resolve(id: DependencyId): Promise<HostDependencyResolveResult>;
+  resolve(
+    id: DependencyId,
+    selection?: HostDependencySelection
+  ): Promise<HostDependencyResolveResult>;
 }
 
 export interface DependencyState {

--- a/packages/core/src/services/host-dependencies/api/contract.ts
+++ b/packages/core/src/services/host-dependencies/api/contract.ts
@@ -24,7 +24,9 @@ import {
 
 export const hostDependencyResolverContract = defineContract({
   resolve: fallible({
-    input: hostDependencyInputSchema,
+    input: hostDependencyInputSchema.extend({
+      selection: hostDependencySelectionSchema.optional(),
+    }),
     data: resolvedHostDependencySchema,
     error: hostDependencyErrorSchema,
   }),

--- a/packages/core/src/services/host-dependencies/node/component.ts
+++ b/packages/core/src/services/host-dependencies/node/component.ts
@@ -61,7 +61,7 @@ const toCommandFailedError = (error: unknown): HostDependencyError => ({
 export function createHostDependenciesController(runtime: HostDependenciesRuntime) {
   return createController(hostDependenciesContract, {
     resolver: {
-      resolve: ({ id }) => runtime.resolve(id),
+      resolve: ({ id, selection }) => runtime.resolve(id, selection),
     },
     snapshot: runtime.liveHost(),
     runSelfUpdateCommand: {

--- a/packages/core/src/services/host-dependencies/node/install-execution.test.ts
+++ b/packages/core/src/services/host-dependencies/node/install-execution.test.ts
@@ -4,13 +4,13 @@ import {
   buildInstallCommandInvocation,
   isPermissionDeniedOutput,
   resolveElevationDecision,
-  resolveSelection,
+  resolveAutoSelection,
 } from './install-execution';
 
-describe('resolveSelection', () => {
-  it('resolves a saved Windows path across casing variants', () => {
+describe('resolveAutoSelection', () => {
+  it('uses the first discovered path', () => {
     expect(
-      resolveSelection('agent', { kind: 'path', path: 'c:\\tools\\agent.cmd' }, [
+      resolveAutoSelection('agent', [
         {
           command: 'agent',
           path: 'C:\\Tools\\AGENT.cmd',
@@ -21,17 +21,11 @@ describe('resolveSelection', () => {
     ).toMatchObject({ success: true, data: { path: 'C:\\Tools\\AGENT.cmd' } });
   });
 
-  it('keeps POSIX selections case-sensitive', () => {
-    expect(
-      resolveSelection('agent', { kind: 'path', path: '/tools/agent' }, [
-        {
-          command: 'agent',
-          path: '/Tools/agent',
-          realpath: '/Tools/agent',
-          isPathDefault: true,
-        },
-      ])
-    ).toMatchObject({ success: false, error: { type: 'stale-selection' } });
+  it('reports missing when nothing is discovered', () => {
+    expect(resolveAutoSelection('agent', [])).toMatchObject({
+      success: false,
+      error: { type: 'missing' },
+    });
   });
 });
 

--- a/packages/core/src/services/host-dependencies/node/install-execution.ts
+++ b/packages/core/src/services/host-dependencies/node/install-execution.ts
@@ -7,7 +7,6 @@ import type {
   ElevationPolicy,
   HostDependencyDefinition,
   HostDependencyError,
-  HostDependencySelection,
   HostDependencyView,
   HostElevation,
   InstallCommandOption,
@@ -16,7 +15,6 @@ import type {
   PermissionDeniedError,
   Platform,
 } from '#primitives/host-dependencies/api';
-import { nativePathIdentityKey } from '#primitives/path/api';
 import {
   probeHostElevation,
   resolveCommandPath,
@@ -250,27 +248,10 @@ export function currentPlatform(platform: NodeJS.Platform = process.platform): P
   return 'linux';
 }
 
-export function resolveSelection(
+export function resolveAutoSelection(
   id: string,
-  selection: HostDependencySelection,
   candidates: PathCandidate[]
 ): Result<NonNullable<HostDependencyView['resolved']>, HostDependencyError> {
-  if (selection?.kind === 'path') {
-    const selectionKey = executablePathIdentityKey(selection.path);
-    const candidate = candidates.find(
-      (candidate) =>
-        executablePathIdentityKey(candidate.path) === selectionKey ||
-        executablePathIdentityKey(candidate.realpath) === selectionKey
-    );
-    if (!candidate) return err({ type: 'stale-selection', id, path: selection.path });
-    return ok({
-      id,
-      command: candidate.command,
-      path: candidate.path,
-      realpath: candidate.realpath,
-      source: { kind: 'path', path: selection.path },
-    });
-  }
   const first = candidates[0];
   if (!first) return err({ type: 'missing', id });
   return ok({
@@ -280,12 +261,4 @@ export function resolveSelection(
     realpath: first.realpath,
     source: { kind: 'auto' },
   });
-}
-
-function executablePathIdentityKey(path: string): string {
-  try {
-    return nativePathIdentityKey(path);
-  } catch {
-    return `raw:${path}`;
-  }
 }

--- a/packages/core/src/services/host-dependencies/node/overrides.test.ts
+++ b/packages/core/src/services/host-dependencies/node/overrides.test.ts
@@ -1,0 +1,186 @@
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { err } from '@emdash/shared';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IExecutionContext } from '#primitives/exec/api';
+import { createMemoryKeyValueStore } from '#primitives/kv/api';
+import { HostDependenciesRuntime } from './runtime';
+
+describe.skipIf(process.platform === 'win32')('host executable overrides', () => {
+  let directory: string;
+  let wrapper: string;
+  const runtimes: HostDependenciesRuntime[] = [];
+
+  beforeEach(async () => {
+    directory = await mkdtemp(join(tmpdir(), 'emdash-overrides-'));
+    wrapper = join(directory, 'custom agent');
+    await writeFile(wrapper, '#!/bin/sh\nprintf "wrapper\\n"\n', { mode: 0o755 });
+  });
+
+  afterEach(async () => {
+    for (const runtime of runtimes.splice(0)) runtime.dispose();
+    await rm(directory, { recursive: true, force: true });
+  });
+
+  function setup(store = createMemoryKeyValueStore()) {
+    const exec = {
+      root: '',
+      supportsLocalSpawn: true,
+      exec: vi.fn(async (command: string, args: string[] = []) => {
+        if (command === 'which' && args.includes('custom-agent')) {
+          return { stdout: `${wrapper}\n`, stderr: '' };
+        }
+        if (command === 'which' && args.includes('claude')) {
+          return { stdout: `${process.execPath}\n`, stderr: '' };
+        }
+        throw new Error('not found');
+      }),
+      execStreaming: vi.fn(),
+      dispose: vi.fn(),
+    } satisfies IExecutionContext;
+    const runtime = new HostDependenciesRuntime({
+      hostId: 'test-host',
+      definitions: [
+        {
+          id: 'claude',
+          name: 'Claude',
+          category: 'agent',
+          binaryNames: ['claude'],
+          status: 'active',
+        },
+      ],
+      store,
+      exec,
+    });
+    runtimes.push(runtime);
+    return { runtime, store, exec };
+  }
+
+  it('saves an off-PATH wrapper and resolves it after reloading', async () => {
+    const { runtime, store } = setup();
+    expect(await runtime.setSelection('claude', { kind: 'path', path: wrapper })).toMatchObject({
+      success: true,
+      data: { status: 'available', resolved: { path: wrapper } },
+    });
+    expect(await setup(store).runtime.resolve('claude')).toMatchObject({
+      success: true,
+      data: { path: wrapper, source: { kind: 'path', path: wrapper } },
+    });
+  });
+
+  it('reads existing version-1 path records without rewriting them', async () => {
+    const store = createMemoryKeyValueStore();
+    await store.set('host-dependencies:test-host:selections', {
+      version: 1,
+      selections: { claude: { kind: 'path', path: wrapper } },
+    });
+    const save = vi.spyOn(store, 'set');
+    expect(await setup(store).runtime.resolve('claude')).toMatchObject({
+      success: true,
+      data: { path: wrapper },
+    });
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it('accepts an absolute executable in the CLI field', async () => {
+    const { runtime } = setup();
+    expect(await runtime.resolve('claude', { kind: 'cli', command: wrapper })).toMatchObject({
+      success: true,
+      data: { path: wrapper },
+    });
+  });
+
+  it('reports a broken explicit selection without falling back to auto', async () => {
+    const { runtime } = setup();
+    await runtime.setSelection('claude', { kind: 'path', path: wrapper });
+    await rm(wrapper);
+    expect(await runtime.resolve('claude')).toMatchObject({
+      success: false,
+      error: { type: 'invalid-selection' },
+    });
+  });
+
+  it('rejects a non-executable file without replacing the previous selection', async () => {
+    const { runtime } = setup();
+    await runtime.setSelection('claude', { kind: 'path', path: wrapper });
+    const invalid = join(directory, 'not-executable');
+    await writeFile(invalid, 'not executable');
+    await chmod(invalid, 0o644);
+    expect(await runtime.setSelection('claude', { kind: 'path', path: invalid })).toMatchObject({
+      success: false,
+      error: { type: 'invalid-selection' },
+    });
+    expect(await runtime.resolve('claude')).toMatchObject({
+      success: true,
+      data: { path: wrapper },
+    });
+  });
+
+  it('validates without saving, then preserves a command selection across reloads', async () => {
+    const { runtime, store, exec } = setup();
+    const selection = { kind: 'cli' as const, command: 'custom-agent' };
+    expect(await runtime.resolve('claude', selection)).toMatchObject({
+      success: true,
+      data: { path: wrapper },
+    });
+    expect(await runtime.resolve('claude')).toMatchObject({
+      success: true,
+      data: { path: process.execPath, source: { kind: 'auto' } },
+    });
+    expect(await runtime.setSelection('claude', selection)).toMatchObject({ success: true });
+    expect(await setup(store).runtime.resolve('claude')).toMatchObject({
+      success: true,
+      data: { path: wrapper, source: selection },
+    });
+    expect(exec.exec).toHaveBeenCalledWith('which', ['custom-agent'], expect.any(Object));
+    await runtime.setSelection('claude', null);
+    expect(await runtime.resolve('claude')).toMatchObject({
+      success: true,
+      data: { source: { kind: 'auto' } },
+    });
+  });
+
+  it.each([
+    { kind: 'cli' as const, command: 'missing-command' },
+    { kind: 'cli' as const, command: 'srt claude' },
+    { kind: 'cli' as const, command: '-a' },
+    { kind: 'path' as const, path: 'relative/path' },
+  ])('rejects invalid selections: %j', async (selection) => {
+    const { runtime } = setup();
+    expect(await runtime.resolve('claude', selection)).toMatchObject({
+      success: false,
+      error: { type: 'invalid-selection' },
+    });
+  });
+
+  it('preserves both the cached and stored selection when saving fails', async () => {
+    const { runtime, store } = setup();
+    await runtime.setSelection('claude', { kind: 'path', path: wrapper });
+    vi.spyOn(store, 'set').mockResolvedValueOnce(err({ type: 'io', message: 'disk full' }));
+    expect(await runtime.setSelection('claude', null)).toMatchObject({
+      success: false,
+      error: { type: 'io', message: 'disk full' },
+    });
+    expect(await runtime.resolve('claude')).toMatchObject({
+      success: true,
+      data: { path: wrapper },
+    });
+    expect(await setup(store).runtime.resolve('claude')).toMatchObject({
+      success: true,
+      data: { path: wrapper },
+    });
+  });
+
+  it('rejects directories and unknown providers', async () => {
+    const { runtime } = setup();
+    expect(await runtime.resolve('claude', { kind: 'path', path: directory })).toMatchObject({
+      success: false,
+      error: { type: 'invalid-selection' },
+    });
+    expect(await runtime.resolve('unknown', { kind: 'path', path: wrapper })).toMatchObject({
+      success: false,
+      error: { type: 'unknown-dependency' },
+    });
+  });
+});

--- a/packages/core/src/services/host-dependencies/node/process-resolver-client.ts
+++ b/packages/core/src/services/host-dependencies/node/process-resolver-client.ts
@@ -6,8 +6,8 @@ export function createHostDependencyResolverFromDependency(
   client: ContractClient<HostDependencyResolverContract>
 ): HostDependencyResolver {
   return {
-    async resolve(id) {
-      return client.resolve({ id });
+    async resolve(id, selection) {
+      return client.resolve(selection === undefined ? { id } : { id, selection });
     },
   };
 }

--- a/packages/core/src/services/host-dependencies/node/resolve-override.test.ts
+++ b/packages/core/src/services/host-dependencies/node/resolve-override.test.ts
@@ -1,0 +1,55 @@
+import type * as nodePath from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IExecutionContext } from '#primitives/exec/api';
+import { resolveOverride } from './resolve-override';
+
+vi.mock('node:fs/promises', () => ({
+  stat: vi.fn(async () => ({ isFile: () => true })),
+  access: vi.fn(async () => {}),
+  realpath: vi.fn(async (path: string) => path),
+}));
+
+vi.mock('node:path', async (importOriginal) => {
+  const path = await importOriginal<typeof nodePath>();
+  return { ...path, isAbsolute: path.win32.isAbsolute, extname: path.win32.extname };
+});
+
+describe('Windows executable overrides', () => {
+  const exec = {
+    root: '',
+    supportsLocalSpawn: true,
+    exec: vi.fn(),
+    execStreaming: vi.fn(),
+    dispose: vi.fn(),
+  } satisfies IExecutionContext;
+
+  beforeEach(() => {
+    vi.stubGlobal('process', { ...process, platform: 'win32' });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it.each(['ps1', 'PS1'])(
+    'accepts a PowerShell .%s wrapper in either override field',
+    async (extension) => {
+      const path = `C:\\Scripts\\provider.${extension}`;
+      for (const selection of [
+        { kind: 'path' as const, path },
+        { kind: 'cli' as const, command: path },
+      ]) {
+        expect(await resolveOverride('claude', selection, exec)).toEqual({
+          success: true,
+          data: { id: 'claude', command: path, path, realpath: path, source: selection },
+        });
+      }
+    }
+  );
+
+  it('still rejects unsupported Windows file extensions', async () => {
+    expect(
+      await resolveOverride('claude', { kind: 'path', path: 'C:\\Scripts\\provider.txt' }, exec)
+    ).toMatchObject({ success: false, error: { type: 'invalid-selection' } });
+  });
+});

--- a/packages/core/src/services/host-dependencies/node/resolve-override.ts
+++ b/packages/core/src/services/host-dependencies/node/resolve-override.ts
@@ -1,0 +1,56 @@
+import { constants } from 'node:fs';
+import { access, realpath, stat } from 'node:fs/promises';
+import { extname, isAbsolute } from 'node:path';
+import { err, ok } from '@emdash/shared';
+import type { IExecutionContext } from '#primitives/exec/api';
+import type {
+  HostDependencyResolveResult,
+  InstallOverride,
+} from '#primitives/host-dependencies/api';
+import { resolveCommandPath } from '#services/host-dependencies/api/runtime/probe';
+
+/** Runs on the owning host, alongside its filesystem and shell environment. */
+export async function resolveOverride(
+  id: string,
+  selection: InstallOverride,
+  exec: IExecutionContext
+): Promise<HostDependencyResolveResult> {
+  const invalid = (message: string) => err({ type: 'invalid-selection' as const, id, message });
+  let path: string;
+  if (selection.kind === 'path') {
+    path = selection.path;
+  } else if (isAbsolute(selection.command)) {
+    path = selection.command;
+  } else {
+    if (!/^[^\s/\\\0]+$/.test(selection.command) || selection.command.startsWith('-')) {
+      return invalid(
+        'Enter a command name on PATH. For commands with arguments, use an executable wrapper script.'
+      );
+    }
+    const resolved = await resolveCommandPath(selection.command, exec);
+    if (!resolved)
+      return invalid(`Command "${selection.command}" was not found on this host's PATH.`);
+    path = resolved;
+  }
+  if (!isAbsolute(path) || path.includes('\0')) {
+    return invalid('Enter an absolute path to an executable file.');
+  }
+  try {
+    if (!(await stat(path)).isFile()) return invalid(`"${path}" is not a file.`);
+    await access(path, constants.X_OK);
+    if (process.platform === 'win32' && !/\.(exe|com|cmd|bat)$/i.test(extname(path))) {
+      return invalid(`"${path}" is not a Windows executable (.exe, .com, .cmd or .bat).`);
+    }
+    return ok({
+      id,
+      command: selection.kind === 'cli' ? selection.command : path,
+      path,
+      realpath: await realpath(path),
+      source: selection,
+    });
+  } catch (error) {
+    return invalid(
+      `Cannot use "${path}": ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}

--- a/packages/core/src/services/host-dependencies/node/resolve-override.ts
+++ b/packages/core/src/services/host-dependencies/node/resolve-override.ts
@@ -38,8 +38,8 @@ export async function resolveOverride(
   try {
     if (!(await stat(path)).isFile()) return invalid(`"${path}" is not a file.`);
     await access(path, constants.X_OK);
-    if (process.platform === 'win32' && !/\.(exe|com|cmd|bat)$/i.test(extname(path))) {
-      return invalid(`"${path}" is not a Windows executable (.exe, .com, .cmd or .bat).`);
+    if (process.platform === 'win32' && !/\.(exe|com|cmd|bat|ps1)$/i.test(extname(path))) {
+      return invalid(`"${path}" is not a Windows executable (.exe, .com, .cmd, .bat or .ps1).`);
     }
     return ok({
       id,

--- a/packages/core/src/services/host-dependencies/node/runtime.test.ts
+++ b/packages/core/src/services/host-dependencies/node/runtime.test.ts
@@ -470,7 +470,7 @@ describe('HostDependenciesRuntime snapshot query', () => {
 
     const result = await runtime.setSelection('fake-agent', {
       kind: 'path',
-      path: '/usr/local/bin/fake-agent',
+      path: process.execPath,
     });
     expect(result.success).toBe(true);
     flushStateTurn();
@@ -478,7 +478,7 @@ describe('HostDependenciesRuntime snapshot query', () => {
     const after = await snapshotOf(source);
     expect(after.dependencies['fake-agent']?.selection).toEqual({
       kind: 'path',
-      path: '/usr/local/bin/fake-agent',
+      path: process.execPath,
     });
 
     await lease.release();

--- a/packages/core/src/services/host-dependencies/node/runtime.ts
+++ b/packages/core/src/services/host-dependencies/node/runtime.ts
@@ -49,12 +49,13 @@ import {
   permissionDeniedError,
   resolveElevationDecision,
   resolveInstallerTool,
-  resolveSelection,
+  resolveAutoSelection,
   selectInstallOption,
   type CommandExecutionResult,
   type InstallCommandKind,
   type PreparedInstallCommand,
 } from './install-execution';
+import { resolveOverride } from './resolve-override';
 
 const STORE_KEY_PREFIX = 'host-dependencies';
 const OUTPUT_TAIL_LIMIT = 20_000;
@@ -93,6 +94,7 @@ export class HostDependenciesRuntime {
   private readonly current: Query<HostDependencySnapshot>;
   private readonly stateScope: Scope;
   private readonly installMutex = new KeyedMutex();
+  private readonly selectionMutex = new KeyedMutex();
   private selections: Record<string, HostDependencySelection> | null = null;
   private disposed = false;
   private lastSuccessfulAptUpdateAt: number | null = null;
@@ -145,11 +147,25 @@ export class HostDependenciesRuntime {
     return this.host;
   }
 
-  async resolve(id: DependencyId): Promise<HostDependencyResolveResult> {
+  async resolve(
+    id: DependencyId,
+    selection?: HostDependencySelection
+  ): Promise<HostDependencyResolveResult> {
+    if (selection !== undefined) return this.resolveSelection(id, selection);
     const view = await this.settleView(id);
     if (!view.success) return view;
-    if (!view.data.resolved) return err({ type: 'missing', id });
+    if (!view.data.resolved) return err(view.data.error ?? { type: 'missing', id });
     return ok(view.data.resolved);
+  }
+
+  private async resolveSelection(
+    id: DependencyId,
+    selection: HostDependencySelection
+  ): Promise<HostDependencyResolveResult> {
+    const definition = this.definitions.get(id);
+    if (!definition) return err({ type: 'unknown-dependency', id });
+    if (selection) return resolveOverride(id, selection, this.deps.exec);
+    return resolveAutoSelection(id, await this.enumerate(definition));
   }
 
   async setSelection(
@@ -158,14 +174,21 @@ export class HostDependenciesRuntime {
     options: { mutationIds?: readonly string[] } = {}
   ): Promise<HostDependencyViewResult> {
     if (!this.definitions.has(id)) return err({ type: 'unknown-dependency', id });
-    const selections = await this.loadSelections();
-    if (!selections.success) return err(selections.error);
-    if (selection === null) delete selections.data[id];
-    else selections.data[id] = selection;
-    const saved = await this.saveSelections(selections.data);
-    if (!saved.success) return err(saved.error);
-    this.selections = selections.data;
-    return this.settleView(id, options.mutationIds);
+    if (selection) {
+      const validated = await this.resolveSelection(id, selection);
+      if (!validated.success) return validated;
+    }
+    return this.selectionMutex.runExclusive('selections', async () => {
+      const selections = await this.loadSelections();
+      if (!selections.success) return err(selections.error);
+      const next = { ...selections.data };
+      if (selection === null) delete next[id];
+      else next[id] = selection;
+      const saved = await this.saveSelections(next);
+      if (!saved.success) return err(saved.error);
+      this.selections = next;
+      return this.settleView(id, options.mutationIds);
+    });
   }
 
   async refresh(
@@ -522,7 +545,9 @@ export class HostDependenciesRuntime {
     if (!selections.success) return err(selections.error);
     const candidates = await this.enumerate(definition);
     const selection = selections.data[id] ?? null;
-    const resolved = resolveSelection(definition.id, selection, candidates);
+    const resolved = selection
+      ? await resolveOverride(id, selection, this.deps.exec)
+      : resolveAutoSelection(id, candidates);
     const view: HostDependencyView = {
       hostId: this.deps.hostId,
       definition,

--- a/packages/core/src/workspace-server/releases.test.ts
+++ b/packages/core/src/workspace-server/releases.test.ts
@@ -100,8 +100,8 @@ describe('workspace-server release contracts', () => {
   );
 
   it('extracts a protocol major and rejects invalid protocol versions', () => {
-    expect(PROTOCOL_VERSION).toBe('8.0.0');
-    expect(protocolMajor()).toBe(8);
+    expect(PROTOCOL_VERSION).toBe('9.0.0');
+    expect(protocolMajor()).toBe(9);
     expect(protocolMajor('2.3.4')).toBe(2);
     expect(() => protocolMajor('not-a-version')).toThrow(
       "Invalid protocol version 'not-a-version'"

--- a/packages/core/src/workspace-server/versions/index.ts
+++ b/packages/core/src/workspace-server/versions/index.ts
@@ -1,6 +1,6 @@
 import semver from 'semver';
 
-export const PROTOCOL_VERSION = '8.0.0';
+export const PROTOCOL_VERSION = '9.0.0';
 
 export function protocolMajor(version: string = PROTOCOL_VERSION): number {
   const parsed = semver.parse(version);

--- a/packages/core/src/workspace-server/versions/versions.test.ts
+++ b/packages/core/src/workspace-server/versions/versions.test.ts
@@ -81,7 +81,7 @@ describe('negotiateProtocol', () => {
     });
 
     it('rejects the previous protocol major with upgrade-client', () => {
-      expect(PROTOCOL_VERSION).toBe('8.0.0');
+      expect(PROTOCOL_VERSION).toBe('9.0.0');
       expect(negotiateProtocol('7.1.0')).toEqual({
         compatible: false,
         action: 'upgrade-client',


### PR DESCRIPTION
- Make saved CLI and executable-path overrides take precedence over provider auto-configuration for both terminal and ACP launches.
- Use one host resolution contract for automatic discovery, manual validation, persistence checks, and runtime execution, with explicit errors instead of silent fallback.
- Add settings controls that validate custom commands and paths on the selected host before saving and clearly display invalid override state.
- Bump the workspace protocol major version for the new CLI selection variant.
- Closes #3173