### PR TITLE
fix(machines): allow ssh config key overrides and simplify connection setup

### DIFF
--- a/agents/risky-areas/ssh.md
+++ b/agents/risky-areas/ssh.md
@@ -21,3 +21,9 @@
   across outages, but never across destination identity edits.
 - Do not automatically restart a healthy-but-unresponsive workspace daemon to repair transport;
   sessions and other desktop clients may still depend on it.
+- Test and Save share credential-draft resolution. Blank secrets can retain stored credentials
+  only for an unchanged destination/account/authentication method (and unchanged key selection
+  for passphrases). Changing identity must not silently carry an old secret forward.
+- An edit test loads the saved identity in the main process, tests the draft on a separate
+  ephemeral connection, and never writes secrets or disconnects the saved connection.
+  Stored secrets remain wrapped until SSH connect-config assembly; never send them to the UI.

--- a/agents/risky-areas/ssh.md
+++ b/agents/risky-areas/ssh.md
@@ -27,3 +27,16 @@
 - An edit test loads the saved identity in the main process, tests the draft on a separate
   ephemeral connection, and never writes secrets or disconnects the saved connection.
   Stored secrets remain wrapped until SSH connect-config assembly; never send them to the UI.
+- Connection saves prepare encrypted credential records before a synchronous SQLite transaction,
+  then atomically commit the row, secrets, and identity bindings. Reject a stale row or secret
+  snapshot rather than overwriting a concurrent save; never await inside the transaction.
+- Credential bindings use the effective destination and, for passphrases, the selected key path
+  and content fingerprint. Resolve aliases before credential reuse, including normal reconnects.
+  Legacy passwords may be retained for a verified unchanged destination; legacy passphrases
+  lack a verifiable key binding and require re-entry once. Keep bindings with the encrypted secret
+  so readers cannot mix a credential with another generation's identity.
+- An unchanged key with an unbound legacy passphrase must request re-entry before Save, Test,
+  or reconnect. A rejected save preserves both the row and secret; never interpret an
+  unverified legacy passphrase as absent and silently delete it during a name-only edit.
+- Expand user-relative SSH key paths with the OS home-directory helper, not HOME alone;
+  Windows environments may provide USERPROFILE without HOME.

