### PR TITLE
fix(acp): preserve foreground streams across async event updates

### DIFF
--- a/agents/architecture/acp-runtime.md
+++ b/agents/architecture/acp-runtime.md
@@ -147,6 +147,37 @@ Parsed transcript and raw ACP log exports are live-activation reads. They never 
 conversation because the raw log is activation-local and a post-wake export would describe the
 replay rather than the evicted process.
 
+## Transcript event ownership
+
+The transcript reducer separates foreground content progression from asynchronous tool, agent,
+and plan state. `event-routing.ts` resolves a tool's owning turn (including suppressed edit calls)
+before opening a turn or materializing content. The owner index survives turn completion and is
+reset with the parser on activation/replay. Child calls inherit their parent's owner. Provider
+enrichment must preserve whether a specialized tool notification starts or updates a call via
+`operation`; changing its presentation kind to `subagent` must not erase this distinction.
+
+Only content transitions and new foreground root invocations close a content segment.
+`content-stream.ts` owns both identity and reasoning finalization; `item-fold.ts` applies updates
+without inferring content completion from notification arrival. Provider ids are opaque values in
+a namespace separate from generated ordinals and roles. Reasoning continuation uses exact ids and
+explicit segment ordinals, never prefix matching. Item ids remain deterministic across live and
+replayed input, but consumers must treat them as opaque rather than parse their spelling.
+
+Tool updates, plan revisions, and nested activity preserve the foreground stream even when they
+materialize new rows. A late tool update amends its original turn and never opens a new agent turn.
+SessionCell uses the same foreground classification for idle activity/quiescence. Background tool
+rows remain running across foreground turn completion and settle from their own status updates.
+The optional session `historyRevision` increments when an already committed turn is amended; the
+desktop refreshes history independently of turn completion (deferring replacement while a new
+foreground turn is active). Plans remain session-scoped, with their transcript anchor in the turn
+that first presented the plan; an idle plan notification alone does not start a turn.
+
+For partial provider replay, an update-only call can be recovered within an existing active turn,
+without ending its content. When idle, unmatched tool notifications are retained in a bounded
+128-event window until a call start or parent establishes ownership; older unmatched notifications
+are evicted. This fallback cannot infer ownership absent provider evidence. No status notification
+alone is treated as proof of a new foreground turn.
+
 ## Suspension and Rematerialization
 
 The public identity is always `conversationId`; provider process activations are internal. A

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
@@ -886,6 +886,7 @@ export class AcpChatStore {
   private _subscribeLiveSession(session: AcpLiveSession): void {
     this._unsubs.splice(0).forEach((unsub) => unsub());
     let previousLifecycle = session.sessionState.current().lifecycle;
+    let previousHistoryRevision = session.sessionState.current().historyRevision;
     const disconnectChatSession = getChatUiRuntime().connectSession(
       this.chatState,
       {
@@ -902,11 +903,13 @@ export class AcpChatStore {
       this._bindTerminalOutputs(session),
       session.sessionState.onChange((state) => {
         const replayCompleted = previousLifecycle === 'replaying' && state.lifecycle === 'ready';
+        const historyChanged = previousHistoryRevision !== state.historyRevision;
         previousLifecycle = state.lifecycle;
+        previousHistoryRevision = state.historyRevision;
         runInAction(() => {
           this._syncMessageCount();
         });
-        if (replayCompleted) this._requestHistoryRefresh();
+        if (replayCompleted || historyChanged) this._requestHistoryRefresh();
       }),
       session.activeTurn.onChange(() => runInAction(() => this._syncMessageCount()))
     );

--- a/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-store-submission.test.ts
@@ -891,6 +891,26 @@ describe('AcpChatStore prompt submission', () => {
     store.dispose();
   });
 
+  it('refreshes amended history without a foreground turn transition', async () => {
+    const live = fakeLiveSession({ ...idleState(), historyRevision: 0 }, historyPage('initial'));
+    const store = await bootstrapWithSession(live.session);
+    try {
+      live.loadHistory.mockClear();
+      historySeed.mockClear();
+      live.loadHistory.mockResolvedValue({ success: true, data: historyPage('amended') });
+      live.sessionState.set({ ...idleState(), historyRevision: 1 });
+      await vi.waitFor(() =>
+        expect(historySeed).toHaveBeenCalledWith([expect.objectContaining({ id: 'amended' })])
+      );
+      expect(live.loadHistory).toHaveBeenCalledTimes(1);
+      live.sessionState.set({ ...idleState(), historyRevision: 1, backgroundAgentCount: 1 });
+      await Promise.resolve();
+      expect(live.loadHistory).toHaveBeenCalledTimes(1);
+    } finally {
+      store.dispose();
+    }
+  });
+
   it('keeps rendered history when a suspension-driven refresh is unavailable', async () => {
     const live = fakeLiveSession(idleState(), historyPage('rendered'));
     const store = await bootstrapWithSession(live.session);

--- a/packages/core/src/primitives/acp-transcript/api/normalized-event.ts
+++ b/packages/core/src/primitives/acp-transcript/api/normalized-event.ts
@@ -64,6 +64,7 @@ export type NormalizedEvent =
     }
   | {
       kind: 'subagent';
+      operation?: 'start' | 'update';
       toolCallId: string;
       title: string;
       status: NormalizedToolStatus | null;
@@ -83,6 +84,7 @@ export type NormalizedEvent =
     }
   | {
       kind: 'search';
+      operation?: 'start' | 'update';
       toolCallId: string;
       query: string;
       status: NormalizedToolStatus | null;
@@ -91,6 +93,7 @@ export type NormalizedEvent =
     }
   | {
       kind: 'mcp_tool';
+      operation?: 'start' | 'update';
       toolCallId: string;
       server?: string;
       tool: string;
@@ -100,6 +103,7 @@ export type NormalizedEvent =
     }
   | {
       kind: 'web_fetch';
+      operation?: 'start' | 'update';
       toolCallId: string;
       url: string;
       title?: string;

--- a/packages/core/src/runtimes/acp/api/models/session.ts
+++ b/packages/core/src/runtimes/acp/api/models/session.ts
@@ -37,6 +37,8 @@ export const sessionStateSchema = z.object({
   suspended: z.literal(true).optional(),
   /** Current control-plane turn id, or null when no prompt/replay turn is active. */
   activeTurnId: z.string().nullable(),
+  /** Activation-local revision of amendments to committed turns, independent of foreground work. */
+  historyRevision: z.number().int().nonnegative().optional(),
   pendingPermissions: z.array(acpPermissionRequestSchema),
   /** Last ACP prompt stop reason observed by the machine; separate from transcript outcomes. */
   lastStopReason: stopReasonSchema.nullable(),

--- a/packages/core/src/runtimes/acp/api/models/turns/messages.ts
+++ b/packages/core/src/runtimes/acp/api/models/turns/messages.ts
@@ -3,7 +3,7 @@ import { attachmentRefSchema } from '#runtimes/acp/api/models/attachments';
 
 export const transcriptMessageSchema = z.object({
   kind: z.literal('message'),
-  /** Provider message id scoped to the turn, or reducer-synthesized fallback id. */
+  /** Opaque reducer-owned identity, scoped to the turn, role, and identity origin. */
   id: z.string(),
   /** Stable order within the owning turn, assigned once by the reducer. */
   seq: z.number().int(),

--- a/packages/core/src/runtimes/acp/api/models/turns/thinking.ts
+++ b/packages/core/src/runtimes/acp/api/models/turns/thinking.ts
@@ -5,7 +5,7 @@ export const transcriptThinkingSchema = z.object({
   id: z.string(),
   /** Stable order within the owning turn, assigned once by the reducer. */
   seq: z.number().int(),
-  /** Provider or synthesized stream segment id for merging reasoning chunks. */
+  /** Opaque reducer-owned stream segment identity; never interpreted as a provider id. */
   segmentId: z.string(),
   text: z.string(),
   status: z.enum(['thinking', 'done']),

--- a/packages/core/src/runtimes/acp/api/reducer/acp-transcript-parser.test.ts
+++ b/packages/core/src/runtimes/acp/api/reducer/acp-transcript-parser.test.ts
@@ -226,7 +226,7 @@ describe('AcpTranscriptParser', () => {
     p.push(update);
 
     const turnId = makeTurnId(CID, 0);
-    const expectedId = makeMessageId(turnId, 'auto:user:0', 'user');
+    const expectedId = makeMessageId(turnId, null, 'user');
     expect(p.activeTurn?.items[0].id).toBe(expectedId);
   });
 
@@ -251,8 +251,8 @@ describe('AcpTranscriptParser', () => {
     expect(messages.map((message) => message.text)).toEqual(['do it', 'before', 'after']);
     expect(messages.map((message) => message.id)).toEqual([
       makeMessageId(makeTurnId(CID, 0), 'u1', 'user'),
-      makeMessageId(makeTurnId(CID, 0), 'auto:assistant:0', 'assistant'),
-      makeMessageId(makeTurnId(CID, 0), 'auto:assistant:1', 'assistant'),
+      makeMessageId(makeTurnId(CID, 0), null, 'assistant', 0),
+      makeMessageId(makeTurnId(CID, 0), null, 'assistant', 1),
     ]);
     expect(messages.map((message) => message.seq)).toEqual([0, 1, 3]);
   });
@@ -777,17 +777,11 @@ describe('AcpTranscriptParser', () => {
     });
   });
 
-  it('idle-phase plan opens an agent turn and updates the session-scoped plan slice', () => {
+  it('idle-phase plan updates the session-scoped slice without opening an agent turn', () => {
     const p = new AcpTranscriptParser(deps());
     p.push(planUpdate([{ content: 'Agent step', status: 'in_progress', priority: 'medium' }]), 100);
 
-    expect(p.activeTurn?.initiator).toBe('agent');
-    expect(p.activeTurn?.items.find((item) => item.kind === 'create-plan-tool-call')).toMatchObject(
-      {
-        status: 'running',
-        planId: SESSION_PLAN_ID,
-      }
-    );
+    expect(p.activeTurn).toBeNull();
     expect(p.plan).toEqual({
       id: SESSION_PLAN_ID,
       entries: [
@@ -834,7 +828,7 @@ describe('AcpTranscriptParser', () => {
     expect(
       p.history[0].items.find((item) => item.kind === 'spawn-subagent-tool-call')
     ).toMatchObject({
-      status: 'done',
+      status: 'running',
       background: true,
       agentId: 'agent-1',
     });

--- a/packages/core/src/runtimes/acp/api/reducer/content-stream.ts
+++ b/packages/core/src/runtimes/acp/api/reducer/content-stream.ts
@@ -1,0 +1,74 @@
+import type { TranscriptTurn } from '../models/turns';
+import { makeMessageId, makeThinkingId } from './ids';
+import type { FoldEvent } from './item-fold';
+import type { NormalizedEvent } from './normalized-event';
+
+type ContentEvent = Extract<NormalizedEvent, { kind: 'message' | 'thinking' }>;
+type ContentKind = 'user' | 'assistant' | 'thinking';
+
+export interface SegmentState {
+  open: { kind: ContentKind; providerId: string | null; itemId: string } | null;
+  user: number;
+  assistant: number;
+  thinking: number;
+}
+
+export function initialSegment(): SegmentState {
+  return { open: null, user: 0, assistant: 0, thinking: 0 };
+}
+
+/** The only mid-turn content finalization path. Async state folds never call it. */
+export function closeContent(
+  turn: TranscriptTurn,
+  segment: SegmentState,
+  at: number
+): { turn: TranscriptTurn; segment: SegmentState } {
+  if (!segment.open) return { turn, segment };
+  const open = segment.open;
+  const items =
+    open.kind === 'thinking'
+      ? turn.items.map((item) =>
+          item.kind === 'thinking' && item.id === open.itemId && item.status === 'thinking'
+            ? { ...item, status: 'done' as const, durationMs: at - item.startedAt }
+            : item
+        )
+      : turn.items;
+  return {
+    turn: items === turn.items ? turn : { ...turn, items },
+    segment: { ...segment, open: null },
+  };
+}
+
+/**
+ * Provider ids are opaque, exact identities, separate from generated ordinals.
+ * A foreground transition ends a reasoning segment; subsequent reasoning gets
+ * a new ordinal even if its provider id is reused. No identity is reconstructed
+ * by inspecting strings or scanning finalized rows.
+ */
+export function materializeContent(
+  turn: TranscriptTurn,
+  segment: SegmentState,
+  event: ContentEvent,
+  at: number
+): { turn: TranscriptTurn; segment: SegmentState; event: FoldEvent } {
+  const kind = event.kind === 'thinking' ? 'thinking' : event.role;
+  if (segment.open?.kind === kind && segment.open.providerId === event.messageId) {
+    return { turn, segment, event: { ...event, itemId: segment.open.itemId } };
+  }
+
+  const closed = closeContent(turn, segment, at);
+  const ordinal = closed.segment[kind];
+  const itemId =
+    kind === 'thinking'
+      ? makeThinkingId(turn.id, event.messageId, ordinal)
+      : makeMessageId(turn.id, event.messageId, kind, ordinal);
+  return {
+    turn: closed.turn,
+    segment: {
+      ...closed.segment,
+      open: { kind, providerId: event.messageId, itemId },
+      [kind]: ordinal + 1,
+    },
+    event: { ...event, itemId },
+  };
+}

--- a/packages/core/src/runtimes/acp/api/reducer/event-routing.ts
+++ b/packages/core/src/runtimes/acp/api/reducer/event-routing.ts
@@ -1,0 +1,60 @@
+import type { NormalizedEvent } from './normalized-event';
+
+export type ToolEvent = Extract<NormalizedEvent, { parentToolCallId: string | null }>;
+
+export interface ToolOwner {
+  turnId: string;
+  parentToolCallId: string | null;
+}
+
+export interface EventRoute {
+  /** Null means no transcript owner can be established yet. */
+  turnId: string | null;
+  /** Evidence of foreground progression; independent of whether a row is inserted. */
+  foreground: boolean;
+  tool?: ToolEvent;
+}
+
+export function isToolEvent(event: NormalizedEvent): event is ToolEvent {
+  return 'parentToolCallId' in event;
+}
+
+/**
+ * Resolve ownership before opening a turn or ending content. The owner index
+ * includes suppressed edit calls and survives turn completion. Provider tool ids
+ * are scoped to this parser's session and the index is reset on replay/reset.
+ *
+ * A partial replay can contain only tool updates: recover those in an already
+ * active turn, without claiming foreground progression. Idle unmatched updates
+ * are retained separately until a start or parent establishes their owner.
+ */
+export function routeEvent(
+  event: NormalizedEvent,
+  owners: ReadonlyMap<string, ToolOwner>,
+  activeTurnId: string | null,
+  planTurnId: string | null
+): EventRoute {
+  if (event.kind === 'message' || event.kind === 'thinking') {
+    return { turnId: activeTurnId, foreground: true };
+  }
+  if (event.kind === 'plan') {
+    return { turnId: planTurnId ?? activeTurnId, foreground: false };
+  }
+  if (!isToolEvent(event)) return { turnId: null, foreground: false };
+
+  const owner = owners.get(event.toolCallId);
+  const parentToolCallId = event.parentToolCallId ?? owner?.parentToolCallId ?? null;
+  const parent = parentToolCallId === null ? undefined : owners.get(parentToolCallId);
+  const operation =
+    event.kind === 'tool_update'
+      ? 'update'
+      : event.kind === 'tool_call'
+        ? 'start'
+        : (event.operation ?? 'start');
+  const foreground = !owner && parentToolCallId === null && operation === 'start';
+  return {
+    turnId: owner?.turnId ?? parent?.turnId ?? activeTurnId,
+    foreground,
+    tool: parentToolCallId === event.parentToolCallId ? event : { ...event, parentToolCallId },
+  };
+}

--- a/packages/core/src/runtimes/acp/api/reducer/ids.ts
+++ b/packages/core/src/runtimes/acp/api/reducer/ids.ts
@@ -2,12 +2,12 @@
  * Deterministic, stable id synthesis for transcript items.
  *
  * Ids are synthesized once in the parser and never re-derived downstream.
- * The scheme preserves the existing renderer convention from acp-update-mapper.ts
- * so that a future migration can maintain render identity continuity.
+ * Content ids distinguish roles and provider/generated origins. Provider ids
+ * are JSON-encoded opaque strings; generated ordinals never share their namespace.
  *
  * All functions are pure and total — no nullable returns. When a provider
  * messageId is absent the reducer's segmenter synthesizes a stable messageId
- * before item folding, ensuring every item always has a non-null id.
+ * before item folding, ensuring every item always has a non-null internal id.
  */
 
 /**
@@ -21,24 +21,27 @@ export function makeTurnId(conversationId: string, turnIndex: number): string {
 
 /**
  * Stable message item id.
- * Format: `${turnId}:message:${messageId}`
- *
- * Uses the provider messageId when available; otherwise uses the reducer's
- * synthesized segment id.
+ * Exact provider identity when supplied; otherwise a per-role segment ordinal.
  */
-export function makeMessageId(turnId: string, messageId: string, _role: string): string {
-  return `${turnId}:message:${messageId}`;
+export function makeMessageId(
+  turnId: string,
+  messageId: string | null,
+  role: string,
+  ordinal = 0
+): string {
+  const identity =
+    messageId === null ? `generated:${ordinal}` : `provider:${JSON.stringify(messageId)}`;
+  return `${turnId}:message:${role}:${identity}`;
 }
 
 /**
  * Stable thinking item id.
- * Format: `${turnId}:thinking:${messageId}`
- *
- * A kind-tag prefix ('thinking:') disambiguates from message items when
- * Claude reuses the same messageId across both update kinds.
+ * A separate kind and explicit ordinal distinguish resumed reasoning segments
+ * without interpreting provider ids as prefixes of previously generated ids.
  */
-export function makeThinkingId(turnId: string, messageId: string): string {
-  return `${turnId}:thinking:${messageId}`;
+export function makeThinkingId(turnId: string, messageId: string | null, ordinal = 0): string {
+  const identity = messageId === null ? 'generated' : `provider:${JSON.stringify(messageId)}`;
+  return `${turnId}:thinking:${identity}:${ordinal}`;
 }
 
 /**

--- a/packages/core/src/runtimes/acp/api/reducer/item-fold.ts
+++ b/packages/core/src/runtimes/acp/api/reducer/item-fold.ts
@@ -26,7 +26,7 @@ import type {
   ToolNode,
   ToolStatus,
 } from '../models/turns';
-import { makeDiffId, makeMessageId, makePlanId, makeThinkingId, makeToolId } from './ids';
+import { makeDiffId, makePlanId, makeToolId } from './ids';
 import type {
   NormalizedDiff,
   NormalizedEvent,
@@ -37,8 +37,7 @@ import { toolRunStatus, wrapToolRuns } from './tool-runs';
 
 export type FoldEvent =
   | Exclude<NormalizedEvent, { kind: 'message' | 'thinking' }>
-  | (Extract<NormalizedEvent, { kind: 'message' }> & { messageId: string })
-  | (Extract<NormalizedEvent, { kind: 'thinking' }> & { messageId: string });
+  | (Extract<NormalizedEvent, { kind: 'message' | 'thinking' }> & { itemId: string });
 
 function mapToolStatus(status: NormalizedToolStatus | null | undefined): ToolStatus | undefined {
   switch (status) {
@@ -316,7 +315,7 @@ function upsertSpecialEvent(
   );
   const seq = existing?.seq ?? nextSeq(items);
   const parentToolCallId = event.parentToolCallId ?? undefined;
-  const mapped = mapToolStatus(event.status) ?? 'running';
+  const mapped = mapToolStatus(event.status) ?? existing?.status ?? 'running';
 
   let next: ToolCallItem;
   switch (event.kind) {
@@ -377,27 +376,7 @@ function upsertSpecialEvent(
       break;
   }
 
-  return normalizeToolStructure(upsertToolCallItem(items, next), turnId);
-}
-
-/**
- * Auto-finalize any open thinking rows when a non-thinking content event
- * arrives. Mirrors the renderer's applyFinalizeOpenThinking behavior.
- */
-function finalizeOpenThinking(items: TranscriptItem[], now: number): TranscriptItem[] {
-  let changed = false;
-  const result = items.map((item) => {
-    if (item.kind === 'thinking' && item.status === 'thinking') {
-      changed = true;
-      return {
-        ...item,
-        status: 'done' as const,
-        durationMs: now - item.startedAt,
-      } satisfies TranscriptThinking;
-    }
-    return item;
-  });
-  return changed ? result : items;
+  return normalizeToolStructure(upsertToolCallItem(items, { ...existing, ...next }), turnId);
 }
 
 function replaceFileOperations(
@@ -602,8 +581,8 @@ function normalizeToolStructure(items: TranscriptItem[], turnId: string): Transc
  * Apply one NormalizedEvent to a turn's item list, returning an updated list.
  * The turnId is used for id synthesis — all item ids are scoped to the turn.
  *
- * Content-bearing events (message, tool, diff, plan) auto-finalize any open
- * thinking rows before appending (the agent has moved past the reasoning phase).
+ * Content identity and finalization are resolved by the reducer before folding.
+ * Updating tool/plan state does not imply that foreground reasoning has ended.
  */
 export function foldItem(
   items: TranscriptItem[],
@@ -614,8 +593,8 @@ export function foldItem(
   const flatItems = flattenItems(items);
   switch (event.kind) {
     case 'message': {
-      const id = makeMessageId(turnId, event.messageId, event.role);
-      const base = finalizeOpenThinking(flatItems, at);
+      const id = event.itemId;
+      const base = flatItems;
       const idx = base.findIndex((it) => it.kind === 'message' && it.id === id);
       if (idx >= 0) {
         // Append chunk to existing message.
@@ -646,7 +625,7 @@ export function foldItem(
     }
 
     case 'thinking': {
-      const id = makeThinkingId(turnId, event.messageId);
+      const id = event.itemId;
       const idx = flatItems.findIndex(
         (it) => it.kind === 'thinking' && it.id === id && it.status === 'thinking'
       );
@@ -661,18 +640,19 @@ export function foldItem(
         kind: 'thinking',
         id,
         seq: nextSeq(flatItems),
-        segmentId: event.messageId,
+        segmentId: event.itemId,
         text: event.text,
         status: 'thinking',
         startedAt: at,
       };
-      return normalizeToolStructure([...finalizeOpenThinking(flatItems, at), newThinking], turnId);
+      return normalizeToolStructure([...flatItems, newThinking], turnId);
     }
 
     case 'tool_call': {
       const toolId = makeToolId(turnId, event.toolCallId);
       const parentToolCallId = event.parentToolCallId ?? undefined;
-      const base = finalizeOpenThinking(flatItems, at);
+      const base = flatItems;
+      const existing = base.find((item) => isToolCallItem(item) && item.id === toolId);
       if (event.diffs.length > 0) {
         const next = replaceFileOperations(
           base,
@@ -690,7 +670,7 @@ export function foldItem(
 
       const tool = createToolCallItem({
         id: toolId,
-        seq: nextSeq(base),
+        seq: existing?.seq ?? nextSeq(base),
         toolCallId: event.toolCallId,
         title: event.title,
         toolKind: event.toolKind,
@@ -708,7 +688,7 @@ export function foldItem(
     case 'tool_update': {
       const toolId = makeToolId(turnId, event.toolCallId);
       const parentToolCallId = event.parentToolCallId ?? undefined;
-      let base = finalizeOpenThinking(flatItems, at);
+      let base = flatItems;
       const hadFileOperations = hasFileOperationsForToolCall(base, event.toolCallId);
       if (event.diffs !== undefined) {
         base = replaceFileOperations(
@@ -769,12 +749,12 @@ export function foldItem(
     case 'search':
     case 'mcp_tool':
     case 'web_fetch': {
-      const base = finalizeOpenThinking(flatItems, at);
+      const base = flatItems;
       return upsertSpecialEvent(base, event, turnId);
     }
 
     case 'plan': {
-      const base = finalizeOpenThinking(flatItems, at);
+      const base = flatItems;
       return normalizeToolStructure(upsertPlanToolCall(base, turnId, event), turnId);
     }
 
@@ -790,19 +770,20 @@ export function foldItem(
  * Settle all in-progress states for a committed turn.
  *
  * - thinking status 'thinking' → 'done' + computed durationMs
- * - tool status 'running' → 'done'
+ * - foreground tool status 'running' → 'done'; background subtrees retain live status
  *
  * Input must be plain objects (not Solid/MobX proxies).
  */
 export function finalizeItems(items: TranscriptItem[], at: number): TranscriptItem[] {
-  const finalizeNode = (item: ToolNode): ToolNode => {
+  const finalizeNode = (item: ToolNode, backgroundAncestor = false): ToolNode => {
+    const background = backgroundAncestor || ('background' in item && item.background === true);
     if (isToolGroup(item)) {
-      const children = item.children.map(finalizeNode);
+      const children = item.children.map((child) => finalizeNode(child, background));
       return { ...item, children, status: toolRunStatus(children) };
     }
 
-    const children = item.children?.map(finalizeNode);
-    const status = item.status === 'running' ? 'done' : item.status;
+    const children = item.children?.map((child) => finalizeNode(child, background));
+    const status = item.status === 'running' && !background ? 'done' : item.status;
     return {
       ...item,
       status,

--- a/packages/core/src/runtimes/acp/api/reducer/parser.ts
+++ b/packages/core/src/runtimes/acp/api/reducer/parser.ts
@@ -36,6 +36,7 @@ import type { AgentState } from '../models/agents';
 import type { SessionConfigState, SessionUsage } from '../models/config';
 import type { PlanState } from '../models/plan';
 import type { TranscriptTurn, TranscriptTurnOutcome } from '../models/turns';
+import { routeEvent } from './event-routing';
 import type { EnrichHook, NormalizedEvent } from './normalized-event';
 import { initialState, reduce, type ParserState, type ReducerDeps } from './reducer';
 
@@ -76,6 +77,21 @@ export class AcpTranscriptParser {
 
   pushEvent(event: NormalizedEvent, at = Date.now()): void {
     this.state = reduce(this.state, { kind: 'event', event, at }, this.deps);
+  }
+
+  /** Shared with SessionCell so async state updates cannot create foreground activity. */
+  advancesForeground(event: NormalizedEvent): boolean {
+    return routeEvent(
+      event,
+      this.state.toolOwners,
+      this.activeTurn?.id ?? null,
+      this.state.planTurnId
+    ).foreground;
+  }
+
+  /** Changes to already committed turns; live consumers must refresh their history. */
+  get historyRevision(): number {
+    return this.state.historyRevision;
   }
 
   /**

--- a/packages/core/src/runtimes/acp/api/reducer/reducer.ts
+++ b/packages/core/src/runtimes/acp/api/reducer/reducer.ts
@@ -5,8 +5,8 @@
  * active turn) and the session slices (config, usage, title) side by side.
  * A single reduce() call routes each NormalizedEvent to the appropriate slice:
  *
- *   transcript kinds (message / thinking / tool_call / tool_update / plan)
- *     → turn boundary logic + item fold (unchanged from before).
+ *   content and new foreground calls → turn/segment boundaries + item fold.
+ *   async tool/plan updates → their owner, without foreground side effects.
  *
  *   session kinds (config / mode_selected / commands / usage / title)
  *     → slice update, no turn boundary side-effect.
@@ -29,15 +29,21 @@ import { initialSessionConfigState } from '../models/config';
 import { SESSION_PLAN_ID, type PlanState } from '../models/plan';
 import type {
   TranscriptItem,
-  TranscriptThinking,
   ToolNode,
   TranscriptTurnInitiator,
   TranscriptTurnOutcome,
   TranscriptTurn,
 } from '../models/turns';
 import { deriveConfigGroups } from './config-derive';
+import {
+  closeContent,
+  initialSegment,
+  materializeContent,
+  type SegmentState,
+} from './content-stream';
 import { decodeSessionUpdate } from './decode';
-import { makeMessageId, makeThinkingId, makeTurnId } from './ids';
+import { routeEvent, type ToolEvent, type ToolOwner } from './event-routing';
+import { makeMessageId, makeTurnId } from './ids';
 import { foldItem, finalizeItems, type FoldEvent } from './item-fold';
 import type { EnrichHook, NormalizedEvent } from './normalized-event';
 
@@ -45,15 +51,6 @@ import type { EnrichHook, NormalizedEvent } from './normalized-event';
 // in browser builds; the structural declaration keeps this isomorphic reducer
 // free of node ambient types.
 declare const process: { env: { NODE_ENV?: string } };
-
-type SynthesizedSegmentKind = 'message:user' | 'message:assistant' | 'thinking';
-
-export interface SegmentState {
-  open: SynthesizedSegmentKind | null;
-  user: number;
-  assistant: number;
-  thinking: number;
-}
 
 export interface TranscriptSlice {
   committed: TranscriptTurn[];
@@ -69,6 +66,10 @@ export interface ParserState {
   segment: SegmentState;
   agents: AgentState[];
   plan: PlanState | null;
+  toolOwners: ReadonlyMap<string, ToolOwner>;
+  pendingTools: readonly ToolEvent[];
+  planTurnId: string | null;
+  historyRevision: number;
 }
 
 export type ReducerInput =
@@ -93,15 +94,10 @@ export function initialState(): ParserState {
     segment: initialSegment(),
     agents: [],
     plan: null,
-  };
-}
-
-function initialSegment(): SegmentState {
-  return {
-    open: null,
-    user: 0,
-    assistant: 0,
-    thinking: 0,
+    toolOwners: new Map(),
+    pendingTools: [],
+    planTurnId: null,
+    historyRevision: 0,
   };
 }
 
@@ -153,135 +149,25 @@ export function isNewUserMessage(
 ): boolean {
   if (!active) return true;
   if (event.messageId === null) {
-    if (segment.open === 'message:user') return false;
+    if (segment.open?.kind === 'user') return false;
     return active.items.some((it) => it.kind !== 'message' || it.role !== 'user');
   }
   const id = makeMessageId(active.id, event.messageId, 'user');
   return !active.items.some((it) => it.kind === 'message' && it.id === id);
 }
 
-function segmentStream(kind: SynthesizedSegmentKind): keyof Omit<SegmentState, 'open'> {
-  switch (kind) {
-    case 'message:user':
-      return 'user';
-    case 'message:assistant':
-      return 'assistant';
-    case 'thinking':
-      return 'thinking';
-  }
-}
-
-function segmentKind(
-  event: Extract<NormalizedEvent, { kind: 'message' | 'thinking' }>
-): SynthesizedSegmentKind {
-  if (event.kind === 'thinking') return 'thinking';
-  return event.role === 'user' ? 'message:user' : 'message:assistant';
-}
-
-function synthesizedMessageId(segment: SegmentState, kind: SynthesizedSegmentKind): string {
-  const stream = segmentStream(kind);
-  return `auto:${stream}:${segment[stream]}`;
-}
-
-function closeSynthesizedSegment(
-  transcript: TranscriptSlice,
-  segment: SegmentState,
-  at: number
-): { transcript: TranscriptSlice; segment: SegmentState } {
-  const active = transcript.active;
-  if (!active || !segment.open) return { transcript, segment };
-
-  const openKind = segment.open;
-  const stream = segmentStream(openKind);
-  const messageId = synthesizedMessageId(segment, openKind);
-  const itemId =
-    openKind === 'thinking'
-      ? makeThinkingId(active.id, messageId)
-      : makeMessageId(active.id, messageId, stream);
-  let changed = false;
-  const items = active.items.map((item): TranscriptItem => {
-    if (openKind === 'thinking') {
-      if (item.kind === 'thinking' && item.id === itemId && item.status === 'thinking') {
-        changed = true;
-        return { ...item, status: 'done' as const, durationMs: at - item.startedAt };
-      }
-      return item;
-    }
-    return item;
-  });
-
-  const nextSegment: SegmentState = {
-    ...segment,
-    open: null,
-    [stream]: segment[stream] + 1,
-  };
-
-  if (!changed) return { transcript, segment: nextSegment };
-  return { transcript: { ...transcript, active: { ...active, items } }, segment: nextSegment };
-}
-
-function resolveProviderThinkingMessageId(active: TranscriptTurn, messageId: string): string {
-  for (let i = active.items.length - 1; i >= 0; i -= 1) {
-    const item = active.items[i];
-    if (
-      item.kind === 'thinking' &&
-      item.status === 'thinking' &&
-      (item.segmentId === messageId || item.segmentId.startsWith(`${messageId}:segment:`))
-    ) {
-      return item.segmentId;
-    }
-  }
-
-  const baseId = makeThinkingId(active.id, messageId);
-  const base = active.items.find(
-    (item): item is TranscriptThinking => item.kind === 'thinking' && item.id === baseId
-  );
-  if (!base || base.status !== 'done') return messageId;
-
-  const prefix = `${messageId}:segment:`;
-  const count = active.items.filter(
-    (item) => item.kind === 'thinking' && item.segmentId.startsWith(prefix)
-  ).length;
-  return `${prefix}${count + 1}`;
-}
-
 function materializeEvent(
-  transcript: TranscriptSlice,
+  turn: TranscriptTurn,
   segment: SegmentState,
   event: NormalizedEvent,
+  foreground: boolean,
   at: number
-): { transcript: TranscriptSlice; segment: SegmentState; event: FoldEvent } {
+): { turn: TranscriptTurn; segment: SegmentState; event: FoldEvent } {
   if (event.kind === 'message' || event.kind === 'thinking') {
-    if (event.messageId === null) {
-      const kind = segmentKind(event);
-      const closed =
-        segment.open === kind
-          ? { transcript, segment }
-          : closeSynthesizedSegment(transcript, segment, at);
-      const messageId = synthesizedMessageId(closed.segment, kind);
-      const nextSegment = { ...closed.segment, open: kind };
-      return {
-        transcript: closed.transcript,
-        segment: nextSegment,
-        event: { ...event, messageId },
-      };
-    }
-
-    const closed = closeSynthesizedSegment(transcript, segment, at);
-    if (event.kind === 'thinking' && closed.transcript.active) {
-      return {
-        ...closed,
-        event: {
-          ...event,
-          messageId: resolveProviderThinkingMessageId(closed.transcript.active, event.messageId),
-        },
-      };
-    }
-    return { ...closed, event: event as FoldEvent };
+    return materializeContent(turn, segment, event, at);
   }
-
-  const closed = closeSynthesizedSegment(transcript, segment, at);
-  return { ...closed, event: event as FoldEvent };
+  const content = foreground ? closeContent(turn, segment, at) : { turn, segment };
+  return { ...content, event };
 }
 
 function toAgentStatus(
@@ -307,14 +193,14 @@ function updateAgentSlice(
 ): AgentState[] {
   if (event.kind !== 'subagent' && event.kind !== 'subagent_update') return agents;
 
-  const agentId = event.agentId ?? event.toolCallId;
-  if (!agentId) return agents;
-
-  const toolCallId = event.toolCallId ?? agentId;
   const idx = agents.findIndex(
-    (agent) => agent.agentId === agentId || agent.toolCallId === toolCallId
+    (agent) => agent.agentId === event.agentId || agent.toolCallId === event.toolCallId
   );
-  const status = toAgentStatus(event.status);
+  const existing = idx >= 0 ? agents[idx] : undefined;
+  const agentId = event.agentId ?? existing?.agentId ?? event.toolCallId;
+  if (!agentId) return agents;
+  const toolCallId = event.toolCallId ?? existing?.toolCallId ?? agentId;
+  const status = event.status === null && existing ? existing.status : toAgentStatus(event.status);
   const completedAt =
     status === 'completed' || status === 'failed'
       ? { completedAt: at }
@@ -329,7 +215,7 @@ function updateAgentSlice(
       ...(idx >= 0 ? agents[idx] : {}),
       agentId,
       toolCallId,
-      launchTurnId,
+      launchTurnId: existing?.launchTurnId ?? launchTurnId,
       name: event.title,
       status,
       startedAt: idx >= 0 ? agents[idx].startedAt : at,
@@ -512,7 +398,18 @@ export function reduce(s: ParserState, input: ReducerInput, deps: ReducerDeps): 
       return s;
     case 'subagent_update': {
       const agents = updateAgentSlice(s.agents, event, s.transcript.active?.id ?? null, input.at);
-      return agents === s.agents ? s : { ...s, agents };
+      const toolCallId =
+        event.toolCallId ?? agents.find((agent) => agent.agentId === event.agentId)?.toolCallId;
+      if (!toolCallId || !s.toolOwners.has(toolCallId)) return { ...s, agents };
+      return reduce(
+        { ...s, agents },
+        {
+          kind: 'event',
+          at: input.at,
+          event: { kind: 'tool_update', toolCallId, parentToolCallId: null, status: event.status },
+        },
+        deps
+      );
     }
     default:
       break; // falls through to transcript handling below
@@ -521,7 +418,6 @@ export function reduce(s: ParserState, input: ReducerInput, deps: ReducerDeps): 
   let t = s.transcript;
   let segment = s.segment;
   const plan = updatePlanSlice(s.plan, event, input.at);
-  let agents = s.agents;
 
   // OPEN boundary: a new user message starts a new turn.
   if (event.kind === 'message' && event.role === 'user') {
@@ -532,31 +428,91 @@ export function reduce(s: ParserState, input: ReducerInput, deps: ReducerDeps): 
     }
   }
 
-  // Lazy open: agent-initiated content with no active turn.
-  if (!t.active) {
+  const route = routeEvent(event, s.toolOwners, t.active?.id ?? null, s.planTurnId);
+  // Only foreground content or a new root invocation can open an agent turn.
+  if (route.turnId === null && route.foreground) {
     t = openTurn(t, deps, 'agent');
     segment = initialSegment();
   }
-
-  const materialized = materializeEvent(t, segment, event, input.at);
-  t = materialized.transcript;
-  segment = materialized.segment;
-
-  const active = t.active!;
-  agents = updateAgentSlice(agents, materialized.event, active.id, input.at);
-  const items = foldItem(active.items, materialized.event, active.id, input.at);
-
-  if (
-    items === active.items &&
-    t === s.transcript &&
-    segment === s.segment &&
-    agents === s.agents &&
-    plan === s.plan
-  ) {
-    return s;
+  const turnId = route.turnId ?? (route.foreground ? t.active?.id : null);
+  const routedEvent = route.tool ?? event;
+  if (!turnId) {
+    // Keep a bounded window of unmatched notifications from incomplete replay.
+    // They may establish ownership when their start/parent arrives; they never
+    // create a turn merely because the provider emitted a status notification.
+    return {
+      ...s,
+      agents: updateAgentSlice(s.agents, routedEvent, null, input.at),
+      plan,
+      pendingTools: route.tool ? [...s.pendingTools, route.tool].slice(-128) : s.pendingTools,
+    };
   }
-  const transcript: TranscriptSlice =
-    items === active.items ? t : { ...t, active: { ...active, items } };
-  assertTranscriptInvariants(transcript);
-  return { ...s, transcript, segment, agents, plan };
+
+  const isActive = t.active?.id === turnId;
+  const owner = isActive ? t.active : t.committed.find((turn) => turn.id === turnId);
+  if (!owner) throw new Error(`ACP event owner turn not found: ${turnId}`);
+  const materialized = materializeEvent(owner, segment, routedEvent, route.foreground, input.at);
+  if (isActive) segment = materialized.segment;
+
+  let toolOwners = s.toolOwners;
+  if (route.tool) {
+    const previous = toolOwners.get(route.tool.toolCallId);
+    if (previous?.turnId !== turnId || previous.parentToolCallId !== route.tool.parentToolCallId) {
+      toolOwners = new Map(toolOwners).set(route.tool.toolCallId, {
+        turnId,
+        parentToolCallId: route.tool.parentToolCallId,
+      });
+    }
+  }
+  const pendingForCall = route.tool
+    ? s.pendingTools.filter((pending) => pending.toolCallId === route.tool?.toolCallId)
+    : [];
+  let items = materialized.turn.items;
+  // An update observed before its start contains newer tool state than that
+  // start's initial fields. For update-only recovery, the arriving patch wins.
+  const isUpdate =
+    routedEvent.kind === 'tool_update' ||
+    ('operation' in routedEvent && routedEvent.operation === 'update');
+  const operations = isUpdate
+    ? [...pendingForCall, materialized.event]
+    : [materialized.event, ...pendingForCall];
+  let agents = s.agents;
+  for (const operation of operations) {
+    items = foldItem(items, operation, turnId, input.at);
+    agents = updateAgentSlice(agents, operation, turnId, input.at);
+  }
+  const updated = items === owner.items ? owner : { ...owner, items };
+  const transcript = isActive
+    ? { ...t, active: updated }
+    : { ...t, committed: t.committed.map((turn) => (turn.id === turnId ? updated : turn)) };
+  let result: ParserState = {
+    ...s,
+    transcript,
+    segment,
+    agents,
+    plan,
+    toolOwners,
+    planTurnId: event.kind === 'plan' ? turnId : s.planTurnId,
+    pendingTools: pendingForCall.length
+      ? s.pendingTools.filter((pending) => !pendingForCall.includes(pending))
+      : s.pendingTools,
+    historyRevision: s.historyRevision + (!isActive && updated !== owner ? 1 : 0),
+  };
+  // A parent can establish ownership of previously unseen child calls. Remove
+  // them before folding so each retained notification is replayed exactly once.
+  const ready = result.pendingTools.filter(
+    (pending) =>
+      toolOwners.has(pending.toolCallId) ||
+      (pending.parentToolCallId !== null && toolOwners.has(pending.parentToolCallId))
+  );
+  if (ready.length) {
+    result = {
+      ...result,
+      pendingTools: result.pendingTools.filter((pending) => !ready.includes(pending)),
+    };
+    for (const pending of ready)
+      result = reduce(result, { kind: 'event', event: pending, at: input.at }, deps);
+  }
+  assertTranscriptInvariants(result.transcript);
+  return result;
 }

--- a/packages/core/src/runtimes/acp/api/reducer/stream-ownership.test.ts
+++ b/packages/core/src/runtimes/acp/api/reducer/stream-ownership.test.ts
@@ -1,0 +1,322 @@
+import type { SessionUpdate } from '@agentclientprotocol/sdk';
+import { describe, expect, it } from 'vitest';
+import type { TranscriptItem, ToolNode } from '../models/turns';
+import type { NormalizedEvent } from './normalized-event';
+import { AcpTranscriptParser } from './parser';
+
+const text = (value: string, messageId: string | null = null): NormalizedEvent => ({
+  kind: 'message',
+  role: 'assistant',
+  messageId,
+  text: value,
+});
+const thought = (value: string, messageId: string | null = null): NormalizedEvent => ({
+  kind: 'thinking',
+  messageId,
+  text: value,
+});
+const tool = (toolCallId = 'tool', parentToolCallId: string | null = null): NormalizedEvent => ({
+  kind: 'tool_call',
+  toolCallId,
+  parentToolCallId,
+  title: 'Run',
+  toolKind: 'execute',
+  status: 'in_progress',
+  diffs: [],
+  locations: [],
+});
+const update = (toolCallId = 'tool'): NormalizedEvent => ({
+  kind: 'tool_update',
+  toolCallId,
+  parentToolCallId: null,
+  status: 'completed',
+});
+const plan: NormalizedEvent = {
+  kind: 'plan',
+  entries: [{ content: 'Check', priority: 'medium', status: 'in_progress' }],
+};
+const parser = () => new AcpTranscriptParser({ conversationId: 'stream' });
+function flatten(items: readonly (TranscriptItem | ToolNode)[]): (TranscriptItem | ToolNode)[] {
+  return items.flatMap((item) => [
+    item,
+    ...('children' in item ? flatten(item.children ?? []) : []),
+  ]);
+}
+const messages = (p: AcpTranscriptParser) =>
+  p.activeTurn?.items.filter((item) => item.kind === 'message') ?? [];
+
+describe('content ownership across asynchronous events', () => {
+  const updates: [string, NormalizedEvent][] = [
+    ['status', update()],
+    [
+      'output',
+      {
+        ...update(),
+        kind: 'tool_update',
+        toolCallId: 'tool',
+        parentToolCallId: null,
+        outputText: 'output',
+      },
+    ],
+    ['empty patch', { kind: 'tool_update', toolCallId: 'tool', parentToolCallId: null }],
+    ['plan', plan],
+    ['nested invocation', tool('child', 'tool')],
+    ['repeated invocation', tool()],
+  ];
+  it.each(updates)('preserves text and identity across %s at every delta boundary', (_, event) => {
+    const source = 'The registry still shows `/tmp/path` and **bold**.';
+    for (let split = 1; split < source.length; split++) {
+      const p = parser();
+      p.pushEvent(tool(), 0);
+      p.pushEvent(text(source.slice(0, split)), 10);
+      const id = messages(p)[0].id;
+      p.pushEvent(event, 20);
+      p.pushEvent(text(source.slice(split)), 30);
+      expect(messages(p)).toMatchObject([{ id, text: source }]);
+      expect(messages(p)).toHaveLength(1);
+    }
+  });
+
+  it.each([null, 'provider-reasoning'])('preserves reasoning lifetime with id %s', (messageId) => {
+    const p = parser();
+    p.pushEvent(tool(), 0);
+    p.pushEvent(thought('Analy', messageId), 100);
+    p.pushEvent(update(), 200);
+    p.pushEvent(plan, 250);
+    p.pushEvent(tool('child', 'tool'), 275);
+    p.pushEvent(thought('zing', messageId), 300);
+    expect(p.activeTurn?.items.filter((item) => item.kind === 'thinking')).toMatchObject([
+      { text: 'Analyzing', status: 'thinking', startedAt: 100 },
+    ]);
+    p.endTurn(500);
+    expect(p.history[0].items.filter((item) => item.kind === 'thinking')).toMatchObject([
+      { text: 'Analyzing', status: 'done', durationMs: 400 },
+    ]);
+  });
+
+  it('separates foreground calls and finalizes reasoning on a real content transition', () => {
+    const p = parser();
+    p.pushEvent(thought('first', 'r'), 0);
+    p.pushEvent(tool(), 10);
+    p.pushEvent(thought('second', 'r'), 20);
+    p.pushEvent(text('before'), 30);
+    p.pushEvent(tool('next'), 40);
+    p.pushEvent(text('after'), 50);
+    expect(messages(p).map((item) => item.text)).toEqual(['before', 'after']);
+    expect(p.activeTurn?.items.filter((item) => item.kind === 'thinking')).toMatchObject([
+      { text: 'first', status: 'done', durationMs: 10 },
+      { text: 'second', status: 'done', durationMs: 10 },
+    ]);
+  });
+
+  it('does not split an idless user prompt on a plan update', () => {
+    const p = parser();
+    p.pushEvent({ kind: 'message', role: 'user', messageId: null, text: 'hel' }, 0);
+    p.pushEvent(plan, 10);
+    p.pushEvent({ kind: 'message', role: 'user', messageId: null, text: 'lo' }, 20);
+    expect(p.history).toHaveLength(0);
+    expect(messages(p).map((item) => item.text)).toEqual(['hello']);
+  });
+
+  it('keeps provider ids opaque and separate from generated ids and roles', () => {
+    const p = parser();
+    p.pushEvent({ kind: 'message', role: 'user', messageId: 'same', text: 'user' });
+    p.pushEvent(text('assistant', 'same'));
+    p.pushEvent(text('generated'));
+    p.pushEvent(text('provider', 'auto:assistant:0'));
+    expect(messages(p).map((item) => [item.role, item.text])).toEqual([
+      ['user', 'user'],
+      ['assistant', 'assistant'],
+      ['assistant', 'generated'],
+      ['assistant', 'provider'],
+    ]);
+    expect(new Set(messages(p).map((item) => item.id)).size).toBe(4);
+  });
+
+  it('does not interpret a provider reasoning id as a generated suffix', () => {
+    const p = parser();
+    p.pushEvent(thought('one', 'r:segment:1'), 0);
+    p.pushEvent(thought('two', 'r'), 10);
+    p.pushEvent(text('answer'), 20);
+    p.pushEvent(thought('three', 'r'), 30);
+    p.pushEvent(thought('four', 'auto:thinking:0'), 40);
+    p.pushEvent(thought('five'), 50);
+    const rows = p.activeTurn?.items.filter((item) => item.kind === 'thinking') ?? [];
+    expect(rows.map((item) => item.text)).toEqual(['one', 'two', 'three', 'four', 'five']);
+    expect(new Set(rows.map((item) => item.id)).size).toBe(5);
+  });
+
+  it('routes late tool and child updates to their original turn', () => {
+    const p = parser();
+    p.pushEvent(tool(), 0);
+    p.endTurn(10);
+    p.pushEvent(update(), 20);
+    expect(p.activeTurn).toBeNull();
+    p.pushEvent({ kind: 'message', role: 'user', messageId: 'u2', text: 'next' }, 30);
+    p.pushEvent(text('hel'), 40);
+    p.pushEvent(tool('child', 'tool'), 50);
+    p.pushEvent(
+      {
+        kind: 'tool_update',
+        toolCallId: 'tool',
+        parentToolCallId: null,
+        outputText: 'late output',
+      },
+      60
+    );
+    p.pushEvent(text('lo'), 70);
+    expect(messages(p).map((item) => item.text)).toEqual(['next', 'hello']);
+    expect(flatten(p.history[0].items)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ toolCallId: 'tool', outputText: 'late output' }),
+        expect.objectContaining({ toolCallId: 'child', parentToolCallId: 'tool' }),
+      ])
+    );
+    expect(flatten(p.activeTurn?.items ?? []).some((item) => 'toolCallId' in item)).toBe(false);
+  });
+
+  it('retains an unmatched idle update until the call is introduced', () => {
+    const p = parser();
+    p.pushEvent(update(), 0);
+    expect(p.activeTurn).toBeNull();
+    p.pushEvent(tool(), 10);
+    expect(flatten(p.activeTurn?.items ?? [])).toEqual(
+      expect.arrayContaining([expect.objectContaining({ toolCallId: 'tool', status: 'done' })])
+    );
+  });
+
+  it('recovers child ownership when its parent arrives after the child', () => {
+    const p = parser();
+    p.pushEvent(tool('child', 'parent'), 0);
+    p.pushEvent(update('child'), 10);
+    expect(p.activeTurn).toBeNull();
+    p.pushEvent(tool('parent'), 20);
+    expect(flatten(p.activeTurn?.items ?? [])).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          toolCallId: 'child',
+          parentToolCallId: 'parent',
+          status: 'done',
+        }),
+      ])
+    );
+  });
+
+  it('bounds unmatched idle updates and resets ownership between replays', () => {
+    const p = parser();
+    for (let i = 0; i < 130; i++) p.pushEvent(update(`orphan-${i}`), i);
+    p.pushEvent(tool('orphan-0'), 200);
+    expect(flatten(p.activeTurn?.items ?? [])[0]).toMatchObject({ status: 'running' });
+    p.pushEvent(tool('orphan-129'), 201);
+    expect(flatten(p.activeTurn?.items ?? [])).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ toolCallId: 'orphan-129', status: 'done' }),
+      ])
+    );
+    p.beginReplay();
+    p.pushEvent(update('orphan-129'));
+    expect(p.history).toHaveLength(0);
+    expect(p.activeTurn).toBeNull();
+    expect(p.historyRevision).toBe(0);
+  });
+
+  it('keeps background status independent of foreground completion', () => {
+    const p = parser();
+    p.pushEvent(
+      {
+        kind: 'subagent',
+        operation: 'start',
+        toolCallId: 'agent-tool',
+        agentId: 'agent',
+        parentToolCallId: null,
+        title: 'Investigate',
+        status: 'in_progress',
+        background: true,
+      },
+      0
+    );
+    p.pushEvent(tool('child', 'agent-tool'), 10);
+    p.endTurn(20);
+    expect(
+      flatten(p.history[0].items)
+        .filter((item) => 'toolCallId' in item)
+        .map((item) => item.status)
+    ).toEqual(['running', 'running']);
+    p.pushEvent({ kind: 'subagent_update', agentId: 'agent', status: 'completed' }, 30);
+    expect(p.activeTurn).toBeNull();
+    expect(p.agents[0]).toMatchObject({
+      agentId: 'agent',
+      toolCallId: 'agent-tool',
+      status: 'completed',
+      launchTurnId: p.history[0].id,
+    });
+    expect(p.history[0].items[0]).toMatchObject({ status: 'done' });
+    expect(p.historyRevision).toBe(1);
+  });
+
+  it('applies pending subagent state to both its row and registry', () => {
+    const p = parser();
+    p.pushEvent(
+      {
+        kind: 'subagent',
+        operation: 'update',
+        toolCallId: 'agent-tool',
+        agentId: 'agent',
+        parentToolCallId: null,
+        title: 'Investigate',
+        status: 'completed',
+        background: true,
+      },
+      0
+    );
+    p.pushEvent(
+      {
+        kind: 'subagent',
+        operation: 'start',
+        toolCallId: 'agent-tool',
+        parentToolCallId: null,
+        title: 'Investigate',
+        status: 'in_progress',
+      },
+      10
+    );
+    expect(p.agents[0]).toMatchObject({
+      agentId: 'agent',
+      status: 'completed',
+      launchTurnId: p.activeTurn?.id,
+    });
+    expect(p.activeTurn?.items[0]).toMatchObject({
+      status: 'done',
+      background: true,
+      agentId: 'agent',
+    });
+  });
+
+  it('updates a session plan while idle without starting another turn', () => {
+    const p = parser();
+    p.pushEvent(text('work'), 0);
+    p.pushEvent(plan, 10);
+    p.endTurn(20);
+    p.pushEvent({ kind: 'plan', entries: [] }, 30);
+    expect(p.activeTurn).toBeNull();
+    expect(p.history).toHaveLength(1);
+    expect(p.plan?.entries).toEqual([]);
+    expect(p.history[0].items.find((item) => item.kind === 'create-plan-tool-call')).toMatchObject({
+      status: 'done',
+    });
+  });
+
+  it('produces identical identities and content during live streaming and replay', () => {
+    const updates: SessionUpdate[] = [
+      { sessionUpdate: 'tool_call', toolCallId: 'tool', title: 'Run', kind: 'execute' },
+      { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'hel' } },
+      { sessionUpdate: 'tool_call_update', toolCallId: 'tool', status: 'completed' },
+      { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'lo' } },
+    ];
+    const p = parser();
+    updates.forEach((event, at) => p.push(event, at));
+    p.endTurn(updates.length);
+    const replay = AcpTranscriptParser.replay(updates, { conversationId: 'stream' });
+    expect(replay.committed).toEqual(p.history);
+  });
+});

--- a/packages/core/src/runtimes/acp/node/session/cell.test.ts
+++ b/packages/core/src/runtimes/acp/node/session/cell.test.ts
@@ -345,14 +345,74 @@ describe('SessionCell config options', () => {
 });
 
 describe('SessionCell idle turns and queue commands', () => {
+  it('amends a completed tool without starting agent activity or an idle timer', () => {
+    vi.useFakeTimers();
+    const { cell } = makeCell();
+    try {
+      cell.transcript.pushEvent(
+        {
+          kind: 'tool_call',
+          toolCallId: 'old',
+          title: 'Run',
+          toolKind: 'execute',
+          status: 'in_progress',
+          parentToolCallId: null,
+          diffs: [],
+          locations: [],
+        },
+        0
+      );
+      cell.transcript.endTurn(10);
+      cell.push({
+        kind: 'tool_update',
+        toolCallId: 'old',
+        status: 'failed',
+        parentToolCallId: null,
+        outputText: 'late failure',
+      });
+      expect(cell.sessionState.agentTurnActive).toBe(false);
+      expect(cell.sessionState.isGenerating).toBe(false);
+      expect(cell.history().active).toBeNull();
+      expect(cell.history().committed[0].items[0]).toMatchObject({
+        toolCallId: 'old',
+        status: 'error',
+        outputText: 'late failure',
+      });
+      expect(cell.sessionState.historyRevision).toBe(1);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      cell.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not mistake idle plan revisions or unmatched tool updates for agent activity', () => {
+    const { cell } = makeCell();
+    try {
+      cell.push({ kind: 'plan', entries: [] });
+      cell.push({
+        kind: 'tool_update',
+        toolCallId: 'unknown',
+        parentToolCallId: null,
+        status: 'completed',
+      });
+      expect(cell.sessionState.agentTurnActive).toBe(false);
+      expect(cell.history()).toEqual({ committed: [], active: null });
+    } finally {
+      cell.dispose();
+    }
+  });
+
   it('settles idle agent turns after quiesce', async () => {
     vi.useFakeTimers();
     try {
       const { cell } = makeCell();
 
       cell.push({
-        kind: 'plan',
-        entries: [{ content: 'Background step', status: 'in_progress', priority: 'medium' }],
+        kind: 'message',
+        role: 'assistant',
+        messageId: null,
+        text: 'An unsolicited response',
       });
 
       expect(cell.sessionState.agentTurnActive).toBe(true);

--- a/packages/core/src/runtimes/acp/node/session/cell.ts
+++ b/packages/core/src/runtimes/acp/node/session/cell.ts
@@ -115,7 +115,7 @@ export class SessionCell {
   }
 
   get sessionState(): SessionState {
-    return this.machine.sessionState();
+    return { ...this.machine.sessionState(), historyRevision: this.transcript.historyRevision };
   }
 
   get config(): SessionConfigState {
@@ -699,7 +699,7 @@ export class SessionCell {
   private isIdleAgentTranscriptEvent(event: NormalizedEvent): boolean {
     return (
       this.machine.phase.kind === 'ready' &&
-      this.isTranscriptEvent(event) &&
+      this.transcript.advancesForeground(event) &&
       !(event.kind === 'message' && event.role === 'user')
     );
   }

--- a/packages/plugins/src/agents/impl/claude/acp-transform.test.ts
+++ b/packages/plugins/src/agents/impl/claude/acp-transform.test.ts
@@ -1,5 +1,6 @@
 import type { SessionUpdate } from '@agentclientprotocol/sdk';
 import type { NormalizedEvent } from '@emdash/core/runtimes/acp/api';
+import { AcpTranscriptParser } from '@emdash/core/runtimes/acp/api';
 import { describe, expect, it } from 'vitest';
 import { enrichClaudeUpdate, parseTaskNotification } from './acp-transform';
 
@@ -48,6 +49,56 @@ function makeRaw(meta?: Record<string, unknown>): SessionUpdate {
 // ── enrichClaudeUpdate ────────────────────────────────────────────────────────
 
 describe('enrichClaudeUpdate', () => {
+  it('preserves start/update provenance and content continuity through Agent enrichment', () => {
+    const p = new AcpTranscriptParser({
+      conversationId: 'claude-stream',
+      enrich: enrichClaudeUpdate,
+    });
+    const start: SessionUpdate = {
+      sessionUpdate: 'tool_call',
+      toolCallId: 'agent',
+      title: 'Investigate',
+      kind: 'other',
+      status: 'in_progress',
+      _meta: { claudeCode: { toolName: 'Agent' } },
+    };
+    const update: SessionUpdate = {
+      sessionUpdate: 'tool_call_update',
+      toolCallId: 'agent',
+      status: 'completed',
+      _meta: { claudeCode: { toolName: 'Agent' } },
+    };
+    expect(enrichClaudeUpdate(makeToolCall(), start)).toMatchObject({
+      kind: 'subagent',
+      operation: 'start',
+    });
+    expect(enrichClaudeUpdate(makeToolUpdate(), update)).toMatchObject({
+      kind: 'subagent',
+      operation: 'update',
+    });
+    p.push(start, 0);
+    p.push({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'hel' } }, 10);
+    p.push(update, 20);
+    p.push(
+      {
+        sessionUpdate: 'tool_call',
+        toolCallId: 'child',
+        title: 'Read',
+        kind: 'read',
+        _meta: { claudeCode: { parentToolUseId: 'agent' } },
+      },
+      25
+    );
+    p.push({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'lo' } }, 30);
+    expect(
+      p.activeTurn?.items.filter((item) => item.kind === 'message').map((item) => item.text)
+    ).toEqual(['hello']);
+    p.endTurn(40);
+    p.push(update, 50);
+    expect(p.activeTurn).toBeNull();
+    expect(p.agents[0].launchTurnId).toBe(p.history[0].id);
+  });
+
   it('is identity for message kind', () => {
     const update: NormalizedEvent = {
       kind: 'message',

--- a/packages/plugins/src/agents/impl/claude/acp-transform.ts
+++ b/packages/plugins/src/agents/impl/claude/acp-transform.ts
@@ -53,6 +53,7 @@ export function enrichClaudeUpdate(update: NormalizedEvent, raw: SessionUpdate):
     const asyncLaunch = parseAsyncLaunch(raw);
     return {
       kind: 'subagent',
+      operation: normalizedUpdate.kind === 'tool_call' ? 'start' : 'update',
       toolCallId: normalizedUpdate.toolCallId,
       title: asyncLaunch?.description ?? normalizedUpdate.title ?? 'Agent',
       status: asyncLaunch ? 'in_progress' : (normalizedUpdate.status ?? null),

--- a/packages/plugins/src/agents/impl/codex/__snapshots__/acp-fixture.test.ts.snap
+++ b/packages/plugins/src/agents/impl/codex/__snapshots__/acp-fixture.test.ts.snap
@@ -195,14 +195,14 @@ exports[`Codex ACP fixture parsing > transcript 1`] = `
       "initiator": "user",
       "items": [
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:0:message:auto:user:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:0:message:user:generated:0",
           "kind": "message",
           "role": "user",
           "seq": 0,
           "text": "In one sentence, without reading any files, what is emdash?",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:0:message:auto:assistant:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:0:message:assistant:generated:0",
           "kind": "message",
           "role": "assistant",
           "seq": 1,
@@ -216,14 +216,14 @@ exports[`Codex ACP fixture parsing > transcript 1`] = `
       "initiator": "user",
       "items": [
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:1:message:auto:user:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:1:message:user:generated:0",
           "kind": "message",
           "role": "user",
           "seq": 0,
           "text": "Think about how to explore this repo, then read \`AGENTS.md\` and give me the Repository Structure section as exactly 3 bullet points.",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:1:message:auto:assistant:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:1:message:assistant:generated:0",
           "kind": "message",
           "role": "assistant",
           "seq": 1,
@@ -239,7 +239,7 @@ exports[`Codex ACP fixture parsing > transcript 1`] = `
           "toolCallId": "call_dMOHUTSuSmcFB4JThBpPj5nZ",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:1:message:auto:assistant:1",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:1:message:assistant:generated:1",
           "kind": "message",
           "role": "assistant",
           "seq": 3,
@@ -255,14 +255,14 @@ exports[`Codex ACP fixture parsing > transcript 1`] = `
       "initiator": "user",
       "items": [
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:2:message:auto:user:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:2:message:user:generated:0",
           "kind": "message",
           "role": "user",
           "seq": 0,
           "text": "Search the codebase for the definition of \`toAgentUpdate\` — give the file path and line number.",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:2:message:auto:assistant:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:2:message:assistant:generated:0",
           "kind": "message",
           "role": "assistant",
           "seq": 1,
@@ -278,7 +278,7 @@ exports[`Codex ACP fixture parsing > transcript 1`] = `
           "toolCallId": "call_sqP7LTqUlaTMofbbig96Qk08",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:2:message:auto:assistant:1",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:2:message:assistant:generated:1",
           "kind": "message",
           "role": "assistant",
           "seq": 3,
@@ -292,7 +292,7 @@ exports[`Codex ACP fixture parsing > transcript 1`] = `
       "initiator": "user",
       "items": [
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:3:message:auto:user:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:3:message:user:generated:0",
           "kind": "message",
           "role": "user",
           "seq": 0,
@@ -300,9 +300,9 @@ exports[`Codex ACP fixture parsing > transcript 1`] = `
         },
         {
           "durationMs": 0,
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:3:thinking:auto:thinking:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:3:thinking:generated:0",
           "kind": "thinking",
-          "segmentId": "auto:thinking:0",
+          "segmentId": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:3:thinking:generated:0",
           "seq": 1,
           "startedAt": 1577836800000,
           "status": "done",
@@ -313,7 +313,7 @@ exports[`Codex ACP fixture parsing > transcript 1`] = `
 I think I need to form an answer after reviewing the relevant information. Using a specific tool seems necessary for this task to ensure accuracy and reliability in my response. I want to make sure that I gather all the essential details before crafting my answer. I'll do my best to summarize everything clearly and be helpful for the user's understanding!",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:3:message:auto:assistant:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:3:message:assistant:generated:0",
           "kind": "message",
           "role": "assistant",
           "seq": 2,
@@ -369,7 +369,7 @@ I think I need to form an answer after reviewing the relevant information. Using
           "status": "done",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:3:message:auto:assistant:1",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:3:message:assistant:generated:1",
           "kind": "message",
           "role": "assistant",
           "seq": 6,
@@ -389,7 +389,7 @@ I think I need to form an answer after reviewing the relevant information. Using
           "toolCallId": "call_EpbDQ39xyA1D5C7qfQS7LEVO",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:3:message:auto:assistant:2",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:3:message:assistant:generated:2",
           "kind": "message",
           "role": "assistant",
           "seq": 8,
@@ -403,7 +403,7 @@ I think I need to form an answer after reviewing the relevant information. Using
       "initiator": "user",
       "items": [
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:4:message:auto:user:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:4:message:user:generated:0",
           "kind": "message",
           "role": "user",
           "seq": 0,
@@ -411,9 +411,9 @@ I think I need to form an answer after reviewing the relevant information. Using
         },
         {
           "durationMs": 0,
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:4:thinking:auto:thinking:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:4:thinking:generated:0",
           "kind": "thinking",
-          "segmentId": "auto:thinking:0",
+          "segmentId": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:4:thinking:generated:0",
           "seq": 1,
           "startedAt": 1577836800000,
           "status": "done",
@@ -424,7 +424,7 @@ I think I need to form an answer after reviewing the relevant information. Using
 I need to respond with just a plan since the user is asking for a checklist or to-do plan. It seems like there’s no need for extra detail, but to be accurate, maybe I should check the relevant files. The user asked not to edit, but reading files is still possible. I probably should mention the relevant locations. I think I can use a search tool to look into AgentUpdate uses and create that checklist.",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:4:message:auto:assistant:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:4:message:assistant:generated:0",
           "kind": "message",
           "role": "assistant",
           "seq": 2,
@@ -476,7 +476,7 @@ I need to respond with just a plan since the user is asking for a checklist or t
           "status": "done",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:4:message:auto:assistant:1",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:4:message:assistant:generated:1",
           "kind": "message",
           "role": "assistant",
           "seq": 6,
@@ -494,14 +494,14 @@ I need to respond with just a plan since the user is asking for a checklist or t
       "initiator": "user",
       "items": [
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:5:message:auto:user:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:5:message:user:generated:0",
           "kind": "message",
           "role": "user",
           "seq": 0,
           "text": "Run \`git rev-parse --abbrev-ref HEAD\` and tell me the current branch name.",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:5:message:auto:assistant:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:5:message:assistant:generated:0",
           "kind": "message",
           "role": "assistant",
           "seq": 1,
@@ -518,9 +518,9 @@ I need to respond with just a plan since the user is asking for a checklist or t
         },
         {
           "durationMs": 0,
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:5:thinking:auto:thinking:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:5:thinking:generated:0",
           "kind": "thinking",
-          "segmentId": "auto:thinking:0",
+          "segmentId": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:5:thinking:generated:0",
           "seq": 3,
           "startedAt": 1577836800000,
           "status": "done",
@@ -531,7 +531,7 @@ I need to respond with just a plan since the user is asking for a checklist or t
 I need to mention that if the branch name is "HEAD," it might be in a detached state. I’ve got to make sure I communicate that clearly so anyone working with git understands what it means for their version control. It’s essential to emphasize what being in a detached HEAD state implies regarding committing changes, as it can lead to confusion if not properly addressed. I'll keep it straightforward and informative!",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:5:message:auto:assistant:1",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:5:message:assistant:generated:1",
           "kind": "message",
           "role": "assistant",
           "seq": 4,
@@ -545,14 +545,14 @@ I need to mention that if the branch name is "HEAD," it might be in a detached s
       "initiator": "user",
       "items": [
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:6:message:auto:user:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:6:message:user:generated:0",
           "kind": "message",
           "role": "user",
           "seq": 0,
           "text": "Run \`ls packages\` and list the workspace package names.",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:6:message:auto:assistant:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:6:message:assistant:generated:0",
           "kind": "message",
           "role": "assistant",
           "seq": 1,
@@ -567,7 +567,7 @@ I need to mention that if the branch name is "HEAD," it might be in a detached s
           "toolCallId": "call_DagRCdNzm1jDfGHSmO0H6Awg",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:6:message:auto:assistant:1",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:6:message:assistant:generated:1",
           "kind": "message",
           "role": "assistant",
           "seq": 3,
@@ -581,7 +581,7 @@ I need to mention that if the branch name is "HEAD," it might be in a detached s
       "initiator": "user",
       "items": [
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:7:message:auto:user:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:7:message:user:generated:0",
           "kind": "message",
           "role": "user",
           "seq": 0,
@@ -589,9 +589,9 @@ I need to mention that if the branch name is "HEAD," it might be in a detached s
         },
         {
           "durationMs": 0,
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:7:thinking:auto:thinking:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:7:thinking:generated:0",
           "kind": "thinking",
-          "segmentId": "auto:thinking:0",
+          "segmentId": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:7:thinking:generated:0",
           "seq": 1,
           "startedAt": 1577836800000,
           "status": "done",
@@ -602,7 +602,7 @@ I need to mention that if the branch name is "HEAD," it might be in a detached s
 I'm thinking about how to edit a file effectively. I need to use apply_patch, but first, I might want to ensure that the directory exists. I want to be careful because apply_patch can also create the file if the path is specified correctly. Making sure everything is in place will help avoid errors and complications later on. I just need to keep these steps in mind for a smooth process!",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:7:message:auto:assistant:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:7:message:assistant:generated:0",
           "kind": "message",
           "role": "assistant",
           "seq": 2,
@@ -620,7 +620,7 @@ I'm thinking about how to edit a file effectively. I need to use apply_patch, bu
           "toolCallId": "call_5G3PTdzqpvPGdY6lSvFGLGJH",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:7:message:auto:assistant:1",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:7:message:assistant:generated:1",
           "kind": "message",
           "role": "assistant",
           "seq": 4,
@@ -634,14 +634,14 @@ I'm thinking about how to edit a file effectively. I need to use apply_patch, bu
       "initiator": "user",
       "items": [
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:8:message:auto:user:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:8:message:user:generated:0",
           "kind": "message",
           "role": "user",
           "seq": 0,
           "text": "Append the line \`generated by fixture script\` to \`.acp-fixture-scratch/NOTES.md\`.",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:8:message:auto:assistant:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:8:message:assistant:generated:0",
           "kind": "message",
           "role": "assistant",
           "seq": 1,
@@ -662,7 +662,7 @@ generated by fixture script
           "toolCallId": "call_tXyN5u55PGr31y1rBSbwDPRP",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:8:message:auto:assistant:1",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:8:message:assistant:generated:1",
           "kind": "message",
           "role": "assistant",
           "seq": 3,
@@ -676,7 +676,7 @@ generated by fixture script
       "initiator": "user",
       "items": [
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:9:message:auto:user:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:9:message:user:generated:0",
           "kind": "message",
           "role": "user",
           "seq": 0,
@@ -684,9 +684,9 @@ generated by fixture script
         },
         {
           "durationMs": 0,
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:9:thinking:auto:thinking:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:9:thinking:generated:0",
           "kind": "thinking",
-          "segmentId": "auto:thinking:0",
+          "segmentId": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:9:thinking:generated:0",
           "seq": 1,
           "startedAt": 1577836800000,
           "status": "done",
@@ -697,7 +697,7 @@ generated by fixture script
 I need to rename a file first, then possibly apply a patch. After that, I might move it to a new location and then delete the original. It feels a bit convoluted, but I think breaking it into steps helps ensure I’m not missing anything important. Maybe I should confirm all the necessary changes before committing to the deletions to avoid errors later! Let's just take it step by step.",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:9:message:auto:assistant:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:9:message:assistant:generated:0",
           "kind": "message",
           "role": "assistant",
           "seq": 2,
@@ -705,9 +705,9 @@ I need to rename a file first, then possibly apply a patch. After that, I might 
         },
         {
           "durationMs": 0,
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:9:thinking:auto:thinking:1",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:9:thinking:generated:1",
           "kind": "thinking",
-          "segmentId": "auto:thinking:1",
+          "segmentId": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:9:thinking:generated:1",
           "seq": 3,
           "startedAt": 1577836800000,
           "status": "done",
@@ -718,7 +718,7 @@ I need to rename a file first, then possibly apply a patch. After that, I might 
 I need to figure out if I should move content or maybe make some changes. It's looking like I might use the delete/add method. I don’t think renaming is necessary. I can add the new content first, and then I can go ahead and delete the old stuff. That seems like a straightforward approach! I wonder if there’s a more efficient way, but this sounds like it could work well.",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:9:message:auto:assistant:1",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:9:message:assistant:generated:1",
           "kind": "message",
           "role": "assistant",
           "seq": 4,
@@ -750,7 +750,7 @@ generated by fixture script
           "toolCallId": "call_krldrCarRuXYq8c00DESs1zE",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:9:message:auto:assistant:2",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:9:message:assistant:generated:2",
           "kind": "message",
           "role": "assistant",
           "seq": 7,
@@ -764,14 +764,14 @@ generated by fixture script
       "initiator": "user",
       "items": [
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:message:auto:user:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:message:user:generated:0",
           "kind": "message",
           "role": "user",
           "seq": 0,
           "text": "Use a subagent (Task tool) to find all files under \`packages/core/src/acp\` that contain the string \`stopReason\`, then summarize what each file does.",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:message:auto:assistant:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:message:assistant:generated:0",
           "kind": "message",
           "role": "assistant",
           "seq": 1,
@@ -779,9 +779,9 @@ generated by fixture script
         },
         {
           "durationMs": 0,
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:thinking:auto:thinking:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:thinking:generated:0",
           "kind": "thinking",
-          "segmentId": "auto:thinking:0",
+          "segmentId": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:thinking:generated:0",
           "seq": 2,
           "startedAt": 1577836800000,
           "status": "done",
@@ -792,7 +792,7 @@ generated by fixture script
 I think I need to spawn an explorer and likely use one subagent for this task. I want to read about the AGENTS already in context. I’ll use the explorer to search for files that contain “stopReason” under packages/core/src/acp, and I'll summarize what each file does. I might ask to use a tool like rg and read the matching files for more details. Let's see what I can discover!",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:message:auto:assistant:1",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:message:assistant:generated:1",
           "kind": "message",
           "role": "assistant",
           "seq": 3,
@@ -809,7 +809,7 @@ I think I need to spawn an explorer and likely use one subagent for this task. I
           "toolKind": "other",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:message:auto:assistant:2",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:message:assistant:generated:2",
           "kind": "message",
           "role": "assistant",
           "seq": 5,
@@ -827,9 +827,9 @@ I think I need to spawn an explorer and likely use one subagent for this task. I
         },
         {
           "durationMs": 0,
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:thinking:auto:thinking:1",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:thinking:generated:1",
           "kind": "thinking",
-          "segmentId": "auto:thinking:1",
+          "segmentId": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:thinking:generated:1",
           "seq": 7,
           "startedAt": 1577836800000,
           "status": "done",
@@ -840,7 +840,7 @@ I think I need to spawn an explorer and likely use one subagent for this task. I
 I need to think about whether I should send a request to check the agent's status or not. I could inspect things locally while I wait. I wonder if it's okay to continue without overlapping with the subagent's work. But since the user specifically asked to use the subagent, I might just wait a bit longer or send a progress inquiry. It feels like the agent is still busy, so maybe waiting more is better.",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:message:auto:assistant:3",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:message:assistant:generated:3",
           "kind": "message",
           "role": "assistant",
           "seq": 8,
@@ -858,9 +858,9 @@ I need to think about whether I should send a request to check the agent's statu
         },
         {
           "durationMs": 0,
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:thinking:auto:thinking:2",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:thinking:generated:2",
           "kind": "thinking",
-          "segmentId": "auto:thinking:2",
+          "segmentId": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:thinking:generated:2",
           "seq": 10,
           "startedAt": 1577836800000,
           "status": "done",
@@ -871,7 +871,7 @@ I need to think about whether I should send a request to check the agent's statu
 I need to decide if I should use send_input to ask for a complete response. Maybe I could handle this myself? Since the user requested the use of a subagent, I wonder if I should mention that it might stall. But it could be better if the agent just runs. I think I’ll query with an interrupt to request a concise report. That seems like a good way to get clarity!",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:message:auto:assistant:4",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:message:assistant:generated:4",
           "kind": "message",
           "role": "assistant",
           "seq": 11,
@@ -888,7 +888,7 @@ I need to decide if I should use send_input to ask for a complete response. Mayb
           "toolKind": "other",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:message:auto:assistant:5",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:message:assistant:generated:5",
           "kind": "message",
           "role": "assistant",
           "seq": 13,
@@ -906,9 +906,9 @@ I need to decide if I should use send_input to ask for a complete response. Mayb
         },
         {
           "durationMs": 0,
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:thinking:auto:thinking:3",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:thinking:generated:3",
           "kind": "thinking",
-          "segmentId": "auto:thinking:3",
+          "segmentId": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:thinking:generated:3",
           "seq": 15,
           "startedAt": 1577836800000,
           "status": "done",
@@ -919,7 +919,7 @@ I need to decide if I should use send_input to ask for a complete response. Mayb
 It seems the subagent might be unavailable, so I'm thinking we could conduct a local search ourselves. The user requested that we use the subagent, though, so I wonder if I should mention that it didn't return any results. However, if the subagent stalled, we could still summarize the findings from a local search. I'll use local rg to gather data on stopReason files and see what we can put together.",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:message:auto:assistant:6",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:message:assistant:generated:6",
           "kind": "message",
           "role": "assistant",
           "seq": 16,
@@ -954,9 +954,9 @@ It seems the subagent might be unavailable, so I'm thinking we could conduct a l
         },
         {
           "durationMs": 0,
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:thinking:auto:thinking:4",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:thinking:generated:4",
           "kind": "thinking",
-          "segmentId": "auto:thinking:4",
+          "segmentId": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:thinking:generated:4",
           "seq": 19,
           "startedAt": 1577836800000,
           "status": "done",
@@ -967,7 +967,7 @@ It seems the subagent might be unavailable, so I'm thinking we could conduct a l
 I need to filter out files containing the term "stopReason" from the output. The relevant files likely include session-machine.ts, acp-session-runtime.ts, and a few test files like acp-session-runtime.test.ts. The user wants a summary of what each file does, focusing on all matches in the specified directory, although I might skip the snapshots. I should list out the unique matching files using the rg command effectively. Let's proceed concisely!",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:message:auto:assistant:7",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:message:assistant:generated:7",
           "kind": "message",
           "role": "assistant",
           "seq": 20,
@@ -984,9 +984,9 @@ I need to filter out files containing the term "stopReason" from the output. The
         },
         {
           "durationMs": 0,
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:thinking:auto:thinking:5",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:thinking:generated:5",
           "kind": "thinking",
-          "segmentId": "auto:thinking:5",
+          "segmentId": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:thinking:generated:5",
           "seq": 22,
           "startedAt": 1577836800000,
           "status": "done",
@@ -997,7 +997,7 @@ I need to filter out files containing the term "stopReason" from the output. The
 I need to summarize what each file does. I'm wondering if mentioning that the subagent is stalled is necessary—probably not. Should I close the agent? Maybe that's a good idea! Closing after the final summary could help keep things tidy. Let’s aim to close it at the end! It feels like a good plan to keep everything organized, which will help us stay on track with what we're doing.",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:message:auto:assistant:8",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:message:assistant:generated:8",
           "kind": "message",
           "role": "assistant",
           "seq": 23,
@@ -1014,7 +1014,7 @@ I need to summarize what each file does. I'm wondering if mentioning that the su
           "toolKind": "other",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:message:auto:assistant:9",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:10:message:assistant:generated:9",
           "kind": "message",
           "role": "assistant",
           "seq": 25,
@@ -1040,7 +1040,7 @@ I need to summarize what each file does. I'm wondering if mentioning that the su
       "initiator": "user",
       "items": [
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:11:message:auto:user:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:11:message:user:generated:0",
           "kind": "message",
           "role": "user",
           "seq": 0,
@@ -1048,9 +1048,9 @@ I need to summarize what each file does. I'm wondering if mentioning that the su
         },
         {
           "durationMs": 0,
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:11:thinking:auto:thinking:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:11:thinking:generated:0",
           "kind": "thinking",
-          "segmentId": "auto:thinking:0",
+          "segmentId": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:11:thinking:generated:0",
           "seq": 1,
           "startedAt": 1577836800000,
           "status": "done",
@@ -1061,7 +1061,7 @@ I need to summarize what each file does. I'm wondering if mentioning that the su
 I need to gather information from the files I've already read. There's no need to browse for new sources. I can use existing knowledge from session-machine.ts as a foundation. My goal is to ensure the answer is detailed while also being concise. I think using headings for each phase will help organize the information effectively. Let’s get started on crafting this response!",
         },
         {
-          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:11:message:auto:assistant:0",
+          "id": "019f259a-9386-7e20-9af4-b4fdcd67bdac:turn:11:message:assistant:generated:0",
           "kind": "message",
           "role": "assistant",
           "seq": 2,


### PR DESCRIPTION
- Separate foreground content progression from asynchronous tool, subagent, and plan updates so streamed text and reasoning remain intact.
- Route late and nested tool updates to their owning turns without creating phantom activity; preserve background tool lifecycles and recover out-of-order notifications.
- Use collision-free content identities and preserve tool start/update provenance through Claude event enrichment.
- Refresh amended transcript history through an optional session revision field and document event ownership semantics, retaining the unreleased protocol version 9.0.0.
- Fixes #3166.