### PR TITLE
fix(wire): preserve optimistic state through invalidation

### DIFF
--- a/apps/emdash-desktop/src/core/features/source-control/browser/stores/git-checkout-store.test.ts
+++ b/apps/emdash-desktop/src/core/features/source-control/browser/stores/git-checkout-store.test.ts
@@ -5,8 +5,11 @@ import type {
 } from '@emdash/core/runtimes/git/api';
 import { localBranchRefSchema, remoteBranchRefSchema } from '@emdash/core/runtimes/git/api';
 import { err, ok } from '@emdash/shared';
-import { cell, expose, flushStateTurn } from '@emdash/wire/state';
+import { createScope } from '@emdash/shared/concurrency';
+import { createManualClock } from '@emdash/shared/testing';
+import { cell, expose, flushStateTurn, query, type Query } from '@emdash/wire/state';
 import { createTestWire } from '@emdash/wire/testing';
+import { autorun } from 'mobx';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type * as SourceControlClientModule from '@core/features/source-control/api/browser/client';
 import { portablePath } from '@core/primitives/desktop-runtime/api';
@@ -230,6 +233,72 @@ describe('GitCheckoutStore', () => {
     store.dispose();
   });
 
+  it.each(['stage', 'unstage'] as const)(
+    'keeps optimistic membership throughout %s when a watcher invalidates the status read',
+    async (direction) => {
+      await wire?.dispose();
+      const scope = createScope();
+      const clock = createManualClock();
+      const fetchStarted = deferred<void>();
+      const fetched = deferred<CheckoutStatusState>();
+      const statusQuery = query({
+        initial: direction === 'stage' ? status('src/index.ts') : stagedStatus('src/index.ts'),
+        fetch: () => {
+          fetchStarted.resolve();
+          return fetched.promise;
+        },
+        scope,
+        clock,
+        debounceMs: 100,
+      });
+      wire = createSourceControlWire(statusQuery);
+      const store = new GitCheckoutStore('project-1', 'workspace-1', '/repo');
+      store.start();
+      await waitFor(() => store.hasData && store.fileChanges.length > 0);
+      const membership = () => ({
+        staged: hasPath(store.stagedFileChanges, 'src/index.ts'),
+        unstaged: hasPath(store.unstagedFileChanges, 'src/index.ts'),
+      });
+      const transitions: ReturnType<typeof membership>[] = [];
+      const stop = autorun(() => {
+        const current = membership();
+        const previous = transitions.at(-1);
+        if (current.staged !== previous?.staged || current.unstaged !== previous?.unstaged) {
+          transitions.push(current);
+        }
+      });
+      const before = { staged: direction === 'unstage', unstaged: direction === 'stage' };
+      const after = { staged: direction === 'stage', unstaged: direction === 'unstage' };
+      try {
+        const operation =
+          direction === 'stage'
+            ? store.stageFiles(['src/index.ts'])
+            : store.unstageFiles(['src/index.ts']);
+        releaseStage.resolve();
+        releaseUnstage.resolve();
+        await fetchStarted.promise;
+        expect(membership()).toEqual(after);
+        statusQuery.invalidate();
+        flushStateTurn();
+        fetched.resolve(
+          direction === 'stage' ? stagedStatus('src/index.ts') : status('src/index.ts')
+        );
+        await operation;
+        expect(membership()).toEqual(after);
+
+        // Let the watcher's debounced follow-up read complete as well.
+        await clock.advanceBy(100);
+        await statusQuery.refresh();
+        await waitFor(() => membership().staged === after.staged);
+        expect(transitions).toEqual([before, after]);
+      } finally {
+        stop();
+        store.dispose();
+        await scope.dispose();
+      }
+    }
+  );
+
   it('rolls optimistic staged membership back when the mutation fails', async () => {
     failStage = true;
     statusState.set(status('src/index.ts'));
@@ -268,7 +337,7 @@ describe('GitCheckoutStore', () => {
   });
 });
 