--- a/apps/emdash-desktop/src/core/features/machines/api/node/machines-service.ts
+++ b/apps/emdash-desktop/src/core/features/machines/api/node/machines-service.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
 import { and, eq, isNull, ne } from 'drizzle-orm';
 import {
   createConversationRegistry,
@@ -16,25 +17,29 @@ import {
   type SshConnectionMetadata,
   type SshConnectionUsage,
 } from '@core/primitives/ssh/api';
-import type { AppDb } from '@core/services/app-db/node/db';
+import type { AppDb, DrizzleTx } from '@core/services/app-db/node/db';
 import {
   projects,
   sshConnections as sshConnectionsTable,
   type SshConnectionInsert,
 } from '@core/services/app-db/node/schema';
-import { resolveCredentialDraft } from '@core/services/ssh/node/credentials/resolve-credential-draft';
+import { resolveSshConfig } from '@core/services/ssh/node/config/resolve-ssh-config';
+import {
+  assertPasswordDestination,
+  effectiveSshConfig,
+  readSshPrivateKey,
+} from '@core/services/ssh/node/credentials/credential-identity';
+import {
+  resolveCredentialDraft,
+  type ResolvedCredentialDraft,
+} from '@core/services/ssh/node/credentials/resolve-credential-draft';
 import type { SshCredentialService } from '@core/services/ssh/node/credentials/ssh-credential-service';
 import type { SaveMachineInput } from '..';
+import { captureMachineSave, persistMachine } from '../../node/machine-persistence';
 
 type MachinesCredentials = Pick<
   SshCredentialService,
-  | 'getPassword'
-  | 'getPassphrase'
-  | 'storePassword'
-  | 'storePassphrase'
-  | 'deletePassword'
-  | 'deletePassphrase'
-  | 'deleteAllCredentials'
+  'getPassword' | 'getPassphrase' | 'deleteAllCredentials'
 >;
 
 type MachinesSshRuntime = {
@@ -49,6 +54,9 @@ type MachinesLog = {
 export interface MachinesServiceDeps {
   db: AppDb;
   credentials: MachinesCredentials;
+  prepareCredentials: (id: string, credentials: ResolvedCredentialDraft) => (tx: DrizzleTx) => void;
+  resolveSshConfig?: typeof resolveSshConfig;
+  readFile?: (path: string, encoding: BufferEncoding) => Promise<string>;
   ssh: MachinesSshRuntime;
   log: MachinesLog;
   createId?: () => string;
@@ -139,15 +147,8 @@ export class MachinesService implements Hookable<MachinesServiceHooks> {
 
     const { password: _password, passphrase: _passphrase, ...dbConfig } = config;
 
-    const existingRows =
-      config.id === undefined
-        ? []
-        : await this.deps.db
-            .select()
-            .from(sshConnectionsTable)
-            .where(eq(sshConnectionsTable.id, connectionId))
-            .limit(1);
-    const existingMetadata: SshConnectionMetadata = existingRows[0]?.metadata ?? {};
+    const before = captureMachineSave(this.deps.db, connectionId);
+    const existingMetadata: SshConnectionMetadata = before.connection?.metadata ?? {};
 
     const metadataUpdate: SshConnectionMetadata = {};
     if (Object.prototype.hasOwnProperty.call(config, 'sshConfigAlias')) {
@@ -161,54 +162,50 @@ export class MachinesService implements Hookable<MachinesServiceHooks> {
     }
     const metadata = mergeSshConnectionMetadata(existingMetadata, metadataUpdate);
 
-    const previous = existingRows[0] ? sshConfigFromRow(existingRows[0]) : undefined;
+    const previous = before.connection ? sshConfigFromRow(before.connection) : undefined;
+    const draft = {
+      ...config,
+      sshConfigAlias: metadata.sshConfigAlias,
+      proxyJump: metadata.proxyJump,
+    };
+    const resolved = draft.sshConfigAlias
+      ? await (this.deps.resolveSshConfig ?? resolveSshConfig)(draft.sshConfigAlias)
+      : undefined;
+    const effective = effectiveSshConfig(draft, resolved);
+    assertPasswordDestination(draft, effective);
+    const key =
+      draft.authType === 'key'
+        ? await readSshPrivateKey(draft, resolved, this.deps.readFile ?? readFile)
+        : undefined;
     const credentials = await resolveCredentialDraft(
-      { ...config, sshConfigAlias: metadata.sshConfigAlias, proxyJump: metadata.proxyJump },
+      effective,
       previous,
-      this.deps.credentials
+      this.deps.credentials,
+      key?.fingerprint
     );
-    if (credentials.password) {
-      await this.deps.credentials.storePassword(connectionId, credentials.password);
-    } else if (previous) {
-      await this.deps.credentials.deletePassword(connectionId);
-    }
-    if (credentials.passphrase) {
-      await this.deps.credentials.storePassphrase(connectionId, credentials.passphrase);
-    } else if (previous) {
-      await this.deps.credentials.deletePassphrase(connectionId);
-    }
+    const applyCredentials = this.deps.prepareCredentials(connectionId, credentials);
 
     const insertData: SshConnectionInsert = {
       id: connectionId,
       name: dbConfig.name,
-      host: dbConfig.host,
-      port: dbConfig.port,
+      host: effective.host,
+      port: effective.port,
       metadata,
-      username: dbConfig.username,
+      username: effective.username,
       authType: dbConfig.authType,
       privateKeyPath: dbConfig.privateKeyPath ?? null,
       useAgent: dbConfig.useAgent ? 1 : 0,
     };
 
-    await this.deps.db
-      .insert(sshConnectionsTable)
-      .values(insertData)
-      .onConflictDoUpdate({
-        target: sshConnectionsTable.id,
-        set: {
-          name: insertData.name,
-          host: insertData.host,
-          port: insertData.port,
-          metadata: insertData.metadata,
-          username: insertData.username,
-          authType: insertData.authType,
-          privateKeyPath: insertData.privateKeyPath,
-          useAgent: insertData.useAgent,
-          updatedAt: new Date(this.now()).toISOString(),
-        },
-      });
+    persistMachine(
+      this.deps.db,
+      before,
+      insertData,
+      applyCredentials,
+      new Date(this.now()).toISOString()
+    );
 
-    if (existingRows.length > 0) {
+    if (previous) {
       await this.deps.ssh.dropConnection(connectionId).catch((error: unknown) => {
         this.deps.log.warn('MachinesService.saveMachine: error disconnecting previous config', {
           connectionId,
@@ -220,6 +217,9 @@ export class MachinesService implements Hookable<MachinesServiceHooks> {
 
     return {
       ...dbConfig,
+      host: effective.host,
+      port: effective.port,
+      username: effective.username,
       id: connectionId,
       sshConfigAlias: metadata.sshConfigAlias,
       forwardAgent: metadata.forwardAgent,

--- a/apps/emdash-desktop/src/core/features/machines/api/node/machines-service.ts
+++ b/apps/emdash-desktop/src/core/features/machines/api/node/machines-service.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from 'node:crypto';
-import { secret, type Secret } from '@emdash/shared';
 import { and, eq, isNull, ne } from 'drizzle-orm';
 import {
   createConversationRegistry,
@@ -23,13 +22,20 @@ import {
   sshConnections as sshConnectionsTable,
   type SshConnectionInsert,
 } from '@core/services/app-db/node/schema';
+import { resolveCredentialDraft } from '@core/services/ssh/node/credentials/resolve-credential-draft';
+import type { SshCredentialService } from '@core/services/ssh/node/credentials/ssh-credential-service';
 import type { SaveMachineInput } from '..';
 
-type MachinesCredentials = {
-  storePassword(connectionId: string, password: Secret<string>): Promise<void>;
-  storePassphrase(connectionId: string, passphrase: Secret<string>): Promise<void>;
-  deleteAllCredentials(connectionId: string): Promise<void>;
-};
+type MachinesCredentials = Pick<
+  SshCredentialService,
+  | 'getPassword'
+  | 'getPassphrase'
+  | 'storePassword'
+  | 'storePassphrase'
+  | 'deletePassword'
+  | 'deletePassphrase'
+  | 'deleteAllCredentials'
+>;
 
 type MachinesSshRuntime = {
   dropConnection(connectionId: string): Promise<void>;
@@ -131,28 +137,13 @@ export class MachinesService implements Hookable<MachinesServiceHooks> {
       );
     }
 
-    // Wrap wire-fresh credential strings into Secret at first touch; they
-    // stay wrapped through the credential service and secrets store.
-    if (config.password) {
-      await this.deps.credentials.storePassword(
-        connectionId,
-        secret(config.password, 'ssh-password')
-      );
-    }
-    if (config.passphrase) {
-      await this.deps.credentials.storePassphrase(
-        connectionId,
-        secret(config.passphrase, 'ssh-passphrase')
-      );
-    }
-
     const { password: _password, passphrase: _passphrase, ...dbConfig } = config;
 
     const existingRows =
       config.id === undefined
         ? []
         : await this.deps.db
-            .select({ metadata: sshConnectionsTable.metadata })
+            .select()
             .from(sshConnectionsTable)
             .where(eq(sshConnectionsTable.id, connectionId))
             .limit(1);
@@ -169,6 +160,23 @@ export class MachinesService implements Hookable<MachinesServiceHooks> {
       metadataUpdate.proxyJump = config.proxyJump;
     }
     const metadata = mergeSshConnectionMetadata(existingMetadata, metadataUpdate);
+
+    const previous = existingRows[0] ? sshConfigFromRow(existingRows[0]) : undefined;
+    const credentials = await resolveCredentialDraft(
+      { ...config, sshConfigAlias: metadata.sshConfigAlias, proxyJump: metadata.proxyJump },
+      previous,
+      this.deps.credentials
+    );
+    if (credentials.password) {
+      await this.deps.credentials.storePassword(connectionId, credentials.password);
+    } else if (previous) {
+      await this.deps.credentials.deletePassword(connectionId);
+    }
+    if (credentials.passphrase) {
+      await this.deps.credentials.storePassphrase(connectionId, credentials.passphrase);
+    } else if (previous) {
+      await this.deps.credentials.deletePassphrase(connectionId);
+    }
 
     const insertData: SshConnectionInsert = {
       id: connectionId,

--- a/apps/emdash-desktop/src/core/features/machines/browser/add-machine-modal.tsx
+++ b/apps/emdash-desktop/src/core/features/machines/browser/add-machine-modal.tsx
@@ -3,7 +3,9 @@ import { ArrowLeftIcon } from 'lucide-react';
 import { useModalController } from '@core/manifests/browser/modal-api';
 import { defineModal } from '@core/primitives/modals/react';
 import type { SshConfig } from '@core/primitives/ssh/api';
-import { MachineFormActions, MachineFormFields, useMachineForm } from './machine-form';
+import { MachineFormFields } from './machine-form';
+import { MachineFormActions } from './machine-form-actions';
+import { useMachineForm } from './use-machine-form';
 
 export interface AddMachineModalProps {
   initialConfig?: SshConfig;
@@ -25,7 +27,7 @@ export function AddMachineModal({ initialConfig, dismissControl = 'back' }: AddM
       header={
         <Dialog.Header
           showCloseButton={!showBackButton}
-          className="-mt-2 w-full flex-row items-center justify-between gap-2"
+          className="w-full flex-row items-center justify-between gap-2"
         >
           <div className={`flex items-center gap-2 ${showBackButton ? '-ml-2' : ''}`}>
             {showBackButton && (
@@ -42,7 +44,9 @@ export function AddMachineModal({ initialConfig, dismissControl = 'back' }: AddM
       footer={
         <Dialog.Footer>
           <MachineFormActions
-            controller={controller}
+            actions={controller.actions}
+            resolution={controller.config.resolution}
+            isEditing={controller.isEditing}
             formId={MACHINE_MODAL_FORM_ID}
             cancelAction={
               !showBackButton ? (
@@ -50,7 +54,7 @@ export function AddMachineModal({ initialConfig, dismissControl = 'back' }: AddM
                   type="button"
                   variant="secondary"
                   onClick={modal.dismiss}
-                  disabled={controller.isSubmitting}
+                  disabled={controller.isSaving}
                 >
                   Cancel
                 </Button>

--- a/apps/emdash-desktop/src/core/features/machines/browser/machine-authentication-fields.tsx
+++ b/apps/emdash-desktop/src/core/features/machines/browser/machine-authentication-fields.tsx
@@ -1,0 +1,140 @@
+import { FormFieldShell, useFieldContext } from '@emdash/ui/react/form';
+import { Button, Input, Select } from '@emdash/ui/react/primitives';
+import { useState } from 'react';
+import type { MachineFormMode } from './machine-form-model';
+import type { MachineEditorForm } from './use-machine-form';
+
+function PrivateKeyField({ inheritedKey, alias }: { inheritedKey?: string; alias: string }) {
+  const field = useFieldContext<string>();
+  const [draft, setDraft] = useState<string | null>(null);
+  return (
+    <FormFieldShell
+      label="Private key"
+      description={
+        alias && (field.state.value || !inheritedKey) ? (
+          <span className="flex flex-wrap items-center justify-between gap-2">
+            <span>{field.state.value ? 'Custom key' : 'Enter a private key path'}</span>
+            {field.state.value && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="xs"
+                onClick={() => {
+                  field.handleChange('');
+                  setDraft(null);
+                }}
+              >
+                Reset to SSH config
+              </Button>
+            )}
+          </span>
+        ) : undefined
+      }
+    >
+      {({ id, invalid }) => (
+        <Input
+          id={id}
+          name={field.name}
+          aria-invalid={invalid || undefined}
+          value={draft ?? (field.state.value || inheritedKey || '')}
+          placeholder="~/.ssh/id_ed25519"
+          autoComplete="off"
+          onChange={(event) => {
+            setDraft(event.target.value);
+            field.handleChange(event.target.value);
+          }}
+          onBlur={() => {
+            setDraft(null);
+            field.handleBlur();
+          }}
+        />
+      )}
+    </FormFieldShell>
+  );
+}
+
+export function MachineAuthenticationFields({
+  form,
+  mode,
+  alias,
+  inheritedKey,
+  reuse,
+}: {
+  form: MachineEditorForm;
+  mode: MachineFormMode;
+  alias: string;
+  inheritedKey?: string;
+  reuse: { password: boolean; passphrase: boolean };
+}) {
+  return (
+    <section className="grid gap-3" aria-label="Authentication settings">
+      <form.AppField name={`${mode}.authType`}>
+        {(field) => (
+          <FormFieldShell label="Authentication" orientation="horizontal">
+            {({ id }) => (
+              <Select.Root
+                value={field.state.value}
+                onValueChange={(value) => {
+                  if (value) field.handleChange(value);
+                }}
+              >
+                <Select.Trigger id={id} onBlur={field.handleBlur}>
+                  <Select.Value>
+                    {field.state.value === 'key'
+                      ? 'SSH Key'
+                      : field.state.value === 'agent'
+                        ? 'Agent'
+                        : 'Password'}
+                  </Select.Value>
+                </Select.Trigger>
+                <Select.Content>
+                  <Select.Item value="key">SSH Key</Select.Item>
+                  <Select.Item value="agent">Agent</Select.Item>
+                  <Select.Item value="password">Password</Select.Item>
+                </Select.Content>
+              </Select.Root>
+            )}
+          </FormFieldShell>
+        )}
+      </form.AppField>
+      <form.Subscribe
+        selector={(state) => ({
+          authType: state.values[mode].authType,
+        })}
+      >
+        {({ authType }) =>
+          authType === 'key' ? (
+            <>
+              <form.AppField name={`${mode}.privateKeyPath`}>
+                {() => <PrivateKeyField key={alias} alias={alias} inheritedKey={inheritedKey} />}
+              </form.AppField>
+              <form.AppField name={`${mode}.passphrase`}>
+                {(field) => (
+                  <field.TextField
+                    label="Passphrase (optional)"
+                    type="password"
+                    autoComplete="off"
+                    placeholder={reuse.passphrase ? 'Leave blank to keep existing' : 'Optional'}
+                  />
+                )}
+              </form.AppField>
+            </>
+          ) : authType === 'password' ? (
+            <form.AppField name={`${mode}.password`}>
+              {(field) => (
+                <field.TextField
+                  label="Password"
+                  type="password"
+                  autoComplete="current-password"
+                  placeholder={reuse.password ? 'Leave blank to keep existing' : undefined}
+                />
+              )}
+            </form.AppField>
+          ) : (
+            <p className="text-sm text-foreground-muted">Uses keys available in your SSH agent.</p>
+          )
+        }
+      </form.Subscribe>
+    </section>
+  );
+}

--- a/apps/emdash-desktop/src/core/features/machines/browser/machine-authentication-fields.tsx
+++ b/apps/emdash-desktop/src/core/features/machines/browser/machine-authentication-fields.tsx
@@ -114,7 +114,7 @@ export function MachineAuthenticationFields({
                     label="Passphrase (optional)"
                     type="password"
                     autoComplete="off"
-                    placeholder={reuse.passphrase ? 'Leave blank to keep existing' : 'Optional'}
+                    placeholder={reuse.passphrase ? 'Leave blank to reuse if verified' : 'Optional'}
                   />
                 )}
               </form.AppField>

--- a/apps/emdash-desktop/src/core/features/machines/browser/machine-connection-details.tsx
+++ b/apps/emdash-desktop/src/core/features/machines/browser/machine-connection-details.tsx
@@ -1,0 +1,163 @@
+import { Button, Tooltip } from '@emdash/ui/react/primitives';
+import { card } from '@emdash/ui/styles/recipes/card';
+import { CheckCircle2, Copy } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import type { SshConfigHost } from '@core/primitives/ssh/api';
+
+export function MachineConnectionDetails({
+  host,
+  target,
+}: {
+  host: SshConfigHost;
+  target: string;
+}) {
+  return (
+    <div className={card({ padding: 'md', radius: 'lg' })}>
+      <dl className="grid gap-2 text-sm">
+        <div className="grid grid-cols-[9rem_minmax(0,1fr)] gap-3">
+          <dt className="text-foreground-muted">Host</dt>
+          <dd className="break-all">{host?.hostname || target}</dd>
+        </div>
+        <div className="grid grid-cols-[9rem_minmax(0,1fr)] gap-3">
+          <dt className="text-foreground-muted">Port</dt>
+          <dd>{host?.port ?? 22}</dd>
+        </div>
+        <div className="grid grid-cols-[9rem_minmax(0,1fr)] gap-3">
+          <dt className="text-foreground-muted">Username</dt>
+          <dd className="break-all">{host?.user || 'Not specified'}</dd>
+        </div>
+        <CopyableConnectionDetail
+          key={`jump-${host?.proxyJump}`}
+          label="Jump host"
+          value={host?.proxyJump}
+        />
+        {host?.proxyCommand && (
+          <CopyableConnectionDetail
+            key={host.proxyCommand}
+            label="Proxy command"
+            value={host.proxyCommand}
+            copyOnValueClick
+          />
+        )}
+        <div className="grid grid-cols-[9rem_minmax(0,1fr)] gap-3">
+          <dt className="text-foreground-muted">Forward SSH agent</dt>
+          <dd>{host?.forwardAgent ? 'On' : 'Off'}</dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+function CopyableConnectionDetail({
+  label,
+  value,
+  copyOnValueClick = false,
+}: {
+  label: string;
+  value?: string;
+  copyOnValueClick?: boolean;
+}) {
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'error'>('idle');
+  const copyValue = async () => {
+    if (!value) return;
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopyState('copied');
+    } catch {
+      setCopyState('error');
+    }
+  };
+  useEffect(() => {
+    if (copyState !== 'copied') return;
+    const timeout = setTimeout(() => setCopyState('idle'), 2000);
+    return () => clearTimeout(timeout);
+  }, [copyState]);
+  return (
+    <div className="group grid min-w-0 grid-cols-[9rem_minmax(0,1fr)] items-center gap-3">
+      <dt className="text-foreground-muted">{label}</dt>
+      <dd className="min-w-0">
+        {value ? (
+          <div className="flex min-w-0 items-center gap-1">
+            {copyOnValueClick ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="xs"
+                className="group/copy relative min-w-0 flex-1 justify-start px-0 text-sm font-normal"
+                style={{ cursor: 'pointer', userSelect: 'none' }}
+                aria-label={`Copy ${label.toLowerCase()}`}
+                onClick={copyValue}
+              >
+                <span
+                  className="pointer-events-none block truncate transition-opacity group-hover/copy:opacity-30 group-focus-visible/copy:opacity-30"
+                  style={{ userSelect: 'none' }}
+                >
+                  {value}
+                </span>
+                <span
+                  aria-hidden="true"
+                  className={`pointer-events-none absolute inset-0 flex items-center justify-center transition-opacity group-hover/copy:opacity-100 group-focus-visible/copy:opacity-100 [@media(hover:none)]:opacity-100 ${copyState === 'copied' ? 'opacity-100' : 'opacity-0'}`}
+                >
+                  <span className="bg-surface rounded p-1">
+                    {copyState === 'copied' ? (
+                      <CheckCircle2 className="size-3" />
+                    ) : (
+                      <Copy className="size-3" />
+                    )}
+                  </span>
+                </span>
+              </Button>
+            ) : (
+              <Tooltip.Root>
+                <Tooltip.Trigger render={<span tabIndex={0} className="min-w-0 flex-1 truncate" />}>
+                  {value}
+                </Tooltip.Trigger>
+                <Tooltip.Content>
+                  <span className="break-all">{value}</span>
+                </Tooltip.Content>
+              </Tooltip.Root>
+            )}
+            {!copyOnValueClick && (
+              <Tooltip.Root>
+                <Tooltip.Trigger
+                  render={
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="xs"
+                      icon
+                      className="shrink-0 opacity-0 group-focus-within:opacity-100 group-hover:opacity-100 [@media(hover:none)]:opacity-100"
+                      aria-label={`Copy ${label.toLowerCase()}`}
+                      onClick={copyValue}
+                    />
+                  }
+                >
+                  {copyState === 'copied' ? (
+                    <CheckCircle2 className="size-3" />
+                  ) : (
+                    <Copy className="size-3" />
+                  )}
+                </Tooltip.Trigger>
+                <Tooltip.Content>
+                  {copyState === 'copied' ? 'Copied' : `Copy ${label.toLowerCase()}`}
+                </Tooltip.Content>
+              </Tooltip.Root>
+            )}
+          </div>
+        ) : (
+          'None'
+        )}
+        <div
+          role="status"
+          className={copyState === 'error' ? 'text-xs text-foreground-muted' : 'sr-only'}
+        >
+          {copyState === 'error'
+            ? 'Could not copy. Try again.'
+            : copyState === 'copied'
+              ? `${label} copied to clipboard.`
+              : null}
+        </div>
+      </dd>
+    </div>
+  );
+}

--- a/apps/emdash-desktop/src/core/features/machines/browser/machine-form-actions.tsx
+++ b/apps/emdash-desktop/src/core/features/machines/browser/machine-form-actions.tsx
@@ -1,0 +1,127 @@
+import { Button } from '@emdash/ui/react/primitives';
+import { CheckCircle2, ChevronDown, ChevronUp, LoaderCircle, XCircle } from 'lucide-react';
+import { useState, type ReactNode } from 'react';
+import type { MachineFormController, MachineTestState } from './use-machine-form';
+import type { SshConfigResolution } from './use-ssh-config-hosts';
+
+export function MachineFormActions({
+  actions,
+  resolution,
+  isEditing,
+  formId,
+  cancelAction,
+}: {
+  actions: MachineFormController['actions'];
+  resolution: SshConfigResolution;
+  isEditing: boolean;
+  formId: string;
+  cancelAction?: ReactNode;
+}) {
+  const resolving = !actions.ready && resolution.status === 'resolving';
+  return (
+    <div className="flex w-full items-center justify-between gap-3">
+      <div className="flex items-center gap-2">
+        {actions.ready && (
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={actions.test}
+            disabled={actions.isTesting || actions.isSaving}
+          >
+            {actions.isTesting ? (
+              <>
+                <LoaderCircle className="size-4 animate-spin" />
+                Testing…
+              </>
+            ) : (
+              'Test Connection'
+            )}
+          </Button>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        {cancelAction}
+        <Button
+          type="submit"
+          variant="primary"
+          form={formId}
+          disabled={actions.disabled || resolving}
+        >
+          {actions.isSaving ? (
+            <>
+              <LoaderCircle className="size-4 animate-spin" />
+              Saving…
+            </>
+          ) : !actions.ready ? (
+            resolving ? (
+              'Resolving…'
+            ) : resolution.status === 'failed' ? (
+              'Retry'
+            ) : (
+              'Resolve'
+            )
+          ) : isEditing ? (
+            'Save'
+          ) : (
+            'Add host'
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function MachineFormFeedback({ test, saveError }: MachineFormController['feedback']) {
+  return (
+    <>
+      {test.status !== 'idle' && <TestFeedback key={test.status} test={test} />}
+      {saveError && (
+        <p role="alert" className="text-sm text-foreground-destructive">
+          Could not save connection: {saveError}
+        </p>
+      )}
+    </>
+  );
+}
+
+function TestFeedback({ test }: { test: Exclude<MachineTestState, { status: 'idle' }> }) {
+  const [showDebugLogs, setShowDebugLogs] = useState(false);
+  const result = test.status === 'finished' ? test.result : undefined;
+  const failed = result && !result.success;
+  return (
+    <div className="border-input rounded-md border px-3 py-2 text-sm">
+      <div className="flex items-center gap-2">
+        {test.status === 'testing' ? (
+          <LoaderCircle className="text-muted-foreground size-4 animate-spin" />
+        ) : failed ? (
+          <XCircle className="text-destructive size-4" />
+        ) : (
+          <CheckCircle2 className="size-4 text-foreground-success" />
+        )}
+        <span className="flex-1 font-medium">
+          {test.status === 'testing'
+            ? 'Testing connection…'
+            : failed
+              ? (result.error ?? 'Connection failed')
+              : `Connected${result?.latency ? ` (${result.latency}ms)` : ''}`}
+        </span>
+        {failed && result.debugLogs?.length ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            onClick={() => setShowDebugLogs((value) => !value)}
+          >
+            {showDebugLogs ? <ChevronUp className="size-3" /> : <ChevronDown className="size-3" />}
+            Logs
+          </Button>
+        ) : null}
+      </div>
+      {showDebugLogs && result?.debugLogs && (
+        <pre className="bg-muted text-muted-foreground mt-2 max-h-32 overflow-y-auto rounded px-2 py-1.5 text-xs">
+          {result.debugLogs.join('\n')}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/apps/emdash-desktop/src/core/features/machines/browser/machine-form-model.ts
+++ b/apps/emdash-desktop/src/core/features/machines/browser/machine-form-model.ts
@@ -1,6 +1,112 @@
-import type { SshConfigHost } from '@core/primitives/ssh/api';
+import type { SshConfig, SshConfigHost } from '@core/primitives/ssh/api';
+import { createMachineFormSchema, type MachineFormValues } from './machine-form-schema';
 
 export type MachineAuthType = 'password' | 'key' | 'agent';
+export type MachineFormMode = 'manual' | 'config';
+export type MachineAuthenticationDraft = Pick<
+  MachineFormValues,
+  'authType' | 'password' | 'privateKeyPath' | 'passphrase'
+>;
+export type MachineManualDraft = Omit<MachineFormValues, 'name' | 'sshConfigAlias'>;
+export interface MachineEditorValues {
+  name: string;
+  manual: MachineManualDraft;
+  config: MachineAuthenticationDraft;
+}
+export type MachineConnectionSource =
+  | { mode: 'manual' }
+  | { mode: 'config'; alias: string; resolved: SshConfigHost };
+
+export function authenticationDraft(config?: SshConfig): MachineAuthenticationDraft {
+  return {
+    authType: config?.authType ?? 'password',
+    password: '',
+    privateKeyPath: config?.privateKeyPath ?? '',
+    passphrase: '',
+  };
+}
+
+export function machineEditorDefaults(initial?: SshConfig): MachineEditorValues {
+  const manual = initial?.sshConfigAlias ? undefined : initial;
+  return {
+    name: initial?.name ?? '',
+    manual: {
+      ...authenticationDraft(manual),
+      host: manual?.host ?? '',
+      port: manual?.port ?? 22,
+      username: manual?.username ?? '',
+      forwardAgent: manual?.forwardAgent ?? false,
+      proxyJump: manual?.proxyJump ?? '',
+    },
+    config: authenticationDraft(initial?.sshConfigAlias ? initial : undefined),
+  };
+}
+
+/** Compose editable intent and read-only resolution without storing the resolution in the form. */
+export function machineDraftValues(
+  values: MachineEditorValues,
+  source: MachineConnectionSource
+): MachineFormValues {
+  if (source.mode === 'manual') return { name: values.name, ...values.manual, sshConfigAlias: '' };
+  return {
+    name: values.name,
+    ...values.config,
+    sshConfigAlias: source.alias,
+    host: source.resolved.hostname || source.alias,
+    port: source.resolved.port ?? 22,
+    username: source.resolved.user ?? '',
+    proxyJump: '',
+    forwardAgent: false,
+  };
+}
+
+export function validateMachineDraft(
+  values: MachineEditorValues,
+  source: MachineConnectionSource,
+  previous?: SshConfig
+) {
+  const result = createMachineFormSchema(previous).safeParse(machineDraftValues(values, source));
+  if (result.success) return undefined;
+  return {
+    fields: Object.fromEntries(
+      result.error.issues.map((issue) => [
+        issue.path[0] === 'name' ? 'name' : `${source.mode}.${String(issue.path[0])}`,
+        issue.message,
+      ])
+    ),
+  };
+}
+
+export const DUPLICATE_CONNECTION_NAME_ERROR =
+  'An SSH connection with this name already exists. Choose a different name.';
+
+export function formatMachineError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const withoutIpcPrefix = message.replace(/^Error invoking remote method 'ssh\.[^']+':\s*/, '');
+  return /UNIQUE constraint failed: ssh_connections\.name/.test(withoutIpcPrefix)
+    ? DUPLICATE_CONNECTION_NAME_ERROR
+    : withoutIpcPrefix;
+}
+
+export function machineConnectionConfig(
+  value: MachineFormValues
+): Omit<SshConfig, 'id'> & { password?: string; passphrase?: string } {
+  const alias = value.sshConfigAlias || undefined;
+  return {
+    name: value.name || alias || value.host,
+    host: value.host,
+    port: value.port,
+    username: value.username || alias || value.host,
+    sshConfigAlias: alias,
+    authType: value.authType,
+    privateKeyPath: value.authType === 'key' ? value.privateKeyPath.trim() || undefined : undefined,
+    useAgent: value.authType === 'agent',
+    forwardAgent: alias ? undefined : value.forwardAgent,
+    proxyJump: alias ? undefined : value.proxyJump.trim(),
+    password: value.authType === 'password' ? value.password : undefined,
+    passphrase: value.authType === 'key' ? value.passphrase : undefined,
+  };
+}
 
 export function suggestedAuthTypeForSshConfigHost(host: SshConfigHost): MachineAuthType {
   if (host.identityAgent) return 'agent';

--- a/apps/emdash-desktop/src/core/features/machines/browser/machine-form-schema.test.ts
+++ b/apps/emdash-desktop/src/core/features/machines/browser/machine-form-schema.test.ts
@@ -13,8 +13,6 @@ const baseValues: MachineFormValues = {
   sshConfigAlias: '',
   forwardAgent: false,
   proxyJump: '',
-  proxyCommand: '',
-  isEditing: false,
 };
 
 describe('machineFormSchema', () => {
@@ -98,7 +96,6 @@ describe('machineFormSchema', () => {
       username: '',
       authType: 'password',
       password: '',
-      isEditing: false,
     });
 
     expect(result.success).toBe(false);

--- a/apps/emdash-desktop/src/core/features/machines/browser/machine-form-schema.ts
+++ b/apps/emdash-desktop/src/core/features/machines/browser/machine-form-schema.ts
@@ -1,7 +1,17 @@
 import * as z from 'zod';
+import { sshCredentialReuse } from '@core/primitives/ssh/api/credential-reuse';
+import type { SshConfig } from '@core/primitives/ssh/api/ssh';
 
 const manualHostPattern = /^[a-zA-Z0-9._\-[\]:]+$/;
 const sshAliasPattern = /^[A-Za-z0-9._@%+:/[\]-]+$/;
+
+export const sshConfigTargetSchema = z
+  .string()
+  .min(1, 'Enter a host')
+  .refine(
+    (value) => !value.startsWith('-') && sshAliasPattern.test(value),
+    'Enter a valid SSH config alias or hostname'
+  );
 
 function hasLeadingOrTrailingWhitespace(value: string): boolean {
   return value !== value.trim();
@@ -19,85 +29,91 @@ function addWhitespaceIssue(
   });
 }
 
-export const machineFormSchema = z
-  .object({
-    name: z.string().min(1, 'Name is required'),
-    host: z.string().min(1, 'Host is required'),
-    port: z
-      .number()
-      .int()
-      .min(1, 'Port must be at least 1')
-      .max(65535, 'Port must be at most 65535'),
-    username: z.string(),
-    authType: z.enum(['password', 'key', 'agent']),
-    password: z.string(),
-    privateKeyPath: z.string(),
-    passphrase: z.string(),
-    sshConfigAlias: z.string(),
-    forwardAgent: z.boolean(),
-    proxyJump: z.string(),
-    proxyCommand: z.string(),
-    isEditing: z.boolean(),
-  })
-  .superRefine((val, ctx) => {
-    if (hasLeadingOrTrailingWhitespace(val.name)) {
-      addWhitespaceIssue(ctx, 'name', 'Connection name');
-    }
-    if (hasLeadingOrTrailingWhitespace(val.host)) {
-      addWhitespaceIssue(ctx, 'host', 'Host');
-    }
-    if (hasLeadingOrTrailingWhitespace(val.username)) {
-      addWhitespaceIssue(ctx, 'username', 'Username');
-    }
-    if (hasLeadingOrTrailingWhitespace(val.privateKeyPath)) {
-      addWhitespaceIssue(ctx, 'privateKeyPath', 'Private key path');
-    }
-    if (hasLeadingOrTrailingWhitespace(val.sshConfigAlias)) {
-      addWhitespaceIssue(ctx, 'sshConfigAlias', 'SSH config alias');
-    }
-    if (hasLeadingOrTrailingWhitespace(val.proxyJump)) {
-      addWhitespaceIssue(ctx, 'proxyJump', 'ProxyJump');
-    }
+export function createMachineFormSchema(previous?: SshConfig) {
+  return z
+    .object({
+      name: z.string(),
+      host: z.string().min(1, 'Host is required'),
+      port: z
+        .number()
+        .int()
+        .min(1, 'Port must be at least 1')
+        .max(65535, 'Port must be at most 65535'),
+      username: z.string(),
+      authType: z.enum(['password', 'key', 'agent']),
+      password: z.string(),
+      privateKeyPath: z.string(),
+      passphrase: z.string(),
+      sshConfigAlias: z.string(),
+      forwardAgent: z.boolean(),
+      proxyJump: z.string(),
+    })
+    .superRefine((val, ctx) => {
+      if (hasLeadingOrTrailingWhitespace(val.name)) {
+        addWhitespaceIssue(ctx, 'name', 'Connection name');
+      }
+      if (hasLeadingOrTrailingWhitespace(val.host)) {
+        addWhitespaceIssue(ctx, 'host', 'Host');
+      }
+      if (hasLeadingOrTrailingWhitespace(val.username)) {
+        addWhitespaceIssue(ctx, 'username', 'Username');
+      }
+      if (val.authType === 'key' && hasLeadingOrTrailingWhitespace(val.privateKeyPath)) {
+        addWhitespaceIssue(ctx, 'privateKeyPath', 'Private key path');
+      }
+      if (hasLeadingOrTrailingWhitespace(val.sshConfigAlias)) {
+        addWhitespaceIssue(ctx, 'sshConfigAlias', 'SSH config alias');
+      }
+      if (hasLeadingOrTrailingWhitespace(val.proxyJump)) {
+        addWhitespaceIssue(ctx, 'proxyJump', 'ProxyJump');
+      }
 
-    if (val.sshConfigAlias) {
+      if (val.sshConfigAlias) {
+        if (
+          !hasLeadingOrTrailingWhitespace(val.sshConfigAlias) &&
+          (val.sshConfigAlias.startsWith('-') || !sshAliasPattern.test(val.sshConfigAlias))
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Invalid SSH config alias',
+            path: ['sshConfigAlias'],
+          });
+        }
+      } else if (!hasLeadingOrTrailingWhitespace(val.host) && !manualHostPattern.test(val.host)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Invalid hostname or IP address',
+          path: ['host'],
+        });
+      }
+      if (!val.sshConfigAlias && !val.username) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Username is required',
+          path: ['username'],
+        });
+      }
       if (
-        !hasLeadingOrTrailingWhitespace(val.sshConfigAlias) &&
-        (val.sshConfigAlias.startsWith('-') || !sshAliasPattern.test(val.sshConfigAlias))
+        val.authType === 'password' &&
+        !val.password &&
+        !sshCredentialReuse(val, previous).password
       ) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: 'Invalid SSH config alias',
-          path: ['sshConfigAlias'],
+          message: 'Password is required',
+          path: ['password'],
         });
       }
-    } else if (!hasLeadingOrTrailingWhitespace(val.host) && !manualHostPattern.test(val.host)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'Invalid hostname or IP address',
-        path: ['host'],
-      });
-    }
-    if (!val.sshConfigAlias && !val.username) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'Username is required',
-        path: ['username'],
-      });
-    }
-    if (val.authType === 'password' && !val.password && !val.isEditing) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'Password is required',
-        path: ['password'],
-      });
-    }
-    if (val.authType === 'key' && !val.sshConfigAlias && !val.privateKeyPath) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'Private key path is required',
-        path: ['privateKeyPath'],
-      });
-    }
-  });
+      if (val.authType === 'key' && !val.sshConfigAlias && !val.privateKeyPath) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Private key path is required',
+          path: ['privateKeyPath'],
+        });
+      }
+    });
+}
+
+export const machineFormSchema = createMachineFormSchema();
 
 export type MachineFormValues = z.infer<typeof machineFormSchema>;

--- a/apps/emdash-desktop/src/core/features/machines/browser/machine-form.browser.test.tsx
+++ b/apps/emdash-desktop/src/core/features/machines/browser/machine-form.browser.test.tsx
@@ -691,7 +691,9 @@ it('only offers passphrase retention for the saved key and requires a password w
     privateKeyPath: '/keys/old',
   });
   const passphrase = page.getByLabelText('Passphrase (optional)', { exact: true });
-  await expect.element(passphrase).toHaveAttribute('placeholder', 'Leave blank to keep existing');
+  await expect
+    .element(passphrase)
+    .toHaveAttribute('placeholder', 'Leave blank to reuse if verified');
   await page.getByRole('textbox', { name: 'Private key', exact: true }).fill('/keys/new');
   await expect.element(passphrase).toHaveAttribute('placeholder', 'Optional');
   await selectAuthentication('Password');
@@ -700,6 +702,44 @@ it('only offers passphrase retention for the saved key and requires a password w
   await page.getByRole('button', { name: 'Save', exact: true }).click();
   await expect.element(password).toHaveAttribute('aria-invalid', 'true');
   expect(store.saveConnection).not.toHaveBeenCalled();
+});
+
+it('shows a legacy passphrase re-entry request and lets the user retry without losing the draft', async () => {
+  await render({
+    id: 'legacy-key',
+    name: 'Work',
+    host: 'work.internal',
+    port: 22,
+    username: 'alice',
+    authType: 'key',
+    privateKeyPath: '/keys/work',
+  });
+  store.saveConnection.mockRejectedValueOnce(
+    new Error(
+      'Re-enter your SSH key passphrase once to verify it for this key. Your saved passphrase has not been changed.'
+    )
+  );
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect
+    .element(page.getByRole('alert'))
+    .toHaveTextContent('Re-enter your SSH key passphrase');
+  await expect
+    .element(page.getByRole('textbox', { name: 'Private key', exact: true }))
+    .toHaveValue('/keys/work');
+  await expect
+    .element(page.getByRole('textbox', { name: 'Host', exact: true }))
+    .toHaveValue('work.internal');
+  await page.getByLabelText('Passphrase (optional)', { exact: true }).fill('re-entered passphrase');
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect.poll(() => store.saveConnection.mock.calls.length).toBe(2);
+  expect(store.saveConnection).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      id: 'legacy-key',
+      privateKeyPath: '/keys/work',
+      passphrase: 're-entered passphrase',
+    })
+  );
+  await expect.element(page.getByRole('alert')).not.toBeInTheDocument();
 });
 
 it('keeps resolution failures visible and offers an explicit manual path', async () => {

--- a/apps/emdash-desktop/src/core/features/machines/browser/machine-form.browser.test.tsx
+++ b/apps/emdash-desktop/src/core/features/machines/browser/machine-form.browser.test.tsx
@@ -1,0 +1,777 @@
+import { Dialog } from '@emdash/ui/react/primitives';
+import '@emdash/ui/style.css';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { flushSync } from 'react-dom';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import type { SshConfig, SshConfigHost } from '@core/primitives/ssh/api';
+
+const store = vi.hoisted(() => ({
+  connections: [] as SshConfig[],
+  getSshConfigHosts: vi.fn<() => Promise<SshConfigHost[]>>(),
+  getSshConfigHost: vi.fn<(target: string) => Promise<SshConfigHost>>(),
+  saveConnection: vi.fn(async () => ({ id: 'saved' })),
+  testConnection: vi.fn(async () => ({ success: true })),
+}));
+
+vi.mock('@core/features/machines/contributions/app-stores', () => ({
+  getMachinesStore: () => store,
+}));
+vi.mock('@core/manifests/browser/modal-api', () => ({
+  useModalController: () => ({ complete: vi.fn(), dismiss: vi.fn() }),
+}));
+
+import { AddMachineModal } from './add-machine-modal';
+
+const resolvedHost: SshConfigHost = {
+  host: 'work-dev',
+  hostname: 'dev.internal',
+  user: 'alice',
+  port: 2222,
+  identityFile: 'C:/Users/alice/.ssh/id_rsa',
+  proxyJump: 'bastion.internal',
+};
+let container: HTMLDivElement;
+let root: Root;
+let queryClient: QueryClient;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  store.connections = [];
+  store.getSshConfigHosts.mockResolvedValue([resolvedHost]);
+  store.getSshConfigHost.mockImplementation(async (target) => ({ ...resolvedHost, host: target }));
+  container = document.createElement('div');
+  container.style.width = '440px';
+  document.body.appendChild(container);
+  root = createRoot(container);
+  queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+});
+
+afterEach(async () => {
+  flushSync(() => root.unmount());
+  queryClient.clear();
+  container.remove();
+});
+
+async function render(initialConfig?: SshConfig) {
+  flushSync(() =>
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <Dialog.Root open>
+          <Dialog.Content>
+            <AddMachineModal initialConfig={initialConfig} dismissControl="close" />
+          </Dialog.Content>
+        </Dialog.Root>
+      </QueryClientProvider>
+    )
+  );
+}
+
+async function selectAuthentication(label: string) {
+  await page.getByRole('combobox', { name: 'Authentication', exact: true }).click();
+  await page.getByRole('option', { name: label, exact: true }).click();
+}
+
+async function resolveTarget(target = 'work-dev') {
+  await page.getByRole('combobox', { name: 'Host', exact: true }).fill(target);
+  await page.getByText('Resolve', { exact: true }).click();
+  await expect.element(page.getByText('Username', { exact: true })).toBeVisible();
+}
+
+it('keeps an accessible host name without a visible label and does not open on focus', async () => {
+  await render();
+  const input = page.getByRole('combobox', { name: 'Host', exact: true });
+  await expect.element(page.getByText('Host', { exact: true })).not.toBeInTheDocument();
+  await expect.element(input).toHaveAttribute('placeholder', 'Select or enter a host');
+  input.element().focus();
+  await expect.element(input).toHaveFocus();
+  await expect.element(input).toHaveAttribute('aria-expanded', 'false');
+  const title = page.getByText('Add SSH Connection', { exact: true });
+  await title.click();
+  await expect.element(input).not.toHaveFocus();
+  await expect.element(input).toHaveAttribute('aria-expanded', 'false');
+  await input.click();
+  await expect.element(input).toHaveAttribute('aria-expanded', 'true');
+  await title.click();
+  await expect.element(input).toHaveAttribute('aria-expanded', 'false');
+});
+
+it('opens with the input, arrow button, typing, and keyboard without reopening on dismissal', async () => {
+  await render();
+  const input = page.getByRole('combobox', { name: 'Host', exact: true });
+  const trigger = page.getByRole('button', {
+    name: 'Show SSH config hosts',
+    exact: true,
+    includeHidden: true,
+  });
+  await input.click();
+  await expect.element(input).toHaveAttribute('aria-expanded', 'true');
+  await userEvent.keyboard('{Escape}');
+  await expect.element(input).toHaveAttribute('aria-expanded', 'false');
+  await userEvent.keyboard('{ArrowDown}');
+  await expect.element(input).toHaveAttribute('aria-expanded', 'true');
+  await userEvent.keyboard('{Escape}');
+  await input.fill('work');
+  await expect.element(input).toHaveAttribute('aria-expanded', 'true');
+  await page.getByRole('option', { name: /work-dev/ }).click();
+  await expect.element(input).toHaveAttribute('aria-expanded', 'false');
+  await trigger.click();
+  await expect.element(input).toHaveAttribute('aria-expanded', 'true');
+  await trigger.click();
+  await expect.element(input).toHaveAttribute('aria-expanded', 'false');
+});
+
+it('offers aliases on click, resolves only on Resolve, and saves an inherited key as absent', async () => {
+  await render();
+  await expect
+    .element(
+      page.getByText(
+        'Choose a host from your SSH config, or enter a hostname. OpenSSH will resolve its connection settings.'
+      )
+    )
+    .toBeVisible();
+  await page.getByRole('combobox', { name: 'Host', exact: true }).click();
+  await expect
+    .element(page.getByText('Hosts from SSH config', { exact: true }))
+    .not.toBeInTheDocument();
+  await expect.element(page.getByRole('separator')).not.toBeInTheDocument();
+  await page.getByRole('option', { name: /work-dev/ }).click();
+  expect(store.getSshConfigHost).not.toHaveBeenCalled();
+  await page.getByText('Resolve', { exact: true }).click();
+  await expect.element(page.getByText('Username', { exact: true })).toBeVisible();
+  await expect
+    .element(page.getByText('From SSH config: work-dev', { exact: true }))
+    .not.toBeInTheDocument();
+  await expect
+    .element(page.getByRole('textbox', { name: 'Private key', exact: true }))
+    .toBeEnabled();
+  await page.getByRole('button', { name: 'Test Connection', exact: true }).click();
+  await expect.poll(() => store.testConnection.mock.calls.length).toBe(1);
+  await page.getByRole('button', { name: 'Add host', exact: true }).click();
+  await expect.poll(() => store.saveConnection.mock.calls.length).toBe(1);
+  const expected = { sshConfigAlias: 'work-dev', privateKeyPath: undefined, host: 'dev.internal' };
+  expect(store.testConnection).toHaveBeenCalledWith(expect.objectContaining(expected));
+  expect(store.saveConnection).toHaveBeenCalledWith(expect.objectContaining(expected));
+});
+
+it('explains that an unmatched hostname can still be resolved and waits for the explicit action', async () => {
+  let completeLookup!: (value: SshConfigHost) => void;
+  store.getSshConfigHost.mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        completeLookup = resolve;
+      })
+  );
+  await render();
+  await page.getByRole('combobox', { name: 'Host', exact: true }).fill('new.example.com');
+  await expect
+    .element(page.getByText('No saved hosts match. You can still resolve this hostname.'))
+    .toBeVisible();
+  expect(store.getSshConfigHost).not.toHaveBeenCalled();
+  await page.getByText('Resolve', { exact: true }).click();
+  await expect.poll(() => store.getSshConfigHost.mock.calls.length).toBe(1);
+  expect(store.getSshConfigHost).toHaveBeenCalledWith('new.example.com');
+  await expect
+    .element(page.getByRole('button', { name: 'Resolving…', exact: true }))
+    .toBeDisabled();
+  completeLookup({ ...resolvedHost, host: 'new.example.com' });
+  await expect.element(page.getByText('Username', { exact: true })).toBeVisible();
+  await expect.element(page.getByRole('button', { name: 'Add host', exact: true })).toBeVisible();
+});
+
+it('shows resolved settings in the shared form with editable credentials and inherited connection details', async () => {
+  store.getSshConfigHost.mockResolvedValue({
+    ...resolvedHost,
+    proxyCommand: 'ssh bastion -W %h:%p',
+    forwardAgent: true,
+  });
+  await render();
+  await resolveTarget();
+  await expect
+    .element(page.getByRole('combobox', { name: 'Host', exact: true }))
+    .not.toBeInTheDocument();
+  await expect
+    .element(page.getByRole('button', { name: 'SSH config', exact: true }))
+    .toHaveAttribute('aria-pressed', 'true');
+  await expect
+    .element(page.getByRole('textbox', { name: 'Host', exact: true }))
+    .not.toBeInTheDocument();
+  await expect.element(page.getByText('dev.internal', { exact: true })).toBeVisible();
+  await expect
+    .element(page.getByRole('spinbutton', { name: 'Port', exact: true }))
+    .not.toBeInTheDocument();
+  await expect.element(page.getByText('2222', { exact: true })).toBeVisible();
+  await expect
+    .element(page.getByRole('textbox', { name: 'Username', exact: true }))
+    .not.toBeInTheDocument();
+  await expect.element(page.getByText('alice', { exact: true })).toBeVisible();
+  await expect
+    .element(page.getByRole('textbox', { name: 'Private key', exact: true }))
+    .not.toHaveAttribute('readonly');
+  await expect.element(page.getByLabelText('Passphrase (optional)', { exact: true })).toBeVisible();
+  await page.getByLabelText('Passphrase (optional)', { exact: true }).fill('test-passphrase');
+  await expect
+    .element(page.getByRole('button', { name: 'Advanced settings', exact: true }))
+    .not.toBeInTheDocument();
+  await expect
+    .element(page.getByRole('textbox', { name: 'Jump host', exact: true }))
+    .not.toBeInTheDocument();
+  await expect.element(page.getByText('bastion.internal', { exact: true })).toBeVisible();
+  await expect
+    .element(page.getByRole('textbox', { name: 'Proxy command', exact: true }))
+    .not.toBeInTheDocument();
+  await expect.element(page.getByText('ssh bastion -W %h:%p', { exact: true })).toBeVisible();
+  const copy = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue();
+  try {
+    await page.getByRole('button', { name: 'Copy jump host', exact: true }).click();
+    expect(copy).toHaveBeenCalledWith('bastion.internal');
+    const proxyValue = page.getByRole('button', { name: 'Copy proxy command', exact: true });
+    expect(getComputedStyle(proxyValue.element()).cursor).toBe('pointer');
+    expect(getComputedStyle(proxyValue.element()).userSelect).toBe('none');
+    await proxyValue.click();
+    expect(copy).toHaveBeenLastCalledWith('ssh bastion -W %h:%p');
+    await userEvent.keyboard('{Enter}');
+    expect(copy).toHaveBeenCalledTimes(3);
+    await page.getByRole('button', { name: 'Copy proxy command', exact: true }).click();
+    expect(copy).toHaveBeenCalledWith('ssh bastion -W %h:%p');
+    await expect
+      .element(page.getByText('Proxy command copied to clipboard.', { exact: true }))
+      .toBeInTheDocument();
+    copy.mockRejectedValueOnce(new Error('Clipboard unavailable'));
+    await page.getByRole('button', { name: 'Copy proxy command', exact: true }).click();
+    await expect
+      .element(page.getByText('Could not copy. Try again.', { exact: true }))
+      .toBeVisible();
+  } finally {
+    copy.mockRestore();
+  }
+  await page.getByRole('button', { name: 'Test Connection', exact: true }).click();
+  await expect.poll(() => store.testConnection.mock.calls.length).toBe(1);
+  expect(store.testConnection).toHaveBeenCalledWith(
+    expect.objectContaining({
+      sshConfigAlias: 'work-dev',
+      passphrase: 'test-passphrase',
+      proxyJump: undefined,
+    })
+  );
+  await expect
+    .element(page.getByRole('button', { name: 'Change', exact: true }))
+    .not.toBeInTheDocument();
+  await expect.element(page.getByText('From SSH config', { exact: true })).not.toBeInTheDocument();
+  await expect
+    .element(page.getByText(/These settings follow your SSH config/))
+    .not.toBeInTheDocument();
+});
+
+it('keeps manual credentials together with a visible passphrase and concise agent guidance', async () => {
+  await render();
+  await page.getByRole('button', { name: 'Manual', exact: true }).click();
+  await selectAuthentication('SSH Key');
+  await expect.element(page.getByLabelText('Passphrase (optional)', { exact: true })).toBeVisible();
+  await expect
+    .element(page.getByRole('textbox', { name: 'Host', exact: true }))
+    .not.toHaveAttribute('readonly');
+  await selectAuthentication('Agent');
+  await expect
+    .element(page.getByText('Uses keys available in your SSH agent.', { exact: true }))
+    .toBeVisible();
+  await expect
+    .element(page.getByLabelText('Passphrase (optional)', { exact: true }))
+    .not.toBeInTheDocument();
+});
+
+it('keeps independent connection drafts across tabs, sharing only the name', async () => {
+  await render();
+  await resolveTarget();
+  await page.getByRole('textbox', { name: 'Connection name', exact: true }).fill('Work');
+  await page.getByRole('textbox', { name: 'Private key', exact: true }).fill('/keys/config');
+  await page.getByLabelText('Passphrase (optional)', { exact: true }).fill('config secret');
+  await page.getByRole('button', { name: 'Manual', exact: true }).click();
+  await expect.element(page.getByRole('textbox', { name: 'Host', exact: true })).toHaveValue('');
+  await expect
+    .element(page.getByRole('textbox', { name: 'Username', exact: true }))
+    .toHaveValue('');
+  await page.getByRole('textbox', { name: 'Host', exact: true }).fill('manual.internal');
+  await page.getByRole('textbox', { name: 'Username', exact: true }).fill('bob');
+  await selectAuthentication('SSH Key');
+  await expect
+    .element(page.getByRole('textbox', { name: 'Private key', exact: true }))
+    .toHaveValue('');
+  await expect
+    .element(page.getByLabelText('Passphrase (optional)', { exact: true }))
+    .toHaveValue('');
+  await page.getByRole('textbox', { name: 'Private key', exact: true }).fill('/keys/manual');
+  await page.getByLabelText('Passphrase (optional)', { exact: true }).fill('manual secret');
+  await page.getByRole('button', { name: 'Advanced settings', exact: true }).click();
+  await page.getByRole('textbox', { name: /^Jump host/ }).fill('manual-bastion');
+  await page.getByRole('button', { name: 'SSH config', exact: true }).click();
+  await expect
+    .element(page.getByRole('textbox', { name: 'Private key', exact: true }))
+    .toHaveValue('/keys/config');
+  await page.getByRole('button', { name: 'Test Connection', exact: true }).click();
+  await expect.poll(() => store.testConnection.mock.calls.length).toBe(1);
+  expect(store.testConnection).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      name: 'Work',
+      sshConfigAlias: 'work-dev',
+      privateKeyPath: '/keys/config',
+      passphrase: 'config secret',
+    })
+  );
+  await page.getByRole('button', { name: 'Manual', exact: true }).click();
+  await expect.element(page.getByText('Connected', { exact: true })).not.toBeInTheDocument();
+  await expect
+    .element(page.getByRole('textbox', { name: 'Host', exact: true }))
+    .toHaveValue('manual.internal');
+  await page.getByRole('button', { name: 'Add host', exact: true }).click();
+  await expect.poll(() => store.saveConnection.mock.calls.length).toBe(1);
+  expect(store.saveConnection).toHaveBeenCalledWith(
+    expect.objectContaining({
+      name: 'Work',
+      host: 'manual.internal',
+      username: 'bob',
+      sshConfigAlias: undefined,
+      privateKeyPath: '/keys/manual',
+      passphrase: 'manual secret',
+      proxyJump: 'manual-bastion',
+    })
+  );
+});
+
+it('does not validate an unused key after changing authentication to Agent', async () => {
+  await render();
+  await resolveTarget();
+  await page.getByRole('textbox', { name: 'Private key', exact: true }).fill('/keys/invalid ');
+  await page.getByRole('button', { name: 'Add host', exact: true }).click();
+  await expect
+    .element(page.getByRole('textbox', { name: 'Private key', exact: true }))
+    .toHaveAttribute('aria-invalid', 'true');
+  await selectAuthentication('Agent');
+  await page.getByRole('button', { name: 'Add host', exact: true }).click();
+  await expect.poll(() => store.saveConnection.mock.calls.length).toBe(1);
+  expect(store.saveConnection).toHaveBeenCalledWith(
+    expect.objectContaining({
+      authType: 'agent',
+      privateKeyPath: undefined,
+    })
+  );
+});
+
+it('keeps a saved manual draft and its validation errors out of SSH config', async () => {
+  await render({
+    id: 'existing',
+    name: 'Saved',
+    host: 'manual.internal',
+    port: 2200,
+    username: 'bob',
+    authType: 'key',
+    privateKeyPath: '/keys/manual',
+  });
+  await page.getByRole('textbox', { name: 'Host', exact: true }).fill('invalid host');
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect
+    .element(page.getByRole('textbox', { name: 'Host', exact: true }))
+    .toHaveAttribute('aria-invalid', 'true');
+  await page.getByRole('button', { name: 'SSH config', exact: true }).click();
+  await expect.element(page.getByRole('combobox', { name: 'Host', exact: true })).toHaveValue('');
+  await resolveTarget();
+  await expect
+    .element(page.getByRole('textbox', { name: 'Private key', exact: true }))
+    .toHaveValue(resolvedHost.identityFile);
+  await page.getByRole('button', { name: 'Test Connection', exact: true }).click();
+  await expect.poll(() => store.testConnection.mock.calls.length).toBe(1);
+  await page.getByRole('button', { name: 'Manual', exact: true }).click();
+  await expect
+    .element(page.getByRole('textbox', { name: 'Host', exact: true }))
+    .toHaveValue('invalid host');
+  await page.getByRole('textbox', { name: 'Host', exact: true }).fill('manual.internal');
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect.poll(() => store.saveConnection.mock.calls.length).toBe(1);
+  expect(store.saveConnection).toHaveBeenCalledWith(
+    expect.objectContaining({
+      id: 'existing',
+      name: 'Saved',
+      host: 'manual.internal',
+      port: 2200,
+      username: 'bob',
+      privateKeyPath: '/keys/manual',
+      sshConfigAlias: undefined,
+    })
+  );
+});
+
+it('does not show a previous tab’s late connection test result', async () => {
+  let completeTest!: (value: { success: boolean }) => void;
+  const pendingTest = new Promise<{ success: boolean }>((resolve) => {
+    completeTest = resolve;
+  });
+  store.testConnection.mockImplementationOnce(() => pendingTest);
+  await render();
+  await resolveTarget();
+  await page.getByRole('button', { name: 'Test Connection', exact: true }).click();
+  await expect.poll(() => store.testConnection.mock.calls.length).toBe(1);
+  await page.getByRole('button', { name: 'Manual', exact: true }).click();
+  completeTest({ success: true });
+  await pendingTest;
+  await page.getByRole('textbox', { name: 'Host', exact: true }).fill('manual.internal');
+  await expect.element(page.getByText('Connected', { exact: true })).not.toBeInTheDocument();
+  await page.getByRole('button', { name: 'SSH config', exact: true }).click();
+  await expect.element(page.getByText('Connected', { exact: true })).not.toBeInTheDocument();
+  await expect
+    .element(page.getByRole('button', { name: 'Test Connection', exact: true }))
+    .toBeEnabled();
+});
+
+it('does not carry a key override or an automatic name into a new modal', async () => {
+  await render();
+  await resolveTarget('first.internal');
+  await page.getByRole('textbox', { name: 'Private key', exact: true }).fill('/keys/first_ed25519');
+  await page.getByRole('button', { name: 'Test Connection', exact: true }).click();
+  await expect.poll(() => store.testConnection.mock.calls.length).toBe(1);
+  flushSync(() => root.render(null));
+  await render();
+  await resolveTarget('second.internal');
+  await expect
+    .element(page.getByRole('textbox', { name: 'Private key', exact: true }))
+    .toHaveValue(resolvedHost.identityFile);
+  await page.getByRole('button', { name: 'Add host', exact: true }).click();
+  await expect.poll(() => store.saveConnection.mock.calls.length).toBe(1);
+  expect(store.saveConnection).toHaveBeenCalledWith(
+    expect.objectContaining({
+      name: 'second.internal',
+      sshConfigAlias: 'second.internal',
+      privateKeyPath: undefined,
+    })
+  );
+});
+
+it('ignores a late lookup after switching to manual entry', async () => {
+  let completeLookup!: (value: SshConfigHost) => void;
+  store.getSshConfigHost.mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        completeLookup = resolve;
+      })
+  );
+  await render();
+  await page.getByRole('combobox', { name: 'Host', exact: true }).fill('slow.internal');
+  await page.getByText('Resolve', { exact: true }).click();
+  await expect.poll(() => store.getSshConfigHost.mock.calls.length).toBe(1);
+  await page.getByRole('button', { name: 'Manual', exact: true }).click();
+  completeLookup({ ...resolvedHost, host: 'slow.internal' });
+  await expect.element(page.getByRole('textbox', { name: 'Host', exact: true })).toHaveValue('');
+  await page.getByRole('textbox', { name: 'Host', exact: true }).fill('manual.internal');
+  await page.getByRole('textbox', { name: 'Username', exact: true }).fill('manual-user');
+  await selectAuthentication('Agent');
+  await page.getByRole('button', { name: 'Add host', exact: true }).click();
+  await expect.poll(() => store.saveConnection.mock.calls.length).toBe(1);
+  expect(store.saveConnection).toHaveBeenCalledWith(
+    expect.objectContaining({
+      host: 'manual.internal',
+      username: 'manual-user',
+      port: 22,
+      sshConfigAlias: undefined,
+    })
+  );
+  await page.getByRole('button', { name: 'SSH config', exact: true }).click();
+  await expect.element(page.getByText('dev.internal', { exact: true })).toBeVisible();
+  await expect
+    .element(page.getByRole('textbox', { name: 'Private key', exact: true }))
+    .toHaveValue(resolvedHost.identityFile);
+});
+
+it('rejects unsafe targets before resolution and can retry a failed lookup', async () => {
+  await render();
+  await page.getByRole('combobox', { name: 'Host', exact: true }).fill('-oProxyCommand=bad');
+  await page.getByText('Resolve', { exact: true }).click();
+  await expect
+    .element(page.getByRole('alert'))
+    .toHaveTextContent('Enter a valid SSH config alias or hostname');
+  expect(store.getSshConfigHost).not.toHaveBeenCalled();
+  store.getSshConfigHost.mockRejectedValueOnce(new Error('Configuration unavailable'));
+  await page.getByRole('combobox', { name: 'Host', exact: true }).fill('retry.internal');
+  await page.getByText('Resolve', { exact: true }).click();
+  await expect.element(page.getByRole('alert')).toHaveTextContent('Configuration unavailable');
+  await page.getByRole('button', { name: 'Retry', exact: true }).click();
+  await expect.element(page.getByText('Username', { exact: true })).toBeVisible();
+});
+
+it('keeps authentication choices when SSH configuration refreshes', async () => {
+  await render();
+  await resolveTarget('auth.internal');
+  await selectAuthentication('Agent');
+  await queryClient.invalidateQueries({ queryKey: ['ssh-config-host', 'auth.internal'] });
+  await expect
+    .element(page.getByRole('combobox', { name: 'Authentication', exact: true }))
+    .toHaveTextContent('Agent');
+});
+
+it('refreshes the resolved preview and submitted settings without changing either draft', async () => {
+  await render();
+  await page.getByRole('button', { name: 'Manual', exact: true }).click();
+  await page.getByRole('textbox', { name: 'Host', exact: true }).fill('manual.internal');
+  await page.getByRole('textbox', { name: 'Username', exact: true }).fill('manual-user');
+  await page.getByRole('spinbutton', { name: 'Port', exact: true }).fill('2200');
+  await page.getByLabelText('Password', { exact: true }).fill('manual password');
+  await page.getByRole('button', { name: 'Advanced settings', exact: true }).click();
+  await page.getByRole('switch', { name: /^Forward SSH agent/ }).click();
+  await page.getByRole('button', { name: 'SSH config', exact: true }).click();
+  await resolveTarget();
+  await page.getByRole('textbox', { name: 'Private key', exact: true }).fill('/keys/custom');
+  await page.getByLabelText('Passphrase (optional)', { exact: true }).fill('config passphrase');
+  store.getSshConfigHost.mockResolvedValue({
+    ...resolvedHost,
+    hostname: 'updated.internal',
+    user: 'updated-user',
+    port: 2223,
+  });
+  await queryClient.invalidateQueries({ queryKey: ['ssh-config-host', 'work-dev'] });
+  await expect.element(page.getByText('updated.internal', { exact: true })).toBeVisible();
+  await expect.element(page.getByText('updated-user', { exact: true })).toBeVisible();
+  await expect.element(page.getByText('2223', { exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Test Connection', exact: true }).click();
+  await expect.poll(() => store.testConnection.mock.calls.length).toBe(1);
+  await page.getByRole('button', { name: 'Add host', exact: true }).click();
+  await expect.poll(() => store.saveConnection.mock.calls.length).toBe(1);
+  const expected = {
+    host: 'updated.internal',
+    username: 'updated-user',
+    port: 2223,
+    privateKeyPath: '/keys/custom',
+    passphrase: 'config passphrase',
+    sshConfigAlias: 'work-dev',
+  };
+  expect(store.testConnection).toHaveBeenCalledWith(expect.objectContaining(expected));
+  expect(store.saveConnection).toHaveBeenCalledWith(expect.objectContaining(expected));
+  await page.getByRole('button', { name: 'Manual', exact: true }).click();
+  await expect
+    .element(page.getByLabelText('Password', { exact: true }))
+    .toHaveValue('manual password');
+  await page.getByRole('button', { name: 'Add host', exact: true }).click();
+  await expect.poll(() => store.saveConnection.mock.calls.length).toBe(2);
+  expect(store.saveConnection).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      host: 'manual.internal',
+      username: 'manual-user',
+      port: 2200,
+      authType: 'password',
+      password: 'manual password',
+      forwardAgent: true,
+      sshConfigAlias: undefined,
+    })
+  );
+});
+
+it('keeps a successful Test separate from a failed Save and allows retry', async () => {
+  store.saveConnection.mockRejectedValueOnce(new Error('Storage unavailable'));
+  await render();
+  await resolveTarget();
+  await page.getByRole('button', { name: 'Test Connection', exact: true }).click();
+  await expect.element(page.getByText('Connected', { exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Add host', exact: true }).click();
+  await expect
+    .element(page.getByRole('alert'))
+    .toHaveTextContent('Could not save connection: Storage unavailable');
+  await expect.element(page.getByText('Connected', { exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Add host', exact: true }).click();
+  await expect.poll(() => store.saveConnection.mock.calls.length).toBe(2);
+  await expect.element(page.getByRole('alert')).not.toBeInTheDocument();
+  expect(store.testConnection).toHaveBeenCalledTimes(1);
+});
+
+it('shows a duplicate error beside the name when the host fallback already exists', async () => {
+  store.connections = [
+    {
+      id: 'other',
+      name: 'duplicate.internal',
+      host: 'other',
+      port: 22,
+      username: 'alice',
+      authType: 'agent',
+    },
+  ];
+  await render();
+  await resolveTarget('duplicate.internal');
+  await expect.element(page.getByRole('button', { name: 'Add host', exact: true })).toBeDisabled();
+  await expect
+    .element(page.getByRole('alert'))
+    .toHaveTextContent('An SSH connection with this name already exists');
+  expect(store.saveConnection).not.toHaveBeenCalled();
+  await page
+    .getByRole('textbox', { name: 'Connection name', exact: true })
+    .fill('Another connection');
+  await page.getByRole('button', { name: 'Add host', exact: true }).click();
+  await expect.poll(() => store.saveConnection.mock.calls.length).toBe(1);
+});
+
+it('resolves a typed target without suggestions and preserves overrides through refetch, Test, and Save', async () => {
+  store.getSshConfigHosts.mockResolvedValue([]);
+  await render();
+  await resolveTarget('build.internal');
+  const key = page.getByRole('textbox', { name: 'Private key', exact: true });
+  await key.fill('C:/Users/alice/.ssh/id_ed25519');
+  await queryClient.invalidateQueries({ queryKey: ['ssh-config-host', 'build.internal'] });
+  await expect.element(key).toHaveValue('C:/Users/alice/.ssh/id_ed25519');
+  await page.getByRole('button', { name: 'Test Connection', exact: true }).click();
+  await expect.poll(() => store.testConnection.mock.calls.length).toBe(1);
+  await page.getByRole('button', { name: 'Add host', exact: true }).click();
+  await expect.poll(() => store.saveConnection.mock.calls.length).toBe(1);
+  const expected = {
+    sshConfigAlias: 'build.internal',
+    privateKeyPath: 'C:/Users/alice/.ssh/id_ed25519',
+  };
+  expect(store.testConnection).toHaveBeenCalledWith(expect.objectContaining(expected));
+  expect(store.saveConnection).toHaveBeenCalledWith(expect.objectContaining(expected));
+});
+
+it('retains a saved override on edit and can reset it to SSH config', async () => {
+  await render({
+    id: 'existing',
+    name: 'Work',
+    host: 'dev.internal',
+    port: 22,
+    username: 'alice',
+    authType: 'key',
+    sshConfigAlias: 'work-dev',
+    privateKeyPath: 'C:/Users/alice/.ssh/id_ed25519',
+  });
+  await expect.element(page.getByText('Username', { exact: true })).toBeVisible();
+  await expect
+    .element(page.getByRole('textbox', { name: 'Private key', exact: true }))
+    .toHaveValue('C:/Users/alice/.ssh/id_ed25519');
+  await page.getByRole('button', { name: 'Reset to SSH config' }).click();
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect.poll(() => store.saveConnection.mock.calls.length).toBe(1);
+  expect(store.saveConnection).toHaveBeenCalledWith(
+    expect.objectContaining({ privateKeyPath: undefined })
+  );
+});
+
+it('tests edits with the saved ID and only offers password retention for the same destination', async () => {
+  await render({
+    id: 'saved-password',
+    name: 'Work',
+    host: 'work.internal',
+    port: 22,
+    username: 'alice',
+    authType: 'password',
+  });
+  const password = page.getByLabelText('Password', { exact: true });
+  await expect.element(password).toHaveValue('');
+  await expect.element(password).toHaveAttribute('placeholder', 'Leave blank to keep existing');
+  await page.getByRole('button', { name: 'Test Connection', exact: true }).click();
+  await expect.poll(() => store.testConnection.mock.calls.length).toBe(1);
+  expect(store.testConnection).toHaveBeenLastCalledWith(
+    expect.objectContaining({ id: 'saved-password', host: 'work.internal', password: '' })
+  );
+  await page.getByRole('textbox', { name: 'Host', exact: true }).fill('another.internal');
+  await expect.element(password).not.toHaveAttribute('placeholder', 'Leave blank to keep existing');
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect.element(password).toHaveAttribute('aria-invalid', 'true');
+  expect(store.saveConnection).not.toHaveBeenCalled();
+  await password.fill('new secret');
+  await page.getByRole('button', { name: 'Test Connection', exact: true }).click();
+  await expect.poll(() => store.testConnection.mock.calls.length).toBe(2);
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect.poll(() => store.saveConnection.mock.calls.length).toBe(1);
+  const expected = { id: 'saved-password', host: 'another.internal', password: 'new secret' };
+  expect(store.testConnection).toHaveBeenLastCalledWith(expect.objectContaining(expected));
+  expect(store.saveConnection).toHaveBeenLastCalledWith(expect.objectContaining(expected));
+});
+
+it('only offers passphrase retention for the saved key and requires a password when switching auth', async () => {
+  await render({
+    id: 'saved-key',
+    name: 'Work',
+    host: 'work.internal',
+    port: 22,
+    username: 'alice',
+    authType: 'key',
+    privateKeyPath: '/keys/old',
+  });
+  const passphrase = page.getByLabelText('Passphrase (optional)', { exact: true });
+  await expect.element(passphrase).toHaveAttribute('placeholder', 'Leave blank to keep existing');
+  await page.getByRole('textbox', { name: 'Private key', exact: true }).fill('/keys/new');
+  await expect.element(passphrase).toHaveAttribute('placeholder', 'Optional');
+  await selectAuthentication('Password');
+  const password = page.getByLabelText('Password', { exact: true });
+  await expect.element(password).not.toHaveAttribute('placeholder', 'Leave blank to keep existing');
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect.element(password).toHaveAttribute('aria-invalid', 'true');
+  expect(store.saveConnection).not.toHaveBeenCalled();
+});
+
+it('keeps resolution failures visible and offers an explicit manual path', async () => {
+  store.getSshConfigHost.mockRejectedValue(new Error('Could not read SSH configuration'));
+  await render();
+  await page.getByRole('combobox', { name: 'Host', exact: true }).fill('example.test');
+  await page.getByText('Resolve', { exact: true }).click();
+  await expect
+    .element(page.getByRole('alert'))
+    .toHaveTextContent('Could not read SSH configuration');
+  expect(store.testConnection).not.toHaveBeenCalled();
+  expect(store.saveConnection).not.toHaveBeenCalled();
+  await page.getByRole('button', { name: 'Manual', exact: true }).click();
+  await expect.element(page.getByRole('textbox', { name: 'Host', exact: true })).toHaveValue('');
+  await page.getByRole('textbox', { name: 'Host', exact: true }).fill('example.test');
+  await page.getByRole('textbox', { name: 'Username', exact: true }).fill('alice');
+  await selectAuthentication('Agent');
+  await page.getByRole('button', { name: 'Add host', exact: true }).click();
+  await expect.poll(() => store.saveConnection.mock.calls.length).toBe(1);
+  expect(store.saveConnection).toHaveBeenCalledWith(
+    expect.objectContaining({
+      host: 'example.test',
+      sshConfigAlias: undefined,
+      authType: 'agent',
+    })
+  );
+});
+
+it.each(['config', 'manual'] as const)(
+  'uses an optional name in %s mode and returns to the host when cleared',
+  async (mode) => {
+    await render();
+    await expect
+      .element(page.getByRole('button', { name: 'SSH config', exact: true }))
+      .toHaveAttribute('aria-pressed', 'true');
+    const name = page.getByRole('textbox', { name: 'Connection name', exact: true });
+    await name.fill('My workstation');
+    if (mode === 'manual') {
+      await page.getByRole('button', { name: 'Manual', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Host', exact: true }).fill('manual.internal');
+      await page.getByRole('textbox', { name: 'Username', exact: true }).fill('alice');
+      await selectAuthentication('Agent');
+    } else {
+      await resolveTarget('config.internal');
+    }
+    await expect.element(name).toHaveValue('My workstation');
+    await page.getByRole('button', { name: 'Test Connection', exact: true }).click();
+    await expect.poll(() => store.testConnection.mock.calls.length).toBe(1);
+    expect(store.testConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'My workstation' })
+    );
+    await name.fill('');
+    await page.getByRole('button', { name: 'Add host', exact: true }).click();
+    await expect.poll(() => store.saveConnection.mock.calls.length).toBe(1);
+    expect(store.saveConnection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: mode === 'manual' ? 'manual.internal' : 'config.internal',
+      })
+    );
+    await expect.element(name).toHaveValue('');
+  }
+);
+
+it('shows manual routing under Advanced settings and keeps the name across source switches', async () => {
+  await render();
+  const name = page.getByRole('textbox', { name: 'Connection name', exact: true });
+  await name.fill('My server');
+  await page.getByRole('button', { name: 'Manual', exact: true }).click();
+  await page.getByRole('button', { name: 'Advanced settings', exact: true }).click();
+  await expect.element(page.getByRole('textbox', { name: /^Jump host/ })).toBeVisible();
+  await expect.element(name).toHaveValue('My server');
+  await page.getByRole('button', { name: 'SSH config', exact: true }).click();
+  await expect.element(name).toHaveValue('My server');
+  await expect.element(page.getByRole('combobox', { name: 'Host', exact: true })).toBeVisible();
+});

--- a/apps/emdash-desktop/src/core/features/machines/browser/machine-form.tsx
+++ b/apps/emdash-desktop/src/core/features/machines/browser/machine-form.tsx
@@ -1,365 +1,12 @@
-import { ComboboxPopover } from '@emdash/ui/react/components';
-import { FormFieldShell, useAppForm, useFieldContext } from '@emdash/ui/react/form';
-import { Button, Collapsible, Tooltip } from '@emdash/ui/react/primitives';
-import {
-  CheckCircle2,
-  ChevronDown,
-  ChevronUp,
-  InfoIcon,
-  LoaderCircle,
-  XCircle,
-} from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
-import { getMachinesStore } from '@core/features/machines/contributions/app-stores';
-import type { ConnectionTestResult, SshConfig, SshConfigHost } from '@core/primitives/ssh/api';
-import { suggestedAuthTypeForSshConfigHost, type MachineAuthType } from './machine-form-model';
-import { machineFormSchema } from './machine-form-schema';
-import { useSshConfigHost, useSshConfigHosts } from './use-ssh-config-hosts';
-
-type TestState = 'idle' | 'testing' | 'success' | 'error';
-
-const MANUAL_CONNECTION_VALUE = '__manual__';
-const EMPTY_SSH_CONFIG_HOSTS: SshConfigHost[] = [];
-const DUPLICATE_CONNECTION_NAME_ERROR =
-  'An SSH connection with this name already exists. Choose a different name.';
-
-function formatMachineError(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error);
-  const withoutIpcPrefix = message.replace(/^Error invoking remote method 'ssh\.[^']+':\s*/, '');
-
-  if (/UNIQUE constraint failed: ssh_connections\.name/.test(withoutIpcPrefix)) {
-    return DUPLICATE_CONNECTION_NAME_ERROR;
-  }
-
-  return withoutIpcPrefix;
-}
-
-function FieldInfoTooltip({ label, children }: { label: string; children: ReactNode }) {
-  return (
-    <Tooltip.Root>
-      <Tooltip.Trigger
-        render={
-          <button
-            type="button"
-            className="focus-visible:ring-primary/30 relative inline-flex size-4 shrink-0 items-center justify-center rounded-full text-foreground-passive transition-colors before:absolute before:-inset-2.5 before:content-[''] hover:text-foreground focus-visible:ring-2 focus-visible:outline-none"
-            aria-label={`About ${label}`}
-          >
-            <InfoIcon className="size-3.5" aria-hidden="true" />
-          </button>
-        }
-      />
-      <Tooltip.Content
-        side="top"
-        align="start"
-        className="max-w-[240px] items-start text-left leading-relaxed whitespace-normal"
-      >
-        {children}
-      </Tooltip.Content>
-    </Tooltip.Root>
-  );
-}
-
-function FieldLabelWithInfo({ label, info }: { label: string; info: ReactNode }) {
-  return (
-    <span className="flex w-fit items-center gap-1.5">
-      {label}
-      <FieldInfoTooltip label={label}>{info}</FieldInfoTooltip>
-    </span>
-  );
-}
-
-function SshConfigAliasField({
-  hosts,
-  hostsByAlias,
-  loadError,
-  onSelectHost,
-  onSelectManual,
-}: {
-  hosts: SshConfigHost[];
-  hostsByAlias: Map<string, SshConfigHost>;
-  loadError: string | null;
-  onSelectHost: (host: SshConfigHost) => void;
-  onSelectManual: () => void;
-}) {
-  const field = useFieldContext<string>();
-  const selectedHost = hostsByAlias.get(field.state.value);
-  const options = [
-    { value: MANUAL_CONNECTION_VALUE, label: 'Manual connection' },
-    ...hosts.map((host) => ({ value: host.host, label: host.host })),
-  ];
-
-  return (
-    <FormFieldShell
-      label={
-        <FieldLabelWithInfo
-          label="SSH Config"
-          info="Select an entry from ~/.ssh/config to prefill host, user, key, proxy, and agent forwarding settings."
-        />
-      }
-      description={loadError}
-    >
-      {({ id }) =>
-        hosts.length > 0 ? (
-          <ComboboxPopover
-            items={options}
-            value={field.state.value || MANUAL_CONNECTION_VALUE}
-            onValueChange={(value) => {
-              if (value === MANUAL_CONNECTION_VALUE) {
-                onSelectManual();
-                field.handleChange('');
-                return;
-              }
-
-              const host = hostsByAlias.get(value);
-              if (host) onSelectHost(host);
-            }}
-            itemToKey={(item) => item.value}
-            itemToLabel={(item) => item.label}
-            filter={(item, query) => item.label.toLowerCase().includes(query.toLowerCase())}
-            appearance="input"
-            className="w-full"
-            contentWidth="trigger"
-            searchPlaceholder="Search SSH config..."
-            renderTrigger={() => (
-              <span className="flex min-w-0 flex-1 items-center gap-1.5 text-left">
-                {selectedHost ? (
-                  <span className="truncate">{selectedHost.host}</span>
-                ) : field.state.value ? (
-                  <span className="truncate">{field.state.value}</span>
-                ) : (
-                  'Manual connection'
-                )}
-              </span>
-            )}
-            renderItem={(item) => <span className="truncate">{item.label}</span>}
-            triggerId={id}
-          />
-        ) : (
-          <input id={id} name={field.name} value={field.state.value} type="hidden" readOnly />
-        )
-      }
-    </FormFieldShell>
-  );
-}
-
-export interface UseMachineFormOptions {
-  initialConfig?: SshConfig;
-  onSaved: (connectionId: string) => void;
-}
-
-export function useMachineForm({ initialConfig, onSaved }: UseMachineFormOptions) {
-  const machines = getMachinesStore();
-  const isEditing = !!initialConfig;
-  const [testState, setTestState] = useState<TestState>('idle');
-  const [testResult, setTestResult] = useState<ConnectionTestResult | null>(null);
-  const [showDebugLogs, setShowDebugLogs] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [isAdvancedOpen, setIsAdvancedOpen] = useState(
-    !!initialConfig?.proxyJump || initialConfig?.forwardAgent === true
-  );
-  const [selectedSshConfigAlias, setSelectedSshConfigAlias] = useState(
-    initialConfig?.sshConfigAlias ?? ''
-  );
-
-  const findDuplicateMachine = useCallback(
-    (name: string) =>
-      machines.connections.find(
-        (connection) =>
-          connection.name === name && (!initialConfig || connection.id !== initialConfig.id)
-      ),
-    [initialConfig, machines]
-  );
-
-  const form = useAppForm({
-    defaultValues: {
-      name: initialConfig?.name ?? '',
-      host: initialConfig?.host ?? '',
-      port: initialConfig?.port ?? 22,
-      username: initialConfig?.username ?? '',
-      authType: (initialConfig?.authType ?? 'password') as MachineAuthType,
-      password: '',
-      privateKeyPath: initialConfig?.privateKeyPath ?? '',
-      passphrase: '',
-      sshConfigAlias: initialConfig?.sshConfigAlias ?? '',
-      forwardAgent: initialConfig?.forwardAgent ?? false,
-      proxyJump: initialConfig?.proxyJump ?? '',
-      proxyCommand: '',
-      isEditing,
-    },
-    validators: {
-      onSubmit: machineFormSchema,
-    },
-    onSubmit: async ({ value }) => {
-      setIsSubmitting(true);
-      try {
-        if (findDuplicateMachine(value.name)) {
-          setTestState('idle');
-          setTestResult(null);
-          return;
-        }
-
-        const isAliasBacked = value.sshConfigAlias.trim().length > 0;
-        const proxyJump = value.proxyJump.trim();
-        const username = value.username || value.sshConfigAlias || value.host;
-        const privateKeyPath = value.privateKeyPath.trim();
-        const config: Partial<Pick<SshConfig, 'id'>> &
-          Omit<SshConfig, 'id'> & { password?: string; passphrase?: string } = {
-          id: initialConfig?.id,
-          name: value.name,
-          host: value.host,
-          port: value.port,
-          username,
-          sshConfigAlias: value.sshConfigAlias || undefined,
-          authType: value.authType,
-          privateKeyPath:
-            value.authType === 'key' && !isAliasBacked ? privateKeyPath || undefined : undefined,
-          useAgent: value.authType === 'agent',
-          forwardAgent: isAliasBacked ? undefined : value.forwardAgent,
-          proxyJump: isAliasBacked ? undefined : proxyJump,
-          password: value.authType === 'password' ? value.password : undefined,
-          passphrase: value.authType === 'key' ? value.passphrase : undefined,
-        };
-        const saved = await machines.saveConnection(config);
-        onSaved(saved.id);
-      } catch (error) {
-        setTestState('error');
-        setTestResult({ success: false, error: formatMachineError(error) });
-      } finally {
-        setIsSubmitting(false);
-      }
-    },
-  });
-
-  const buildTestConfig = (): SshConfig & { password?: string; passphrase?: string } => {
-    const value = form.state.values;
-    const username = value.username || value.sshConfigAlias || value.host;
-    const privateKeyPath = value.privateKeyPath.trim();
-    return {
-      id: '',
-      name: value.name,
-      host: value.host,
-      port: value.port,
-      username,
-      sshConfigAlias: value.sshConfigAlias || undefined,
-      authType: value.authType,
-      privateKeyPath:
-        value.authType === 'key' && !value.sshConfigAlias ? privateKeyPath || undefined : undefined,
-      useAgent: value.authType === 'agent',
-      forwardAgent: value.sshConfigAlias ? undefined : value.forwardAgent,
-      proxyJump: value.sshConfigAlias ? undefined : value.proxyJump.trim() || undefined,
-      password: value.authType === 'password' ? value.password : undefined,
-      passphrase: value.authType === 'key' ? value.passphrase : undefined,
-    };
-  };
-
-  const validateConnectionForm = async (): Promise<boolean> => {
-    await form.validateAllFields('submit');
-    await form.validate('submit');
-    return form.state.isValid;
-  };
-
-  const sshConfigHostsQuery = useSshConfigHosts();
-  const resolvedSshConfigHostQuery = useSshConfigHost(selectedSshConfigAlias);
-  const sshConfigHosts = sshConfigHostsQuery.data ?? EMPTY_SSH_CONFIG_HOSTS;
-  const sshConfigLoadError = sshConfigHostsQuery.error
-    ? sshConfigHostsQuery.error instanceof Error
-      ? sshConfigHostsQuery.error.message
-      : String(sshConfigHostsQuery.error)
-    : null;
-  const sshConfigHostsByAlias = useMemo(
-    () => new Map(sshConfigHosts.map((host) => [host.host, host])),
-    [sshConfigHosts]
-  );
-  const selectedSshConfigHost =
-    resolvedSshConfigHostQuery.data ?? sshConfigHostsByAlias.get(selectedSshConfigAlias);
-
-  const applySshConfigHostFields = useCallback(
-    (host: SshConfigHost) => {
-      form.setFieldValue('host', host.hostname || host.host);
-      form.setFieldValue('port', host.port ?? 22);
-      form.setFieldValue('username', host.user ?? form.state.values.username);
-      form.setFieldValue('authType', suggestedAuthTypeForSshConfigHost(host));
-      form.setFieldValue('privateKeyPath', host.identityFile ?? form.state.values.privateKeyPath);
-      form.setFieldValue('forwardAgent', host.forwardAgent ?? false);
-      form.setFieldValue('proxyJump', host.proxyJump ?? '');
-      form.setFieldValue('proxyCommand', host.proxyCommand ?? '');
-    },
-    [form]
-  );
-
-  useEffect(() => {
-    if (!selectedSshConfigAlias || !selectedSshConfigHost) return;
-    if (form.state.values.sshConfigAlias !== selectedSshConfigAlias) return;
-    applySshConfigHostFields(selectedSshConfigHost);
-  }, [applySshConfigHostFields, form, selectedSshConfigAlias, selectedSshConfigHost]);
-
-  const applySshConfigHost = (host: SshConfigHost) => {
-    setSelectedSshConfigAlias(host.host);
-    form.setFieldValue('sshConfigAlias', host.host);
-    form.setFieldValue('name', form.state.values.name || host.host);
-    applySshConfigHostFields(host);
-    setIsAdvancedOpen(true);
-  };
-
-  const selectManualConnection = () => {
-    setSelectedSshConfigAlias('');
-    form.setFieldValue('sshConfigAlias', '');
-    form.setFieldValue('name', '');
-    form.setFieldValue('host', '');
-    form.setFieldValue('port', 22);
-    form.setFieldValue('username', '');
-    form.setFieldValue('authType', 'password');
-    form.setFieldValue('privateKeyPath', '');
-    form.setFieldValue('passphrase', '');
-    form.setFieldValue('forwardAgent', false);
-    form.setFieldValue('proxyJump', '');
-    form.setFieldValue('proxyCommand', '');
-    setIsAdvancedOpen(false);
-  };
-
-  const handleTestConnection = async () => {
-    setTestResult(null);
-    setShowDebugLogs(false);
-    const isValid = await validateConnectionForm();
-    if (!isValid) {
-      setTestState('idle');
-      return;
-    }
-
-    setTestState('testing');
-    try {
-      const result = await machines.testConnection(buildTestConfig());
-      setTestResult(result);
-      setTestState(result.success ? 'success' : 'error');
-    } catch (error) {
-      setTestState('error');
-      setTestResult({ success: false, error: formatMachineError(error) });
-    }
-  };
-
-  return {
-    form,
-    isEditing,
-    isSubmitting,
-    isAdvancedOpen,
-    setIsAdvancedOpen,
-    testState,
-    testResult,
-    showDebugLogs,
-    setShowDebugLogs,
-    sshConfigHosts,
-    sshConfigHostsByAlias,
-    sshConfigLoadError,
-    shouldShowSshConfigField:
-      sshConfigHosts.length > 0 || !!selectedSshConfigAlias || !!sshConfigLoadError,
-    findDuplicateMachine,
-    applySshConfigHost,
-    selectManualConnection,
-    handleTestConnection,
-  };
-}
-
-export type MachineFormController = ReturnType<typeof useMachineForm>;
+import { FormFieldShell } from '@emdash/ui/react/form';
+import { Input, ToggleGroup, Tooltip } from '@emdash/ui/react/primitives';
+import { LoaderCircle } from 'lucide-react';
+import { MachineAuthenticationFields } from './machine-authentication-fields';
+import { MachineConnectionDetails } from './machine-connection-details';
+import { MachineFormFeedback } from './machine-form-actions';
+import { MachineHostPicker } from './machine-host-picker';
+import { MachineManualFields, MachineManualRouting } from './machine-manual-fields';
+import type { MachineFormController } from './use-machine-form';
 
 export function MachineFormFields({
   controller,
@@ -370,364 +17,124 @@ export function MachineFormFields({
 }) {
   const {
     form,
-    isEditing,
-    isAdvancedOpen,
-    setIsAdvancedOpen,
-    testState,
-    testResult,
-    showDebugLogs,
-    setShowDebugLogs,
-    sshConfigHosts,
-    sshConfigHostsByAlias,
-    sshConfigLoadError,
-    shouldShowSshConfigField,
-    findDuplicateMachine,
-    applySshConfigHost,
-    selectManualConnection,
+    mode,
+    selectMode,
+    name,
+    config,
+    details,
+    authentication,
+    actions,
+    feedback,
+    isSaving,
   } = controller;
-
+  const showConnection = mode === 'manual' || !!details;
   return (
     <Tooltip.Provider delay={150}>
       <form
         id={formId}
         onSubmit={(event) => {
           event.preventDefault();
-          void form.handleSubmit();
+          actions.submit();
         }}
       >
-        <div className="grid gap-3">
-          <form.AppField name="name">
-            {(field) => {
-              const isDuplicate = !!findDuplicateMachine(field.state.value);
-              return (
-                <>
-                  <field.TextField
-                    label="Connection Name"
-                    placeholder="My Server"
-                    aria-invalid={isDuplicate || undefined}
-                  />
-                  {isDuplicate && (
-                    <p role="alert" className="text-sm text-foreground-destructive">
-                      {DUPLICATE_CONNECTION_NAME_ERROR}
-                    </p>
-                  )}
-                </>
-              );
-            }}
-          </form.AppField>
-
-          {shouldShowSshConfigField && (
-            <form.AppField name="sshConfigAlias">
-              {() => (
-                <SshConfigAliasField
-                  hosts={sshConfigHosts}
-                  hostsByAlias={sshConfigHostsByAlias}
-                  loadError={sshConfigLoadError}
-                  onSelectHost={applySshConfigHost}
-                  onSelectManual={selectManualConnection}
-                />
-              )}
-            </form.AppField>
-          )}
-
-          <form.Subscribe selector={(state) => state.values.sshConfigAlias}>
-            {(sshConfigAlias) => {
-              const isAliasBacked = !!sshConfigAlias;
-              return (
-                <>
-                  <div className="grid grid-cols-[1fr_6rem] gap-3">
-                    <form.AppField name="host">
-                      {(field) => (
-                        <field.TextField
-                          label="Host"
-                          placeholder="203.0.113.10"
-                          disabled={isAliasBacked}
-                        />
-                      )}
-                    </form.AppField>
-                    <form.AppField name="port">
-                      {(field) => <field.NumberField label="Port" disabled={isAliasBacked} />}
-                    </form.AppField>
-                  </div>
-
-                  <form.AppField name="username">
-                    {(field) => (
-                      <field.TextField
-                        label="Username"
-                        placeholder="ubuntu"
-                        autoComplete="off"
-                        disabled={isAliasBacked}
+        <fieldset disabled={isSaving} className="m-0 grid min-w-0 gap-4 border-0 p-0">
+          <div className="grid gap-1">
+            <div className="flex items-center gap-3">
+              <form.AppField name="name">
+                {(field) => (
+                  <FormFieldShell className="min-w-0 flex-1">
+                    {({ id, invalid }) => (
+                      <Input
+                        id={id}
+                        name={field.name}
+                        bare
+                        autoFocus
+                        aria-label="Connection name"
+                        title="Optional. Defaults to the host."
+                        placeholder={name.fallback || 'Connection name'}
+                        className="min-w-0 px-0 text-lg!"
+                        value={field.state.value}
+                        onChange={(event) => field.handleChange(event.target.value)}
+                        onBlur={field.handleBlur}
+                        aria-invalid={!!name.error || invalid || undefined}
+                        aria-describedby={name.error ? formId + '-name-error' : undefined}
                       />
                     )}
-                  </form.AppField>
-                </>
-              );
-            }}
-          </form.Subscribe>
-
-          <form.AppField name="authType">
-            {(field) => (
-              <field.RadioGroupField
-                label={
-                  <FieldLabelWithInfo
-                    label="Authentication"
-                    info="Choose how Emdash authenticates to the remote server. SSH config entries can preselect the best option."
-                  />
-                }
-                layout="row"
-                options={[
-                  { value: 'password', label: 'Password' },
-                  { value: 'key', label: 'SSH Key' },
-                  { value: 'agent', label: 'Agent' },
-                ]}
+                  </FormFieldShell>
+                )}
+              </form.AppField>
+              <ToggleGroup.Root
+                aria-label="Connection source"
+                className="shrink-0 bg-transparent"
+                value={[mode]}
+                onValueChange={([value]) => {
+                  if (value === 'manual' || value === 'config') selectMode(value);
+                }}
+              >
+                <ToggleGroup.Item value="config" disabled={isSaving}>
+                  SSH config
+                </ToggleGroup.Item>
+                <ToggleGroup.Item value="manual" disabled={isSaving}>
+                  Manual
+                </ToggleGroup.Item>
+              </ToggleGroup.Root>
+            </div>
+            {name.error && (
+              <p
+                id={formId + '-name-error'}
+                role="alert"
+                className="text-sm text-foreground-destructive"
+              >
+                {name.error}
+              </p>
+            )}
+          </div>
+          <div className="grid gap-4">
+            {mode === 'config' && !showConnection && (
+              <>
+                <MachineHostPicker
+                  id={formId + '-target'}
+                  target={config.target}
+                  onTargetChange={config.changeTarget}
+                  hosts={config.hosts}
+                  disabled={isSaving}
+                />
+                {config.suggestionsError && (
+                  <p className="text-sm text-foreground-muted">{config.suggestionsError}</p>
+                )}
+                {config.resolution.status === 'resolving' && (
+                  <p
+                    role="status"
+                    className="flex items-center gap-2 text-sm text-foreground-muted"
+                  >
+                    <LoaderCircle className="size-4 animate-spin" /> Resolving connection settings…
+                  </p>
+                )}
+                {config.resolution.status === 'failed' && (
+                  <p role="alert" className="text-sm text-foreground-destructive">
+                    {config.resolution.error}
+                  </p>
+                )}
+              </>
+            )}
+            {mode === 'config' && details && (
+              <MachineConnectionDetails host={details} target={config.target} />
+            )}
+            {mode === 'manual' && <MachineManualFields form={form} />}
+            {showConnection && (
+              <MachineAuthenticationFields
+                key={mode}
+                form={form}
+                mode={mode}
+                alias={mode === 'config' ? config.target : ''}
+                {...authentication}
               />
             )}
-          </form.AppField>
-
-          <form.Subscribe
-            selector={(state) => ({
-              authType: state.values.authType,
-              sshConfigAlias: state.values.sshConfigAlias,
-            })}
-          >
-            {({ authType, sshConfigAlias }) => {
-              if (authType === 'password') {
-                return (
-                  <form.AppField name="password">
-                    {(field) => (
-                      <field.TextField
-                        label="Password"
-                        type="password"
-                        autoComplete="current-password"
-                        placeholder={isEditing ? 'Leave blank to keep existing' : undefined}
-                      />
-                    )}
-                  </form.AppField>
-                );
-              }
-
-              if (authType === 'key') {
-                return (
-                  <>
-                    <form.AppField name="privateKeyPath">
-                      {(field) => (
-                        <field.TextField
-                          label={
-                            <FieldLabelWithInfo
-                              label="Private Key Path"
-                              info="Path on this machine to the private key used for the connection, for example ~/.ssh/id_ed25519."
-                            />
-                          }
-                          placeholder="~/.ssh/id_rsa"
-                          disabled={!!sshConfigAlias}
-                        />
-                      )}
-                    </form.AppField>
-                    <form.AppField name="passphrase">
-                      {(field) => (
-                        <field.TextField
-                          label={
-                            <FieldLabelWithInfo
-                              label="Passphrase"
-                              info="Only needed if the selected private key is encrypted with a passphrase."
-                            />
-                          }
-                          type="password"
-                          placeholder={isEditing ? 'Leave blank to keep existing' : 'Optional'}
-                          autoComplete="off"
-                          description={
-                            !isEditing ? 'Leave empty if your key has no passphrase.' : undefined
-                          }
-                        />
-                      )}
-                    </form.AppField>
-                  </>
-                );
-              }
-
-              return (
-                <p className="text-sm text-foreground-muted">
-                  The SSH agent running on this machine will be used for authentication. Make sure
-                  your key is loaded into the agent.
-                </p>
-              );
-            }}
-          </form.Subscribe>
-
-          <form.Subscribe
-            selector={(state) => ({
-              sshConfigAlias: state.values.sshConfigAlias,
-              proxyCommand: state.values.proxyCommand,
-            })}
-          >
-            {({ sshConfigAlias, proxyCommand }) => {
-              const isAliasBacked = !!sshConfigAlias;
-              const showProxyCommand = isAliasBacked && proxyCommand.trim().length > 0;
-
-              return (
-                <Collapsible.Root
-                  open={isAliasBacked || isAdvancedOpen}
-                  onOpenChange={isAliasBacked ? undefined : setIsAdvancedOpen}
-                >
-                  <Collapsible.Trigger type="button" disabled={isAliasBacked}>
-                    Advanced
-                  </Collapsible.Trigger>
-                  <Collapsible.Panel className="grid gap-3 pt-2">
-                    {showProxyCommand ? (
-                      <form.AppField name="proxyCommand">
-                        {(field) => (
-                          <field.TextField
-                            label={
-                              <FieldLabelWithInfo
-                                label="ProxyCommand"
-                                info="Command from your SSH config used to reach this host through a proxy. It is read-only here because it comes from ~/.ssh/config."
-                              />
-                            }
-                            disabled
-                          />
-                        )}
-                      </form.AppField>
-                    ) : (
-                      <form.AppField name="proxyJump">
-                        {(field) => (
-                          <field.TextField
-                            label={
-                              <FieldLabelWithInfo
-                                label="ProxyJump"
-                                info="Optional bastion host to connect through before reaching the target server, for example user@bastion:2222."
-                              />
-                            }
-                            placeholder="bastion or user@bastion:2222"
-                            autoComplete="off"
-                            disabled={isAliasBacked}
-                          />
-                        )}
-                      </form.AppField>
-                    )}
-
-                    <form.AppField name="forwardAgent">
-                      {(field) => (
-                        <field.SwitchField
-                          label={
-                            <FieldLabelWithInfo
-                              label="ForwardAgent"
-                              info="Forward your local SSH agent to the remote server so nested SSH and Git commands can use your loaded local keys. Enable only for trusted hosts."
-                            />
-                          }
-                          disabled={isAliasBacked}
-                          className="rounded-md border border-border px-3 py-2"
-                        />
-                      )}
-                    </form.AppField>
-                  </Collapsible.Panel>
-                </Collapsible.Root>
-              );
-            }}
-          </form.Subscribe>
-        </div>
-      </form>
-
-      {testState !== 'idle' && (
-        <div className="border-input rounded-md border px-3 py-2 text-sm">
-          <div className="flex items-center gap-2">
-            {testState === 'testing' && (
-              <LoaderCircle className="text-muted-foreground size-4 animate-spin" />
-            )}
-            {testState === 'success' && <CheckCircle2 className="size-4 text-foreground-success" />}
-            {testState === 'error' && <XCircle className="text-destructive size-4" />}
-            <span className="flex-1 font-medium">
-              {testState === 'testing' && 'Testing connection…'}
-              {testState === 'success' &&
-                `Connected${testResult?.latency ? ` (${testResult.latency}ms)` : ''}`}
-              {testState === 'error' && (testResult?.error ?? 'Connection failed')}
-            </span>
-            {testState === 'error' && testResult?.debugLogs?.length ? (
-              <button
-                type="button"
-                onClick={() => setShowDebugLogs((value) => !value)}
-                className="text-muted-foreground flex items-center gap-1 text-xs hover:text-foreground"
-              >
-                {showDebugLogs ? (
-                  <ChevronUp className="size-3" />
-                ) : (
-                  <ChevronDown className="size-3" />
-                )}
-                Logs
-              </button>
-            ) : null}
+            {mode === 'manual' && <MachineManualRouting form={form} />}
           </div>
-          {showDebugLogs && testResult?.debugLogs && (
-            <pre className="bg-muted text-muted-foreground mt-2 max-h-32 overflow-y-auto rounded px-2 py-1.5 text-xs">
-              {testResult.debugLogs.join('\n')}
-            </pre>
-          )}
-        </div>
-      )}
+        </fieldset>
+      </form>
+      <MachineFormFeedback {...feedback} />
     </Tooltip.Provider>
-  );
-}
-
-export function MachineFormActions({
-  controller,
-  formId,
-  leadingAction,
-  cancelAction,
-}: {
-  controller: MachineFormController;
-  formId: string;
-  leadingAction?: ReactNode;
-  cancelAction?: ReactNode;
-}) {
-  const { form, isSubmitting, testState, findDuplicateMachine, handleTestConnection } = controller;
-
-  return (
-    <div className="flex w-full items-center justify-between gap-3">
-      <div className="flex items-center gap-2">
-        {leadingAction}
-        <Button
-          type="button"
-          variant="secondary"
-          onClick={() => void handleTestConnection()}
-          disabled={testState === 'testing'}
-        >
-          {testState === 'testing' ? (
-            <>
-              <LoaderCircle className="size-4 animate-spin" />
-              Testing…
-            </>
-          ) : (
-            'Test Connection'
-          )}
-        </Button>
-      </div>
-
-      <div className="flex items-center gap-2">
-        {cancelAction}
-        <form.Subscribe
-          selector={(state) => ({
-            canSubmit: state.canSubmit,
-            name: state.values.name,
-          })}
-        >
-          {({ canSubmit, name }) => (
-            <form.AppForm>
-              <form.SubmitButton
-                form={formId}
-                disabled={isSubmitting || !canSubmit || !!findDuplicateMachine(name)}
-              >
-                {isSubmitting ? (
-                  <>
-                    <LoaderCircle className="size-4 animate-spin" />
-                    Saving…
-                  </>
-                ) : (
-                  'Save'
-                )}
-              </form.SubmitButton>
-            </form.AppForm>
-          )}
-        </form.Subscribe>
-      </div>
-    </div>
   );
 }

--- a/apps/emdash-desktop/src/core/features/machines/browser/machine-host-picker.tsx
+++ b/apps/emdash-desktop/src/core/features/machines/browser/machine-host-picker.tsx
@@ -1,0 +1,82 @@
+import { Combobox, Field } from '@emdash/ui/react/primitives';
+import { ChevronDown } from 'lucide-react';
+import { useState } from 'react';
+import type { SshConfigHost } from '@core/primitives/ssh/api';
+
+export function MachineHostPicker({
+  id,
+  target,
+  onTargetChange,
+  hosts,
+  disabled,
+}: {
+  id: string;
+  target: string;
+  onTargetChange: (target: string) => void;
+  hosts: SshConfigHost[];
+  disabled: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const suggestions = hosts.filter((host) =>
+    host.host.toLowerCase().includes(target.toLowerCase())
+  );
+  return (
+    <Field.Root>
+      <Combobox.Root
+        items={suggestions.map((host) => host.host)}
+        inputValue={target}
+        onInputValueChange={(value, details) => {
+          if (details.reason === 'input-change') onTargetChange(value);
+        }}
+        value={target || null}
+        onValueChange={(value) => {
+          if (value) onTargetChange(value);
+        }}
+        open={open}
+        onOpenChange={setOpen}
+        filter={null}
+        disabled={disabled}
+      >
+        <Combobox.Input
+          id={id}
+          aria-label="Host"
+          variant="default"
+          showTrigger={false}
+          rightAddon={
+            <Combobox.Trigger aria-label="Show SSH config hosts">
+              <ChevronDown className="size-4" />
+            </Combobox.Trigger>
+          }
+          placeholder="Select or enter a host"
+          autoComplete="off"
+        />
+        <Combobox.Content>
+          <Combobox.Empty className="px-3">
+            No saved hosts match. You can still resolve this hostname.
+          </Combobox.Empty>
+          <Combobox.List>
+            <Combobox.Group>
+              {suggestions.map((host) => (
+                <Combobox.Item key={host.host} value={host.host}>
+                  <span className="flex min-w-0 flex-col">
+                    <span className="truncate">{host.host}</span>
+                    {host.hostname && (
+                      <span className="truncate text-xs text-foreground-muted">
+                        {host.user ? `${host.user}@` : ''}
+                        {host.hostname}
+                      </span>
+                    )}
+                  </span>
+                </Combobox.Item>
+              ))}
+            </Combobox.Group>
+          </Combobox.List>
+        </Combobox.Content>
+      </Combobox.Root>
+      <Field.Description>
+        Choose a host from your SSH config, or enter a hostname. OpenSSH will resolve its connection
+        settings.
+      </Field.Description>
+    </Field.Root>
+  );
+}

--- a/apps/emdash-desktop/src/core/features/machines/browser/machine-manual-fields.tsx
+++ b/apps/emdash-desktop/src/core/features/machines/browser/machine-manual-fields.tsx
@@ -1,0 +1,95 @@
+import { Collapsible, Tooltip } from '@emdash/ui/react/primitives';
+import { InfoIcon } from 'lucide-react';
+import { useState, type ReactNode } from 'react';
+import type { MachineEditorForm } from './use-machine-form';
+
+function FieldInfoTooltip({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <Tooltip.Root>
+      <Tooltip.Trigger
+        render={
+          <button
+            type="button"
+            className="focus-visible:ring-primary/30 relative inline-flex size-4 shrink-0 items-center justify-center rounded-full text-foreground-passive transition-colors before:absolute before:-inset-2.5 before:content-[''] hover:text-foreground focus-visible:ring-2 focus-visible:outline-none"
+            aria-label={`About ${label}`}
+          >
+            <InfoIcon className="size-3.5" aria-hidden="true" />
+          </button>
+        }
+      />
+      <Tooltip.Content
+        side="top"
+        align="start"
+        className="max-w-[240px] items-start text-left leading-relaxed whitespace-normal"
+      >
+        {children}
+      </Tooltip.Content>
+    </Tooltip.Root>
+  );
+}
+
+function FieldLabelWithInfo({ label, info }: { label: string; info: ReactNode }) {
+  return (
+    <span className="flex w-fit items-center gap-1.5">
+      {label}
+      <FieldInfoTooltip label={label}>{info}</FieldInfoTooltip>
+    </span>
+  );
+}
+
+export function MachineManualFields({ form }: { form: MachineEditorForm }) {
+  return (
+    <>
+      <div className="grid grid-cols-[1fr_6rem] gap-3">
+        <form.AppField name="manual.host">
+          {(field) => <field.TextField label="Host" placeholder="203.0.113.10" />}
+        </form.AppField>
+        <form.AppField name="manual.port">
+          {(field) => <field.NumberField label="Port" />}
+        </form.AppField>
+      </div>
+      <form.AppField name="manual.username">
+        {(field) => <field.TextField label="Username" placeholder="ubuntu" autoComplete="off" />}
+      </form.AppField>
+    </>
+  );
+}
+
+export function MachineManualRouting({ form }: { form: MachineEditorForm }) {
+  const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
+  return (
+    <Collapsible.Root open={isAdvancedOpen} onOpenChange={setIsAdvancedOpen}>
+      <div className="w-fit">
+        <Collapsible.Trigger type="button">Advanced settings</Collapsible.Trigger>
+      </div>
+      <Collapsible.Panel className="grid gap-3 pt-2">
+        <form.AppField name="manual.proxyJump">
+          {(field) => (
+            <field.TextField
+              label={
+                <FieldLabelWithInfo
+                  label="Jump host"
+                  info="Optional bastion host to connect through, for example user@bastion:2222."
+                />
+              }
+              placeholder="bastion or user@bastion:2222"
+              autoComplete="off"
+            />
+          )}
+        </form.AppField>
+        <form.AppField name="manual.forwardAgent">
+          {(field) => (
+            <field.SwitchField
+              label={
+                <FieldLabelWithInfo
+                  label="Forward SSH agent"
+                  info="Forward your local SSH agent to the remote server. Enable only for trusted hosts."
+                />
+              }
+            />
+          )}
+        </form.AppField>
+      </Collapsible.Panel>
+    </Collapsible.Root>
+  );
+}

--- a/apps/emdash-desktop/src/core/features/machines/browser/use-machine-form.ts
+++ b/apps/emdash-desktop/src/core/features/machines/browser/use-machine-form.ts
@@ -1,0 +1,207 @@
+import { useAppForm } from '@emdash/ui/react/form';
+import { useStore } from '@tanstack/react-form';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { getMachinesStore } from '@core/features/machines/contributions/app-stores';
+import type { ConnectionTestResult, SshConfig } from '@core/primitives/ssh/api';
+import { sshCredentialReuse } from '@core/primitives/ssh/api/credential-reuse';
+import {
+  authenticationDraft,
+  DUPLICATE_CONNECTION_NAME_ERROR,
+  formatMachineError,
+  machineConnectionConfig,
+  machineDraftValues,
+  machineEditorDefaults,
+  suggestedAuthTypeForSshConfigHost,
+  validateMachineDraft,
+  type MachineConnectionSource,
+  type MachineFormMode,
+} from './machine-form-model';
+import { useSshConfigDraft } from './use-ssh-config-hosts';
+
+export type MachineTestState =
+  | { status: 'idle' }
+  | { status: 'testing' }
+  | { status: 'finished'; result: ConnectionTestResult };
+type SaveState = { status: 'idle' } | { status: 'saving' } | { status: 'failed'; error: string };
+const MANUAL_SOURCE: MachineConnectionSource = { mode: 'manual' };
+
+export function useMachineForm({
+  initialConfig,
+  onSaved,
+}: {
+  initialConfig?: SshConfig;
+  onSaved: (connectionId: string) => void;
+}) {
+  const machines = getMachinesStore();
+  const [mode, setMode] = useState<MachineFormMode>(
+    initialConfig && !initialConfig.sshConfigAlias ? 'manual' : 'config'
+  );
+  const config = useSshConfigDraft(initialConfig?.sshConfigAlias);
+  const { resolution } = config;
+  const resolvedHost =
+    resolution.status === 'resolved'
+      ? resolution.host
+      : resolution.status === 'resolving'
+        ? resolution.preview
+        : undefined;
+  const resolvedAlias = resolution.status === 'resolved' ? resolution.alias : '';
+  const configSource = useMemo<MachineConnectionSource | null>(
+    () =>
+      resolvedAlias && resolvedHost
+        ? { mode: 'config', alias: resolvedAlias, resolved: resolvedHost }
+        : null,
+    [resolvedAlias, resolvedHost]
+  );
+  const source = mode === 'manual' ? MANUAL_SOURCE : configSource;
+  const [defaults] = useState(() => machineEditorDefaults(initialConfig));
+  const form = useAppForm({
+    defaultValues: defaults,
+    validators: {
+      onSubmit: ({ value }) =>
+        source ? validateMachineDraft(value, source, initialConfig) : undefined,
+    },
+  });
+  const values = useStore(form.store, (state) => state.values);
+  const [test, setTest] = useState<MachineTestState>({ status: 'idle' });
+  const [save, setSave] = useState<SaveState>({ status: 'idle' });
+  const generation = useRef(0);
+  const operation = useRef<'test' | 'save' | null>(null);
+  const mounted = useRef(true);
+  const seededAlias = useRef(initialConfig?.sshConfigAlias ?? '');
+  const isSaving = save.status === 'saving';
+  const invalidate = useCallback(() => {
+    generation.current++;
+    if (operation.current === 'test') operation.current = null;
+    setTest({ status: 'idle' });
+    setSave((current) => (current.status === 'saving' ? current : { status: 'idle' }));
+  }, []);
+
+  useEffect(() => {
+    if (!resolvedAlias || !resolvedHost || seededAlias.current === resolvedAlias) return;
+    form.setFieldValue('config', {
+      ...authenticationDraft(),
+      authType: suggestedAuthTypeForSshConfigHost(resolvedHost),
+    });
+    seededAlias.current = resolvedAlias;
+  }, [form, resolvedAlias, resolvedHost]);
+
+  useEffect(() => {
+    invalidate();
+    let previous = form.state.values;
+    const subscription = form.store.subscribe(() => {
+      const next = form.state.values;
+      if (next.name !== previous.name || next[mode] !== previous[mode]) invalidate();
+      previous = next;
+    });
+    return () => subscription.unsubscribe();
+  }, [form, mode, source, invalidate]);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  const fallbackName = mode === 'manual' ? values.manual.host : config.target;
+  const name = values.name || fallbackName;
+  const nameError = machines.connections.some(
+    (connection) => connection.name === name && connection.id !== initialConfig?.id
+  )
+    ? DUPLICATE_CONNECTION_NAME_ERROR
+    : null;
+  const candidate = source ? machineDraftValues(values, source) : null;
+  const reuse = candidate
+    ? sshCredentialReuse(candidate, initialConfig)
+    : { password: false, passphrase: false };
+
+  const selectMode = (next: MachineFormMode) => {
+    if (isSaving || next === mode) return;
+    invalidate();
+    setMode(next);
+  };
+  const changeTarget = (target: string) => {
+    if (isSaving || target === config.target) return;
+    invalidate();
+    config.changeTarget(target);
+    seededAlias.current = '';
+    form.setFieldValue('config', authenticationDraft());
+  };
+  const resolve = () => {
+    if (!isSaving) {
+      invalidate();
+      config.resolve();
+    }
+  };
+
+  // Both operations validate and consume exactly the same draft snapshot.
+  const run = async (kind: 'test' | 'save') => {
+    if (
+      !source ||
+      operation.current === 'save' ||
+      (kind === 'test' && operation.current === 'test') ||
+      nameError
+    )
+      return;
+    generation.current++;
+    if (kind === 'test' || operation.current === 'test') setTest({ status: 'idle' });
+    setSave({ status: 'idle' });
+    operation.current = kind;
+    const currentGeneration = generation.current;
+    const snapshot = machineConnectionConfig(machineDraftValues(form.state.values, source));
+    try {
+      await form.validateAllFields('submit');
+      await form.validate('submit');
+      if (!mounted.current || currentGeneration !== generation.current || !form.state.isValid)
+        return;
+      if (kind === 'test') {
+        setTest({ status: 'testing' });
+        const result = await machines.testConnection({ ...snapshot, id: initialConfig?.id ?? '' });
+        if (mounted.current && currentGeneration === generation.current)
+          setTest({ status: 'finished', result });
+      } else {
+        setSave({ status: 'saving' });
+        const saved = await machines.saveConnection({ ...snapshot, id: initialConfig?.id });
+        if (!mounted.current) return;
+        onSaved(saved.id);
+        setSave({ status: 'idle' });
+      }
+    } catch (error) {
+      if (!mounted.current) return;
+      if (kind === 'save') setSave({ status: 'failed', error: formatMachineError(error) });
+      else if (currentGeneration === generation.current)
+        setTest({
+          status: 'finished',
+          result: { success: false, error: formatMachineError(error) },
+        });
+    } finally {
+      if (currentGeneration === generation.current || kind === 'save') operation.current = null;
+    }
+  };
+
+  return {
+    form,
+    mode,
+    selectMode,
+    isEditing: !!initialConfig,
+    isSaving,
+    name: { fallback: fallbackName, error: nameError },
+    config: { ...config, changeTarget, resolve },
+    authentication: {
+      reuse,
+      inheritedKey: mode === 'config' ? resolvedHost?.identityFile : undefined,
+    },
+    details: mode === 'config' ? resolvedHost : undefined,
+    actions: {
+      ready: !!source,
+      isSaving,
+      isTesting: test.status === 'testing',
+      disabled: isSaving || (!!source && !!nameError),
+      submit: () => (source ? void run('save') : resolve()),
+      test: () => void run('test'),
+    },
+    feedback: { test, saveError: save.status === 'failed' ? save.error : null },
+  };
+}
+
+export type MachineFormController = ReturnType<typeof useMachineForm>;
+export type MachineEditorForm = MachineFormController['form'];

--- a/apps/emdash-desktop/src/core/features/machines/browser/use-ssh-config-hosts.ts
+++ b/apps/emdash-desktop/src/core/features/machines/browser/use-ssh-config-hosts.ts
@@ -1,5 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
 import { getMachinesStore } from '@core/features/machines/contributions/app-stores';
+import type { SshConfigHost } from '@core/primitives/ssh/api';
+import { formatMachineError } from './machine-form-model';
+import { sshConfigTargetSchema } from './machine-form-schema';
 
 export function useSshConfigHosts() {
   const machines = getMachinesStore();
@@ -19,4 +23,54 @@ export function useSshConfigHost(alias: string) {
     queryFn: () => machines.getSshConfigHost(trimmedAlias),
     enabled: trimmedAlias.length > 0,
   });
+}
+
+export type SshConfigResolution =
+  | { status: 'choosing' }
+  | { status: 'resolving'; preview?: SshConfigHost }
+  | { status: 'resolved'; host: SshConfigHost; alias: string }
+  | { status: 'failed'; error: string };
+
+export function useSshConfigDraft(initialAlias = '') {
+  const [target, setTarget] = useState(initialAlias);
+  const [alias, setAlias] = useState(initialAlias);
+  const [targetError, setTargetError] = useState<string | null>(null);
+  const hosts = useSshConfigHosts();
+  const query = useSshConfigHost(alias);
+  let resolution: SshConfigResolution = { status: 'choosing' };
+  if (targetError) resolution = { status: 'failed', error: targetError };
+  else if (alias && query.isFetching) resolution = { status: 'resolving', preview: query.data };
+  else if (alias && query.error)
+    resolution = { status: 'failed', error: formatMachineError(query.error) };
+  else if (alias && query.data) resolution = { status: 'resolved', host: query.data, alias };
+
+  const changeTarget = (value: string) => {
+    if (value === target) return;
+    setTarget(value);
+    setAlias('');
+    setTargetError(null);
+  };
+  const resolve = () => {
+    if (resolution.status === 'resolving') return;
+    const value = target.trim();
+    const parsed = sshConfigTargetSchema.safeParse(value);
+    if (!parsed.success) {
+      setTargetError(parsed.error.issues[0].message);
+      return;
+    }
+    setTarget(value);
+    setTargetError(null);
+    if (alias === value) void query.refetch();
+    else setAlias(value);
+  };
+  return {
+    target,
+    changeTarget,
+    resolve,
+    resolution,
+    hosts: hosts.data ?? [],
+    suggestionsError: hosts.error
+      ? 'SSH config suggestions could not be loaded. You can still enter a hostname.'
+      : null,
+  };
 }

--- a/apps/emdash-desktop/src/core/features/machines/node/machine-persistence.ts
+++ b/apps/emdash-desktop/src/core/features/machines/node/machine-persistence.ts
@@ -1,0 +1,52 @@
+import { eq, inArray } from 'drizzle-orm';
+import type { AppDb, DrizzleTx } from '@core/services/app-db/node/db';
+import {
+  appSecrets,
+  sshConnections,
+  type SshConnectionInsert,
+} from '@core/services/app-db/node/schema';
+import { sshCredentialKeys } from '@core/services/ssh/node/credentials/credential-record';
+
+export function captureMachineSave(db: AppDb | DrizzleTx, id: string) {
+  return {
+    connection: db.select().from(sshConnections).where(eq(sshConnections.id, id)).get(),
+    credentials: db
+      .select()
+      .from(appSecrets)
+      .where(inArray(appSecrets.key, Object.values(sshCredentialKeys(id))))
+      .orderBy(appSecrets.key)
+      .all(),
+  };
+}
+
+export function persistMachine(
+  db: AppDb,
+  before: ReturnType<typeof captureMachineSave>,
+  row: SshConnectionInsert,
+  applyCredentials: (tx: DrizzleTx) => void,
+  updatedAt: string
+) {
+  db.transaction((tx) => {
+    if (JSON.stringify(captureMachineSave(tx, row.id)) !== JSON.stringify(before)) {
+      throw new Error('This connection changed while saving. Reopen it and try again.');
+    }
+    tx.insert(sshConnections)
+      .values(row)
+      .onConflictDoUpdate({
+        target: sshConnections.id,
+        set: {
+          name: row.name,
+          host: row.host,
+          port: row.port,
+          metadata: row.metadata,
+          username: row.username,
+          authType: row.authType,
+          privateKeyPath: row.privateKeyPath,
+          useAgent: row.useAgent,
+          updatedAt,
+        },
+      })
+      .run();
+    applyCredentials(tx);
+  });
+}

--- a/apps/emdash-desktop/src/core/features/machines/node/machines-service.db.test.ts
+++ b/apps/emdash-desktop/src/core/features/machines/node/machines-service.db.test.ts
@@ -67,11 +67,14 @@ describe('MachinesService', () => {
       credentials: {
         getPassword,
         getPassphrase,
-        storePassword,
-        storePassphrase,
-        deletePassword,
-        deletePassphrase,
         deleteAllCredentials,
+      },
+      readFile: async () => 'test key',
+      prepareCredentials: (id, credentials) => () => {
+        if (credentials.password) storePassword(id, credentials.password);
+        else deletePassword(id);
+        if (credentials.passphrase) storePassphrase(id, credentials.passphrase);
+        else deletePassphrase(id);
       },
       ssh: {
         dropConnection,
@@ -83,6 +86,25 @@ describe('MachinesService', () => {
 
   afterEach(() => {
     fixture.close();
+  });
+
+  it('does not write credentials when the connection row write fails', async () => {
+    await insertSshConnection(fixture.db);
+    fixture.sqlite.exec(`CREATE TRIGGER fail_connection_write BEFORE INSERT ON ssh_connections
+      BEGIN SELECT RAISE(ABORT, 'database write failed'); END`);
+    await expect(
+      service.saveMachine({
+        id: 'ssh-1',
+        name: 'Existing SSH',
+        host: 'new.example.com',
+        port: 22,
+        username: 'jona',
+        authType: 'password',
+        password: 'replacement',
+      })
+    ).rejects.toThrow('database write failed');
+    expect(storePassword).not.toHaveBeenCalled();
+    expect(deletePassphrase).not.toHaveBeenCalled();
   });
 
   it('rejects retaining a password after changing the destination without mutating the saved machine', async () => {
@@ -154,7 +176,7 @@ describe('MachinesService', () => {
       });
       const get = authType === 'password' ? getPassword : getPassphrase;
       const store = authType === 'password' ? storePassword : storePassphrase;
-      expect(get).toHaveBeenCalledWith('ssh-1');
+      expect(get).toHaveBeenCalledWith('ssh-1', expect.any(String));
       expect(store.mock.calls[0][1].expose()).toBe(
         authType === 'password' ? 'saved-password' : 'saved-passphrase'
       );

--- a/apps/emdash-desktop/src/core/features/machines/node/machines-service.db.test.ts
+++ b/apps/emdash-desktop/src/core/features/machines/node/machines-service.db.test.ts
@@ -1,3 +1,4 @@
+import { secret } from '@emdash/shared';
 import { openFixture } from '@tooling/utils/db';
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -43,17 +44,33 @@ describe('MachinesService', () => {
   const deleteAllCredentials = vi.fn();
   const dropConnection = vi.fn();
   const removeRuntimeState = vi.fn();
+  const getPassword = vi.fn();
+  const getPassphrase = vi.fn();
+  const storePassword = vi.fn();
+  const storePassphrase = vi.fn();
+  const deletePassword = vi.fn();
+  const deletePassphrase = vi.fn();
 
   beforeEach(async () => {
     fixture = await openFixture('empty');
     deleteAllCredentials.mockReset();
     dropConnection.mockReset().mockResolvedValue(undefined);
     removeRuntimeState.mockReset();
+    getPassword.mockReset().mockResolvedValue(secret('saved-password'));
+    getPassphrase.mockReset().mockResolvedValue(secret('saved-passphrase'));
+    storePassword.mockReset();
+    storePassphrase.mockReset();
+    deletePassword.mockReset();
+    deletePassphrase.mockReset();
     service = new MachinesService({
       db: fixture.db,
       credentials: {
-        storePassword: vi.fn(),
-        storePassphrase: vi.fn(),
+        getPassword,
+        getPassphrase,
+        storePassword,
+        storePassphrase,
+        deletePassword,
+        deletePassphrase,
         deleteAllCredentials,
       },
       ssh: {
@@ -66,6 +83,135 @@ describe('MachinesService', () => {
 
   afterEach(() => {
     fixture.close();
+  });
+
+  it('rejects retaining a password after changing the destination without mutating the saved machine', async () => {
+    await insertSshConnection(fixture.db);
+    await fixture.db
+      .update(sshConnections)
+      .set({ authType: 'password' })
+      .where(eq(sshConnections.id, 'ssh-1'));
+    await expect(
+      service.saveMachine({
+        id: 'ssh-1',
+        name: 'Existing SSH',
+        host: 'different.example.com',
+        port: 22,
+        username: 'jona',
+        authType: 'password',
+        password: '',
+      })
+    ).rejects.toThrow('Enter a password');
+    expect(getPassword).not.toHaveBeenCalled();
+    expect(storePassword).not.toHaveBeenCalled();
+    expect(deletePassword).not.toHaveBeenCalled();
+    expect(dropConnection).not.toHaveBeenCalled();
+    const [saved] = await fixture.db
+      .select()
+      .from(sshConnections)
+      .where(eq(sshConnections.id, 'ssh-1'));
+    expect(saved.host).toBe('example.com');
+  });
+
+  it('clears the old passphrase when switching keys', async () => {
+    await insertSshConnection(fixture.db);
+    await fixture.db
+      .update(sshConnections)
+      .set({ authType: 'key', privateKeyPath: '/keys/old' })
+      .where(eq(sshConnections.id, 'ssh-1'));
+    await service.saveMachine({
+      id: 'ssh-1',
+      name: 'Existing SSH',
+      host: 'example.com',
+      port: 22,
+      username: 'jona',
+      authType: 'key',
+      privateKeyPath: '/keys/new',
+      passphrase: '',
+    });
+    expect(getPassphrase).not.toHaveBeenCalled();
+    expect(deletePassphrase).toHaveBeenCalledWith('ssh-1');
+  });
+
+  it.each(['password', 'key'] as const)(
+    'retains compatible %s credentials without returning them',
+    async (authType) => {
+      await insertSshConnection(fixture.db);
+      await fixture.db
+        .update(sshConnections)
+        .set({ authType, privateKeyPath: '/keys/work' })
+        .where(eq(sshConnections.id, 'ssh-1'));
+      const saved = await service.saveMachine({
+        id: 'ssh-1',
+        name: 'Renamed',
+        host: 'example.com',
+        port: 22,
+        username: 'jona',
+        authType,
+        privateKeyPath: '/keys/work',
+        password: '',
+        passphrase: '',
+      });
+      const get = authType === 'password' ? getPassword : getPassphrase;
+      const store = authType === 'password' ? storePassword : storePassphrase;
+      expect(get).toHaveBeenCalledWith('ssh-1');
+      expect(store.mock.calls[0][1].expose()).toBe(
+        authType === 'password' ? 'saved-password' : 'saved-passphrase'
+      );
+      expect(saved).not.toHaveProperty('password');
+      expect(saved).not.toHaveProperty('passphrase');
+    }
+  );
+
+  it.each(['password', 'key'] as const)(
+    'stores replacement %s credentials and clears inactive secrets',
+    async (authType) => {
+      await insertSshConnection(fixture.db);
+      const saved = await service.saveMachine({
+        id: 'ssh-1',
+        name: 'Existing SSH',
+        host: 'new.example.com',
+        port: 22,
+        username: 'jona',
+        authType,
+        privateKeyPath: '/keys/new',
+        password: 'new password',
+        passphrase: 'new passphrase',
+      });
+      expect(getPassword).not.toHaveBeenCalled();
+      expect(getPassphrase).not.toHaveBeenCalled();
+      const store = authType === 'password' ? storePassword : storePassphrase;
+      expect(store.mock.calls[0][1].expose()).toBe(
+        authType === 'password' ? 'new password' : 'new passphrase'
+      );
+      expect(authType === 'password' ? deletePassphrase : deletePassword).toHaveBeenCalledWith(
+        'ssh-1'
+      );
+      expect(saved).not.toHaveProperty('password');
+      expect(saved).not.toHaveProperty('passphrase');
+    }
+  );
+
+  it('rejects a missing retained password before writing or disconnecting', async () => {
+    await insertSshConnection(fixture.db);
+    await fixture.db
+      .update(sshConnections)
+      .set({ authType: 'password' })
+      .where(eq(sshConnections.id, 'ssh-1'));
+    getPassword.mockResolvedValue(null);
+    await expect(
+      service.saveMachine({
+        id: 'ssh-1',
+        name: 'Existing SSH',
+        host: 'example.com',
+        port: 22,
+        username: 'jona',
+        authType: 'password',
+        password: '',
+      })
+    ).rejects.toThrow('Enter a password');
+    expect(storePassword).not.toHaveBeenCalled();
+    expect(dropConnection).not.toHaveBeenCalled();
   });
 
   it('rejects duplicate machine names with a user-facing error', async () => {

--- a/apps/emdash-desktop/src/core/primitives/ssh/api/credential-reuse.ts
+++ b/apps/emdash-desktop/src/core/primitives/ssh/api/credential-reuse.ts
@@ -1,0 +1,26 @@
+import type { SshConfig } from './ssh';
+
+type CredentialIdentity = Pick<
+  SshConfig,
+  'host' | 'port' | 'username' | 'sshConfigAlias' | 'authType' | 'privateKeyPath' | 'proxyJump'
+>;
+
+/** A blank credential may retain a secret only for the same connection identity. */
+export function sshCredentialReuse(next: CredentialIdentity, previous?: CredentialIdentity) {
+  const sameConnection =
+    !!previous &&
+    next.host === previous.host &&
+    next.port === previous.port &&
+    next.username === previous.username &&
+    (next.sshConfigAlias || '') === (previous.sshConfigAlias || '') &&
+    (!!next.sshConfigAlias || (next.proxyJump || '') === (previous.proxyJump || '')) &&
+    next.authType === previous.authType;
+
+  return {
+    password: sameConnection && next.authType === 'password',
+    passphrase:
+      sameConnection &&
+      next.authType === 'key' &&
+      (next.privateKeyPath?.trim() || '') === (previous?.privateKeyPath?.trim() || ''),
+  };
+}

--- a/apps/emdash-desktop/src/core/primitives/ssh/api/credential-reuse.ts
+++ b/apps/emdash-desktop/src/core/primitives/ssh/api/credential-reuse.ts
@@ -5,7 +5,10 @@ type CredentialIdentity = Pick<
   'host' | 'port' | 'username' | 'sshConfigAlias' | 'authType' | 'privateKeyPath' | 'proxyJump'
 >;
 
-/** A blank credential may retain a secret only for the same connection identity. */
+/**
+ * Form-level eligibility, not proof that a secret is reusable. The main process must
+ * also verify the resolved destination and the stored credential's effective-key binding.
+ */
 export function sshCredentialReuse(next: CredentialIdentity, previous?: CredentialIdentity) {
   const sameConnection =
     !!previous &&

--- a/apps/emdash-desktop/src/core/services/ssh/node/connect/production-connect-config.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/connect/production-connect-config.ts
@@ -23,8 +23,8 @@ async function findSshConfigByHostName(hostname: string) {
 export function createProductionSshConnectConfigResolver(credentials: ConnectCredentials) {
   return createSshConnectConfigResolver({
     readFile,
-    getPassword: (connectionId) => credentials.getPassword(connectionId),
-    getPassphrase: (connectionId) => credentials.getPassphrase(connectionId),
+    getPassword: (connectionId, identity) => credentials.getPassword(connectionId, identity),
+    getPassphrase: (connectionId, identity) => credentials.getPassphrase(connectionId, identity),
     resolveSshConfig,
     findSshConfigByHostName,
     spawnProxyCommand,

--- a/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.test.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.test.ts
@@ -25,6 +25,33 @@ function baseConfig(partial: Partial<SshConfig> = {}): SshConfig {
 }
 
 describe('testing edited credentials', () => {
+  it.each([{ hostname: 'replacement.example.com' }, { user: 'other' }, { port: 2222 }])(
+    'rejects a stale alias destination before retrieving a password: %j',
+    async (change) => {
+      const config = baseConfig({ sshConfigAlias: 'work' });
+      const getPassword = vi.fn(async () => secret('original password'));
+      await expect(
+        resolveSshConnectConfig(
+          { kind: 'transient', config, previous: config },
+          deps({
+            getPassword,
+            resolveSshConfig: async () => ({
+              hostname: config.host,
+              user: config.username,
+              port: config.port,
+              identityFile: [],
+              identityAgentDisabled: false,
+              identitiesOnly: false,
+              forwardAgent: false,
+              ...change,
+            }),
+          })
+        )
+      ).rejects.toThrow('SSH config changed');
+      expect(getPassword).not.toHaveBeenCalled();
+    }
+  );
+
   it('uses a stored password for an unchanged connection with a blank draft password', async () => {
     const config = baseConfig();
     const getPassword = vi.fn(async () => secret('stored-password'));
@@ -33,7 +60,7 @@ describe('testing edited credentials', () => {
       deps({ getPassword })
     );
     expect(result.config.password).toBe('stored-password');
-    expect(getPassword).toHaveBeenCalledWith(config.id);
+    expect(getPassword).toHaveBeenCalledWith(config.id, expect.any(String));
   });
 
   it('uses a stored passphrase for the same key', async () => {
@@ -499,7 +526,11 @@ describe('resolveSshConnectConfig', () => {
         {
           kind: 'transient',
           config: {
-            ...baseConfig({ sshConfigAlias: 'corp-dev', authType: 'password' }),
+            ...baseConfig({
+              sshConfigAlias: 'corp-dev',
+              authType: 'password',
+              host: 'dev.internal',
+            }),
             password: 'pw',
           },
         },
@@ -534,7 +565,7 @@ describe('resolveSshConnectConfig', () => {
         { kind: 'persisted', row: row({ authType: 'password' }) },
         deps({ getPassword: async () => null })
       )
-    ).rejects.toThrow('No password found');
+    ).rejects.toThrow('Enter a password');
 
     await expect(
       resolveSshConnectConfig(
@@ -691,7 +722,11 @@ describe('resolveSshConnectConfig', () => {
         {
           kind: 'transient',
           config: {
-            ...baseConfig({ sshConfigAlias: 'corp-dev', authType: 'password' }),
+            ...baseConfig({
+              sshConfigAlias: 'corp-dev',
+              authType: 'password',
+              host: 'dev.internal',
+            }),
             password: 'pw',
           },
         },
@@ -843,6 +878,9 @@ describe('resolveSshConnectConfig', () => {
         kind: 'persisted',
         row: row({
           authType: 'key',
+          host: 'dev.internal',
+          username: 'deploy',
+          port: 2222,
           privateKeyPath: null,
           metadata: { sshConfigAlias: 'corp-dev' },
         }),

--- a/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.test.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.test.ts
@@ -2,7 +2,7 @@ import { PassThrough } from 'node:stream';
 import { secret } from '@emdash/shared';
 import type { ParsedKey, SignCallback } from 'ssh2';
 import { BaseAgent, utils } from 'ssh2';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { SshConfig } from '@core/primitives/ssh/api';
 import type { SshConnectionRow } from '@core/services/app-db/node/schema';
 import {
@@ -23,6 +23,28 @@ function baseConfig(partial: Partial<SshConfig> = {}): SshConfig {
     ...partial,
   };
 }
+
+describe('testing edited credentials', () => {
+  it('uses a stored password for an unchanged connection with a blank draft password', async () => {
+    const config = baseConfig();
+    const getPassword = vi.fn(async () => secret('stored-password'));
+    const result = await resolveSshConnectConfig(
+      { kind: 'transient', config: { ...config, password: '' }, previous: config },
+      deps({ getPassword })
+    );
+    expect(result.config.password).toBe('stored-password');
+    expect(getPassword).toHaveBeenCalledWith(config.id);
+  });
+
+  it('uses a stored passphrase for the same key', async () => {
+    const config = baseConfig({ authType: 'key', privateKeyPath: '/keys/work' });
+    const result = await resolveSshConnectConfig(
+      { kind: 'transient', config, previous: config },
+      deps({ getPassphrase: async () => secret('stored-passphrase') })
+    );
+    expect(result.config.passphrase).toBe('stored-passphrase');
+  });
+});
 
 function deps(overrides: Partial<SshConnectDeps> = {}): SshConnectDeps {
   return {
@@ -106,6 +128,58 @@ function row(partial: Partial<SshConnectionRow> = {}): SshConnectionRow {
 }
 
 describe('resolveSshConnectConfig', () => {
+  it.each(['transient', 'persisted'] as const)(
+    'uses a key override with an SSH config target for %s connections',
+    async (kind) => {
+      const override = 'C:/Users/alice/.ssh/id_ed25519';
+      const readFiles: string[] = [];
+      const input =
+        kind === 'transient'
+          ? {
+              kind,
+              config: baseConfig({
+                authType: 'key',
+                sshConfigAlias: 'work.internal',
+                privateKeyPath: override,
+              }),
+            }
+          : {
+              kind,
+              row: row({
+                authType: 'key',
+                metadata: { sshConfigAlias: 'work.internal' },
+                privateKeyPath: override,
+              }),
+            };
+      const result = await resolveSshConnectConfig(
+        input,
+        deps({
+          readFile: async (path) => {
+            readFiles.push(path);
+            return 'OVERRIDE KEY';
+          },
+          resolveSshConfig: async () => ({
+            hostname: 'resolved.internal',
+            user: 'alice',
+            port: 2222,
+            identityFile: ['C:/Users/alice/.ssh/id_rsa'],
+            identityAgentDisabled: false,
+            identitiesOnly: false,
+            forwardAgent: false,
+            proxyJump: 'bastion',
+          }),
+        })
+      );
+      expect(readFiles).toEqual([override]);
+      expect(result.config).toMatchObject({
+        host: 'resolved.internal',
+        port: 2222,
+        privateKey: 'OVERRIDE KEY',
+      });
+      expect(result.debugLogs).toEqual(['proxy-jump']);
+    }
+  );
+
   it('uses ssh -G as authoritative for alias-backed ProxyCommand', async () => {
     const spawned: string[] = [];
     const result = await resolveSshConnectConfig(

--- a/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.ts
@@ -36,8 +36,8 @@ export type SshConnectInput = PersistedConnectInput | TransientConnectInput;
 
 export interface SshConnectDeps {
   readFile: (path: string, encoding: BufferEncoding) => Promise<string>;
-  getPassword: (connectionId: string) => Promise<Secret<string> | null>;
-  getPassphrase: (connectionId: string) => Promise<Secret<string> | null>;
+  getPassword: (connectionId: string, identity: string) => Promise<Secret<string> | null>;
+  getPassphrase: (connectionId: string, identity: string) => Promise<Secret<string> | null>;
   resolveSshConfig: (alias: string) => Promise<ResolvedSshConfig>;
   findSshConfigByHostName: (hostname: string) => Promise<ResolvedSshConfig | undefined>;
   spawnProxyCommand: (command: string, tokens: ProxyTokens) => Omit<TransportResult, 'process'>;

--- a/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/connect/resolve-ssh-connect-config.ts
@@ -30,6 +30,7 @@ export type PersistedConnectInput = { kind: 'persisted'; row: SshConnectionRow }
 export type TransientConnectInput = {
   kind: 'transient';
   config: SshConfig & { password?: string; passphrase?: string };
+  previous?: SshConfig;
 };
 export type SshConnectInput = PersistedConnectInput | TransientConnectInput;
 

--- a/apps/emdash-desktop/src/core/services/ssh/node/connect/ssh-connect-auth.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/connect/ssh-connect-auth.ts
@@ -13,6 +13,7 @@ import {
   resolveAgentSocketFromResolved,
   type ResolvedSshConfig,
 } from '../config/resolve-ssh-config';
+import { resolveCredentialDraft } from '../credentials/resolve-credential-draft';
 import type { SshConnectDeps, SshConnectInput } from './resolve-ssh-connect-config';
 
 const { utils } = ssh2;
@@ -124,14 +125,18 @@ export async function buildAuthConfig(
   resolved: ResolvedSshConfig | undefined,
   deps: SshConnectDeps
 ): Promise<AuthResult> {
+  const draftCredentials =
+    input.kind === 'transient'
+      ? await resolveCredentialDraft(input.config, input.previous, deps)
+      : undefined;
   switch (base.authType) {
     case 'password': {
       // Boundary disclosure: stored credentials leave Secret via .expose()
-      // only here, where the ssh2 connect config is assembled. Transient
-      // credentials arrive as plain strings straight off the wire.
+      // only here, where the ssh2 connect config is assembled. Draft
+      // credentials are wrapped or retained by resolveCredentialDraft.
       const password =
         input.kind === 'transient'
-          ? input.config.password
+          ? draftCredentials?.password?.expose()
           : (await deps.getPassword(input.row.id))?.expose();
       if (!password) throw new Error(`No password found for SSH connection '${base.name}'`);
       return { config: { password } };
@@ -145,7 +150,7 @@ export async function buildAuthConfig(
       // Boundary disclosure: same contract as the password case above.
       const passphrase =
         input.kind === 'transient'
-          ? input.config.passphrase
+          ? draftCredentials?.passphrase?.expose()
           : (await deps.getPassphrase(input.row.id))?.expose();
       return { config: { privateKey, ...(passphrase ? { passphrase } : {}) } };
     }

--- a/apps/emdash-desktop/src/core/services/ssh/node/connect/ssh-connect-auth.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/connect/ssh-connect-auth.ts
@@ -13,6 +13,12 @@ import {
   resolveAgentSocketFromResolved,
   type ResolvedSshConfig,
 } from '../config/resolve-ssh-config';
+import {
+  assertPasswordDestination,
+  effectiveSshConfig,
+  expandSshKeyPath,
+  readSshPrivateKey,
+} from '../credentials/credential-identity';
 import { resolveCredentialDraft } from '../credentials/resolve-credential-draft';
 import type { SshConnectDeps, SshConnectInput } from './resolve-ssh-connect-config';
 
@@ -21,12 +27,6 @@ const { utils } = ssh2;
 export interface AuthResult {
   config: Partial<ConnectConfig>;
   agentSocketPath?: string;
-}
-
-function expandTilde(filePath: string): string {
-  if (filePath === '~') return process.env.HOME ?? filePath;
-  if (filePath.startsWith('~/')) return `${process.env.HOME ?? ''}${filePath.slice(1)}`;
-  return filePath;
 }
 
 type AgentPublicKey = ParsedKey | Buffer | string | PublicKeyEntry;
@@ -90,7 +90,7 @@ class IdentityFilteredAgent extends BaseAgent {
 }
 
 async function readIdentityKey(path: string, deps: SshConnectDeps): Promise<ParsedKey | undefined> {
-  const data = await deps.readFile(expandTilde(path), 'utf-8').catch(() => undefined);
+  const data = await deps.readFile(expandSshKeyPath(path), 'utf-8').catch(() => undefined);
   if (!data) return undefined;
   const parsed = utils.parseKey(data);
   return parsed instanceof Error ? undefined : parsed;
@@ -125,33 +125,22 @@ export async function buildAuthConfig(
   resolved: ResolvedSshConfig | undefined,
   deps: SshConnectDeps
 ): Promise<AuthResult> {
-  const draftCredentials =
-    input.kind === 'transient'
-      ? await resolveCredentialDraft(input.config, input.previous, deps)
-      : undefined;
+  const effective = effectiveSshConfig(input.kind === 'transient' ? input.config : base, resolved);
+  const previous = input.kind === 'transient' ? input.previous : base;
+  assertPasswordDestination(base, effective);
   switch (base.authType) {
     case 'password': {
-      // Boundary disclosure: stored credentials leave Secret via .expose()
-      // only here, where the ssh2 connect config is assembled. Draft
-      // credentials are wrapped or retained by resolveCredentialDraft.
-      const password =
-        input.kind === 'transient'
-          ? draftCredentials?.password?.expose()
-          : (await deps.getPassword(input.row.id))?.expose();
+      const credentials = await resolveCredentialDraft(effective, previous, deps);
+      const password = credentials.password?.expose();
       if (!password) throw new Error(`No password found for SSH connection '${base.name}'`);
       return { config: { password } };
     }
 
     case 'key': {
-      const keyPath = base.privateKeyPath?.trim() || resolved?.identityFile[0];
-      if (!keyPath)
-        throw new Error(`Private key path is required for SSH connection '${base.name}'`);
-      const privateKey = await deps.readFile(expandTilde(keyPath), 'utf-8');
+      const { privateKey, fingerprint } = await readSshPrivateKey(base, resolved, deps.readFile);
+      const credentials = await resolveCredentialDraft(effective, previous, deps, fingerprint);
       // Boundary disclosure: same contract as the password case above.
-      const passphrase =
-        input.kind === 'transient'
-          ? draftCredentials?.passphrase?.expose()
-          : (await deps.getPassphrase(input.row.id))?.expose();
+      const passphrase = credentials.passphrase?.expose();
       return { config: { privateKey, ...(passphrase ? { passphrase } : {}) } };
     }
 

--- a/apps/emdash-desktop/src/core/services/ssh/node/credentials/credential-identity.test.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/credentials/credential-identity.test.ts
@@ -1,0 +1,52 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, expect, it, vi } from 'vitest';
+import { expandSshKeyPath, readSshPrivateKey } from './credential-identity';
+
+afterEach(() => vi.unstubAllEnvs());
+
+it('expands a key path using the OS home directory when HOME is unset', () => {
+  vi.stubEnv('HOME', undefined);
+  expect(expandSshKeyPath('~')).toBe(homedir());
+  expect(expandSshKeyPath('~/.ssh/id_ed25519')).toBe(join(homedir(), '.ssh/id_ed25519'));
+});
+
+it.each(['/keys/work', 'C:\\Users\\alice\\.ssh\\id_ed25519', 'keys/work', '~other/key'])(
+  'preserves paths without a current-user home prefix: %s',
+  (path) => {
+    expect(expandSshKeyPath(path)).toBe(path);
+  }
+);
+
+it.runIf(process.platform === 'win32')('supports the native Windows home prefix', () => {
+  expect(expandSshKeyPath('~\\.ssh\\id_ed25519')).toBe(join(homedir(), '.ssh', 'id_ed25519'));
+});
+
+it('reads both explicit and inherited keys from the expanded home directory', async () => {
+  vi.stubEnv('HOME', undefined);
+  const readFile = vi.fn(async () => 'key contents');
+  const config = {
+    name: 'Work',
+    host: 'work.internal',
+    port: 22,
+    username: 'alice',
+    authType: 'key' as const,
+  };
+  const resolved = {
+    hostname: config.host,
+    user: config.username,
+    port: 22,
+    identityFile: ['~/.ssh/id_ed25519'],
+    identityAgentDisabled: false,
+    identitiesOnly: false,
+    forwardAgent: false,
+  };
+  const explicit = await readSshPrivateKey(
+    { ...config, privateKeyPath: '~/.ssh/id_ed25519' },
+    undefined,
+    readFile
+  );
+  const inherited = await readSshPrivateKey(config, resolved, readFile);
+  expect(readFile).toHaveBeenCalledWith(join(homedir(), '.ssh/id_ed25519'), 'utf-8');
+  expect(inherited.fingerprint).toBe(explicit.fingerprint);
+});

--- a/apps/emdash-desktop/src/core/services/ssh/node/credentials/credential-identity.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/credentials/credential-identity.ts
@@ -1,0 +1,80 @@
+import { createHash } from 'node:crypto';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { SshConfig } from '@core/primitives/ssh/api';
+import type { ResolvedSshConfig } from '../config/resolve-ssh-config';
+
+export function effectiveSshConfig<T extends Omit<SshConfig, 'id'>>(
+  config: T,
+  resolved?: ResolvedSshConfig
+): T {
+  return {
+    ...config,
+    host: resolved?.hostname || config.host,
+    port: resolved?.port ?? config.port,
+    username: resolved?.user || config.username,
+  };
+}
+
+export function assertPasswordDestination(
+  config: Omit<SshConfig, 'id'>,
+  effective: Omit<SshConfig, 'id'>
+) {
+  if (
+    config.authType === 'password' &&
+    (config.host !== effective.host ||
+      config.port !== effective.port ||
+      config.username !== effective.username)
+  ) {
+    throw new Error(
+      'SSH config changed the destination. Resolve the host again before continuing.'
+    );
+  }
+}
+
+export function sshCredentialIdentity(
+  config: Omit<SshConfig, 'id'>,
+  keyFingerprint?: string
+): string {
+  if (config.authType === 'key' && !keyFingerprint)
+    throw new Error('Private key identity is required');
+  return createHash('sha256')
+    .update(
+      JSON.stringify([
+        config.host,
+        config.port,
+        config.username,
+        config.authType,
+        config.sshConfigAlias || '',
+        config.sshConfigAlias ? '' : config.proxyJump || '',
+        config.authType === 'key' ? config.privateKeyPath?.trim() || '' : '',
+        config.authType === 'key' ? keyFingerprint : '',
+      ])
+    )
+    .digest('hex');
+}
+
+export function expandSshKeyPath(path: string): string {
+  if (path === '~') return homedir();
+  if (path.startsWith('~/') || (process.platform === 'win32' && path.startsWith('~\\'))) {
+    return join(homedir(), path.slice(2));
+  }
+  return path;
+}
+
+export async function readSshPrivateKey(
+  config: Omit<SshConfig, 'id'>,
+  resolved: ResolvedSshConfig | undefined,
+  readFile: (path: string, encoding: BufferEncoding) => Promise<string>
+) {
+  const selected = config.privateKeyPath?.trim() || resolved?.identityFile[0];
+  if (!selected)
+    throw new Error(`Private key path is required for SSH connection '${config.name}'`);
+  const path = expandSshKeyPath(selected);
+  const privateKey = await readFile(path, 'utf-8');
+  // Include contents to detect replacement at the same path, not just IdentityFile edits.
+  const fingerprint = createHash('sha256')
+    .update(JSON.stringify([path, privateKey]))
+    .digest('hex');
+  return { privateKey, fingerprint };
+}

--- a/apps/emdash-desktop/src/core/services/ssh/node/credentials/credential-record.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/credentials/credential-record.ts
@@ -1,0 +1,62 @@
+import type { Secret } from '@emdash/shared';
+import type { ResolvedCredentialDraft } from './resolve-credential-draft';
+
+export function sshCredentialKeys(connectionId: string) {
+  return {
+    password: `ssh:${connectionId}:password`,
+    passphrase: `ssh:${connectionId}:passphrase`,
+    boundPassword: `ssh:${connectionId}:password:v1`,
+    boundPassphrase: `ssh:${connectionId}:passphrase:v1`,
+  };
+}
+
+export function bindCredential(value: Secret<string>, identity: string): Secret<string> {
+  return value.map((value) => JSON.stringify({ version: 1, identity, value }));
+}
+
+/** The binding and value are read together; a concurrent save cannot mix generations. */
+export function readBoundCredential(
+  record: Secret<string>,
+  identity: string
+): Secret<string> | null {
+  let matches = false;
+  const value = record.map((raw) => {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      throw new Error('Invalid stored SSH credential');
+    }
+    if (
+      !parsed ||
+      typeof parsed !== 'object' ||
+      !('version' in parsed) ||
+      parsed.version !== 1 ||
+      !('identity' in parsed) ||
+      typeof parsed.identity !== 'string' ||
+      !('value' in parsed) ||
+      typeof parsed.value !== 'string'
+    ) {
+      throw new Error('Invalid stored SSH credential');
+    }
+    matches = parsed.identity === identity;
+    return parsed.value;
+  });
+  return matches ? value : null;
+}
+
+export function sshCredentialChanges(connectionId: string, credentials: ResolvedCredentialDraft) {
+  const keys = sshCredentialKeys(connectionId);
+  return new Map<string, Secret<string> | null>([
+    [keys.password, null],
+    [keys.passphrase, null],
+    [
+      keys.boundPassword,
+      credentials.password ? bindCredential(credentials.password, credentials.identity) : null,
+    ],
+    [
+      keys.boundPassphrase,
+      credentials.passphrase ? bindCredential(credentials.passphrase, credentials.identity) : null,
+    ],
+  ]);
+}

--- a/apps/emdash-desktop/src/core/services/ssh/node/credentials/resolve-credential-draft.test.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/credentials/resolve-credential-draft.test.ts
@@ -1,0 +1,132 @@
+import { secret } from '@emdash/shared';
+import { describe, expect, it, vi } from 'vitest';
+import type { SshConfig } from '@core/primitives/ssh/api/ssh';
+import { resolveCredentialDraft } from './resolve-credential-draft';
+
+const saved: SshConfig = {
+  id: 'saved',
+  name: 'Work',
+  host: 'work.internal',
+  port: 22,
+  username: 'alice',
+  authType: 'password',
+};
+
+function credentials() {
+  return {
+    getPassword: vi.fn(async () => secret('saved password')),
+    getPassphrase: vi.fn(async () => secret('saved passphrase')),
+  };
+}
+
+describe('resolveCredentialDraft', () => {
+  it.each([
+    { host: 'another.internal' },
+    { port: 2222 },
+    { username: 'bob' },
+    { sshConfigAlias: 'another-alias' },
+    { proxyJump: 'another-bastion' },
+  ])('does not reuse a password after changing %j', async (change) => {
+    const store = credentials();
+    await expect(resolveCredentialDraft({ ...saved, ...change }, saved, store)).rejects.toThrow(
+      'Enter a password'
+    );
+    expect(store.getPassword).not.toHaveBeenCalled();
+  });
+
+  it('requires a new password when switching from another authentication method', async () => {
+    const store = credentials();
+    await expect(
+      resolveCredentialDraft(saved, { ...saved, authType: 'key' }, store)
+    ).rejects.toThrow('Enter a password');
+    expect(store.getPassword).not.toHaveBeenCalled();
+  });
+
+  it('retains the stored password when only the name changes', async () => {
+    const store = credentials();
+    const result = await resolveCredentialDraft(
+      { ...saved, name: 'Renamed', password: '' },
+      saved,
+      store
+    );
+    expect(result.password?.expose()).toBe('saved password');
+    expect(result.passphrase).toBeNull();
+    expect(store.getPassword).toHaveBeenCalledWith('saved');
+  });
+
+  it('uses an entered password without looking up the old secret or trimming it', async () => {
+    const store = credentials();
+    const result = await resolveCredentialDraft(
+      { ...saved, host: 'another.internal', password: ' new password ' },
+      saved,
+      store
+    );
+    expect(result.password?.expose()).toBe(' new password ');
+    expect(store.getPassword).not.toHaveBeenCalled();
+  });
+
+  it('reports a missing saved password instead of treating edit mode as sufficient', async () => {
+    await expect(
+      resolveCredentialDraft(saved, saved, {
+        getPassword: async () => null,
+        getPassphrase: async () => null,
+      })
+    ).rejects.toThrow('Enter a password');
+  });
+
+  it('does not look up secrets for a new connection', async () => {
+    const store = credentials();
+    await expect(resolveCredentialDraft(saved, undefined, store)).rejects.toThrow(
+      'Enter a password'
+    );
+    expect(store.getPassword).not.toHaveBeenCalled();
+  });
+
+  it('retains a passphrase only for the same key selection', async () => {
+    const store = credentials();
+    const key = { ...saved, authType: 'key' as const, privateKeyPath: '/keys/old' };
+    expect((await resolveCredentialDraft(key, key, store)).passphrase?.expose()).toBe(
+      'saved passphrase'
+    );
+    store.getPassphrase.mockClear();
+    const result = await resolveCredentialDraft(
+      { ...key, privateKeyPath: '/keys/new' },
+      key,
+      store
+    );
+    expect(result.passphrase).toBeNull();
+    expect(store.getPassphrase).not.toHaveBeenCalled();
+  });
+
+  it('does not inherit a passphrase when overriding or resetting the SSH config key', async () => {
+    const store = credentials();
+    const inherited = { ...saved, sshConfigAlias: 'work', authType: 'key' as const };
+    const overridden = { ...inherited, privateKeyPath: '/keys/custom' };
+    expect((await resolveCredentialDraft(overridden, inherited, store)).passphrase).toBeNull();
+    expect((await resolveCredentialDraft(inherited, overridden, store)).passphrase).toBeNull();
+    expect(store.getPassphrase).not.toHaveBeenCalled();
+  });
+
+  it('uses an entered passphrase for a replacement key', async () => {
+    const store = credentials();
+    const result = await resolveCredentialDraft(
+      { ...saved, authType: 'key', privateKeyPath: '/keys/new', passphrase: ' new phrase ' },
+      saved,
+      store
+    );
+    expect(result.passphrase?.expose()).toBe(' new phrase ');
+    expect(store.getPassphrase).not.toHaveBeenCalled();
+  });
+
+  it('ignores inactive secrets when selecting Agent', async () => {
+    const store = credentials();
+    const result = await resolveCredentialDraft(
+      { ...saved, authType: 'agent', password: 'unused', passphrase: 'unused' },
+      saved,
+      store
+    );
+    expect(result).toEqual({ password: null, passphrase: null });
+    expect(store.getPassword).not.toHaveBeenCalled();
+    expect(store.getPassphrase).not.toHaveBeenCalled();
+  });
+});

--- a/apps/emdash-desktop/src/core/services/ssh/node/credentials/resolve-credential-draft.test.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/credentials/resolve-credential-draft.test.ts
@@ -51,7 +51,7 @@ describe('resolveCredentialDraft', () => {
     );
     expect(result.password?.expose()).toBe('saved password');
     expect(result.passphrase).toBeNull();
-    expect(store.getPassword).toHaveBeenCalledWith('saved');
+    expect(store.getPassword).toHaveBeenCalledWith('saved', expect.any(String));
   });
 
   it('uses an entered password without looking up the old secret or trimming it', async () => {
@@ -85,14 +85,15 @@ describe('resolveCredentialDraft', () => {
   it('retains a passphrase only for the same key selection', async () => {
     const store = credentials();
     const key = { ...saved, authType: 'key' as const, privateKeyPath: '/keys/old' };
-    expect((await resolveCredentialDraft(key, key, store)).passphrase?.expose()).toBe(
-      'saved passphrase'
-    );
+    expect(
+      (await resolveCredentialDraft(key, key, store, 'key-fingerprint')).passphrase?.expose()
+    ).toBe('saved passphrase');
     store.getPassphrase.mockClear();
     const result = await resolveCredentialDraft(
       { ...key, privateKeyPath: '/keys/new' },
       key,
-      store
+      store,
+      'new-key-fingerprint'
     );
     expect(result.passphrase).toBeNull();
     expect(store.getPassphrase).not.toHaveBeenCalled();
@@ -102,8 +103,12 @@ describe('resolveCredentialDraft', () => {
     const store = credentials();
     const inherited = { ...saved, sshConfigAlias: 'work', authType: 'key' as const };
     const overridden = { ...inherited, privateKeyPath: '/keys/custom' };
-    expect((await resolveCredentialDraft(overridden, inherited, store)).passphrase).toBeNull();
-    expect((await resolveCredentialDraft(inherited, overridden, store)).passphrase).toBeNull();
+    expect(
+      (await resolveCredentialDraft(overridden, inherited, store, 'override')).passphrase
+    ).toBeNull();
+    expect(
+      (await resolveCredentialDraft(inherited, overridden, store, 'inherited')).passphrase
+    ).toBeNull();
     expect(store.getPassphrase).not.toHaveBeenCalled();
   });
 
@@ -112,7 +117,8 @@ describe('resolveCredentialDraft', () => {
     const result = await resolveCredentialDraft(
       { ...saved, authType: 'key', privateKeyPath: '/keys/new', passphrase: ' new phrase ' },
       saved,
-      store
+      store,
+      'new-key-fingerprint'
     );
     expect(result.passphrase?.expose()).toBe(' new phrase ');
     expect(store.getPassphrase).not.toHaveBeenCalled();
@@ -125,7 +131,7 @@ describe('resolveCredentialDraft', () => {
       saved,
       store
     );
-    expect(result).toEqual({ password: null, passphrase: null });
+    expect(result).toMatchObject({ password: null, passphrase: null });
     expect(store.getPassword).not.toHaveBeenCalled();
     expect(store.getPassphrase).not.toHaveBeenCalled();
   });

--- a/apps/emdash-desktop/src/core/services/ssh/node/credentials/resolve-credential-draft.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/credentials/resolve-credential-draft.ts
@@ -1,30 +1,43 @@
 import { secret, type Secret } from '@emdash/shared';
 import { sshCredentialReuse } from '@core/primitives/ssh/api/credential-reuse';
 import type { SshConfig } from '@core/primitives/ssh/api/ssh';
-import type { SshCredentialService } from './ssh-credential-service';
+import { sshCredentialIdentity } from './credential-identity';
+
+export interface CredentialLookup {
+  getPassword(connectionId: string, identity: string): Promise<Secret<string> | null>;
+  getPassphrase(connectionId: string, identity: string): Promise<Secret<string> | null>;
+}
+
+export interface ResolvedCredentialDraft {
+  password: Secret<string> | null;
+  passphrase: Secret<string> | null;
+  identity: string;
+}
 
 /** Shared by transient tests and saves. Retained secrets never cross the renderer boundary. */
 export async function resolveCredentialDraft(
   draft: Omit<SshConfig, 'id'> & { password?: string; passphrase?: string },
   previous: SshConfig | undefined,
-  credentials: Pick<SshCredentialService, 'getPassword' | 'getPassphrase'>
-): Promise<{ password: Secret<string> | null; passphrase: Secret<string> | null }> {
+  credentials: CredentialLookup,
+  keyFingerprint?: string
+): Promise<ResolvedCredentialDraft> {
   const reuse = sshCredentialReuse(draft, previous);
+  const identity = sshCredentialIdentity(draft, keyFingerprint);
   let password: Secret<string> | null = null;
   let passphrase: Secret<string> | null = null;
   if (draft.authType === 'password') {
     password = draft.password
       ? secret(draft.password, 'ssh-password')
       : reuse.password && previous
-        ? await credentials.getPassword(previous.id)
+        ? await credentials.getPassword(previous.id, identity)
         : null;
     if (!password) throw new Error('Enter a password for this connection.');
   } else if (draft.authType === 'key') {
     passphrase = draft.passphrase
       ? secret(draft.passphrase, 'ssh-passphrase')
       : reuse.passphrase && previous
-        ? await credentials.getPassphrase(previous.id)
+        ? await credentials.getPassphrase(previous.id, identity)
         : null;
   }
-  return { password, passphrase };
+  return { password, passphrase, identity };
 }

--- a/apps/emdash-desktop/src/core/services/ssh/node/credentials/resolve-credential-draft.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/credentials/resolve-credential-draft.ts
@@ -1,0 +1,30 @@
+import { secret, type Secret } from '@emdash/shared';
+import { sshCredentialReuse } from '@core/primitives/ssh/api/credential-reuse';
+import type { SshConfig } from '@core/primitives/ssh/api/ssh';
+import type { SshCredentialService } from './ssh-credential-service';
+
+/** Shared by transient tests and saves. Retained secrets never cross the renderer boundary. */
+export async function resolveCredentialDraft(
+  draft: Omit<SshConfig, 'id'> & { password?: string; passphrase?: string },
+  previous: SshConfig | undefined,
+  credentials: Pick<SshCredentialService, 'getPassword' | 'getPassphrase'>
+): Promise<{ password: Secret<string> | null; passphrase: Secret<string> | null }> {
+  const reuse = sshCredentialReuse(draft, previous);
+  let password: Secret<string> | null = null;
+  let passphrase: Secret<string> | null = null;
+  if (draft.authType === 'password') {
+    password = draft.password
+      ? secret(draft.password, 'ssh-password')
+      : reuse.password && previous
+        ? await credentials.getPassword(previous.id)
+        : null;
+    if (!password) throw new Error('Enter a password for this connection.');
+  } else if (draft.authType === 'key') {
+    passphrase = draft.passphrase
+      ? secret(draft.passphrase, 'ssh-passphrase')
+      : reuse.passphrase && previous
+        ? await credentials.getPassphrase(previous.id)
+        : null;
+  }
+  return { password, passphrase };
+}

--- a/apps/emdash-desktop/src/core/services/ssh/node/credentials/ssh-credential-service.test.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/credentials/ssh-credential-service.test.ts
@@ -26,6 +26,53 @@ function makeService() {
 }
 
 describe('SshCredentialService', () => {
+  it('does not reuse a passphrase for a different effective key identity', async () => {
+    const { service } = makeService();
+    await service.storePassphrase('conn-1', secret('old passphrase'), 'old-key-identity');
+    expect((await service.getPassphrase('conn-1', 'old-key-identity'))?.expose()).toBe(
+      'old passphrase'
+    );
+    await expect(service.getPassphrase('conn-1', 'new-key-identity')).resolves.toBeNull();
+  });
+
+  it('does not reuse a bound password for another destination or fall back to a legacy secret', async () => {
+    const { service, store } = makeService();
+    await service.storePassword('conn-1', secret('new password'), 'destination-a');
+    await store.setSecret('ssh:conn-1:password', secret('stale legacy password'));
+    await expect(service.getPassword('conn-1', 'destination-b')).resolves.toBeNull();
+    expect((await service.getPassword('conn-1', 'destination-a'))?.expose()).toBe('new password');
+  });
+
+  it('does not infer a binding for legacy passphrases', async () => {
+    const { service } = makeService();
+    await service.storePassphrase('conn-1', secret('legacy passphrase'));
+    await expect(service.getPassphrase('conn-1', 'effective-key')).rejects.toThrow(
+      'Re-enter your SSH key passphrase'
+    );
+    expect((await service.getPassphrase('conn-1'))?.expose()).toBe('legacy passphrase');
+  });
+
+  it('keeps bound credentials redacted and deletes them with the connection', async () => {
+    const { service, store } = makeService();
+    await service.storePassword('conn-1', secret('password'), 'destination');
+    await service.storePassphrase('conn-1', secret('passphrase'), 'key');
+    expect(inspect([...store.secrets.values()])).not.toContain('passphrase');
+    expect(JSON.stringify(await service.getPassword('conn-1', 'destination'))).toContain(REDACTED);
+    await expect(service.hasPassword('conn-1')).resolves.toBe(true);
+    await expect(service.hasPassphrase('conn-1')).resolves.toBe(true);
+    await service.deleteAllCredentials('conn-1');
+    expect(store.secrets.size).toBe(0);
+  });
+
+  it('reports malformed bound records without exposing their contents', async () => {
+    const { service, store } = makeService();
+    await store.setSecret('ssh:conn-1:password:v1', secret('{secret-value'));
+    await expect(service.getPassword('conn-1', 'destination')).rejects.toThrow(
+      'Invalid stored SSH credential'
+    );
+    await expect(service.getPassword('conn-1', 'destination')).rejects.not.toThrow('secret-value');
+  });
+
   it('round-trips a password intact', async () => {
     const { service } = makeService();
     await service.storePassword('conn-1', secret('hunter2', 'ssh-password'));

--- a/apps/emdash-desktop/src/core/services/ssh/node/credentials/ssh-credential-service.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/credentials/ssh-credential-service.ts
@@ -1,5 +1,6 @@
 import type { Secret } from '@emdash/shared';
 import type { SecretStore } from '@core/primitives/secrets/api/secret-store';
+import { bindCredential, readBoundCredential, sshCredentialKeys } from './credential-record';
 
 /**
  * Stores and retrieves SSH passwords and passphrases as `Secret`-typed values.
@@ -11,24 +12,38 @@ export class SshCredentialService {
   constructor(private readonly secrets: SecretStore) {}
 
   private passwordSecretKey(connectionId: string): string {
-    return `ssh:${connectionId}:password`;
+    return sshCredentialKeys(connectionId).password;
   }
 
   private passphraseSecretKey(connectionId: string): string {
-    return `ssh:${connectionId}:passphrase`;
+    return sshCredentialKeys(connectionId).passphrase;
   }
 
-  async storePassword(connectionId: string, password: Secret<string>): Promise<void> {
+  async storePassword(
+    connectionId: string,
+    password: Secret<string>,
+    identity?: string
+  ): Promise<void> {
     try {
-      await this.secrets.setSecret(this.passwordSecretKey(connectionId), password);
+      const keys = sshCredentialKeys(connectionId);
+      await this.secrets.setSecret(
+        identity ? keys.boundPassword : keys.password,
+        identity ? bindCredential(password, identity) : password
+      );
+      await this.secrets.deleteSecret(identity ? keys.password : keys.boundPassword);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to store password for connection ${connectionId}: ${message}`);
     }
   }
 
-  async getPassword(connectionId: string): Promise<Secret<string> | null> {
+  async getPassword(connectionId: string, identity?: string): Promise<Secret<string> | null> {
     try {
+      if (identity) {
+        const bound = await this.secrets.getSecret(sshCredentialKeys(connectionId).boundPassword);
+        if (bound) return readBoundCredential(bound, identity);
+        // Legacy passwords are eligible only after the caller verifies the saved destination.
+      }
       return await this.secrets.getSecret(this.passwordSecretKey(connectionId));
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -39,6 +54,7 @@ export class SshCredentialService {
   async deletePassword(connectionId: string): Promise<void> {
     try {
       await this.secrets.deleteSecret(this.passwordSecretKey(connectionId));
+      await this.secrets.deleteSecret(sshCredentialKeys(connectionId).boundPassword);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to delete password for connection ${connectionId}: ${message}`);
@@ -47,24 +63,45 @@ export class SshCredentialService {
 
   async hasPassword(connectionId: string): Promise<boolean> {
     try {
-      const credential = await this.secrets.getSecret(this.passwordSecretKey(connectionId));
+      const credential =
+        (await this.secrets.getSecret(sshCredentialKeys(connectionId).boundPassword)) ??
+        (await this.secrets.getSecret(this.passwordSecretKey(connectionId)));
       return credential !== null;
     } catch {
       return false;
     }
   }
 
-  async storePassphrase(connectionId: string, passphrase: Secret<string>): Promise<void> {
+  async storePassphrase(
+    connectionId: string,
+    passphrase: Secret<string>,
+    identity?: string
+  ): Promise<void> {
     try {
-      await this.secrets.setSecret(this.passphraseSecretKey(connectionId), passphrase);
+      const keys = sshCredentialKeys(connectionId);
+      await this.secrets.setSecret(
+        identity ? keys.boundPassphrase : keys.passphrase,
+        identity ? bindCredential(passphrase, identity) : passphrase
+      );
+      await this.secrets.deleteSecret(identity ? keys.passphrase : keys.boundPassphrase);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to store passphrase for connection ${connectionId}: ${message}`);
     }
   }
 
-  async getPassphrase(connectionId: string): Promise<Secret<string> | null> {
+  async getPassphrase(connectionId: string, identity?: string): Promise<Secret<string> | null> {
     try {
+      if (identity) {
+        const bound = await this.secrets.getSecret(sshCredentialKeys(connectionId).boundPassphrase);
+        if (bound) return readBoundCredential(bound, identity);
+        if (await this.secrets.getSecret(this.passphraseSecretKey(connectionId))) {
+          throw new Error(
+            'Re-enter your SSH key passphrase once to verify it for this key. Your saved passphrase has not been changed.'
+          );
+        }
+        return null;
+      }
       return await this.secrets.getSecret(this.passphraseSecretKey(connectionId));
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -75,6 +112,7 @@ export class SshCredentialService {
   async deletePassphrase(connectionId: string): Promise<void> {
     try {
       await this.secrets.deleteSecret(this.passphraseSecretKey(connectionId));
+      await this.secrets.deleteSecret(sshCredentialKeys(connectionId).boundPassphrase);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to delete passphrase for connection ${connectionId}: ${message}`);
@@ -83,7 +121,9 @@ export class SshCredentialService {
 
   async hasPassphrase(connectionId: string): Promise<boolean> {
     try {
-      const credential = await this.secrets.getSecret(this.passphraseSecretKey(connectionId));
+      const credential =
+        (await this.secrets.getSecret(sshCredentialKeys(connectionId).boundPassphrase)) ??
+        (await this.secrets.getSecret(this.passphraseSecretKey(connectionId)));
       return credential !== null;
     } catch {
       return false;

--- a/apps/emdash-desktop/src/core/services/ssh/node/ssh-service.test.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/ssh-service.test.ts
@@ -271,7 +271,7 @@ describe('SshService.testConnection', () => {
           password: '',
         })
       ).resolves.toMatchObject({ success: true });
-      expect(getPassword).toHaveBeenCalledWith('ssh-1');
+      expect(getPassword).toHaveBeenCalledWith('ssh-1', expect.any(String));
       expect(manager.getAllConnectionStates()).toEqual({ 'ssh-1': 'connected' });
       expect(fixture.updateSets).toEqual([]);
     } finally {

--- a/apps/emdash-desktop/src/core/services/ssh/node/ssh-service.test.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/ssh-service.test.ts
@@ -1,11 +1,16 @@
 import { generateKeyPairSync } from 'node:crypto';
 import { EventEmitter, once } from 'node:events';
+import { secret } from '@emdash/shared';
 import { Server, type Client, type ConnectConfig } from 'ssh2';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ConnectionState, SshConfig } from '@core/primitives/ssh/api';
 import type { AppDb } from '@core/services/app-db/node/db';
 import type { SshConnectionRow } from '@core/services/app-db/node/schema';
-import type { SshConnectResult } from './connect/resolve-ssh-connect-config';
+import {
+  resolveSshConnectConfig,
+  type SshConnectInput,
+  type SshConnectResult,
+} from './connect/resolve-ssh-connect-config';
 import { SshConnectionManager } from './lifecycle/ssh-connection-manager';
 import { SshService, type SshServiceDeps } from './ssh-service';
 
@@ -27,13 +32,14 @@ const baseConfig: SshConfig & { password?: string } = {
 
 function createService(options: {
   manager: SshConnectionManager;
-  resolve: () => Promise<SshConnectResult>;
+  resolve: (input: SshConnectInput) => Promise<SshConnectResult>;
+  db?: AppDb;
   createId?: () => string;
   now?: () => number;
   capture?: SshServiceDeps['telemetry']['capture'];
 }): SshService {
   return new SshService({
-    db: {} as AppDb,
+    db: options.db ?? ({} as AppDb),
     manager: options.manager,
     runtime: { remove: vi.fn() },
     resolveConnectConfig: options.resolve,
@@ -199,6 +205,7 @@ function createIntentFixture(options: {
 
   return {
     service,
+    db,
     manager,
     row,
     updateSets,
@@ -212,6 +219,63 @@ describe('SshService.testConnection', () => {
   afterEach(() => {
     for (const server of servers.splice(0)) {
       server.close();
+    }
+  });
+
+  it('loads the saved identity for an edit but tests the draft on a separate connection', async () => {
+    const fixture = createIntentFixture({ shouldConnect: 1 });
+    const draft = { ...baseConfig, id: 'ssh-1', host: 'edited.example.com' };
+    await expect(fixture.service.testConnection(draft)).resolves.toMatchObject({ success: true });
+    expect(fixture.resolveConnectConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'transient',
+        config: draft,
+        previous: expect.objectContaining({ id: 'ssh-1', host: 'corp.example.com' }),
+      })
+    );
+    expect(fixture.updateSets).toEqual([]);
+    expect(fixture.manager.dropConnection).not.toHaveBeenCalledWith('ssh-1');
+  });
+
+  it('authenticates with a retained password without disturbing a live saved connection', async () => {
+    const { server, port } = await startServer();
+    servers.push(server);
+    const fixture = createIntentFixture({ shouldConnect: 1 });
+    Object.assign(fixture.row, {
+      host: '127.0.0.1',
+      port,
+      username: 'alice',
+      authType: 'password',
+    });
+    const manager = new SshConnectionManager();
+    const getPassword = vi.fn(async () => secret('secret'));
+    const service = createService({
+      db: fixture.db,
+      manager,
+      resolve: (input) => resolveSshConnectConfig(input, { getPassword }),
+    });
+    try {
+      await manager.createConnection('ssh-1', async () => ({
+        config: { host: '127.0.0.1', port, username: 'alice', password: 'secret' },
+        cleanup: () => {},
+        debugLogs: [],
+      }));
+      await expect(
+        service.testConnection({
+          id: 'ssh-1',
+          name: 'Renamed draft',
+          host: '127.0.0.1',
+          port,
+          username: 'alice',
+          authType: 'password',
+          password: '',
+        })
+      ).resolves.toMatchObject({ success: true });
+      expect(getPassword).toHaveBeenCalledWith('ssh-1');
+      expect(manager.getAllConnectionStates()).toEqual({ 'ssh-1': 'connected' });
+      expect(fixture.updateSets).toEqual([]);
+    } finally {
+      await manager.disconnectAll();
     }
   });
 

--- a/apps/emdash-desktop/src/core/services/ssh/node/ssh-service.ts
+++ b/apps/emdash-desktop/src/core/services/ssh/node/ssh-service.ts
@@ -8,7 +8,7 @@ import type {
   SshConfig,
   SshService as SshServiceContract,
 } from '@core/primitives/ssh/api';
-import { SshConnectionNotFoundError } from '@core/primitives/ssh/api';
+import { SshConnectionNotFoundError, sshConfigFromRow } from '@core/primitives/ssh/api';
 import {
   SshConnectionFailure,
   type SshConnectionControl,
@@ -125,7 +125,14 @@ export class SshService implements SshServiceContract {
       await this.deps.manager.createConnection(
         connectionId,
         async () => {
-          const resolved = await this.deps.resolveConnectConfig({ kind: 'transient', config });
+          const previous = config.id
+            ? sshConfigFromRow(await this.loadConnectionRow(config.id))
+            : undefined;
+          const resolved = await this.deps.resolveConnectConfig({
+            kind: 'transient',
+            config,
+            previous,
+          });
           debugLogs = resolved.debugLogs;
           const existingDebug = resolved.config.debug;
           return {

--- a/apps/emdash-desktop/src/main/bootstrap/boot/phases/infrastructure.ts
+++ b/apps/emdash-desktop/src/main/bootstrap/boot/phases/infrastructure.ts
@@ -6,6 +6,7 @@ import type { SshService } from '@core/primitives/ssh/api';
 import type { AppDb } from '@core/services/app-db/node/db';
 import { sshConnections } from '@core/services/app-db/node/schema';
 import { createHosts, type Hosts } from '@core/services/hosts/node/hosts';
+import { sshCredentialChanges } from '@core/services/ssh/node/credentials/credential-record';
 import { SshCredentialService } from '@core/services/ssh/node/credentials/ssh-credential-service';
 import { createSshService } from '@main/bootstrap/core/ssh-service-factory';
 import { getDesktopClientId } from '@main/core/runtime/desktop-client-id';
@@ -25,6 +26,8 @@ export async function bootInfrastructure(database: DatabaseBundle): Promise<Infr
     scope: appScope,
     db: database.db,
     credentials: new SshCredentialService(encryptedAppSecretsStore),
+    prepareCredentials: (id, credentials) =>
+      encryptedAppSecretsStore.prepareChanges(sshCredentialChanges(id, credentials)),
     logger: log,
     telemetry: telemetryService,
   });

--- a/apps/emdash-desktop/src/main/bootstrap/core/ssh-service-factory.test.ts
+++ b/apps/emdash-desktop/src/main/bootstrap/core/ssh-service-factory.test.ts
@@ -30,6 +30,7 @@ describe('createSshService', () => {
       scope,
       db: {} as AppDb,
       credentials,
+      prepareCredentials: () => () => {},
       logger,
       telemetry: { capture: vi.fn() },
     });

--- a/apps/emdash-desktop/src/main/bootstrap/core/ssh-service-factory.ts
+++ b/apps/emdash-desktop/src/main/bootstrap/core/ssh-service-factory.ts
@@ -1,6 +1,9 @@
 import type { Scope } from '@emdash/shared/concurrency';
 import type { Logger } from '@emdash/shared/logger';
-import { MachinesService } from '@core/features/machines/api/node/machines-service';
+import {
+  MachinesService,
+  type MachinesServiceDeps,
+} from '@core/features/machines/api/node/machines-service';
 import type { SshServiceHandle } from '@core/manifests/node/ssh-service-handle';
 import type { AppDb } from '@core/services/app-db/node/db';
 import { resolveSshConfig } from '@core/services/ssh/node/config/resolve-ssh-config';
@@ -15,6 +18,7 @@ export interface CreateSshServiceDeps {
   scope: Scope;
   db: AppDb;
   credentials: SshCredentialService;
+  prepareCredentials: MachinesServiceDeps['prepareCredentials'];
   logger: Logger;
   telemetry: SshServiceDeps['telemetry'];
 }
@@ -40,6 +44,7 @@ export function createSshService(deps: CreateSshServiceDeps): SshServiceHandle {
   const machines = new MachinesService({
     db: deps.db,
     credentials: deps.credentials,
+    prepareCredentials: deps.prepareCredentials,
     ssh,
     log: deps.logger,
   });

--- a/apps/emdash-desktop/src/main/host/secrets/encrypted-app-secrets-store.ts
+++ b/apps/emdash-desktop/src/main/host/secrets/encrypted-app-secrets-store.ts
@@ -1,7 +1,7 @@
 import { secret, type Secret } from '@emdash/shared';
 import { eq } from 'drizzle-orm';
 import { safeStorage } from 'electron';
-import type { AppDb } from '@core/services/app-db/node/db';
+import type { AppDb, DrizzleTx } from '@core/services/app-db/node/db';
 import { appSecrets } from '@core/services/app-db/node/schema';
 import { getAppDb } from '@main/db/instance';
 
@@ -33,12 +33,32 @@ export class EncryptedAppSecretsStore {
   }
 
   async setSecret(key: string, value: Secret<string>): Promise<void> {
+    await this.setEncryptedSecret(key, this.encrypt(value));
+  }
+
+  /** Encrypt before entering the caller's synchronous SQLite transaction. */
+  prepareChanges(changes: ReadonlyMap<string, Secret<string> | null>): (tx: DrizzleTx) => void {
+    const prepared = [...changes].map(([key, value]) => ({
+      key,
+      encrypted: value ? this.encrypt(value) : null,
+    }));
+    return (tx) => {
+      for (const { key, encrypted } of prepared) {
+        if (encrypted === null) tx.delete(appSecrets).where(eq(appSecrets.key, key)).run();
+        else
+          tx.insert(appSecrets)
+            .values({ key, secret: encrypted })
+            .onConflictDoUpdate({ target: appSecrets.key, set: { secret: encrypted } })
+            .run();
+      }
+    };
+  }
+
+  private encrypt(value: Secret<string>): string {
     this.assertSecureStorageAvailable();
     // Boundary disclosure: the Electron safeStorage write is a documented
     // .expose() site — plaintext leaves the Secret only to be encrypted.
-    const encryptedSecret = this.safeStorageApi.encryptString(value.expose()).toString('base64');
-
-    await this.setEncryptedSecret(key, encryptedSecret);
+    return this.safeStorageApi.encryptString(value.expose()).toString('base64');
   }
 
   async setEncryptedSecret(key: string, encryptedSecret: string): Promise<void> {

--- a/apps/emdash-desktop/src/main/host/secrets/machine-save-credentials.db.test.ts
+++ b/apps/emdash-desktop/src/main/host/secrets/machine-save-credentials.db.test.ts
@@ -1,0 +1,332 @@
+import { generateKeyPairSync } from 'node:crypto';
+import { secret } from '@emdash/shared';
+import { deferred } from '@emdash/shared/testing';
+import { openFixture } from '@tooling/utils/db';
+import { eq } from 'drizzle-orm';
+import { utils } from 'ssh2';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MachinesService } from '@core/features/machines/api/node/machines-service';
+import { captureMachineSave } from '@core/features/machines/node/machine-persistence';
+import type { SshConfig } from '@core/primitives/ssh/api';
+import { appSecrets, sshConnections } from '@core/services/app-db/node/schema';
+import { resolveSshConnectConfig } from '@core/services/ssh/node/connect/resolve-ssh-connect-config';
+import {
+  sshCredentialChanges,
+  sshCredentialKeys,
+} from '@core/services/ssh/node/credentials/credential-record';
+import { SshCredentialService } from '@core/services/ssh/node/credentials/ssh-credential-service';
+import { EncryptedAppSecretsStore } from '@main/host/secrets/encrypted-app-secrets-store';
+
+vi.mock('electron', () => ({ safeStorage: undefined }));
+
+describe('atomic, identity-bound machine credentials', () => {
+  let fixture: Awaited<ReturnType<typeof openFixture>>;
+  let store: EncryptedAppSecretsStore;
+  let credentials: SshCredentialService;
+  let service: MachinesService;
+  let beforeCommit: (() => void) | undefined;
+  const encrypt = vi.fn((value: string) => Buffer.from(`encrypted:${value}`));
+  const dropConnection = vi.fn(async () => {});
+  const readFile = vi.fn(async (path: string) => `key contents at ${path}`);
+  const resolveSshConfig = vi.fn(async () => ({
+    hostname: 'work.internal',
+    user: 'alice',
+    port: 22,
+    identityFile: ['/keys/old'],
+    identityAgentDisabled: false,
+    identitiesOnly: false,
+    forwardAgent: false,
+  }));
+  const original: SshConfig = {
+    id: 'one',
+    name: 'Work',
+    host: 'work.internal',
+    port: 22,
+    username: 'alice',
+    authType: 'password',
+  };
+
+  beforeEach(async () => {
+    fixture = await openFixture('empty');
+    beforeCommit = undefined;
+    encrypt.mockClear();
+    dropConnection.mockClear();
+    readFile.mockReset().mockImplementation(async (path) => `key contents at ${path}`);
+    resolveSshConfig.mockReset().mockResolvedValue({
+      hostname: original.host,
+      user: original.username,
+      port: original.port,
+      identityFile: ['/keys/old'],
+      identityAgentDisabled: false,
+      identitiesOnly: false,
+      forwardAgent: false,
+    });
+    store = new EncryptedAppSecretsStore(
+      fixture.db,
+      {
+        isEncryptionAvailable: () => true,
+        encryptString: encrypt,
+        decryptString: (value: Buffer) => value.toString().slice('encrypted:'.length),
+      } as unknown as Electron.SafeStorage,
+      'darwin'
+    );
+    credentials = new SshCredentialService(store);
+    service = new MachinesService({
+      db: fixture.db,
+      credentials,
+      readFile,
+      resolveSshConfig,
+      now: () => 0,
+      prepareCredentials: (id, values) => {
+        const apply = store.prepareChanges(sshCredentialChanges(id, values));
+        beforeCommit?.();
+        return apply;
+      },
+      ssh: { dropConnection, removeRuntimeState: vi.fn() },
+      log: { warn: vi.fn() },
+    });
+  });
+
+  afterEach(() => fixture.close());
+
+  const connectDeps = () => ({
+    readFile,
+    resolveSshConfig,
+    getPassword: credentials.getPassword.bind(credentials),
+    getPassphrase: credentials.getPassphrase.bind(credentials),
+  });
+
+  it.each(['manual', 'config'] as const)(
+    'preserves a legacy passphrase until explicit re-entry for %s connections',
+    async (mode) => {
+      const { privateKey } = generateKeyPairSync('rsa', {
+        modulusLength: 2048,
+        publicKeyEncoding: { type: 'spki', format: 'pem' },
+        privateKeyEncoding: {
+          type: 'pkcs1',
+          format: 'pem',
+          cipher: 'aes-256-cbc',
+          passphrase: 'legacy-passphrase',
+        },
+      });
+      expect(utils.parseKey(privateKey, 'legacy-passphrase')).not.toBeInstanceOf(Error);
+      readFile.mockResolvedValue(privateKey);
+      const config = {
+        ...original,
+        authType: 'key' as const,
+        privateKeyPath: mode === 'manual' ? '/keys/unchanged' : undefined,
+        sshConfigAlias: mode === 'config' ? 'work' : undefined,
+      };
+      fixture.db
+        .insert(sshConnections)
+        .values({ ...config, useAgent: 0, metadata: { sshConfigAlias: config.sshConfigAlias } })
+        .run();
+      await credentials.storePassphrase(config.id, secret('legacy-passphrase'));
+      const before = captureMachineSave(fixture.db, config.id);
+      const draft = { ...config, name: 'Only renamed', passphrase: '' };
+      await expect(service.saveMachine(draft)).rejects.toThrow('Re-enter your SSH key passphrase');
+      await expect(
+        resolveSshConnectConfig(
+          { kind: 'transient', config: draft, previous: config },
+          connectDeps()
+        )
+      ).rejects.toThrow('Re-enter your SSH key passphrase');
+      await expect(
+        resolveSshConnectConfig({ kind: 'persisted', row: before.connection! }, connectDeps())
+      ).rejects.toThrow('Re-enter your SSH key passphrase');
+      expect(captureMachineSave(fixture.db, config.id)).toEqual(before);
+      expect(dropConnection).not.toHaveBeenCalled();
+
+      await service.saveMachine({ ...draft, passphrase: 'legacy-passphrase' });
+      expect(await store.getSecret(sshCredentialKeys(config.id).passphrase)).toBeNull();
+      const row = captureMachineSave(fixture.db, config.id).connection!;
+      const result = await resolveSshConnectConfig({ kind: 'persisted', row }, connectDeps());
+      expect(
+        utils.parseKey(result.config.privateKey!, result.config.passphrase)
+      ).not.toBeInstanceOf(Error);
+      await service.saveMachine({ ...draft, name: 'Renamed again' });
+      expect(
+        (await resolveSshConnectConfig({ kind: 'persisted', row }, connectDeps())).config.passphrase
+      ).toBe('legacy-passphrase');
+    }
+  );
+
+  it('preserves the old row and secrets when another writer claims the name after the pre-check', async () => {
+    await service.saveMachine({ ...original, password: 'original password' });
+    const before = captureMachineSave(fixture.db, original.id);
+    beforeCommit = () => {
+      fixture.db
+        .insert(sshConnections)
+        .values({ ...original, id: 'other', name: 'Contended', useAgent: 0 })
+        .run();
+    };
+    await expect(
+      service.saveMachine({
+        ...original,
+        name: 'Contended',
+        host: 'new.internal',
+        password: 'replacement',
+      })
+    ).rejects.toThrow('UNIQUE constraint failed');
+    expect(captureMachineSave(fixture.db, original.id)).toEqual(before);
+    expect(dropConnection).not.toHaveBeenCalled();
+  });
+
+  it.each(['replace', 'delete'] as const)(
+    'rolls back the row and secrets when credential %s fails',
+    async (operation) => {
+      await service.saveMachine({ ...original, password: 'original password' });
+      const before = captureMachineSave(fixture.db, original.id);
+      fixture.sqlite
+        .exec(`CREATE TRIGGER fail_secret BEFORE ${operation === 'replace' ? 'INSERT' : 'DELETE'} ON app_secrets
+      BEGIN SELECT RAISE(ABORT, 'credential write failed'); END`);
+      await expect(
+        service.saveMachine({
+          ...original,
+          name: 'Changed',
+          authType: operation === 'replace' ? 'password' : 'agent',
+          password: 'replacement',
+        })
+      ).rejects.toThrow('credential write failed');
+      expect(captureMachineSave(fixture.db, original.id)).toEqual(before);
+      expect(dropConnection).not.toHaveBeenCalled();
+    }
+  );
+
+  it('does not change storage if encryption fails', async () => {
+    await service.saveMachine({ ...original, password: 'original password' });
+    const before = captureMachineSave(fixture.db, original.id);
+    encrypt.mockImplementationOnce(() => {
+      throw new Error('encryption unavailable');
+    });
+    await expect(service.saveMachine({ ...original, password: 'replacement' })).rejects.toThrow(
+      'encryption unavailable'
+    );
+    expect(captureMachineSave(fixture.db, original.id)).toEqual(before);
+  });
+
+  it('rejects a concurrent stale save even when only the credential changed', async () => {
+    await service.saveMachine({ ...original, password: 'original password' });
+    // Keep timestamps equal, so the credential snapshot must catch this conflict.
+    await service.saveMachine({ ...original, password: 'original password' });
+    const started = deferred();
+    const resume = deferred();
+    const getPassword = credentials.getPassword.bind(credentials);
+    vi.spyOn(credentials, 'getPassword').mockImplementationOnce(async (id, identity) => {
+      const value = await getPassword(id, identity);
+      started.resolve();
+      await resume.promise;
+      return value;
+    });
+    const pending = service.saveMachine({ ...original, password: '' });
+    const rejected = expect(pending).rejects.toThrow('changed while saving');
+    await started.promise;
+    await service.saveMachine({ ...original, password: 'winning password' });
+    resume.resolve();
+    await rejected;
+    const result = await resolveSshConnectConfig(
+      { kind: 'transient', config: original, previous: original },
+      connectDeps()
+    );
+    expect(result.config.password).toBe('winning password');
+  });
+
+  it.each(['path', 'contents'] as const)(
+    'does not reuse the inherited passphrase after key %s changes',
+    async (change) => {
+      const config = { ...original, authType: 'key' as const, sshConfigAlias: 'work' };
+      await service.saveMachine({ ...config, passphrase: 'old key passphrase' });
+      const input = { kind: 'transient' as const, config, previous: config };
+      expect((await resolveSshConnectConfig(input, connectDeps())).config.passphrase).toBe(
+        'old key passphrase'
+      );
+      if (change === 'path')
+        resolveSshConfig.mockResolvedValue({
+          ...(await resolveSshConfig()),
+          identityFile: ['/keys/new'],
+        });
+      else readFile.mockResolvedValue('replacement contents at the same path');
+      expect(
+        (await resolveSshConnectConfig(input, connectDeps())).config.passphrase
+      ).toBeUndefined();
+      const row = fixture.db
+        .select()
+        .from(sshConnections)
+        .where(eq(sshConnections.id, original.id))
+        .get()!;
+      expect(
+        (await resolveSshConnectConfig({ kind: 'persisted', row }, connectDeps())).config.passphrase
+      ).toBeUndefined();
+      await service.saveMachine(config);
+      expect(await store.getSecret(sshCredentialKeys(config.id).boundPassphrase)).toBeNull();
+      await service.saveMachine({ ...config, passphrase: 'replacement passphrase' });
+      expect((await resolveSshConnectConfig(input, connectDeps())).config.passphrase).toBe(
+        'replacement passphrase'
+      );
+    }
+  );
+
+  it.each([{ hostname: 'new.internal' }, { user: 'other' }, { port: 2222 }])(
+    'rejects effective destination drift on save, test, and reconnect: %j',
+    async (change) => {
+      const config = { ...original, sshConfigAlias: 'work' };
+      await service.saveMachine({ ...config, password: 'original password' });
+      const before = captureMachineSave(fixture.db, original.id);
+      resolveSshConfig.mockResolvedValue({ ...(await resolveSshConfig()), ...change });
+      const getPassword = vi.spyOn(credentials, 'getPassword');
+      for (const password of ['', 'newly entered password']) {
+        await expect(service.saveMachine({ ...config, password })).rejects.toThrow(
+          'SSH config changed'
+        );
+        await expect(
+          resolveSshConnectConfig(
+            { kind: 'transient', config: { ...config, password }, previous: config },
+            connectDeps()
+          )
+        ).rejects.toThrow('SSH config changed');
+      }
+      await expect(
+        resolveSshConnectConfig({ kind: 'persisted', row: before.connection! }, connectDeps())
+      ).rejects.toThrow('SSH config changed');
+      expect(getPassword).not.toHaveBeenCalled();
+      expect(captureMachineSave(fixture.db, original.id)).toEqual(before);
+    }
+  );
+
+  it('does not combine an old connection snapshot with a newly saved destination password', async () => {
+    await service.saveMachine({ ...original, password: 'old password' });
+    const row = captureMachineSave(fixture.db, original.id).connection!;
+    await service.saveMachine({
+      ...original,
+      host: 'replacement.internal',
+      password: 'new password',
+    });
+    await expect(
+      resolveSshConnectConfig({ kind: 'persisted', row }, connectDeps())
+    ).rejects.toThrow('Enter a password');
+  });
+
+  it('upgrades a compatible legacy password but does not guess a legacy passphrase binding', async () => {
+    fixture.db
+      .insert(sshConnections)
+      .values({ ...original, useAgent: 0 })
+      .run();
+    await credentials.storePassword(original.id, secret('legacy password'));
+    await service.saveMachine(original);
+    expect(await store.getSecret(sshCredentialKeys(original.id).password)).toBeNull();
+    expect(
+      (
+        await resolveSshConnectConfig(
+          { kind: 'transient', config: original, previous: original },
+          connectDeps()
+        )
+      ).config.password
+    ).toBe('legacy password');
+    await credentials.storePassphrase(original.id, secret('unbound passphrase'));
+    await expect(credentials.getPassphrase(original.id, 'unknown-key')).rejects.toThrow(
+      'Re-enter your SSH key passphrase'
+    );
+    const rows = fixture.db.select().from(appSecrets).all();
+    expect(rows.every((row) => !row.secret.includes('legacy password'))).toBe(true);
+  });
+});

--- a/apps/emdash-desktop/vitest.config.ts
+++ b/apps/emdash-desktop/vitest.config.ts
@@ -114,6 +114,11 @@ export default defineConfig({
               // slice-isolation tests colocated with core slices as
               // *.browser.test.{ts,tsx}.
               extends: true as const,
+              // Prebundle before mounting query-backed React forms. A late JSX
+              // optimization reload can otherwise split their provider contexts.
+              optimizeDeps: {
+                include: ['react/jsx-dev-runtime', '@tanstack/react-query'],
+              },
               test: {
                 name: 'browser',
                 browser: {

--- a/packages/ui/src/react/primitives/combobox/combobox.stories.tsx
+++ b/packages/ui/src/react/primitives/combobox/combobox.stories.tsx
@@ -35,6 +35,26 @@ export const Default: Story = {
   ),
 };
 
+export const StandaloneInput: Story = {
+  render: () => (
+    <Box className={s.w64}>
+      <Combobox.Root items={FRUITS}>
+        <Combobox.Input variant="default" aria-label="Fruit" placeholder="Search fruits…" />
+        <Combobox.Content>
+          <Combobox.List>
+            {(fruit: string) => (
+              <Combobox.Item key={fruit} value={fruit}>
+                {fruit}
+              </Combobox.Item>
+            )}
+          </Combobox.List>
+          <Combobox.Empty>No fruits found.</Combobox.Empty>
+        </Combobox.Content>
+      </Combobox.Root>
+    </Box>
+  ),
+};
+
 export const WithGroups: Story = {
   render: () => (
     <Box className={s.w64}>

--- a/packages/ui/src/react/primitives/combobox/combobox.tsx
+++ b/packages/ui/src/react/primitives/combobox/combobox.tsx
@@ -47,6 +47,7 @@ function ComboboxInput({
   leftAddon,
   rightAddon,
   inputRef,
+  variant = 'embedded',
   ...props
 }: ComboboxPrimitive.Input.Props & {
   showTrigger?: boolean;
@@ -54,10 +55,11 @@ function ComboboxInput({
   leftAddon?: React.ReactNode;
   rightAddon?: React.ReactNode;
   inputRef?: React.RefObject<HTMLInputElement | null>;
+  variant?: React.ComponentProps<typeof InputGroup.Root>['variant'];
 }) {
   return (
     <InputGroup.Root
-      variant="embedded"
+      variant={variant}
       className={typeof className === 'string' ? className : undefined}
     >
       {leftAddon && <InputGroup.Addon align="inline-start">{leftAddon}</InputGroup.Addon>}


### PR DESCRIPTION
- allow private key and authentication overrides for ssh config connections, with reset to the inherited key.
- add explicit host resolution, a read-only connection summary, and independent manual and ssh config drafts with a shared optional name.
- split the form into focused views and a shared validation and submission workflow, preserving config refreshes and separating connection results from save errors.
- reuse stored credentials only for unchanged connection identities and key selections; keep edit checks isolated from saved connections and secrets in the main process.
- support standalone combobox inputs and prebundle browser dependencies to prevent provider-context splits during form mounting.