### PR TITLE
fix(git): preserve credential config across child processes

### DIFF
--- a/packages/core/src/primitives/git-credentials/api/env.test.ts
+++ b/packages/core/src/primitives/git-credentials/api/env.test.ts
@@ -1,3 +1,5 @@
+import { execFileSync } from 'node:child_process';
+import { devNull, tmpdir } from 'node:os';
 import { describe, expect, it } from 'vitest';
 import {
   applyGitCredentialsToEnv,
@@ -15,18 +17,37 @@ const helperSpec: GitCredentialsSessionSpec = {
 };
 
 function gitConfigPairs(env: Record<string, string>): [string, string][] {
-  const count = Number(env.GIT_CONFIG_COUNT ?? '0');
-  const pairs: [string, string][] = [];
-  for (let i = 0; i < count; i += 1) {
-    pairs.push([env[`GIT_CONFIG_KEY_${i}`]!, env[`GIT_CONFIG_VALUE_${i}`]!]);
-  }
-  return pairs;
+  const output = execFileSync('git', ['config', '--null', '--list'], {
+    cwd: tmpdir(),
+    env: {
+      ...env,
+      PATH: process.env.PATH,
+      SystemRoot: process.env.SystemRoot,
+      GIT_CONFIG_NOSYSTEM: '1',
+      GIT_CONFIG_GLOBAL: devNull,
+    },
+    encoding: 'utf8',
+  });
+  return output
+    .split('\0')
+    .filter(Boolean)
+    .map((entry) => {
+      const separator = entry.indexOf('\n');
+      return [entry.slice(0, separator), entry.slice(separator + 1)];
+    });
 }
 
 describe('applyGitCredentialsToEnv', () => {
   it('returns the env untouched for system mode and for no spec', () => {
-    const env = { PATH: '/bin', GIT_ASKPASS: '/usr/bin/whatever' };
-    expect(applyGitCredentialsToEnv(env, { mode: 'system' })).toEqual(env);
+    const env = {
+      PATH: '/bin',
+      GIT_ASKPASS: '/usr/bin/whatever',
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'credential.helper',
+      GIT_CONFIG_VALUE_0: '',
+      GIT_CONFIG_PARAMETERS: "'user.name'='Inherited'",
+    };
+    expect(applyGitCredentialsToEnv(env, { mode: 'system' })).toBe(env);
     expect(applyGitCredentialsToEnv(env, undefined)).toEqual(env);
   });
 
@@ -106,12 +127,20 @@ describe('applyGitCredentialsToEnv', () => {
       const scrubbed = applyGitCredentialsToEnv(helperEnv, { mode: 'none' });
       expect(scrubbed.EMDASH_GIT_CREDENTIAL_PORT).toBeUndefined();
       expect(scrubbed.EMDASH_GIT_CREDENTIAL_NONCE).toBeUndefined();
-      expect(gitConfigPairs(scrubbed)).toEqual([['credential.helper', '']]);
+      expect(gitConfigPairs(scrubbed).at(-1)).toEqual(['credential.helper', '']);
     });
   });
 });
 
 describe('gitCredentialOperationEnv', () => {
+  it('preserves unrelated inherited parameters when used as an operation overlay', () => {
+    const env = {
+      GIT_CONFIG_PARAMETERS: "'user.name'='Inherited'",
+      ...gitCredentialOperationEnv(channel, 'github.com'),
+    };
+    expect(gitConfigPairs(env)).toContainEqual(['user.name', 'Inherited']);
+  });
+
   it('produces a standalone overlay for one host', () => {
     const env = gitCredentialOperationEnv(channel, 'github.example.com');
     expect(env.EMDASH_GIT_CREDENTIAL_PORT).toBe('45678');

--- a/packages/core/src/primitives/git-credentials/api/env.ts
+++ b/packages/core/src/primitives/git-credentials/api/env.ts
@@ -90,15 +90,24 @@ export function gitCredentialOperationEnv(
   channel: GitCredentialChannel,
   host: string
 ): Record<string, string> {
-  return applyGitCredentialsToEnv({}, { mode: 'effective-account', channel, hosts: [host] });
+  // This is an overlay onto the Git runtime's env, not a complete session env.
+  // Keep indexed config here so we do not replace inherited PARAMETERS. These
+  // commands launch Git directly and do not cross an editor's env filtering.
+  const env: Record<string, string> = {
+    [GIT_CREDENTIAL_PORT_ENV_VAR]: String(channel.port),
+    [GIT_CREDENTIAL_NONCE_ENV_VAR]: channel.nonce,
+    GIT_CONFIG_COUNT: '2',
+  };
+  helperConfigPairs([host]).forEach((pair, index) => {
+    env[`GIT_CONFIG_KEY_${index}`] = pair.key;
+    env[`GIT_CONFIG_VALUE_${index}`] = pair.value;
+  });
+  return env;
 }
 
-function injectEmdashHelper(
-  env: Record<string, string>,
-  spec: Extract<GitCredentialsSessionSpec, { mode: 'effective-account' }>
-): Record<string, string> {
-  const pairs = readGitConfigPairs(env);
-  for (const host of spec.hosts) {
+function helperConfigPairs(hosts: string[]): GitConfigPair[] {
+  const pairs: GitConfigPair[] = [];
+  for (const host of hosts) {
     const key = `credential.https://${host}.helper`;
     // An empty entry resets previously-configured helpers for this host so
     // the session authenticates as exactly the effective account there;
@@ -106,11 +115,22 @@ function injectEmdashHelper(
     pairs.push({ key, value: '' });
     pairs.push({ key, value: GIT_CREDENTIAL_HELPER_COMMAND });
   }
+  return pairs;
+}
+
+function injectEmdashHelper(
+  env: Record<string, string>,
+  spec: Extract<GitCredentialsSessionSpec, { mode: 'effective-account' }>
+): Record<string, string> {
   return {
     ...withoutGitConfigEntries(env),
     [GIT_CREDENTIAL_PORT_ENV_VAR]: String(spec.channel.port),
     [GIT_CREDENTIAL_NONCE_ENV_VAR]: spec.channel.nonce,
-    ...gitConfigEnv(pairs),
+    ...gitConfigEnv(
+      readGitConfigPairs(env),
+      env.GIT_CONFIG_PARAMETERS,
+      helperConfigPairs(spec.hosts)
+    ),
   };
 }
 
@@ -118,10 +138,6 @@ function scrubCredentialHelpers(env: Record<string, string>): Record<string, str
   const pairs = readGitConfigPairs(env).filter(
     (pair) => !CREDENTIAL_HELPER_CONFIG_KEY.test(pair.key)
   );
-  // A single empty credential.helper entry resets every helper configured in
-  // system/global/local git config (the decision ticket's scrub semantics).
-  pairs.push({ key: 'credential.helper', value: '' });
-
   const scrubbed = withoutGitConfigEntries(env);
   delete scrubbed[GIT_CREDENTIAL_PORT_ENV_VAR];
   delete scrubbed[GIT_CREDENTIAL_NONCE_ENV_VAR];
@@ -131,7 +147,8 @@ function scrubCredentialHelpers(env: Record<string, string>): Record<string, str
     // env-level empty wins over core.askpass config.
     GIT_ASKPASS: '',
     SSH_ASKPASS: '',
-    ...gitConfigEnv(pairs),
+    // Reset helpers after all inherited config, including PARAMETERS.
+    ...gitConfigEnv(pairs, env.GIT_CONFIG_PARAMETERS, [{ key: 'credential.helper', value: '' }]),
   };
 }
 
@@ -157,11 +174,28 @@ function withoutGitConfigEntries(env: Record<string, string>): Record<string, st
   return next;
 }
 
-function gitConfigEnv(pairs: GitConfigPair[]): Record<string, string> {
-  const env: Record<string, string> = { GIT_CONFIG_COUNT: String(pairs.length) };
-  pairs.forEach((pair, index) => {
-    env[`GIT_CONFIG_KEY_${index}`] = pair.key;
-    env[`GIT_CONFIG_VALUE_${index}`] = pair.value;
-  });
-  return env;
+function gitConfigEnv(
+  inheritedPairs: GitConfigPair[],
+  inheritedParameters: string | undefined,
+  pairs: GitConfigPair[]
+): Record<string, string> {
+  // Use Git's -c propagation format: a logical empty value is encoded inside
+  // a non-empty variable. VS Code's extension host can drop empty env values,
+  // leaving indexed GIT_CONFIG_KEY_n entries without their required VALUE_n.
+  // Git reads indexed entries before PARAMETERS; preserve that ordering, then
+  // apply our reset/helper policy last. Keep inherited parameter quoting intact.
+  const encode = (pair: GitConfigPair) =>
+    `${quoteGitParameter(pair.key)}=${quoteGitParameter(pair.value)}`;
+  return {
+    GIT_CONFIG_PARAMETERS: [
+      ...inheritedPairs.map(encode),
+      ...(inheritedParameters ? [inheritedParameters] : []),
+      ...pairs.map(encode),
+    ].join(' '),
+  };
+}
+
+function quoteGitParameter(value: string): string {
+  // Git's sq_dequote parser accepts escaped apostrophes outside quoted spans.
+  return `'${value.replaceAll("'", "'\\''")}'`;
 }

--- a/packages/core/src/services/pty/api/terminal-env.integration.test.ts
+++ b/packages/core/src/services/pty/api/terminal-env.integration.test.ts
@@ -1,0 +1,154 @@
+import { execFile, execFileSync } from 'node:child_process';
+import { once } from 'node:events';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { devNull, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  applyGitCredentialsToEnv,
+  type GitCredentialsSessionSpec,
+} from '#primitives/git-credentials/api';
+import { buildTerminalEnv } from './terminal-env';
+
+const cwd = mkdtempSync(join(tmpdir(), 'emdash-credential-env-'));
+beforeAll(() => {
+  git({}, ['init', '--quiet']);
+});
+afterAll(() => rmSync(cwd, { recursive: true, force: true }));
+
+const baseEnv = {
+  PATH: process.env.PATH ?? '',
+  ...(process.env.SystemRoot ? { SystemRoot: process.env.SystemRoot } : {}),
+  HOME: cwd,
+  GIT_CONFIG_NOSYSTEM: '1',
+  GIT_CONFIG_GLOBAL: devNull,
+  GIT_TERMINAL_PROMPT: '0',
+};
+const spec: GitCredentialsSessionSpec = {
+  mode: 'effective-account',
+  channel: { port: 1, nonce: 'test-only' },
+  hosts: ['github.com'],
+};
+
+function git(env: Record<string, string>, args: string[], input?: string) {
+  return execFileSync('git', args, {
+    cwd,
+    env: { ...baseEnv, ...env },
+    input,
+    encoding: 'utf8',
+    timeout: 10_000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+}
+
+function dropEmpty(env: Record<string, string>) {
+  return Object.fromEntries(Object.entries(env).filter(([, value]) => value !== ''));
+}
+
+describe('credential config across child environment filtering', () => {
+  it.each([spec, { mode: 'none' } as const])('keeps Git usable in $mode mode', (mode) => {
+    const env = dropEmpty(buildTerminalEnv({ baseEnv, gitCredentials: mode }));
+    expect(() => git(env, ['config', '--list'])).not.toThrow();
+    expect(git(env, ['rev-parse', '--is-inside-work-tree'])).toBe('true\n');
+    expect(
+      git(env, [
+        'config',
+        '--get-all',
+        mode.mode === 'none' ? 'credential.helper' : 'credential.https://github.com.helper',
+      ]).startsWith('\n')
+    ).toBe(true);
+  });
+
+  it('preserves indexed and parameter config, including empty and quoted values, in Git order', () => {
+    const value = 'quotes \' and "; backslash \\; dollar $HOME; newline\nnext';
+    const env = dropEmpty(
+      applyGitCredentialsToEnv(
+        {
+          GIT_CONFIG_COUNT: '2',
+          GIT_CONFIG_KEY_0: 'test.value',
+          GIT_CONFIG_VALUE_0: value,
+          GIT_CONFIG_KEY_1: 'test.empty',
+          GIT_CONFIG_VALUE_1: '',
+          GIT_CONFIG_PARAMETERS: "'test.value'='inherited'",
+        },
+        spec
+      )
+    );
+    expect(git(env, ['config', '--get-all', 'test.value'])).toBe(`${value}\ninherited\n`);
+    expect(git(env, ['config', '--get', 'test.empty'])).toBe('\n');
+    expect(git(env, ['-c', 'test.value=explicit', 'config', '--get', 'test.value'])).toBe(
+      'explicit\n'
+    );
+  });
+
+  it.each([spec, { mode: 'none' } as const])('resets inherited helpers in $mode mode', (mode) => {
+    const env = dropEmpty(
+      applyGitCredentialsToEnv(
+        {
+          GIT_CONFIG_PARAMETERS: "'credential.helper'='!echo username=wrong; echo password=wrong'",
+        },
+        mode
+      )
+    );
+    // The Emdash test channel is deliberately unavailable. Neither mode may
+    // fall back to the inherited helper and authenticate as the wrong account.
+    expect(() => git(env, ['credential', 'fill'], 'protocol=https\nhost=github.com\n\n')).toThrow(
+      /could not read Username|unable to get password from user/
+    );
+    if (mode.mode === 'effective-account') {
+      expect(git(env, ['credential', 'fill'], 'protocol=https\nhost=example.com\n\n')).toContain(
+        'username=wrong'
+      );
+    }
+  });
+
+  it('authenticates through the real terminal helper after filtering, without using inherited helpers', async () => {
+    const requests: { url: string | undefined; nonce: string | string[] | undefined }[] = [];
+    const server = createServer((request, response) => {
+      requests.push({ url: request.url, nonce: request.headers['x-emdash-token'] });
+      request.resume();
+      response.end('username=emdash-test\npassword=synthetic-test-password\n');
+    });
+    server.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+    try {
+      const address = server.address();
+      if (!address || typeof address === 'string') throw new Error('Missing test server port');
+      const env = dropEmpty(
+        buildTerminalEnv({
+          baseEnv: {
+            ...baseEnv,
+            GIT_CONFIG_PARAMETERS:
+              "'credential.helper'='!echo username=wrong; echo password=wrong'",
+          },
+          gitCredentials: {
+            mode: 'effective-account',
+            hosts: ['github.com'],
+            channel: { port: address.port, nonce: 'test-channel' },
+          },
+        })
+      );
+      const stdout = await new Promise<string>((resolve, reject) => {
+        const child = execFile(
+          'git',
+          ['credential', 'fill'],
+          {
+            cwd,
+            env,
+            encoding: 'utf8',
+            timeout: 10_000,
+          },
+          (error, output) => (error ? reject(error) : resolve(output))
+        );
+        child.stdin?.end('protocol=https\nhost=github.com\n\n');
+      });
+      expect(stdout).toContain('username=emdash-test');
+      expect(requests).toEqual([{ url: '/git-credential/get', nonce: 'test-channel' }]);
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
+      );
+    }
+  });
+});

--- a/packages/core/src/services/pty/api/terminal-env.test.ts
+++ b/packages/core/src/services/pty/api/terminal-env.test.ts
@@ -37,10 +37,9 @@ describe('buildTerminalEnv git credentials', () => {
     });
     expect(env.EMDASH_GIT_CREDENTIAL_PORT).toBe('51234');
     expect(env.EMDASH_GIT_CREDENTIAL_NONCE).toBe('session-nonce');
-    expect(env.GIT_CONFIG_COUNT).toBe('2');
-    expect(env.GIT_CONFIG_KEY_0).toBe('credential.https://github.com.helper');
-    expect(env.GIT_CONFIG_VALUE_0).toBe('');
-    expect(env.GIT_CONFIG_VALUE_1).toBe(GIT_CREDENTIAL_HELPER_COMMAND);
+    expect(env.GIT_CONFIG_COUNT).toBeUndefined();
+    expect(env.GIT_CONFIG_PARAMETERS).toContain("'credential.https://github.com.helper'=''");
+    expect(env.GIT_CONFIG_PARAMETERS).toContain(GIT_CREDENTIAL_HELPER_COMMAND);
   });
 
   it('none scrubs credential helpers even when overrides set them', () => {
@@ -51,9 +50,8 @@ describe('buildTerminalEnv git credentials', () => {
     });
     expect(env.GIT_ASKPASS).toBe('');
     expect(env.SSH_ASKPASS).toBe('');
-    expect(env.GIT_CONFIG_COUNT).toBe('1');
-    expect(env.GIT_CONFIG_KEY_0).toBe('credential.helper');
-    expect(env.GIT_CONFIG_VALUE_0).toBe('');
+    expect(env.GIT_CONFIG_COUNT).toBeUndefined();
+    expect(env.GIT_CONFIG_PARAMETERS).toBe("'credential.helper'=''");
   });
 
   it('system and absent leave credential-related env untouched', () => {


### PR DESCRIPTION
- encode session git credential configuration in a non-empty parameter value so vscode extension hosts cannot break indexed key/value pairs by dropping empty environment values
- preserve inherited git configuration order and apply the emdash credential policy last while keeping direct emdash git operations on their existing overlay path
- cover repository discovery, credential helper selection, quoting, inherited configuration, and explicit command-line precedence
- fixes #3184