-function createSourceControlWire() {
+function createSourceControlWire(statusQuery?: Query<CheckoutStatusState>) {
   const repositoryProvider = expose(sourceControlContract.repository.model, {
     refs: cell({ branches: [], tags: [], remoteHeads: [] }),
     remotes: cell({ remotes: [] }),
@@ -276,7 +345,7 @@ function createSourceControlWire() {
   const checkoutProvider = expose(
     sourceControlContract.checkout.model,
     {
-      status: statusState,
+      status: statusQuery ?? statusState,
       head: headState,
     },
     {
@@ -287,9 +356,9 @@ function createSourceControlWire() {
           if (failStage) return err({ type: 'git_error', message: 'stage failed' });
           const path = context.input.paths[0];
           if (!path) return ok<void>();
-          const revision = statusState.set(stagedStatus(path), {
-            mutationIds: [context.mutationId],
-          });
+          const revision = statusQuery
+            ? statusQuery.refresh({ mutationIds: [context.mutationId] })
+            : statusState.set(stagedStatus(path), { mutationIds: [context.mutationId] });
           await context.observed('status', revision);
           return ok<void>();
         },
@@ -298,9 +367,9 @@ function createSourceControlWire() {
           await releaseUnstage.promise;
           const path = context.input.paths[0];
           if (!path) return ok<void>();
-          const revision = statusState.set(status(path), {
-            mutationIds: [context.mutationId],
-          });
+          const revision = statusQuery
+            ? statusQuery.refresh({ mutationIds: [context.mutationId] })
+            : statusState.set(status(path), { mutationIds: [context.mutationId] });
           await context.observed('status', revision);
           return ok<void>();
         },

--- a/packages/wire/src/state/02-primitives.md
+++ b/packages/wire/src/state/02-primitives.md
@@ -141,10 +141,14 @@ Lifecycle and scheduling (all inherited from `ComputedLiveState`, renamed):
 The two write channels ([01-concepts.md §8](./01-concepts.md#8-two-write-channels-into-a-query)):
 
 - `invalidate()` / pokes: "truth may have changed" — refetch, maybe publish.
+  An invalidation during a read requests a follow-up read; it does not
+  supersede the in-flight result. That result publishes with the mutation
+  acknowledgements captured before the read started.
 - `settle()`: "truth changed; here is the result" — publish now, without IO.
   Ordering rules: refreshes run on the query's `lane`; `settle` is a
-  synchronous write-through that bumps the revision, and any fetch *started
-  before* the settle is discarded when it resolves (stale-fetch guard). A
+  synchronous write-through, and any fetch *started before* the settle is
+  discarded when it resolves, even if the settled value is equal to the
+  current value. Freshness-only revision changes do not trigger this guard. A
   reducer-style `settle(prev => ...)` on a cold query (no `prev`) is dropped —
   there is nothing to patch, and the next observation fetches anyway.
 

--- a/packages/wire/src/state/04-wire-integration.md
+++ b/packages/wire/src/state/04-wire-integration.md
@@ -101,6 +101,13 @@ The end-to-end chain, all pieces of which exist today except the derived hop:
    has applied the tagged update; optimistic overlays drop the corresponding
    patch.
 
+Settlement evidence belongs to a publication: `expose` records the published
+node revision and mutation IDs together with the cursor carrying that value.
+Both immediate and pending `observed` waits check that record. A newer local
+snapshot marked stale or loading cannot settle a mutation against an older
+published cursor. An already published revision remains observable even if
+the query has since become stale.
+
 A `mutationId` is considered *pending* on a node from the tagged
 settle/refresh until the next publish that consumes that input revision.
 `derived` folds tags only from input revisions that advanced, so tags do not

--- a/packages/wire/src/state/bridge/expose.test.ts
+++ b/packages/wire/src/state/bridge/expose.test.ts
@@ -168,6 +168,113 @@ describe('state expose bridge', () => {
     await provider.dispose();
   });
 
+  it.each([
+    { status: 'stale', tagged: false },
+    { status: 'stale', tagged: true },
+    { status: 'loading', tagged: false },
+    { status: 'loading', tagged: true },
+  ] as const)(
+    'waits for publication of $status revisions (tagged=$tagged)',
+    async ({ status, tagged }) => {
+      const base = cell({ count: 0 });
+      const provider = expose(
+        contract,
+        { value: base },
+        {
+          mutations: {
+            async increment(context) {
+              const revision = base.set(
+                { count: context.input.by },
+                {
+                  status,
+                  mutationIds: tagged ? [context.mutationId] : undefined,
+                }
+              );
+              await context.observed('value', revision);
+              return ok<void>();
+            },
+          },
+        }
+      );
+      const lease = provider.acquireState({ id: 'one' }, 'value');
+      const source = await lease.ready();
+      const before = await source.snapshot();
+      let completed = false;
+      const resultPromise = provider
+        .runMutation('increment', {
+          key: { id: 'one' },
+          input: { by: 2 },
+          mutationId: 'm1',
+        })
+        .then((result) => {
+          completed = true;
+          return result;
+        });
+
+      try {
+        await settleAsync(20);
+        expect(completed).toBe(false);
+        expect((await source.snapshot()).data).toEqual({ count: 0 });
+
+        base.set({ count: 2 }, { status: 'live', mutationIds: ['m1'] });
+        const result = await resultPromise;
+        if (!result.success) throw new Error('Expected mutation success');
+        const published = await source.snapshot();
+        expect(published.data).toEqual({ count: 2 });
+        expect(result.data.cursors[0]?.cursor).toEqual({
+          generation: published.generation,
+          sequence: published.sequence,
+        });
+        expect(published.sequence).toBeGreaterThan(before.sequence);
+      } finally {
+        base.set({ count: 2 }, { status: 'live', mutationIds: ['m1'] });
+        await resultPromise;
+        await lease.release();
+        await provider.dispose();
+      }
+    }
+  );
+
+  it('settles an already published revision even when the current state is stale', async () => {
+    const base = cell({ count: 0 });
+    const provider = expose(
+      contract,
+      { value: base },
+      {
+        mutations: {
+          async increment(context) {
+            const revision = base.set(
+              { count: context.input.by },
+              { mutationIds: [context.mutationId] }
+            );
+            flushStateTurn();
+            base.set({ count: context.input.by }, { status: 'stale' });
+            await context.observed('value', revision);
+            return ok<void>();
+          },
+        },
+      }
+    );
+    const lease = provider.acquireState({ id: 'one' }, 'value');
+    const source = await lease.ready();
+    const result = await provider.runMutation('increment', {
+      key: { id: 'one' },
+      input: { by: 2 },
+      mutationId: 'm1',
+    });
+
+    if (!result.success) throw new Error('Expected mutation success');
+    const published = await source.snapshot();
+    expect(published.data).toEqual({ count: 2 });
+    expect(result.data.cursors[0]?.cursor).toEqual({
+      generation: published.generation,
+      sequence: published.sequence,
+    });
+    expect(snapshot(base).status).toBe('stale');
+    await lease.release();
+    await provider.dispose();
+  });
+
   it('dedupes duplicate mutation ids while the handler is in flight', async () => {
     const base = cell({ count: 0 });
     const release = deferred<void>();

--- a/packages/wire/src/state/bridge/expose.ts
+++ b/packages/wire/src/state/bridge/expose.ts
@@ -101,6 +101,7 @@ type StateRecord = {
   name: string;
   node: Readable<unknown>;
   liveState: LiveStateSource<unknown> | undefined;
+  published: { revision: Revision; cursor: LiveCursor } | undefined;
   readyWaiters: ReadyWaiter[];
   waiters: RevisionWaiter[];
 };
@@ -149,6 +150,7 @@ export function expose<Group extends LiveModelDef>(
         name,
         node,
         liveState: undefined,
+        published: undefined,
         readyWaiters: [],
         waiters: [],
       };
@@ -274,9 +276,9 @@ export function expose<Group extends LiveModelDef>(
     mutationId: string
   ): Promise<LiveCursor> {
     const record = records.ensure({ key, name }).value;
-    const current = snapshot(record.node);
-    if (record.liveState && matchesWaiter(record, current, revision, mutationId))
-      return Promise.resolve(record.liveState.cursor);
+    const published = record.published;
+    if (published && matchesWaiter(published.revision, revision, mutationId))
+      return Promise.resolve(published.cursor);
     return new Promise((resolve, reject) => {
       record.waiters.push({ revision, mutationId, resolve, reject });
     });
@@ -303,6 +305,13 @@ export function expose<Group extends LiveModelDef>(
       ? publishLiveState(record, liveState, current)
       : (record.liveState = new LiveStateSource(current.value)).cursor;
     if (!record.liveState) throw new Error('Exposed state failed to initialize');
+    const publishedRevision: Revision = {
+      nodeId: record.node.__stateNode.id,
+      revision: current.revision,
+      generation: current.generation,
+      mutationIds: current.mutationIds,
+    };
+    record.published = { revision: publishedRevision, cursor };
     const readyLiveState = record.liveState;
 
     const readyWaiters = record.readyWaiters;
@@ -310,10 +319,10 @@ export function expose<Group extends LiveModelDef>(
     for (const waiter of readyWaiters) waiter.resolve(readyLiveState);
 
     const ready = record.waiters.filter((waiter) =>
-      matchesWaiter(record, current, waiter.revision, waiter.mutationId)
+      matchesWaiter(publishedRevision, waiter.revision, waiter.mutationId)
     );
     record.waiters = record.waiters.filter(
-      (waiter) => !matchesWaiter(record, current, waiter.revision, waiter.mutationId)
+      (waiter) => !matchesWaiter(publishedRevision, waiter.revision, waiter.mutationId)
     );
     for (const waiter of ready) waiter.resolve(cursor);
   }
@@ -351,14 +360,9 @@ export function expose<Group extends LiveModelDef>(
     for (const waiter of waiters) waiter.reject(error);
   }
 
-  function matchesWaiter(
-    record: StateRecord,
-    current: Snapshot<unknown>,
-    revision: Revision,
-    mutationId: string
-  ): boolean {
-    if (current.mutationIds?.includes(mutationId)) return true;
-    return record.node.__stateNode.id === revision.nodeId && current.revision >= revision.revision;
+  function matchesWaiter(published: Revision, revision: Revision, mutationId: string): boolean {
+    if (published.mutationIds?.includes(mutationId)) return true;
+    return published.nodeId === revision.nodeId && published.revision >= revision.revision;
   }
 
   function assertActive(): void {

--- a/packages/wire/src/state/query.test.ts
+++ b/packages/wire/src/state/query.test.ts
@@ -255,7 +255,7 @@ describe('state query', () => {
     expect(current.mutationIds).toContain('s1');
   });
 
-  it('delivers mutation ids from a refresh superseded by an invalidation', async () => {
+  it('publishes refreshed data with its mutation ids despite an in-flight invalidation', async () => {
     const clock = createManualClock();
     const pending = deferred<number>();
     let fetchIndex = 0;
@@ -267,13 +267,51 @@ describe('state query', () => {
     });
 
     await model.refresh();
-    const superseded = model.refresh({ mutationIds: ['m1'] });
+    const refreshing = model.refresh({ mutationIds: ['m1'] });
     model.invalidate();
     pending.resolve(2);
-    await superseded;
+    await refreshing;
     await settleAsync();
 
-    expect(snapshot(model).mutationIds).toContain('m1');
+    expect(snapshot(model)).toMatchObject({ value: 2, status: 'live', mutationIds: ['m1'] });
+  });
+
+  it('publishes an interrupted refresh and still performs the requested follow-up read', async () => {
+    const clock = createManualClock();
+    const pending = deferred<number>();
+    let fetchCount = 0;
+    const model = query({
+      initial: 1,
+      fetch: () => (++fetchCount === 1 ? pending.promise : Promise.resolve(3)),
+      debounceMs: 10,
+      clock,
+      scope,
+    });
+    const recorded = recordSnapshots(model);
+
+    const refreshing = model.refresh({ mutationIds: ['m1'] });
+    model.invalidate();
+    pending.resolve(2);
+    await refreshing;
+    await settleAsync();
+    expect(snapshot(model)).toMatchObject({ value: 2, status: 'live', mutationIds: ['m1'] });
+
+    await clock.advanceBy(10);
+    await settleAsync();
+    expect(fetchCount).toBe(2);
+    expect(snapshot(model)).toMatchObject({ value: 3, status: 'live' });
+    await recorded.dispose();
+  });
+
+  it('lets an equal-value settle supersede an older in-flight read', async () => {
+    const pending = deferred<number>();
+    const model = query({ initial: 1, fetch: () => pending.promise, scope });
+    const refreshing = model.refresh();
+    model.settle(1);
+    pending.resolve(2);
+    await refreshing;
+
+    expect(snapshot(model).value).toBe(1);
   });
 
   it('delivers every callers mutation ids across coalesced refreshes', async () => {

--- a/packages/wire/src/state/query.ts
+++ b/packages/wire/src/state/query.ts
@@ -54,6 +54,7 @@ class QueryNode<T> extends StateNode<T | undefined> implements Query<T> {
   private controller: AbortController | undefined;
   private inFlight: Promise<Revision> | undefined;
   private queued: Promise<Revision> | undefined;
+  private settleVersion = 0;
   /** Mutation ids that have not yet reached a committed snapshot. */
   private readonly pendingAckIds = new Set<string>();
 
@@ -109,6 +110,7 @@ class QueryNode<T> extends StateNode<T | undefined> implements Query<T> {
     if (typeof update === 'function' && previous === undefined) return this.currentRevision();
     const next =
       typeof update === 'function' ? (update as (previous: T | undefined) => T)(previous) : update;
+    this.settleVersion += 1;
     this.initialized = true;
     this.dirty = false;
     // The settled value is authoritative write-through: it reflects every
@@ -142,7 +144,7 @@ class QueryNode<T> extends StateNode<T | undefined> implements Query<T> {
   private runNow(): Promise<Revision> {
     this.queued = undefined;
     this.clearDebounce();
-    const startedAtRevision = this.currentSnapshot().revision;
+    const startedAtSettleVersion = this.settleVersion;
     // Every pending id was requested before this fetch starts, so the fetched
     // value reflects those mutations and may acknowledge them.
     const captured = [...this.pendingAckIds];
@@ -155,7 +157,7 @@ class QueryNode<T> extends StateNode<T | undefined> implements Query<T> {
           this.queryOptions.fetch({ signal: controller.signal })
         );
         this.assertActive();
-        if (this.currentSnapshot().revision > startedAtRevision) {
+        if (this.settleVersion !== startedAtSettleVersion) {
           // Superseded: the fetched value is discarded, but its mutation ids
           // must still reach a committed snapshot.
           return this.publishPendingAcks(captured);


### PR DESCRIPTION
- preserves completed query refresh results when watcher invalidations arrive in flight and schedules the follow-up read
- binds mutation settlement cursors to the authoritative publication carrying the acknowledged state
- covers staging and unstaging races so optimistic file membership remains stable until authoritative state arrives