### PR TITLE
feat(settings): allow hiding the tray icon

### DIFF
--- a/agents/architecture/main-process.md
+++ b/agents/architecture/main-process.md
@@ -52,6 +52,12 @@ The main process is organized into domain modules under `src/main/core/`. Each d
 
 ## When Editing Here
 
+The menu bar/system tray icon is controlled by the desktop app setting
+`interface.showTrayIcon` (Settings → Interface → Application icon, enabled by default).
+Create it only after settings load in the services boot phase; Wire settings updates and resets
+apply visibility immediately through `SettingsRuntimePort`. Hiding it leaves the app running;
+activation or launching the app again restores the main window.
+
 - Check `agents/conventions/main-patterns.md` for controller, service, Result type, and event patterns.
 - Check `agents/conventions/ipc.md` for the RPC controller pattern and typing rules.
 - Check `agents/risky-areas/pty.md` before touching PTY or provider spawn behavior.

--- a/apps/emdash-desktop/src/core/features/settings/browser/components/TrayIconSettingsRow.tsx
+++ b/apps/emdash-desktop/src/core/features/settings/browser/components/TrayIconSettingsRow.tsx
@@ -1,0 +1,36 @@
+import { Switch } from '@emdash/ui/react/primitives';
+import { useAppSettingsKey } from '@core/features/settings/api/browser/use-app-settings-key';
+import { detectPlatformContext } from '@core/primitives/keybindings/api';
+import { ResetToDefaultButton } from './ResetToDefaultButton';
+import { SettingRow } from './SettingRow';
+
+export function TrayIconSettingsRow() {
+  const { value, update, isLoading, isSaving, isFieldOverridden, resetField } =
+    useAppSettingsKey('interface');
+  const location = detectPlatformContext().os === 'mac' ? 'menu bar' : 'system tray';
+  const title = `Show Emdash in the ${location}`;
+  const disabled = isLoading || isSaving;
+
+  return (
+    <SettingRow
+      title={title}
+      description={`Quick access to Emdash from the ${location}.`}
+      control={
+        <>
+          <ResetToDefaultButton
+            visible={isFieldOverridden('showTrayIcon')}
+            defaultLabel="shown"
+            onReset={() => resetField('showTrayIcon')}
+            disabled={disabled}
+          />
+          <Switch
+            aria-label={title}
+            checked={value?.showTrayIcon ?? true}
+            disabled={disabled}
+            onCheckedChange={(checked) => update({ showTrayIcon: checked })}
+          />
+        </>
+      }
+    />
+  );
+}

--- a/apps/emdash-desktop/src/core/features/settings/browser/pages/interface-settings-page.tsx
+++ b/apps/emdash-desktop/src/core/features/settings/browser/pages/interface-settings-page.tsx
@@ -6,6 +6,7 @@ import KeyboardSettingsCard from '../components/KeyboardSettingsCard';
 import SidebarMetadataSettingsCard from '../components/SidebarMetadataSettingsCard';
 import TerminalSettingsCard from '../components/TerminalSettingsCard';
 import ThemeCard from '../components/ThemeCard';
