### PR TITLE
fix(chat-ui): stabilize conversation lifecycle

### DIFF
--- a/agents/integrations/mcp.md
+++ b/agents/integrations/mcp.md
@@ -13,6 +13,11 @@
 - MCP server configs are read, adapted, merged, and written across supported agent ecosystems
 - provider-specific config formats are handled through adapters in `src/main/core/mcp/utils/`
 - the renderer MCP UI manages installed servers and catalog entries
+- Chat's MCP list reports configured servers, not inferred connection health. Codex's recognized
+  synthetic startup failures are translated by its ACP enrichment hook and displayed on the
+  composer MCP trigger/popover instead of opening a transcript turn. Startup errors are scoped to
+  the current Session activation and are not retained as configuration. Other provider diagnostics
+  and ordinary failed MCP tool invocations remain unchanged; there is no health polling.
 
 ## Rules
 

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-panel.tsx
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-panel.tsx
@@ -816,12 +816,12 @@ export const AcpChatPanel = observer(function AcpChatPanel() {
 
   const unavailableWithoutTranscript =
     store.loadError?.kind === 'unavailable' && store.messageCount === 0;
+  const showComposer = store.historyKnown || store.messageCount > 0;
   const showBlockingOverlay =
-    store.session === null &&
+    !showComposer &&
     (store.historyLoading ||
       (store.loadError !== null && store.loadError.kind !== 'unavailable') ||
       unavailableWithoutTranscript);
-  const showComposer = store.session !== null;
   const showHero = showComposer && store.isEmpty && store.loadError === null;
 
   return (
@@ -840,8 +840,8 @@ export const AcpChatPanel = observer(function AcpChatPanel() {
         style={{ position: 'absolute', inset: 0 }}
       />
 
-      {/* Before attach, loading/errors own the content area. Once attached, activation errors are
-          non-blocking and render beside the still-usable composer. */}
+      {/* Unknown restored history owns the content area until it can be laid out. Fresh chats
+          render their centered composer immediately, independently of provider activation. */}
       {overlaySlot &&
         showBlockingOverlay &&
         createPortal(

--- a/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
+++ b/apps/emdash-desktop/src/core/features/conversations/browser/acp/acp-chat-store.ts
@@ -103,6 +103,7 @@ export class AcpChatStore {
 
   session: AcpLiveSession | null = null;
   historyLoading = true;
+  historyKnown: boolean;
   loadError: AcpLoadError | null = null;
   messageCount = 0;
   draftText = '';
@@ -132,6 +133,8 @@ export class AcpChatStore {
     readonly taskId: string,
     readonly hostAccess?: ProjectHostAccess
   ) {
+    const conversation = conversationRegistry.get(taskId)?.conversations.get(conversationId)?.data;
+    this.historyKnown = conversation !== undefined && !conversation.sessionId;
     this.chatContext = getSharedChatContext();
     this._scope = createScope({ label: `acp-chat:${conversationId}` });
     this.chatState = getChatUiRuntime().createChatState(this.chatContext, {
@@ -146,6 +149,7 @@ export class AcpChatStore {
     makeObservable(this, {
       session: observable.ref,
       historyLoading: observable,
+      historyKnown: observable,
       loadError: observable,
       messageCount: observable,
       draftText: observable,
@@ -360,7 +364,7 @@ export class AcpChatStore {
   }
 
   get isEmpty(): boolean {
-    return !this.historyLoading && this.messageCount === 0;
+    return this.historyKnown && this.messageCount === 0;
   }
 
   bootstrap(): void {
@@ -684,6 +688,7 @@ export class AcpChatStore {
         }
         this.historyLoading = false;
         this.loadError = null;
+        this.historyKnown = true;
         this._bootstrapFailed = false;
         this._syncMessageCount();
       });

--- a/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-startup-layout.test.tsx
+++ b/apps/emdash-desktop/src/renderer/tests/browser/acp-chat-startup-layout.test.tsx
@@ -1,0 +1,330 @@
+import * as chatUi from '@emdash/chat-ui';
+import '@emdash/chat-ui/style.css';
+import type {
+  SessionConfigState,
+  SessionMcpServer,
+  SessionState,
+  TranscriptTurn,
+} from '@emdash/core/runtimes/acp/api/client';
+import { ok } from '@emdash/shared';
+import { deferred } from '@emdash/shared/testing';
+import '@emdash/ui/style.css';
+import {
+  client,
+  connect,
+  createController,
+  createWireSessionHub,
+  defineContract,
+  memoryTransportPair,
+} from '@emdash/wire/rpc';
+import { cell, expose, flushStateTurn } from '@emdash/wire/state';
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { expect, it, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import { conversationsContract } from '@core/features/conversations/api';
+import { installChatUiRuntime } from '@core/features/conversations/api/browser/chat/chat-ui-runtime';
+import { AcpChatPanel } from '@core/features/conversations/browser/acp/acp-chat-panel';
+import { AcpChatStore } from '@core/features/conversations/browser/acp/acp-chat-store';
+
+const fixture = vi.hoisted(() => ({
+  client: undefined as unknown,
+  context: undefined as unknown,
+  store: undefined as unknown,
+  restored: false,
+}));
+vi.mock('@core/features/conversations/api/browser/client', () => ({
+  getConversationsClient: async () => fixture.client,
+}));
+vi.mock('@core/features/conversations/api/browser/chat/shared-chat-context', () => ({
+  getSharedChatContext: () => fixture.context,
+}));
+vi.mock('@core/features/conversations/api/browser/stores/conversation-registry', () => ({
+  conversationRegistry: {
+    get: () => ({
+      conversations: new Map([
+        [
+          'startup-diagnostic',
+          {
+            seen: true,
+            data: {
+              providerId: 'codex',
+              sessionId: fixture.restored ? 'existing-session' : undefined,
+            },
+          },
+        ],
+      ]),
+    }),
+  },
+}));
+vi.mock('@core/primitives/mementos/browser', () => ({
+  getMementoClient: () => ({
+    reportError: vi.fn(),
+    subject: () => ({
+      ready: Promise.resolve(),
+      release: async () => {},
+      handle: () => ({
+        value: { version: '1', text: '', attachments: [] },
+        autoPersist: () => () => {},
+      }),
+    }),
+  }),
+}));
+vi.mock('@core/primitives/workbench-shell/browser/tabs/pane-context', () => ({
+  usePaneContext: () => ({
+    pane: {
+      resolvedTabs: [{ isActive: true, kind: 'acp-chat', resource: { store: fixture.store } }],
+    },
+  }),
+}));
+vi.mock('@core/features/agents/api/browser/use-agents', () => ({
+  useAgents: () => ({ data: [] }),
+}));
+vi.mock('@core/features/agents/api/browser/use-agent-metadata', () => ({
+  useAgentMetadata: () => ({ data: [] }),
+}));
+vi.mock('@core/features/agents/contributions/browser/agent-icon', () => ({
+  AgentIcon: () => null,
+}));
+vi.mock('@core/features/integrations/api/browser/use-connected-issue-providers', () => ({
+  useConnectedIssueProviders: () => ({ connectedProviders: [], isProviderUsable: () => false }),
+}));
+vi.mock('@core/features/integrations/contributions/browser/integration-icon', () => ({
+  IntegrationIcon: () => null,
+}));
+vi.mock('@core/features/library/api/browser/prompts/use-prompt-library', () => ({
+  usePromptLibrary: () => ({ value: [] }),
+}));
+vi.mock('@core/features/projects/api/browser/stores/project-selectors', () => ({
+  getProjectHostAccess: () => undefined,
+  getProjectSshConnectionId: () => undefined,
+  getProjectStore: () => undefined,
+  getProjectViewStore: () => undefined,
+  projectData: () => undefined,
+}));
+vi.mock('@core/features/tasks/api/browser/task-state/task-selectors', () => ({
+  asProvisioned: () => undefined,
+  getTaskStore: () => undefined,
+  getRegisteredTaskData: () => undefined,
+}));
+vi.mock('@core/features/source-control/api/browser/stores/source-control-selectors', () => ({
+  getGitRepositoryStore: () => undefined,
+}));
+vi.mock('@core/manifests/browser/project-availability-ui', () => ({
+  projectAvailabilityUi: { getLiveActionDisabledReason: () => undefined },
+}));
+vi.mock('@core/manifests/browser/modal-api', () => ({ openModal: vi.fn() }));
+vi.mock('@core/features/conversations/browser/acp/transcript-file-commands', () => ({
+  createTranscriptFileCommands: () => ({}),
+}));
+
+it.each([
+  { restored: false, populated: false },
+  { restored: true, populated: false },
+  { restored: true, populated: true },
+  { restored: false, populated: false, controls: false },
+])('keeps startup layout stable (%j)', async ({ restored, populated, controls = true }) => {
+  await page.viewport(1100, 800);
+  fixture.restored = restored;
+  installChatUiRuntime(chatUi);
+  const context = chatUi.createChatContext();
+  fixture.context = context;
+  const state = cell<SessionState>({
+    lifecycle: 'closed',
+    suspended: true,
+    activeTurnId: null,
+    pendingPermissions: [],
+    lastStopReason: null,
+    lastTurnErrored: false,
+    queuedPrompts: [],
+    agentTurnActive: false,
+    backgroundAgentCount: 0,
+    isGenerating: false,
+    canSubmit: true,
+    canCancel: false,
+  });
+  const config = cell<SessionConfigState>({
+    modelOptions: null,
+    efforts: null,
+    modeOptions: null,
+    collaborationModeOptions: null,
+    availableCommands: [],
+  });
+  const mcpServers = cell<SessionMcpServer[]>([{ name: 'docs', transport: 'http' }]);
+  const contract = defineContract({
+    acp: defineContract({
+      attach: conversationsContract.acp.attach,
+      session: conversationsContract.acp.session,
+      loadHistory: conversationsContract.acp.loadHistory,
+    }),
+  });
+  const activeTurn = cell<TranscriptTurn | null>(null);
+  const session = expose(contract.acp.session, {
+    state,
+    config,
+    activeTurn,
+    usage: cell(null),
+    plan: cell(null),
+    agents: cell([]),
+    terminals: cell([]),
+    mcpServers,
+  });
+  const historyGate = deferred<void>();
+  const userTurn: TranscriptTurn = {
+    id: 'user-turn',
+    seq: 0,
+    initiator: 'user',
+    items: [{ kind: 'message', id: 'user-message', seq: 0, role: 'user', text: 'Hello' }],
+  };
+  const loadHistory = vi.fn(async () => {
+    await historyGate.promise;
+    return ok({ turns: populated ? [userTurn] : [], nextCursor: null });
+  });
+  const hub = createWireSessionHub(
+    createController(
+      contract,
+      { acp: { attach: async () => ok(undefined), session, loadHistory } },
+      { validate: 'full' }
+    )
+  );
+  const pair = memoryTransportPair();
+  hub.open('startup-layout', pair.right);
+  const connection = connect(pair.left);
+  fixture.client = client(contract, connection);
+  const store = new AcpChatStore('startup-diagnostic', 'project-1', 'task-1');
+  fixture.store = store;
+  const parent = document.createElement('div');
+  parent.style.cssText = 'width:1000px;height:700px;position:relative;font-family:system-ui';
+  parent.className = 'emlight';
+  const css = document.createElement('style');
+  css.textContent =
+    '.relative {position:relative}.absolute {position:absolute}.h-full {height:100%}.overflow-hidden {overflow:hidden}.inset-0 {inset:0}';
+  document.head.append(css);
+  document.body.append(parent);
+  const root = createRoot(parent);
+  const editor = () => parent.querySelector<HTMLElement>('[contenteditable="true"]');
+  const editorY = () => editor()!.getBoundingClientRect().top - parent.getBoundingClientRect().top;
+  let initialEditorY: number | undefined;
+  try {
+    await act(async () => root.render(<AcpChatPanel />));
+    if (!restored) {
+      await vi.waitFor(() => expect(editor()).not.toBeNull());
+      expect(editorY()).toBeLessThan(450);
+      initialEditorY = editorY();
+      expect(parent.textContent).toContain('What are we building today?');
+    }
+    store.bootstrap();
+    await vi.waitFor(() => expect(loadHistory).toHaveBeenCalledOnce());
+    expect(store.historyLoading).toBe(true);
+    if (restored) {
+      expect(editor()).toBeNull();
+      expect(parent.textContent).toContain('Loading chat...');
+    } else {
+      expect(store.isEmpty).toBe(true);
+      expect(editorY()).toBeLessThan(450);
+      expect(parent.textContent).not.toContain('Loading controls');
+      expect(parent.querySelector('[data-slot="combobox-trigger"]')).toBeNull();
+    }
+
+    if (controls)
+      config.set({
+        modelOptions: {
+          configId: 'model',
+          selected: 'test-model',
+          available: [{ id: 'test-model', name: 'Diagnostic Model' }],
+        },
+        efforts: null,
+        modeOptions: {
+          configId: 'mode',
+          selected: 'full',
+          available: [{ id: 'full', name: 'Full access' }],
+        },
+        collaborationModeOptions: null,
+        availableCommands: [],
+      });
+    flushStateTurn();
+    if (!restored && controls) {
+      await vi.waitFor(() => expect(parent.textContent).toContain('Diagnostic Model'));
+      expect(editorY()).toBeLessThan(450);
+    }
+    historyGate.resolve();
+    await vi.waitFor(() => expect(store.historyLoading).toBe(false));
+    await vi.waitFor(() => expect(store.isEmpty).toBe(!populated));
+    await vi.waitFor(() => expect(editor()).not.toBeNull());
+    if (populated) expect(editorY()).toBeGreaterThan(500);
+    else expect(editorY()).toBeLessThan(450);
+    if (initialEditorY !== undefined) expect(editorY()).toBeCloseTo(initialEditorY, 1);
+    const originalEditor = editor();
+    const originalY = editorY();
+    const mcpTrigger = parent.querySelector<HTMLElement>('[aria-label="1 session MCP server"]')!;
+    const mcpWidth = mcpTrigger.getBoundingClientRect().width;
+    const mcpColor = getComputedStyle(mcpTrigger).color;
+    mcpServers.set([{ name: 'docs', transport: 'http', startupError: 'Connection refused' }]);
+    flushStateTurn();
+    await vi.waitFor(() =>
+      expect(
+        parent.querySelector('[aria-label="1 session MCP server, 1 startup failure"]')
+      ).not.toBeNull()
+    );
+    expect(store.isEmpty).toBe(!populated);
+    expect(editor()).toBe(originalEditor);
+    expect(editorY()).toBeCloseTo(originalY, 1);
+    expect(mcpTrigger.getBoundingClientRect().width).toBeCloseTo(mcpWidth, 1);
+    expect(getComputedStyle(mcpTrigger).color).not.toBe(mcpColor);
+    expect(getComputedStyle(mcpTrigger.querySelector('svg')!).color).toBe(
+      getComputedStyle(mcpTrigger).color
+    );
+    expect(mcpTrigger.querySelectorAll('svg')).toHaveLength(1);
+    if (populated) expect(editorY()).toBeGreaterThan(500);
+    else expect(editorY()).toBeLessThan(450);
+    expect(parent.textContent).not.toContain('Loading controls');
+
+    if (!restored) {
+      await page.getByRole('button', { name: '1 session MCP server, 1 startup failure' }).click();
+      expect(document.body.textContent).not.toContain('Connection refused');
+      await page.getByRole('button', { name: 'docs startup error' }).hover();
+      await vi.waitFor(() => expect(document.body.textContent).toContain('Connection refused'));
+      await page.getByRole('tooltip').hover();
+      expect(page.getByRole('tooltip').element().textContent).toBe('Connection refused');
+      const info = page
+        .getByRole('button', { name: 'docs startup error' })
+        .element() as HTMLElement;
+      const row = info.parentElement!.parentElement!;
+      const nameBounds = row.querySelector('span')!.getBoundingClientRect();
+      const infoBounds = info.getBoundingClientRect();
+      const transportBounds = row.querySelector('[data-failed]')!.getBoundingClientRect();
+      expect(infoBounds.left).toBeGreaterThanOrEqual(nameBounds.right);
+      expect(infoBounds.left - nameBounds.right).toBeLessThanOrEqual(8);
+      expect(transportBounds.left).toBeGreaterThanOrEqual(infoBounds.right);
+      expect(getComputedStyle(row.querySelector('[data-failed]')!).color).toBe(
+        getComputedStyle(row.querySelector('span')!).color
+      );
+      await userEvent.keyboard('{Escape}');
+      await userEvent.keyboard('{Tab}');
+      info.focus();
+      await vi.waitFor(() =>
+        expect(page.getByRole('tooltip').element().textContent).toBe('Connection refused')
+      );
+      await page.getByRole('button', { name: '1 session MCP server, 1 startup failure' }).click();
+    }
+
+    if (!populated) {
+      activeTurn.set(userTurn);
+      flushStateTurn();
+      await vi.waitFor(() => expect(store.isEmpty).toBe(false));
+      await vi.waitFor(() => expect(editorY()).toBeGreaterThan(500));
+      expect(parent.textContent).not.toContain('What are we building today?');
+      expect(editor()).toBe(originalEditor);
+    }
+  } finally {
+    historyGate.resolve();
+    await act(async () => root.unmount());
+    store.dispose();
+    connection.dispose();
+    await hub.dispose();
+    await session.dispose();
+    context.dispose();
+    parent.remove();
+    css.remove();
+  }
+});

--- a/packages/core/src/primitives/acp-transcript/api/normalized-event.ts
+++ b/packages/core/src/primitives/acp-transcript/api/normalized-event.ts
@@ -36,6 +36,7 @@ export type NormalizedToolLocation = {
 export type NormalizedToolStatus = 'pending' | 'in_progress' | 'completed' | 'failed';
 
 export type NormalizedEvent =
+  | { kind: 'mcp_startup_failure'; server: string; error: string }
   | {
       kind: 'message';
       promptId?: string;

--- a/packages/core/src/runtimes/acp/api/models/config.ts
+++ b/packages/core/src/runtimes/acp/api/models/config.ts
@@ -43,7 +43,8 @@ export type SessionCommand = z.infer<typeof sessionCommandSchema>;
 
 export const sessionMcpServerSchema = z.object({
   name: z.string(),
-  transport: z.enum(['stdio', 'http', 'sse']),
+  transport: z.enum(['stdio', 'http', 'sse']).optional(),
+  startupError: z.string().optional(),
 });
 export type SessionMcpServer = z.infer<typeof sessionMcpServerSchema>;
 

--- a/packages/core/src/runtimes/acp/api/reducer/reducer.ts
+++ b/packages/core/src/runtimes/acp/api/reducer/reducer.ts
@@ -394,6 +394,7 @@ export function reduce(s: ParserState, input: ReducerInput, deps: ReducerDeps): 
       return { ...s, usage: event.usage };
     case 'title':
       return { ...s, title: event.title };
+    case 'mcp_startup_failure':
     case 'ignored':
       return s;
     case 'subagent_update': {

--- a/packages/core/src/runtimes/acp/node/runtime/conversation-handle.test.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/conversation-handle.test.ts
@@ -18,6 +18,36 @@ import type { SessionRecord } from './conversation-types';
 import { SessionsListProjector } from './sessions-list-projector';
 
 describe('ConversationHandle', () => {
+  it('projects MCP failures without persisting them into the next activation', () => {
+    const setup = makeHandle();
+    const first = setup.handle.beginMaterialization()!;
+    const record = makeRecord(setup.handle, first.epoch);
+    record.mcpServers = [{ name: 'docs', transport: 'http' }];
+    record.cell.mcpStartupFailures.set('docs', 'Connection refused');
+    record.cell.mcpStartupFailures.set('extra', 'Startup cancelled');
+    setup.handle.attachProvisional(record);
+    setup.handle.activate(record);
+    expect(peek(setup.projection.source)).toMatchObject({
+      snapshot: {
+        mcpServers: [
+          { name: 'docs', transport: 'http', startupError: 'Connection refused' },
+          { name: 'extra', startupError: 'Startup cancelled' },
+        ],
+      },
+    });
+    expect(JSON.stringify(setup.handle.intentPayload())).not.toContain('Connection refused');
+
+    const next = setup.handle.beginMaterialization()!;
+    const replacement = makeRecord(setup.handle, next.epoch);
+    replacement.mcpServers = [{ name: 'docs', transport: 'http' }];
+    setup.handle.attachProvisional(replacement);
+    setup.handle.activate(replacement);
+    setup.handle.syncRecord(record);
+    expect(peek(setup.projection.source)).toMatchObject({
+      snapshot: { mcpServers: [{ name: 'docs', transport: 'http' }] },
+    });
+  });
+
   it('invalidates provisional records from superseded materialization epochs', () => {
     const setup = makeHandle();
     const first = setup.handle.beginMaterialization();
@@ -307,6 +337,7 @@ function makeRecord(handle: ConversationHandle, epoch: number): SessionRecord {
       config: initialSessionConfigState,
       configCatalog: { kind: 'pending' },
       usage: null,
+      mcpStartupFailures: new Map(),
       transcript: { title: null, plan: null, agents: [], activeTurn: null },
     } as unknown as SessionRecord['cell'],
     mcpServers: [],

--- a/packages/core/src/runtimes/acp/node/runtime/conversation-handle.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/conversation-handle.ts
@@ -481,11 +481,29 @@ export class ConversationHandle {
       agents: record.cell.transcript.agents,
       activeTurn: record.cell.transcript.activeTurn,
       terminals: this.deps.terminals.listByConversation(this.conversationId),
-      mcpServers:
+      mcpServers: this.withMcpStartupFailures(
+        record,
         this.stateValue === 'materializing' && record.mcpServers.length === 0
           ? this.retainedValue.lastKnownMcpServers
-          : record.mcpServers,
+          : record.mcpServers
+      ),
     };
+  }
+
+  private withMcpStartupFailures(
+    record: SessionRecord,
+    servers: ActivationSnapshot['mcpServers']
+  ): ActivationSnapshot['mcpServers'] {
+    const failures = record.cell.mcpStartupFailures;
+    if (failures.size === 0) return servers;
+    const result = servers.map((server) => ({
+      ...server,
+      startupError: failures.get(server.name),
+    }));
+    for (const [name, startupError] of failures) {
+      if (!servers.some((server) => server.name === name)) result.push({ name, startupError });
+    }
+    return result;
   }
 
   private releaseProjection(): void {

--- a/packages/core/src/runtimes/acp/node/runtime/session-manager.test.ts
+++ b/packages/core/src/runtimes/acp/node/runtime/session-manager.test.ts
@@ -6,6 +6,7 @@ import { observe, peek } from '@emdash/wire/state';
 import { describe, expect, it, vi } from 'vitest';
 import {
   FakeAcpTerminalProcess,
+  FakeAcpAgent,
   makeAcpHarness,
   makeStartInput,
 } from '#runtimes/acp/node/acp-test-support';
@@ -26,6 +27,56 @@ async function launchHarness(conversationId = 'conv-1') {
 }
 
 describe('AcpRuntime session manager', () => {
+  it('publishes adapter startup diagnostics through MCP live state without starting a turn', async () => {
+    const agent = new FakeAcpAgent();
+    const h = makeAcpHarness({
+      acpBehavior: {
+        buildSpawn: () => ({ command: '/fake/node', args: ['agent.js'], env: {} }),
+        connect: agent.behavior.connect,
+        enrich: (event) =>
+          event.kind === 'tool_call' && event.toolCallId === 'startup-diagnostic'
+            ? { kind: 'mcp_startup_failure', server: 'docs', error: 'Connection refused' }
+            : event,
+      },
+    });
+    vi.spyOn(h.deps.agentHost, 'readMcpServers').mockResolvedValueOnce(
+      ok([{ name: 'docs', command: 'docs-mcp' }])
+    );
+    const rt = new AcpRuntime(h.deps);
+    const input = makeStartInput({ conversationId: 'conv-mcp-diagnostic' });
+    await rt.launchSession(input);
+    await agent.capturedClient!.sessionUpdate({
+      sessionId: 'session-1',
+      update: {
+        sessionUpdate: 'tool_call',
+        toolCallId: 'startup-diagnostic',
+        title: 'Startup',
+        status: 'failed',
+        kind: 'other',
+      },
+    });
+    const live = rt.sessionLiveModels(input.conversationId)!;
+    expect(peek(live.states.mcpServers)).toEqual([
+      { name: 'docs', transport: 'stdio', startupError: 'Connection refused' },
+    ]);
+    expect(peek(live.states.activeTurn)).toBeNull();
+    expect(peek(live.states.state)).toMatchObject({ agentTurnActive: false, isGenerating: false });
+
+    // An ordinary failed tool call is still conversational content.
+    await agent.capturedClient!.sessionUpdate({
+      sessionId: 'session-1',
+      update: {
+        sessionUpdate: 'tool_call',
+        toolCallId: 'ordinary-call',
+        title: 'Search docs',
+        status: 'failed',
+        kind: 'other',
+      },
+    });
+    expect(peek(live.states.activeTurn)).not.toBeNull();
+    await rt.dispose();
+  });
+
   it('attaches and exposes a suspended projection without spawning, then activates separately', async () => {
     const h = makeAcpHarness();
     const rt = new AcpRuntime(h.deps);

--- a/packages/core/src/runtimes/acp/node/session/cell.test.ts
+++ b/packages/core/src/runtimes/acp/node/session/cell.test.ts
@@ -25,6 +25,16 @@ function makeCell(agent = new FakeAcpAgent()) {
 }
 
 describe('SessionCell prompts', () => {
+  it('keeps MCP startup failures out of transcript and agent activity', () => {
+    const { cell } = makeCell();
+    cell.push({ kind: 'mcp_startup_failure', server: 'docs', error: 'Connection refused' });
+    expect(cell.mcpStartupFailures.get('docs')).toBe('Connection refused');
+    expect(cell.history()).toEqual({ committed: [], active: null });
+    expect(cell.sessionState.agentTurnActive).toBe(false);
+    expect(cell.sessionState.isGenerating).toBe(false);
+    expect(makeCell().cell.mcpStartupFailures.size).toBe(0);
+  });
+
   it('synthesizes a user message and settles the turn', async () => {
     const { cell, agent } = makeCell();
     agent.prompt = vi.fn().mockResolvedValue({ stopReason: 'end_turn' });

--- a/packages/core/src/runtimes/acp/node/session/cell.ts
+++ b/packages/core/src/runtimes/acp/node/session/cell.ts
@@ -67,6 +67,8 @@ export class SessionCell {
   readonly machine: SessionMachine;
   readonly transcript: AcpTranscriptParser;
   readonly rawLog: RawAcpLog;
+  /** Diagnostics belong to this activation, not to transcript history or retained config. */
+  readonly mcpStartupFailures = new Map<string, string>();
   private readonly permissions = new PermissionBroker();
   private _acpSessionId: string;
   private configCatalogState: SessionConfigCatalog['kind'] = 'pending';
@@ -207,6 +209,11 @@ export class SessionCell {
 
   push(event: NormalizedEvent): void {
     if (event.kind === 'ignored') return;
+    if (event.kind === 'mcp_startup_failure') {
+      this.mcpStartupFailures.set(event.server, event.error);
+      this.deps.callbacks?.onSessionStateChanged?.();
+      return;
+    }
 
     const idleTranscriptEvent = this.isIdleAgentTranscriptEvent(event);
     if (idleTranscriptEvent) this.applyEvent({ type: 'AgentActivity', active: true });

--- a/packages/plugins/src/agents/impl/codex/acp-enrich.test.ts
+++ b/packages/plugins/src/agents/impl/codex/acp-enrich.test.ts
@@ -1,0 +1,36 @@
+import type { SessionUpdate } from '@agentclientprotocol/sdk';
+import { decodeSessionUpdate } from '@emdash/core/runtimes/acp/api';
+import { describe, expect, it } from 'vitest';
+import { enrichCodexUpdate } from './acp-enrich';
+
+const startupFailure = (server: string): SessionUpdate => ({
+  sessionUpdate: 'tool_call',
+  toolCallId: `mcp_startup.${encodeURIComponent(server)}`,
+  title: `mcp__${server}__startup`,
+  kind: 'other',
+  status: 'failed',
+  content: [{ type: 'content', content: { type: 'text', text: 'Connection refused' } }],
+});
+
+describe('Codex MCP startup diagnostics', () => {
+  it('extracts the server identity without parsing diagnostic prose', () => {
+    const raw = startupFailure('docs / team_ä');
+    expect(enrichCodexUpdate(decodeSessionUpdate(raw), raw)).toEqual({
+      kind: 'mcp_startup_failure',
+      server: 'docs / team_ä',
+      error: 'Connection refused',
+    });
+  });
+
+  it.each([
+    { toolCallId: 'ordinary-tool-call' },
+    { toolCallId: 'mcp_startup.%ZZ' },
+    { title: 'mcp__docs__search' },
+    { status: 'completed' as const },
+    { kind: 'execute' as const },
+  ])('preserves nonmatching events: %j', (overrides) => {
+    const raw = { ...startupFailure('docs'), ...overrides } as SessionUpdate;
+    const decoded = decodeSessionUpdate(raw);
+    expect(enrichCodexUpdate(decoded, raw)).toBe(decoded);
+  });
+});

--- a/packages/plugins/src/agents/impl/codex/acp-enrich.ts
+++ b/packages/plugins/src/agents/impl/codex/acp-enrich.ts
@@ -1,0 +1,34 @@
+import type { EnrichHook } from '@emdash/core/runtimes/acp/api';
+
+/** codex-acp represents startup diagnostics as synthetic failed tool calls. */
+export const enrichCodexUpdate: EnrichHook = (event, raw) => {
+  if (
+    event.kind !== 'tool_call' ||
+    event.status !== 'failed' ||
+    event.toolKind !== 'other' ||
+    event.parentToolCallId !== null ||
+    !event.toolCallId.startsWith('mcp_startup.')
+  )
+    return event;
+
+  let server: string;
+  try {
+    server = decodeURIComponent(event.toolCallId.slice('mcp_startup.'.length));
+  } catch {
+    return event;
+  }
+  if (!server || event.title !== `mcp__${server}__startup`) return event;
+  const error =
+    raw.sessionUpdate === 'tool_call'
+      ? raw.content
+          ?.flatMap((entry) =>
+            entry.type === 'content' && entry.content.type === 'text' ? [entry.content.text] : []
+          )
+          .join('\n')
+      : undefined;
+  return {
+    kind: 'mcp_startup_failure',
+    server,
+    error: error || 'MCP server failed to start.',
+  };
+};

--- a/packages/plugins/src/agents/impl/codex/acp-fixture.test.ts
+++ b/packages/plugins/src/agents/impl/codex/acp-fixture.test.ts
@@ -1,8 +1,7 @@
 /**
  * Fixture-driven snapshot tests for Codex ACP transcript parsing.
  *
- * The fixture stores raw ACP output and Codex currently has no provider-specific
- * enrichment hook, so this exercises the parser's baseline decoding.
+ * The fixture stores raw ACP output; use the same enrichment as the live provider.
  */
 
 import {
@@ -14,11 +13,12 @@ import {
 } from '@emdash/core/runtimes/acp/api';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { driveParser, loadFixture } from '../../../../tooling/fixtures/acp/drive-parser';
+import { enrichCodexUpdate } from './acp-enrich';
 
 const fixture = loadFixture(new URL('./fixtures/acp-transcript.json', import.meta.url));
 
 function createParser() {
-  return driveParser(fixture);
+  return driveParser(fixture, { enrich: enrichCodexUpdate });
 }
 
 beforeAll(() => {

--- a/packages/plugins/src/agents/impl/codex/acp.test.ts
+++ b/packages/plugins/src/agents/impl/codex/acp.test.ts
@@ -3,6 +3,7 @@ import type { Agent } from '@agentclientprotocol/sdk';
 import type { AcpClientFactory } from '@emdash/core/services/agent-plugins/api/plugins';
 import { describe, expect, it, vi } from 'vitest';
 import { pluginRegistry } from '../../registry';
+import { enrichCodexUpdate } from './acp-enrich';
 
 describe('codex acp capability', () => {
   it('declares acp: { kind: supported }', () => {
@@ -18,6 +19,11 @@ describe('codex acp behavior', () => {
 
   it('behavior.acp is defined', () => {
     expect(acpBehavior()).toBeDefined();
+  });
+
+  it('registers startup diagnostic enrichment only for Codex', () => {
+    expect(acpBehavior().enrich).toBe(enrichCodexUpdate);
+    expect(pluginRegistry.get('claude')!.behavior.acp!.enrich).not.toBe(enrichCodexUpdate);
   });
 
   describe('buildSpawn', () => {

--- a/packages/plugins/src/agents/impl/codex/index.ts
+++ b/packages/plugins/src/agents/impl/codex/index.ts
@@ -11,6 +11,7 @@ import {
 import { connectStdioAcp } from '../../helpers/acp-stdio';
 import { resolveAdapterAsset } from '../../helpers/adapter-assets';
 import { authenticatedFromEnv, commandAuthStatus } from '../../helpers/auth';
+import { enrichCodexUpdate } from './acp-enrich';
 import { codexAdapter } from './adapter';
 import { buildCodexHookConfig } from './hooks';
 import { icon } from './icon';
@@ -141,6 +142,7 @@ export const provider = registerPluginBehavior(plugin, {
     connect: (io, toClient) => {
       return connectStdioAcp(io, toClient);
     },
+    enrich: enrichCodexUpdate,
   },
   auth: {
     checkStatus: async (ctx) => {

--- a/packages/ui/src/react/components/chat-composer/chat-composer.css.ts
+++ b/packages/ui/src/react/components/chat-composer/chat-composer.css.ts
@@ -198,7 +198,29 @@ export const toolbar = style({
   paddingBottom: '0.5rem',
 });
 
-export const toolbarLeft = style({ display: 'flex', alignItems: 'center', gap: '0.375rem' });
+export const toolbarLeft = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.375rem',
+  minHeight: '2rem',
+});
+
+export const mcpNameGroup = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.25rem',
+  minWidth: 0,
+});
+
+export const mcpInfoIcon = style({
+  transform: 'translateY(1px)',
+});
+
+export const mcpErrorText = style({
+  minWidth: 0,
+  overflowWrap: 'anywhere',
+  whiteSpace: 'pre-wrap',
+});
 export const toolbarRight = style({ display: 'flex', alignItems: 'center', gap: '0.25rem' });
 
 export const permissionModeTrigger = style({
@@ -225,6 +247,7 @@ export const mcpTrigger = style([
     lineHeight: 1,
     outline: 'none',
     selectors: {
+      '&[data-failed]': { color: vars.surfaceDestructiveForeground },
       '&:hover': { backgroundColor: vars.surfaceBaseSelected },
       '&[data-popup-open]': { backgroundColor: vars.surfaceBaseSelected },
     },
@@ -251,6 +274,9 @@ export const mcpRow = style({
   padding: '0.375rem 0.5rem',
   fontSize: tokenVars.textSm,
   color: vars.foreground,
+  selectors: {
+    '&[data-failed]': { color: vars.surfaceDestructiveForeground },
+  },
 });
 
 export const mcpName = style({
@@ -267,6 +293,9 @@ export const mcpBadge = style({
   padding: '0.0625rem 0.3125rem',
   fontSize: tokenVars.textXs,
   color: vars.foregroundMuted,
+  selectors: {
+    '&[data-failed]': { color: vars.surfaceDestructiveForeground },
+  },
 });
 
 // ── Agent trigger ─────────────────────────────────────────────────────────────

--- a/packages/ui/src/react/components/chat-composer/chat-composer.stories.tsx
+++ b/packages/ui/src/react/components/chat-composer/chat-composer.stories.tsx
@@ -576,6 +576,33 @@ export const WithMcpServers: Story = {
   ),
 };
 
+export const WithMcpStartupFailure: Story = {
+  render: () => (
+    <Box className={cx(s.mxAuto, s.maxW2xl)} width="full">
+      <ChatComposer
+        onSubmit={() => {}}
+        mcpServers={[
+          { name: 'openaiDeveloperDocs', transport: 'http' },
+          {
+            name: 'node_repl',
+            transport: 'stdio',
+            startupError:
+              '[codex-acp forwarded startup error] MCP server `node_repl` failed to start: MCP client for `node_repl` failed to start: MCP startup failed: No such file or directory (os error 2)',
+          },
+        ]}
+      />
+    </Box>
+  ),
+};
+
+export const AwaitingProviderControls: Story = {
+  render: () => (
+    <Box className={cx(s.mxAuto, s.maxW2xl)} width="full">
+      <ChatComposer canSubmit={false} onSubmit={() => {}} />
+    </Box>
+  ),
+};
+
 function QueuedPromptsDemo() {
   const [queuedPrompts, setQueuedPrompts] = useState<ComposerQueuedPrompt[]>(MOCK_QUEUED_PROMPTS);
 

--- a/packages/ui/src/react/components/chat-composer/chat-composer.test.tsx
+++ b/packages/ui/src/react/components/chat-composer/chat-composer.test.tsx
@@ -13,6 +13,34 @@ import { ChatComposer } from './index';
 afterEach(cleanup);
 
 describe('ChatComposer', () => {
+  it('shows startup failures on the MCP trigger and affected server, including while disabled', async () => {
+    const { getByRole, findByRole, queryByText, getByText } = render(
+      <ChatComposer
+        disabled
+        onSubmit={() => {}}
+        mcpServers={[
+          { name: 'docs', transport: 'http', startupError: 'Connection refused' },
+          { name: 'filesystem', transport: 'stdio' },
+        ]}
+      />
+    );
+    const trigger = getByRole('button', { name: '2 session MCP servers, 1 startup failure' });
+    expect(trigger.hasAttribute('disabled')).toBe(false);
+    expect(trigger.hasAttribute('data-failed')).toBe(true);
+    expect(trigger.textContent).toBe('2');
+    expect(trigger.querySelectorAll('svg')).toHaveLength(1);
+    fireEvent.click(trigger);
+    const info = await findByRole('button', { name: 'docs startup error' });
+    expect(queryByText('Connection refused')).toBeNull();
+    expect(getByText('docs').parentElement?.parentElement?.hasAttribute('data-failed')).toBe(true);
+    expect(getByText('docs').nextElementSibling).toBe(info);
+    expect(getByText('http').hasAttribute('data-failed')).toBe(true);
+    expect(getByText('stdio').hasAttribute('data-failed')).toBe(false);
+    fireEvent.keyDown(document, { key: 'Tab' });
+    info.focus();
+    expect((await findByRole('tooltip')).textContent).toBe('Connection refused');
+  });
+
   it('shows the selected effort beside the model and keeps the MCP trigger compact', () => {
     const { container, getByRole } = render(
       <ChatComposer
@@ -34,6 +62,7 @@ describe('ChatComposer', () => {
     expect(modelTrigger?.textContent).toBe('GPT-5.6-Sol High');
     const mcpTrigger = getByRole('button', { name: '2 session MCP servers' });
     expect(mcpTrigger.textContent).toBe('2');
+    expect(mcpTrigger.hasAttribute('data-failed')).toBe(false);
   });
 
   it('caps the permission-mode popup at its compact width', async () => {

--- a/packages/ui/src/react/components/chat-composer/index.tsx
+++ b/packages/ui/src/react/components/chat-composer/index.tsx
@@ -4,6 +4,7 @@ import {
   ArrowUp,
   ChevronRight,
   CircleAlert,
+  Info,
   ListTodo,
   Paperclip,
   ShieldCheck,
@@ -14,6 +15,7 @@ import { Combobox } from '@/react/primitives/combobox/combobox';
 import { DropdownMenu } from '@/react/primitives/dropdown-menu';
 import { Popover } from '@/react/primitives/popover';
 import { Select } from '@/react/primitives/select';
+import { Tooltip } from '@/react/primitives/tooltip';
 import { ComboboxPopover } from '../combobox-popover';
 import { McpIcon } from '../mcp-icon/mcp-icon';
 import { PromptEditor } from '../prompt-editor/prompt-editor';
@@ -165,7 +167,8 @@ export interface ComposerCollaborationModeOption {
 
 export interface ComposerMcpServer {
   name: string;
-  transport: string;
+  transport?: string;
+  startupError?: string;
 }
 
 // ── Agent option types ────────────────────────────────────────────────────────
@@ -702,6 +705,7 @@ export function ChatComposer({
   onSendQueuedPromptNow,
   className,
 }: ChatComposerProps) {
+  const mcpFailureCount = mcpServers.filter((server) => server.startupError).length;
   const editorRef = useRef<PromptEditorRef | null>(null);
   const [dragActive, setDragActive] = useState(false);
   const [editorText, setEditorText] = useState('');
@@ -1116,10 +1120,11 @@ export function ChatComposer({
               <Popover.Root>
                 <Popover.Trigger
                   className={styles.mcpTrigger}
-                  disabled={disabled}
+                  data-failed={mcpFailureCount > 0 ? '' : undefined}
+                  openOnHover
                   aria-label={`${mcpServers.length} session MCP ${
                     mcpServers.length === 1 ? 'server' : 'servers'
-                  }`}
+                  }${mcpFailureCount ? `, ${mcpFailureCount} startup ${mcpFailureCount === 1 ? 'failure' : 'failures'}` : ''}`}
                 >
                   <McpIcon size={12} />
                   {mcpServers.length}
@@ -1128,12 +1133,39 @@ export function ChatComposer({
                   align="start"
                   className={cx(styles.mcpPopoverContent, composerThemeScope)}
                   aria-label="Session MCP servers"
+                  initialFocus={false}
                 >
                   <div className={styles.mcpList}>
                     {mcpServers.map((server) => (
-                      <div key={`${server.transport}:${server.name}`} className={styles.mcpRow}>
-                        <span className={styles.mcpName}>{server.name}</span>
-                        <span className={styles.mcpBadge}>{server.transport}</span>
+                      <div
+                        key={`${server.transport}:${server.name}`}
+                        className={styles.mcpRow}
+                        data-failed={server.startupError ? '' : undefined}
+                      >
+                        <div className={styles.mcpNameGroup}>
+                          <span className={styles.mcpName}>{server.name}</span>
+                          {server.startupError && (
+                            <Tooltip.Root>
+                              <Tooltip.Trigger
+                                render={<Button variant="ghost" size="xs" icon />}
+                                aria-label={`${server.name} startup error`}
+                              >
+                                <Info className={styles.mcpInfoIcon} aria-hidden="true" />
+                              </Tooltip.Trigger>
+                              <Tooltip.Content role="tooltip" side="right" align="start">
+                                <span className={styles.mcpErrorText}>{server.startupError}</span>
+                              </Tooltip.Content>
+                            </Tooltip.Root>
+                          )}
+                        </div>
+                        {server.transport && (
+                          <span
+                            className={styles.mcpBadge}
+                            data-failed={server.startupError ? '' : undefined}
+                          >
+                            {server.transport}
+                          </span>
+                        )}
                       </div>
                     ))}
                   </div>


### PR DESCRIPTION
- keep the chat composer centered and immediately usable during conversation startup
- surface mcp startup failures compactly without disrupting the composer layout
- reconcile refreshed transcripts without stale turns, lost queued messages, or obsolete bootstrap errors
- preserve scroll position while history, streaming content, and composer measurements change