### PR TITLE
fix(hosts): prevent focus checks from interrupting terminal input

### DIFF
--- a/apps/emdash-desktop/src/core/services/hosts/node/connection-supervisor.acceptance.test.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/connection-supervisor.acceptance.test.ts
@@ -1,5 +1,7 @@
+import { hostRef } from '@emdash/core/primitives/host/api';
 import { remote, snapshot } from '@emdash/wire/state';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { hostReadyResult } from '../api/availability';
 import {
   createSupervisorDriver,
   createFaultPeer,
@@ -103,6 +105,74 @@ describe('Host connection supervisor acceptance (ADR 0008)', () => {
       await vi.advanceTimersByTimeAsync(20_001);
 
       expect(host.state.kind).not.toBe('ready');
+    });
+
+    it.each(['focus', 'online', 'timer'] as const)(
+      'keeps availability and live commands usable during a healthy %s check',
+      async (cause) => {
+        const ready = host.state;
+        const attachment = await host.getAttachment();
+        const release = peer.stallHealth();
+        try {
+          host.supervisor.revalidate(cause);
+          await vi.advanceTimersByTimeAsync(250);
+
+          // The same readiness result gates Project/terminal commands. Preserve its
+          // identity too, so a successful probe does not refresh downstream stores.
+          expect(host.state).toBe(ready);
+          expect(hostReadyResult(hostRef('remote', 'acceptance-host'), host.state).success).toBe(
+            true
+          );
+          await expect(host.awaitUsable()).resolves.toMatchObject({ success: true });
+          await expect(resourceClient(attachment).increment(undefined)).resolves.toBe(1);
+        } finally {
+          release();
+        }
+        await vi.advanceTimersByTimeAsync(0);
+        expect(host.state).toBe(ready);
+        expect(peer.opens).toBe(1);
+      }
+    );
+
+    it('demotes a quiet focus check when its health deadline expires', async () => {
+      peer.current.dropReplies = true;
+      peer.setOffline(true);
+      host.revalidate('focus');
+
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(host.state.kind).toBe('ready');
+      await vi.advanceTimersByTimeAsync(2);
+      expect(host.state.kind).not.toBe('ready');
+    });
+
+    it('demotes immediately when a request times out during a quiet check', async () => {
+      const release = peer.stallHealth();
+      try {
+        host.revalidate('focus');
+        await vi.advanceTimersByTimeAsync(250);
+        expect(host.state.kind).toBe('ready');
+
+        host.supervisor.revalidate('rpc-timeout');
+        expect(host.state).toMatchObject({ kind: 'preparing', phase: 'checking' });
+      } finally {
+        release();
+      }
+      await vi.advanceTimersByTimeAsync(0);
+      expect(host.state.kind).toBe('ready');
+    });
+
+    it('does not hide a focus check after a scheduling gap expires health evidence', async () => {
+      // Move wall time without running timers, as when the event loop was suspended.
+      vi.setSystemTime(Date.now() + 20_001);
+      const release = peer.stallHealth();
+      try {
+        host.revalidate('focus');
+        expect(host.state).toMatchObject({ kind: 'preparing', phase: 'checking' });
+      } finally {
+        release();
+      }
+      await vi.advanceTimersByTimeAsync(0);
+      expect(host.state.kind).toBe('ready');
     });
 
     for (const cause of ['online', 'focus'] as const) {

--- a/apps/emdash-desktop/src/core/services/hosts/node/connection-supervisor.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/connection-supervisor.ts
@@ -283,7 +283,17 @@ export class HostConnectionSupervisor {
       this.runtimePolicy = { kind: 'active' };
       this.publish({ kind: 'idle' });
     }
+    // Routine hints do not revoke recent health evidence. Keep the same ready
+    // snapshot and allow live input until the probe establishes a failure.
+    const keepReady =
+      state.kind === 'ready' &&
+      this.runtimeConnection.connected &&
+      this.hasFreshHealth() &&
+      (cause === 'focus' || cause === 'online' || cause === 'timer');
     if (this.active) {
+      // A timeout or expired evidence must still demote an in-flight quiet probe.
+      if (state.kind === 'ready' && !keepReady && !this.runtimeBlock)
+        this.publish({ kind: 'checking', generation: this.generation });
       if (
         (cause !== 'retry' && cause !== 'online') ||
         state.kind !== 'recovering' ||
@@ -304,7 +314,7 @@ export class HostConnectionSupervisor {
     const wireProbe = this.runtimeConnection.connected;
     const attemptScope = this.scope.child('connection-attempt');
     this.active = attemptScope;
-    if (cause !== 'timer' && !this.runtimeBlock)
+    if (!keepReady && !this.runtimeBlock)
       this.publish({ kind: 'checking', generation: this.generation });
     const epoch = this.epoch;
     void attemptScope
@@ -332,13 +342,14 @@ export class HostConnectionSupervisor {
           () => {
             if (!this.isCurrent(attemptScope, epoch)) return;
             this.lastValidatedAt = this.clock.now();
-            this.publish(
-              wireProbe
-                ? { kind: 'ready', generation: this.generation }
-                : this.runtimeBlock
-                  ? { kind: 'blocked', layer: 'runtime', issue: this.runtimeBlock }
-                  : { kind: 'idle' }
-            );
+            if (!wireProbe || peek(this.state).kind !== 'ready')
+              this.publish(
+                wireProbe
+                  ? { kind: 'ready', generation: this.generation }
+                  : this.runtimeBlock
+                    ? { kind: 'blocked', layer: 'runtime', issue: this.runtimeBlock }
+                    : { kind: 'idle' }
+              );
             this.resolveWaiters();
           },
           async () => {
@@ -593,6 +604,13 @@ export class HostConnectionSupervisor {
     }
   }
 
+  private hasFreshHealth(): boolean {
+    return (
+      this.clock.now() - this.lastValidatedAt <=
+      (this.options.healthIntervalMs ?? 15_000) + (this.options.healthTimeoutMs ?? 5_000)
+    );
+  }
+
   private scheduleHealth(): void {
     if (
       this.timer?.active ||
@@ -606,10 +624,7 @@ export class HostConnectionSupervisor {
       interval,
       () => {
         this.timer = undefined;
-        if (
-          this.clock.now() - this.lastValidatedAt >
-          interval + (this.options.healthTimeoutMs ?? 5_000)
-        ) {
+        if (!this.hasFreshHealth()) {
           this.resume();
         } else this.revalidate('timer');
       },

--- a/apps/emdash-desktop/src/core/services/hosts/node/testing/connection-supervisor-fixture.ts
+++ b/apps/emdash-desktop/src/core/services/hosts/node/testing/connection-supervisor-fixture.ts
@@ -55,6 +55,7 @@ export function createFaultPeer() {
   const gates: Deferred<void>[] = [];
   let openGate: Deferred<void> | undefined;
   let initializeGate: Deferred<void> | undefined;
+  let healthGate: Deferred<void> | undefined;
   let disposed = false;
   let offline = false;
   let daemonId = 'daemon-1';
@@ -111,12 +112,15 @@ export function createFaultPeer() {
           server: { daemonId: connectedDaemonId, appVersion: '1.0.0', startedAt: 0 },
         });
       },
-      health: () => ({
-        status: 'ok' as const,
-        version: '1.0.0',
-        uptimeMs: 0,
-        protocolVersion: connectedProtocolVersion,
-      }),
+      health: async () => {
+        if (healthGate) await healthGate.promise;
+        return {
+          status: 'ok' as const,
+          version: '1.0.0',
+          uptimeMs: 0,
+          protocolVersion: connectedProtocolVersion,
+        };
+      },
       observation: provider,
       increment: () => ++executions,
     });
@@ -181,6 +185,15 @@ export function createFaultPeer() {
       initializeGate = gate;
       return () => {
         if (initializeGate === gate) initializeGate = undefined;
+        gate.resolve();
+      };
+    },
+    stallHealth() {
+      const gate = deferred<void>();
+      gates.push(gate);
+      healthGate = gate;
+      return () => {
+        if (healthGate === gate) healthGate = undefined;
         gate.resolve();
       };
     },

--- a/apps/emdash-desktop/src/main/gateway/host-availability.test.ts
+++ b/apps/emdash-desktop/src/main/gateway/host-availability.test.ts
@@ -76,18 +76,20 @@ describe('desktop Host availability supervisor projection', () => {
     expect(fixture.availability.stateFor(remoteHost)).toEqual(fixture.driver.state);
   });
 
-  it.each(['online', 'focus'] as const)('does not trust cached ready after %s', async (cause) => {
-    await fixture.availability.ensureReady(remoteHost, 'connect');
-    fixture.peer.current.dropReplies = true;
-    fixture.peer.setOffline(true);
-    fixture.availability.wakeDemanded(cause);
-    expect(fixture.availability.stateFor(remoteHost)).toMatchObject({
-      kind: 'preparing',
-      phase: 'checking',
-    });
-    await vi.advanceTimersByTimeAsync(5_001);
-    expect(fixture.availability.requireReady(remoteHost).success).toBe(false);
-  });
+  it.each(['online', 'focus'] as const)(
+    'keeps recent readiness during %s validation, then revokes it on failure',
+    async (cause) => {
+      await fixture.availability.ensureReady(remoteHost, 'connect');
+      const ready = fixture.availability.stateFor(remoteHost);
+      fixture.peer.current.dropReplies = true;
+      fixture.peer.setOffline(true);
+      fixture.availability.wakeDemanded(cause);
+      expect(fixture.availability.stateFor(remoteHost)).toBe(ready);
+      expect(fixture.availability.requireReady(remoteHost).success).toBe(true);
+      await vi.advanceTimersByTimeAsync(5_001);
+      expect(fixture.availability.requireReady(remoteHost).success).toBe(false);
+    }
+  );
 
   it('keeps disconnected intent authoritative over automatic demand', async () => {
     await fixture.availability.ensureReady(remoteHost, 'connect');

--- a/docs/adr/0008-host-connection-supervisor.md
+++ b/docs/adr/0008-host-connection-supervisor.md
@@ -133,8 +133,11 @@ An ordinary RPC timeout requests validation; it is not conclusive evidence that 
 
 Initial tuning is a 15-second health interval and a five-second response deadline while a
 runtime attachment is maintained. These are configurable policy inputs to the supervisor,
-not timing constants scattered through transports. Idle polling need not cause visible
-`checking` while previous evidence remains fresh. Expiry or an explicit failure demotes
+not timing constants scattered through transports. Routine focus/online hints and idle polling
+keep a ready attachment usable while previous evidence remains fresh (within the health interval
+plus its response deadline). These probes preserve the ready snapshot on success, avoiding UI
+flicker, unnecessary store refreshes, and rejected terminal input. A failed probe demotes availability
+within its response deadline. Expiry or an explicit failure demotes
 availability; a small amount of incidental traffic must not indefinitely hide a wedged
 request/response path. Serving readiness or SSH-access requests does not move an already scheduled
 health deadline.
@@ -188,8 +191,10 @@ readiness waiters. A Connect cannot bypass an in-flight daemon operation.
 ## UI and operation semantics
 
 Machine and task usability indicators derive from Host availability. Preserve Project contexts,
-transcripts, terminal display, and logical session identities through outages. Show checking,
-reconnecting, or a specific blocked issue; gate Host-dependent actions. Do not silently queue
+transcripts, terminal display, and logical session identities through outages. Routine checks of
+a recently healthy attachment remain invisible and accept live input. Show checking after sleep,
+expired evidence, or an explicit request failure; show reconnecting or a specific blocked issue
+when recovery is needed, and gate Host-dependent actions. Do not silently queue
 terminal keystrokes for later execution.
 
 Transport recovery does not replay already-sent mutations. A lost reply leaves the operation's


### PR DESCRIPTION
- keep routine focus, online, and periodic connection checks invisible while recently healthy hosts continue accepting input
- avoid redundant ready-state updates that refresh the ui after successful checks
- preserve recovery guards for sleep, expired health evidence, request timeouts, and failed probes without replaying input, and document the updated availability policy