+import { TrayIconSettingsRow } from '../components/TrayIconSettingsRow';
 
 export function InterfaceSettingsPage() {
   return (
@@ -17,6 +18,9 @@ export function InterfaceSettingsPage() {
       />
       <SettingsSection title="Color mode" bare>
         <ThemeCard />
+      </SettingsSection>
+      <SettingsSection title="Application icon">
+        <TrayIconSettingsRow />
       </SettingsSection>
       <SettingsSection title="Terminal" bare>
         <TerminalSettingsCard />

--- a/apps/emdash-desktop/src/core/features/settings/browser/search/settings-search.ts
+++ b/apps/emdash-desktop/src/core/features/settings/browser/search/settings-search.ts
@@ -1,5 +1,6 @@
 import type { SettingsPageTab } from '@core/features/settings/contributions/views';
 import { settingsPageContributions } from '@core/manifests/browser/settings-page-contributions';
+import { detectPlatformContext } from '@core/primitives/keybindings/api';
 
 export type SettingsSearchEntry = {
   /** Stable kebab-case id; for SettingRow-backed settings it equals slugifySettingLabel(label). */
@@ -19,6 +20,11 @@ export function slugifySettingLabel(label: string): string {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
 }
+
+const trayIconLabel =
+  detectPlatformContext().os === 'mac'
+    ? 'Show Emdash in the menu bar'
+    : 'Show Emdash in the system tray';
 
 export const SETTINGS_SEARCH_INDEX: SettingsSearchEntry[] = [
   // General
@@ -226,6 +232,13 @@ export const SETTINGS_SEARCH_INDEX: SettingsSearchEntry[] = [
   },
 
   // Interface
+  {
+    id: slugifySettingLabel(trayIconLabel),
+    label: trayIconLabel,
+    tab: 'interface',
+    description: 'Keep quick access to Emdash while agents run in the background.',
+    keywords: ['menu bar', 'system tray', 'task bar', 'icon', 'hide', 'disable'],
+  },
   {
     id: 'color-mode',
     label: 'Color mode',

--- a/apps/emdash-desktop/src/core/features/workbench/contributions/settings.ts
+++ b/apps/emdash-desktop/src/core/features/workbench/contributions/settings.ts
@@ -24,6 +24,7 @@ const keyboardSettingsSchema = z
   .default({});
 
 const interfaceSettingsSchema = z.object({
+  showTrayIcon: z.boolean(),
   taskHoverAction: z.enum(['delete', 'archive']),
   autoRightSidebarBehavior: z.boolean(),
   showLeftSidebarLineChanges: z.boolean(),
@@ -55,6 +56,7 @@ export const interfaceSettingsContribution = defineSettingsContribution<
   key: 'interface',
   schema: interfaceSettingsSchema,
   defaults: {
+    showTrayIcon: true,
     taskHoverAction: 'delete',
     autoRightSidebarBehavior: false,
     showLeftSidebarLineChanges: true,

--- a/apps/emdash-desktop/src/core/primitives/app-settings/api/app-settings.ts
+++ b/apps/emdash-desktop/src/core/primitives/app-settings/api/app-settings.ts
@@ -49,6 +49,7 @@ export type TerminalSettings = {
 export type Theme = 'emlight' | 'emdark' | null;
 
 export type InterfaceSettings = {
+  showTrayIcon: boolean;
   taskHoverAction: 'delete' | 'archive';
   autoRightSidebarBehavior: boolean;
   showLeftSidebarLineChanges: boolean;

--- a/apps/emdash-desktop/src/core/services/settings/node/settings-store.test.ts
+++ b/apps/emdash-desktop/src/core/services/settings/node/settings-store.test.ts
@@ -1,3 +1,4 @@
+import { createTestWire } from '@emdash/wire/testing';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import {
@@ -13,6 +14,9 @@ import {
   defineSettingsContribution,
   type SettingsContributionMap,
 } from '@core/primitives/settings/api';
+import { appSettingsContract } from '../api/contract';
+import { AppSettingsService } from './app-settings-service';
+import { createAppSettingsWireController } from './wire-controller';
 
 const rows = vi.hoisted(() => new Map<string, string>());
 
@@ -63,6 +67,49 @@ async function roundTripDefault<K extends AppSettingsKey>(key: K): Promise<void>
 }
 
 describe('SettingsStore contributions', () => {
+  it('applies tray visibility immediately through Wire updates and resets', async () => {
+    rows.clear();
+    const service = new AppSettingsService(new SettingsStore(db, appSettingsContributions));
+    const setTrayVisible = vi.fn();
+    const wire = createTestWire(
+      appSettingsContract,
+      createAppSettingsWireController(service, {
+        setTrayVisible,
+        setTheme: vi.fn(),
+        setKeyboardSettings: vi.fn(),
+        setBrowserSettings: vi.fn(),
+      })
+    );
+    try {
+      const value = { ...getDefaultForKey('interface'), showTrayIcon: false };
+      await wire.client.update({ key: 'interface', value });
+      expect(setTrayVisible).toHaveBeenLastCalledWith(false);
+      await wire.client.resetField({ key: 'interface', field: 'showTrayIcon' });
+      expect(setTrayVisible).toHaveBeenLastCalledWith(true);
+      await wire.client.update({ key: 'interface', value });
+      await wire.client.reset({ key: 'interface' });
+      expect(setTrayVisible).toHaveBeenLastCalledWith(true);
+    } finally {
+      await wire.dispose();
+    }
+  });
+
+  it('preserves old interface preferences and remembers a disabled tray across restarts', async () => {
+    rows.clear();
+    rows.set('interface', JSON.stringify({ hideContextBar: true }));
+    const settings = new SettingsStore(db, appSettingsContributions);
+    const value = await settings.get('interface');
+    expect(value.showTrayIcon).toBe(true);
+    expect(value.hideContextBar).toBe(true);
+
+    await settings.update('interface', { ...value, showTrayIcon: false });
+    const restarted = new SettingsStore(db, appSettingsContributions);
+    expect(await restarted.get('interface')).toEqual({ ...value, showTrayIcon: false });
+
+    await restarted.resetField('interface', 'showTrayIcon');
+    expect(await restarted.get('interface')).toEqual(value);
+  });
+
   for (const key of AppSettingsKeys) {
     it(`round-trips the ${key} contribution defaults`, async () => {
       rows.clear();

--- a/apps/emdash-desktop/src/core/services/settings/node/wire-controller.ts
+++ b/apps/emdash-desktop/src/core/services/settings/node/wire-controller.ts
@@ -6,6 +6,7 @@ export type SettingsRuntimePort = {
   setKeyboardSettings(settings: AppSettings['keyboard']): void;
   setBrowserSettings(settings: AppSettings['browser']): void;
   setTheme(theme: AppSettings['theme']): void;
+  setTrayVisible(visible: boolean): void;
 };
 
 async function reconcileSettingsRuntimeState(
@@ -21,6 +22,9 @@ async function reconcileSettingsRuntimeState(
   }
   if (key === 'browser') {
     runtime.setBrowserSettings(await service.get('browser'));
+  }
+  if (key === 'interface') {
+    runtime.setTrayVisible((await service.get('interface')).showTrayIcon);
   }
 }
 

--- a/apps/emdash-desktop/src/main/bootstrap/boot/phases/services.ts
+++ b/apps/emdash-desktop/src/main/bootstrap/boot/phases/services.ts
@@ -134,6 +134,7 @@ import { HostAttachmentRegistry } from '@main/host/host-attachment-registry';
 import { createSystemNotificationSink } from '@main/host/notifications/system-notification-sink';
 import { encryptedAppSecretsStore } from '@main/host/secrets/encrypted-app-secrets-store';
 import { toPlaintextSecretStore } from '@main/host/secrets/plaintext-secret-store';
+import { setTrayVisible } from '@main/host/tray';
 import { installUpdateNotifications } from '@main/host/updates/update-notifications';
 import { applyNativeTheme, isAppFocused } from '@main/host/window';
 import { log } from '@main/lib/logger';
@@ -650,6 +651,7 @@ export async function bootServices(
     emitHostEvent: (event) => desktopHostEvents.emit(undefined, event),
   });
   await step('services:app-settings-init', () => appSettingsService.initialize());
+  setTrayVisible((await appSettingsService.get('interface')).showTrayIcon);
   applyNativeTheme(await appSettingsService.get('theme'));
   await step('services:automations-init', () => automationsService.initialize());
   await step('services:notifications-init', () => notificationService.initialize());

--- a/apps/emdash-desktop/src/main/bootstrap/boot/phases/window.ts
+++ b/apps/emdash-desktop/src/main/bootstrap/boot/phases/window.ts
@@ -3,7 +3,6 @@ import { app } from 'electron';
 import { installDesktopWire } from '@main/gateway/desktop-wire';
 import { setupApplicationMenu } from '@main/host/menu';
 import { setupAppProtocol } from '@main/host/protocol';
-import { initializeTray } from '@main/host/tray';
 import { createMainWindow } from '@main/host/window';
 import { registerQuitHandler } from '../../shutdown';
 import type { BootSignals } from '../types';
@@ -16,7 +15,6 @@ export function bootWindow(signals: BootSignals): void {
   // must be live before loadURL; traffic queues until controllers register.
   installDesktopWire();
   createMainWindow();
-  initializeTray();
   registerQuitHandler();
   signals.windowPhaseReady = true;
 }

--- a/apps/emdash-desktop/src/main/bootstrap/boot/wiring.ts
+++ b/apps/emdash-desktop/src/main/bootstrap/boot/wiring.ts
@@ -18,6 +18,7 @@ import { browserWebContentsRegistry } from '@main/host/browser/browser-webconten
 import { browserOperations } from '@main/host/browser/controller';
 import { createDevPerfOperations } from '@main/host/dev-perf/controller-operations';
 import { writeRendererLogEntry } from '@main/host/file-logger';
+import { setTrayVisible } from '@main/host/tray';
 import { updateOperations } from '@main/host/updates/controller-operations';
 import { applyNativeTheme } from '@main/host/window';
 import { log } from '@main/lib/logger';
@@ -130,6 +131,7 @@ export function createDesktopWireOptions(
       setKeyboardSettings: (settings) => browserWebContentsRegistry.setKeyboardSettings(settings),
       setBrowserSettings: setBrowserCorsRelaxationSettings,
       setTheme: applyNativeTheme,
+      setTrayVisible,
     },
     telemetry: telemetryService,
     taskService,

--- a/apps/emdash-desktop/src/main/host/tray.test.ts
+++ b/apps/emdash-desktop/src/main/host/tray.test.ts
@@ -1,0 +1,71 @@
+import type * as fs from 'node:fs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { instances, quit, showMainWindow } = vi.hoisted(() => ({
+  instances: [] as Array<{ destroyed: boolean; destroy: () => void }>,
+  quit: vi.fn(),
+  showMainWindow: vi.fn(),
+}));
+
+vi.mock('node:fs', async (importOriginal) => ({
+  ...(await importOriginal<typeof fs>()),
+  readFileSync: vi.fn(() => Buffer.from('icon')),
+}));
+
+vi.mock('electron', () => ({
+  app: { quit },
+  Menu: { buildFromTemplate: vi.fn((items) => items) },
+  nativeImage: {
+    createEmpty: () => ({ addRepresentation: vi.fn(), setTemplateImage: vi.fn() }),
+    createFromPath: () => ({ resize: vi.fn() }),
+  },
+  Tray: class {
+    destroyed = false;
+    constructor() {
+      instances.push(this);
+    }
+    isDestroyed() {
+      return this.destroyed;
+    }
+    destroy() {
+      this.destroyed = true;
+    }
+    setToolTip = vi.fn();
+    setContextMenu = vi.fn();
+    on = vi.fn();
+  },
+}));
+
+vi.mock('./window', () => ({ showMainWindow }));
+
+import { setTrayVisible } from './tray';
+
+afterEach(() => {
+  setTrayVisible(false);
+  instances.length = 0;
+  vi.clearAllMocks();
+});
+
+describe('tray visibility', () => {
+  it('does not create an icon when starting with the preference disabled', () => {
+    setTrayVisible(false);
+    expect(instances).toHaveLength(0);
+  });
+
+  it('removes and restores the icon without duplicates or quitting the app', () => {
+    setTrayVisible(true);
+    setTrayVisible(true);
+    expect(instances).toHaveLength(1);
+
+    setTrayVisible(false);
+    setTrayVisible(false);
+    expect(instances[0].destroyed).toBe(true);
+
+    setTrayVisible(true);
+    setTrayVisible(true);
+    expect(instances).toHaveLength(2);
+    expect(instances[1].destroyed).toBe(false);
+    expect(quit).not.toHaveBeenCalled();
+    expect(showMainWindow).not.toHaveBeenCalled();
+  });
+});

--- a/apps/emdash-desktop/src/main/host/tray.ts
+++ b/apps/emdash-desktop/src/main/host/tray.ts
@@ -28,7 +28,16 @@ function createTrayIcon(): Electron.NativeImage {
   return nativeImage.createFromPath(iconPath).resize({ width: 20, height: 20 });
 }
 
-export function initializeTray(): Tray {
+export function setTrayVisible(visible: boolean): void {
+  if (visible) {
+    initializeTray();
+  } else {
+    if (tray && !tray.isDestroyed()) tray.destroy();
+    tray = null;
+  }
+}
+
+function initializeTray(): Tray {
   if (tray && !tray.isDestroyed()) return tray;
 
   tray = new Tray(createTrayIcon());


### PR DESCRIPTION
- add a platform-aware setting for hiding the menu bar or system tray icon
- apply icon visibility changes immediately and preserve the preference across restarts
- delay icon creation until saved settings are available to avoid startup flashes
